### PR TITLE
Tidy RebalanceTreasury and SimulatedBackend

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -407,7 +407,12 @@ func (b *SimulatedBackend) PendingNonceAt(_ context.Context, account common.Addr
 // SuggestGasPrice implements ContractTransactor.SuggestGasPrice. Since the simulated
 // chain doesn't have miners, we just return a gas price of 1 for any call.
 func (b *SimulatedBackend) SuggestGasPrice(_ context.Context) (*big.Int, error) {
-	return new(big.Int).SetUint64(b.config.UnitPrice), nil
+	current := b.blockchain.CurrentBlock()
+	if b.blockchain.Config().IsMagmaForkEnabled(current.Number()) {
+		return new(big.Int).Mul(current.Header().BaseFee, big.NewInt(2)), nil
+	} else {
+		return new(big.Int).SetUint64(b.config.UnitPrice), nil
+	}
 }
 
 // EstimateGas executes the requested code against the latest block/state and

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -487,7 +487,3 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 func (st *StateTransition) gasUsed() uint64 {
 	return st.initialGas - st.gas
 }
-
-func getBurnAmountMagma(fee *big.Int) *big.Int {
-	return new(big.Int).Div(fee, big.NewInt(2))
-}

--- a/blockchain/system/rebalance.go
+++ b/blockchain/system/rebalance.go
@@ -154,7 +154,7 @@ func newRebalanceReceipt() *rebalanceResult {
 	}
 }
 
-func (result *rebalanceResult) memo(isKip103 bool) []byte {
+func (result *rebalanceResult) Memo(isKip103 bool) []byte {
 	var (
 		memo []byte
 		err  error
@@ -322,8 +322,5 @@ func RebalanceTreasury(state *state.StateDB, chain backends.BlockChainForCaller,
 	remainder := new(big.Int).Sub(totalZeroedAmount, totalAllocatedAmount)
 	result.Burnt.Add(result.Burnt, remainder)
 	result.Success = true
-
-	// Leave a memo for logging
-	logger.Info("successfully executed treasury rebalancing", "memo", string(result.memo(isKIP103)))
 	return result, nil
 }

--- a/blockchain/system/rebalance_test.go
+++ b/blockchain/system/rebalance_test.go
@@ -222,7 +222,7 @@ func rebalanceTreasury(t *testing.T, sender *bind.TransactOpts, config *params.C
 		res, err := RebalanceTreasury(state, chain, chain.CurrentHeader())
 		if chain.Config().Kip103CompatibleBlock != nil && tc.expectBurnt.Cmp(big.NewInt(0)) == -1 {
 			assert.Equal(t, ErrRebalanceNotEnoughBalance, err)
-			t.Log(string(res.memo(true)))
+			t.Log(string(res.Memo(true)))
 			continue
 		}
 
@@ -250,9 +250,9 @@ func rebalanceTreasury(t *testing.T, sender *bind.TransactOpts, config *params.C
 		//	assert.Equal(t, tc.expectKip103Memo, string(res.memo(isKip103)))
 		//}
 
-		t.Log(string(res.memo(isKip103)))
+		t.Log(string(res.Memo(isKip103)))
 		if !isKip103 {
-			assert.Equal(t, tc.expectKip160Memo, string(res.memo(isKip103)))
+			assert.Equal(t, tc.expectKip160Memo, string(res.Memo(isKip103)))
 		}
 	}
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -553,9 +553,13 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	// so the existing state db should be used to apply the rebalancing result.
 	// Only on the KIP-103 or KIP-160 hardfork block, the following logic should be executed
 	if chain.Config().IsKIP160ForkBlock(header.Number) || chain.Config().IsKIP103ForkBlock(header.Number) {
-		_, err := system.RebalanceTreasury(state, chain, header)
+		rebalanceResult, err := system.RebalanceTreasury(state, chain, header)
 		if err != nil {
 			logger.Error("failed to execute treasury rebalancing. State not changed", "err", err)
+		} else {
+			// Leave the memo in the log for later contract finalization
+			isKIP103 := chain.Config().IsKIP103ForkBlock(header.Number) // because memo format differs between KIP-103 and KIP-160
+			logger.Info("successfully executed treasury rebalancing", "memo", string(rebalanceResult.Memo(isKIP103)))
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

- Remove unused `getBurnAmountMagma` function
- Relocate the treasury rebalance memo logging site from system.RebalanceTreasury to engine.Finalize
- SimulatedBackend.SuggestGasPrice returns lastBaseFee*2 or UnitPrice depending on fork level.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
