### PR TITLE
api: Message signing RPCs are EIP-191 compliant

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1191,7 +1191,7 @@ func (api *EthereumAPI) SendRawTransaction(ctx context.Context, input hexutil.By
 }
 
 // Sign calculates an ECDSA signature for:
-// keccack256("\x19Klaytn Signed Message:\n" + len(message) + message).
+// keccack256("\x19Ethereum Signed Message:\n" + len(message) + message).
 //
 // Note, the produced signature conforms to the secp256k1 curve R, S and V values,
 // where the V value will be 27 or 28 for legacy reasons.

--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -480,13 +480,11 @@ func (s *PrivateAccountAPI) Sign(ctx context.Context, data hexutil.Bytes, addr c
 // EcRecover returns the address for the account that was used to create the signature.
 // Note, this function is compatible with eth_sign and personal_sign. As such it recovers
 // the address of:
-// hash = keccak256("\x19Klaytn Signed Message:\n"${message length}${message})
+// hash = keccak256("\x19Ethereum Signed Message:\n"${message length}${message})
 // addr = ecrecover(hash, signature)
 //
 // Note, the signature must conform to the secp256k1 curve R, S and V values, where
 // the V value must be 27 or 28 for legacy reasons.
-//
-// https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_ecRecover
 func (s *PrivateAccountAPI) EcRecover(ctx context.Context, data, sig hexutil.Bytes) (common.Address, error) {
 	if len(sig) != crypto.SignatureLength {
 		return common.Address{}, errors.New("signature must be 65 bytes long")
@@ -498,7 +496,7 @@ func (s *PrivateAccountAPI) EcRecover(ctx context.Context, data, sig hexutil.Byt
 	// Transform yellow paper V from 27/28 to 0/1
 	sig[crypto.RecoveryIDOffset] -= 27
 
-	pubkey, err := klayEcRecover(data, sig)
+	pubkey, err := ethEcRecover(data, sig)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/api/api_private_account.go
+++ b/api/api_private_account.go
@@ -452,7 +452,7 @@ func (s *PrivateAccountAPI) signAsFeePayer(addr common.Address, passwd string, t
 }
 
 // Sign calculates a Kaia ECDSA signature for:
-// keccack256("\x19Klaytn Signed Message:\n" + len(message) + message))
+// keccack256("\x19Ethereum Signed Message:\n" + len(message) + message))
 //
 // Note, the produced signature conforms to the secp256k1 curve R, S and V values,
 // where the V value will be 27 or 28 for legacy reasons.
@@ -469,7 +469,7 @@ func (s *PrivateAccountAPI) Sign(ctx context.Context, data hexutil.Bytes, addr c
 		return nil, err
 	}
 	// Assemble sign the data with the wallet
-	signature, err := wallet.SignHashWithPassphrase(account, passwd, signHash(data))
+	signature, err := wallet.SignHashWithPassphrase(account, passwd, ethSignHash(data))
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -596,6 +596,8 @@ func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, e
 }
 
 // RecoverFromMessage validates that the message is signed by one of the keys in the given account.
+// The signature must be either EIP-191 or KIP-97 compliant, meaning the message must have been prefixed
+// with either "\x19Ethereum Signed Message" or "\x19Klaytn Signed Message" before hashed and signed.
 // Returns the recovered signer address, which may be different from the account address.
 func (s *PublicTransactionPoolAPI) RecoverFromMessage(
 	ctx context.Context, address common.Address, data, sig hexutil.Bytes, blockNumber rpc.BlockNumber,
@@ -616,9 +618,8 @@ func (s *PublicTransactionPoolAPI) RecoverFromMessage(
 	}
 	key := state.GetKey(address)
 
-	// We cannot identify if the signature has signed with kaia or eth prefix without the signer's address.
-	// Even though a user signed message with eth prefix, it will return invalid something in klayEcRecover.
-	// We should call each rcrecover function separately and the actual result will be checked in ValidateMember.
+	// We cannot identify if the signature has signed with EIP-191 or KIP-97 prefix without the signer's address.
+	// Try ecrecover with both prefixes and validate the actual result in ValidateMember.
 	var recoverErr error
 	if pubkey, err := klayEcRecover(data, sig); err == nil {
 		if key.ValidateMember(pubkey, address) {

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -387,7 +387,7 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 }
 
 // Sign calculates an ECDSA signature for:
-// keccack256("\x19Klaytn Signed Message:\n" + len(message) + message).
+// keccack256("\x19Ethereum Signed Message:\n" + len(message) + message).
 //
 // Note, the produced signature conforms to the secp256k1 curve R, S and V values,
 // where the V value will be 27 or 28 for legacy reasons.
@@ -404,7 +404,7 @@ func (s *PublicTransactionPoolAPI) Sign(addr common.Address, data hexutil.Bytes)
 		return nil, err
 	}
 	// Sign the requested hash with the wallet
-	signature, err := wallet.SignHash(account, signHash(data))
+	signature, err := wallet.SignHash(account, ethSignHash(data))
 	if err == nil {
 		signature[crypto.RecoveryIDOffset] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
 	}


### PR DESCRIPTION
## Proposed changes

- There were two different message signing standards in Klaytn
  - [EIP-191](https://eips.ethereum.org/EIPS/eip-191). Prepend `"\x19Ethereum Signed Message:\n" + len(message)` to the message before signing
  - [KIP-97](https://github.com/klaytn/kips/blob/main/KIPs/kip-97.md). Prepend `"\x19Klaytn Signed Message:\n" + len(message)` to the message before signing
- In this PR,
  - Message signing RPCs (i.e. signature producers) are now EIP-191 compliant
  - Message verifying RPCs (i.e. signature consumers) accept both EIP and KIP if possible, only EIP otherwise. 

| RPC                     	| Implementation                              	| Before PR          	| After PR           	|
|-------------------------	|---------------------------------------------	|--------------------	|--------------------	|
| personal_sign           	| PrivateAccountAPI.Sign                      	| KIP-97             	| EIP-191            	|
| eth_sign                	| EthereumAPI.Sign                            	| KIP-97             	| EIP-191            	|
| kaia_sign               	| PublicTransactionPoolAPI.Sign               	| KIP-97             	| EIP-191            	|
| personal_ecRecover      	| PrivateAccountAPI.EcRecover                 	| KIP-97             	| EIP-191            	|
| kaia_recoverFromMessage 	| PublicTransactionPoolAPI.RecoverFromMessage 	| KIP-97 and EIP-191 	| KIP-97 and EIP-191 (unchanged) |

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

- This PR aims to deprecate the KIP-97 in favor of the widely accepted EIP-191. Ethereum tools compatibility should improve.
- A [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md)-style cross-chain replay protection can be achieved by using [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md), not by using KIP-97.
- The KIP-97 signature and verify will still be available via caver-js and caver-java
  - caver-js [keyring.signMessage](https://docs.kaia.io/docs/references/sdk/caver-js/api/caver-wallet/keyring/#keyringsignmessage-), [utils.recover](https://javadoc.io/doc/com.klaytn.caver/core/latest/com/klaytn/caver/utils/Utils.html)
  - caver-java [AbstractKeyring.signMessage​](https://javadoc.io/doc/com.klaytn.caver/core/latest/com/klaytn/caver/wallet/keyring/AbstractKeyring.html), [Utils.recover](https://javadoc.io/doc/com.klaytn.caver/core/latest/com/klaytn/caver/utils/Utils.html)
- See tests here: https://github.com/kaiachain/kaia/issues/14#issuecomment-2203655312