### PR TITLE
api: pass actual Header through newRPCOutput function

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -614,13 +614,13 @@ func getFrom(tx *types.Transaction) common.Address {
 	return from
 }
 
-func NewRPCTransaction(b *types.Block, tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, config *params.ChainConfig) map[string]interface{} {
-	return newRPCTransaction(b, tx, blockHash, blockNumber, index, config)
+func NewRPCTransaction(head *types.Header, tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, config *params.ChainConfig) map[string]interface{} {
+	return newRPCTransaction(head, tx, blockHash, blockNumber, index, config)
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCTransaction(b *types.Block, tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, config *params.ChainConfig) map[string]interface{} {
+func newRPCTransaction(header *types.Header, tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, config *params.ChainConfig) map[string]interface{} {
 	output := tx.MakeRPCOutput()
 	output["senderTxHash"] = tx.SenderTxHashAll()
 	output["blockHash"] = blockHash
@@ -629,8 +629,8 @@ func newRPCTransaction(b *types.Block, tx *types.Transaction, blockHash common.H
 	output["hash"] = tx.Hash()
 	output["transactionIndex"] = hexutil.Uint(index)
 	if tx.Type() == types.TxTypeEthereumDynamicFee {
-		if b != nil {
-			output["gasPrice"] = (*hexutil.Big)(tx.EffectiveGasPrice(b.Header(), config))
+		if header != nil {
+			output["gasPrice"] = (*hexutil.Big)(tx.EffectiveGasPrice(header, config))
 		} else {
 			// transaction is not processed yet
 			output["gasPrice"] = (*hexutil.Big)(tx.EffectiveGasPrice(nil, nil))
@@ -646,12 +646,13 @@ func newRPCPendingTransaction(tx *types.Transaction, config *params.ChainConfig)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
+// non-null of b(block) is guaranteed
 func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *params.ChainConfig) map[string]interface{} {
 	txs := b.Transactions()
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	return newRPCTransaction(b, txs[index], b.Hash(), b.NumberU64(), index, config)
+	return newRPCTransaction(b.Header(), txs[index], b.Hash(), b.NumberU64(), index, config)
 }
 
 // newRPCRawTransactionFromBlockIndex returns the bytes of a transaction given a block and a transaction index.

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -328,7 +328,7 @@ func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
 			rpcTransactions[i] = kaiaApi.RpcOutputReceipt(head, tx, hash, head.Number.Uint64(), uint64(i), receipts[i], api.chain.Config())
 		} else {
 			// fill the transaction output if receipt is not found
-			rpcTransactions[i] = kaiaApi.NewRPCTransaction(b, tx, hash, head.Number.Uint64(), uint64(i), api.chain.Config())
+			rpcTransactions[i] = kaiaApi.NewRPCTransaction(head, tx, hash, head.Number.Uint64(), uint64(i), api.chain.Config())
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

- `GetTransactionByHash` and `RpcOutputReceipt` passes null to the parameter `block` of `newRPCTransaction`. So the calculation of effectiveGasPrice couldn't work.
- This PR fixes those functions to pass actual Header.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn)
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

Test at private network which kaia hardfork has been enabled at `80`
tested two transactions
- tx1: EthereumDynamicFee tx of block 50 which is BEFORE kaia hardfork
- tx2: EthereumDynamicFee tx of block 163 which is AFTER kaia hardfork
```
// main
> kaia.getTransaction("0x6e436476a3f29f95eebfe9e5d28f50b90185170726631c4ae07cd1a0fd260a98").gasPrice
750000000000
> eth.getTransaction("0x6e436476a3f29f95eebfe9e5d28f50b90185170726631c4ae07cd1a0fd260a98").gasPrice
25000000000
> kaia.getTransaction("0x0b964370b5af896ab70b1e4957ec4908435877b3fad6c7b13f54e86b027add93").gasPrice
750000000000
> eth.getTransaction("0x0b964370b5af896ab70b1e4957ec4908435877b3fad6c7b13f54e86b027add93").gasPrice
25000000033
```
```
// PR
> kaia.getTransaction("0x6e436476a3f29f95eebfe9e5d28f50b90185170726631c4ae07cd1a0fd260a98").gasPrice
25000000000
> eth.getTransaction("0x6e436476a3f29f95eebfe9e5d28f50b90185170726631c4ae07cd1a0fd260a98").gasPrice
25000000000
> kaia.getTransaction("0x0b964370b5af896ab70b1e4957ec4908435877b3fad6c7b13f54e86b027add93").gasPrice
25000000033
> eth.getTransaction("0x0b964370b5af896ab70b1e4957ec4908435877b3fad6c7b13f54e86b027add93").gasPrice
25000000033
>
```

