### PR TITLE
api: set kairos testnet burnt amount correctly for totalSupply api

### DIFF
--- a/reward/supply_manager.go
+++ b/reward/supply_manager.go
@@ -214,7 +214,7 @@ func (sm *supplyManager) GetRebalanceBurn(num uint64, forkNum *big.Int, addr com
 		Burnt *big.Int `json:"burnt"`
 	}{}
 
-	if sm.chain.Config().ChainID.Uint64() == 1001 && strings.Contains(memo, "before") {
+	if sm.chain.Config().ChainID.Uint64() == 1001 && strings.HasPrefix(memo, "before") {
 		// correctly set burnt amount for kairos testnet
 		result.Burnt = new(big.Int)
 		result.Burnt.SetString("-3704329462904320084000000000", 10)


### PR DESCRIPTION
## Proposed changes

- This PR set kairos testnet burnt amount correctly for totalSupply api. This change is applied only when `chainid==kairosNetworkId(1001)` and the memo is `before` (check memo output here https://baobab.klaytnscope.com/account/0x3D478E73c9dBebB72332712D7265961B1868d193?tabId=contractCode)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

Tested at private network and the burnt amount is changed like below. This is testnet so zeroed and allocated amount is not set or balance is not allocated.
```
> klay.getTotalSupply('latest')
{
  burntFee: "0x12ab5b35b946200",
  deadBurn: "0x0",
  error: "cannot determine rebalance (kip103, kip160) burn amount: rebalance memo not yet stored",
  kip103Burn: "0x0",
  kip160Burn: null,
  number: "0x25d",
  totalBurnt: null,
  totalMinted: "0x111b0ec57e6499a1f4b117ef38222bc7ce207903800",
  totalSupply: null,
  zeroBurn: "0x0"
}
> klay.getTotalSupply('latest')
{
  burntFee: "0x12fe5e19693ce00",
  deadBurn: "0x0",
  kip103Burn: "0x0",
  kip160Burn: "-0xbf82646906be407e42a4800",
  number: "0x282",
  totalBurnt: "-0xbf826468f3bfe264d967a00",
  totalMinted: "0x111b0ec57e6499a1f4b117ef395642062f3e2503800",
  totalSupply: "0x111b0ec57e6499a1f4b1d7719dbf35c611a2fe6b200",
  zeroBurn: "0x0"
}
```
