### PR TITLE
tracers: debug APIs and chaindatafetcher use new vm.CallTracer

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2795,10 +2795,11 @@ func GetInternalTxTrace(tracer vm.Tracer) (*vm.InternalTxTrace, error) {
 			return nil, err
 		}
 	case *vm.CallTracer:
-		internalTxTrace, err = tracer.GetResultAsInternalTxTrace()
+		callTrace, err := tracer.GetResult()
 		if err != nil {
 			return nil, err
 		}
+		internalTxTrace = callTrace.ToInternalTxTrace()
 	default:
 		logger.Error("To trace internal transactions, VM tracer type should be vm.InternalTxTracer", "actualType", reflect.TypeOf(tracer).String())
 		return nil, ErrInvalidTracer

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2794,6 +2794,11 @@ func GetInternalTxTrace(tracer vm.Tracer) (*vm.InternalTxTrace, error) {
 		if err != nil {
 			return nil, err
 		}
+	case *vm.CallTracer:
+		internalTxTrace, err = tracer.GetResultAsInternalTxTrace()
+		if err != nil {
+			return nil, err
+		}
 	default:
 		logger.Error("To trace internal transactions, VM tracer type should be vm.InternalTxTracer", "actualType", reflect.TypeOf(tracer).String())
 		return nil, ErrInvalidTracer

--- a/blockchain/vm/call_tracer.go
+++ b/blockchain/vm/call_tracer.go
@@ -19,7 +19,6 @@
 package vm
 
 import (
-	"encoding/json"
 	"errors"
 	"math/big"
 	"sync/atomic"
@@ -220,39 +219,13 @@ func (t *CallTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost, ccL
 func (t *CallTracer) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost, ccLeft, ccOpcode uint64, scope *ScopeContext, depth int, err error) {
 }
 
-func (t *CallTracer) GetResult() ([]CallFrame, error) {
+func (t *CallTracer) GetResult() (CallFrame, error) {
 	if len(t.callstack) != 1 {
-		return nil, errors.New("incorrect number of top-level calls")
+		return CallFrame{}, errors.New("incorrect number of top-level calls")
 	}
 
 	// Return with interrupt reason if any
-	return t.callstack, t.interruptReason
-}
-
-func (t *CallTracer) GetResultAsJson() (json.RawMessage, error) {
-	if len(t.callstack) != 1 {
-		return nil, errors.New("incorrect number of top-level calls")
-	}
-
-	result, err := json.Marshal(t.callstack[0])
-	if err != nil {
-		return nil, err
-	}
-
-	// Return with interrupt reason if any
-	return result, t.interruptReason
-}
-
-// Convert to the legacy InternalTxTrace type
-func (t *CallTracer) GetResultAsInternalTxTrace() (*InternalTxTrace, error) {
-	if len(t.callstack) != 1 {
-		return nil, errors.New("incorrect number of top-level calls")
-	}
-
-	result := t.callstack[0].ToInternalTxTrace()
-
-	// Return with interrupt reason if any
-	return result, t.interruptReason
+	return t.callstack[0], t.interruptReason
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.

--- a/blockchain/vm/call_tracer.go
+++ b/blockchain/vm/call_tracer.go
@@ -58,7 +58,7 @@ func (f CallFrame) ToInternalTxTrace() *InternalTxTrace {
 	t.From = &f.From
 	t.To = f.To
 	if f.Value != nil {
-		t.Value = f.Value.Text(16)
+		t.Value = "0x" + f.Value.Text(16)
 	}
 
 	t.Gas = f.Gas
@@ -220,7 +220,16 @@ func (t *CallTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost, ccL
 func (t *CallTracer) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost, ccLeft, ccOpcode uint64, scope *ScopeContext, depth int, err error) {
 }
 
-func (t *CallTracer) GetResult() (json.RawMessage, error) {
+func (t *CallTracer) GetResult() ([]CallFrame, error) {
+	if len(t.callstack) != 1 {
+		return nil, errors.New("incorrect number of top-level calls")
+	}
+
+	// Return with interrupt reason if any
+	return t.callstack, t.interruptReason
+}
+
+func (t *CallTracer) GetResultAsJson() (json.RawMessage, error) {
 	if len(t.callstack) != 1 {
 		return nil, errors.New("incorrect number of top-level calls")
 	}

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -181,7 +181,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 	// If internal transaction tracing is enabled, creates a tracer for a transaction
 	if vmConfig.EnableInternalTxTracing {
 		vmConfig.Debug = true
-		vmConfig.Tracer = NewInternalTxTracer()
+		vmConfig.Tracer = NewCallTracer()
 	}
 
 	evm.interpreter = NewEVMInterpreter(evm)

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -153,7 +153,8 @@ type InternalTxTrace struct {
 	Time  time.Duration      `json:"time,omitempty"`
 	Calls []*InternalTxTrace `json:"calls,omitempty"`
 
-	Reverted *RevertedInfo `json:"reverted,omitempty"`
+	RevertReason string        `json:"revertReason,omitempty"`
+	Reverted     *RevertedInfo `json:"reverted,omitempty"`
 }
 
 type RevertedInfo struct {

--- a/datasync/chaindatafetcher/chaindata_fetcher.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher.go
@@ -320,7 +320,11 @@ func (f *ChainDataFetcher) makeChainEvent(blockNumber uint64) (blockchain.ChainE
 		}
 		for _, r := range results {
 			if r.Result != nil {
-				internalTraces = append(internalTraces, r.Result.(*vm.InternalTxTrace))
+				switch r.Result.(type) {
+				case []vm.CallFrame:
+					cf := r.Result.([]vm.CallFrame)
+					internalTraces = append(internalTraces, cf[0].ToInternalTxTrace())
+				}
 			} else {
 				traceAPIErrorCounter.Inc(1)
 				logger.Error("the trace result is nil", "err", r.Error, "blockNumber", blockNumber)

--- a/datasync/chaindatafetcher/chaindata_fetcher.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher.go
@@ -321,9 +321,9 @@ func (f *ChainDataFetcher) makeChainEvent(blockNumber uint64) (blockchain.ChainE
 		for _, r := range results {
 			if r.Result != nil {
 				switch r.Result.(type) {
-				case []vm.CallFrame:
-					cf := r.Result.([]vm.CallFrame)
-					internalTraces = append(internalTraces, cf[0].ToInternalTxTrace())
+				case vm.CallFrame:
+					cf := r.Result.(vm.CallFrame)
+					internalTraces = append(internalTraces, cf.ToInternalTxTrace())
 				}
 			} else {
 				traceAPIErrorCounter.Inc(1)

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -901,8 +901,8 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 			}
 		}
 
-		if *config.Tracer == fastCallTracer {
-			tracer = vm.NewInternalTxTracer()
+		if *config.Tracer == "fastCallTracer" || *config.Tracer == "callTracer" {
+			tracer = vm.NewCallTracer()
 		} else {
 			// Construct the JavaScript tracer to execute with
 			if tracer, err = New(*config.Tracer, new(Context), api.unsafeTrace); err != nil {
@@ -918,6 +918,8 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 				case *Tracer:
 					t.Stop(errors.New("execution timeout"))
 				case *vm.InternalTxTracer:
+					t.Stop(errors.New("execution timeout"))
+				case *vm.CallTracer:
 					t.Stop(errors.New("execution timeout"))
 				default:
 					logger.Warn("unknown tracer type", "type", reflect.TypeOf(t).String())
@@ -962,6 +964,8 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 	case *Tracer:
 		return tracer.GetResult()
 	case *vm.InternalTxTracer:
+		return tracer.GetResult()
+	case *vm.CallTracer:
 		return tracer.GetResult()
 
 	default:

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -170,7 +170,7 @@ func runTracer(t *testing.T, tc *tracerTestdata, tracer vm.Tracer) (*types.Trans
 	case *Tracer:
 		tracerResult, err = tracer.GetResult()
 	case *vm.CallTracer:
-		tracerResult, err = tracer.GetResult()
+		tracerResult, err = tracer.GetResultAsJson()
 	}
 	require.NoError(t, err)
 	assert.JSONEq(t, string(tc.Result), string(tracerResult))

--- a/node/cn/tracers/tracers_test.go
+++ b/node/cn/tracers/tracers_test.go
@@ -169,10 +169,13 @@ func runTracer(t *testing.T, tc *tracerTestdata, tracer vm.Tracer) (*types.Trans
 	switch tracer := tracer.(type) {
 	case *Tracer:
 		tracerResult, err = tracer.GetResult()
+		require.NoError(t, err)
 	case *vm.CallTracer:
-		tracerResult, err = tracer.GetResultAsJson()
+		callFrame, err := tracer.GetResult()
+		require.NoError(t, err)
+		tracerResult, err = json.Marshal(callFrame)
+		require.NoError(t, err)
 	}
-	require.NoError(t, err)
 	assert.JSONEq(t, string(tc.Result), string(tracerResult))
 
 	return msg, execResult, tracerResult


### PR DESCRIPTION
## Proposed changes

- Follow-up of #15.
- debug RPC API
  - `callTracer` was previously `call_tracer.js` and is now `vm.CallTracer`
  - `fastCallTracer` was previously `vm.InternalTxTracer` and is now `vm.CallTracer`
- chaindatafetcher
  - `ChainEvent.InternalTxTraces` (enabled when `--vm.internaltx`) was previously produced by `vm.InternalTxTracer` and is now `vm.CallTracer`, but preserves the original `InternalTxTrace` output format.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
