### PR TITLE
reward: Fix state regeneration with post-Kaia staking info

### DIFF
--- a/blockchain/system/multicall.go
+++ b/blockchain/system/multicall.go
@@ -76,6 +76,6 @@ func (caller *ContractCallerForMultiCall) CallContract(ctx context.Context, call
 
 // NewMultiCallContractCaller creates a new instance of ContractCaller for MultiCall contract.
 func NewMultiCallContractCaller(state *state.StateDB, chain backends.BlockChainForCaller, header *types.Header) (*multicall.MultiCallContractCaller, error) {
-	c := &ContractCallerForMultiCall{state, chain, header}
+	c := &ContractCallerForMultiCall{state.Copy(), chain, header} // Copy the state to prevent the original state from being modified.
 	return multicall.NewMultiCallContractCaller(MultiCallAddr, c)
 }

--- a/blockchain/system/multicall.go
+++ b/blockchain/system/multicall.go
@@ -75,11 +75,7 @@ func (caller *ContractCallerForMultiCall) CallContract(ctx context.Context, call
 }
 
 // NewMultiCallContractCaller creates a new instance of ContractCaller for MultiCall contract.
-func NewMultiCallContractCaller(chain backends.BlockChainForCaller, header *types.Header) (*multicall.MultiCallContractCaller, error) {
-	state, err := chain.StateAt(header.Root)
-	if err != nil {
-		return nil, err
-	}
+func NewMultiCallContractCaller(state *state.StateDB, chain backends.BlockChainForCaller, header *types.Header) (*multicall.MultiCallContractCaller, error) {
 	c := &ContractCallerForMultiCall{state, chain, header}
 	return multicall.NewMultiCallContractCaller(MultiCallAddr, c)
 }

--- a/blockchain/system/multicall_test.go
+++ b/blockchain/system/multicall_test.go
@@ -42,13 +42,12 @@ func TestContractCallerForMultiCall(t *testing.T) {
 	header := backend.BlockChain().CurrentHeader()
 	chain := backend.BlockChain()
 
-	tempState, _ := backend.BlockChain().StateAt(header.Root)
-	caller, _ := NewMultiCallContractCaller(tempState, chain, header)
+	state, _ := backend.BlockChain().StateAt(header.Root)
+	caller, _ := NewMultiCallContractCaller(state, chain, header)
 	ret, err := caller.MultiCallStakingInfo(&bind.CallOpts{BlockNumber: header.Number})
 	assert.Nil(t, err)
 
 	// Does not affect the original state
-	state, _ := backend.BlockChain().StateAt(header.Root)
 	assert.Equal(t, []byte(nil), state.GetCode(MultiCallAddr))
 
 	// Mock data

--- a/blockchain/system/multicall_test.go
+++ b/blockchain/system/multicall_test.go
@@ -42,7 +42,8 @@ func TestContractCallerForMultiCall(t *testing.T) {
 	header := backend.BlockChain().CurrentHeader()
 	chain := backend.BlockChain()
 
-	caller, _ := NewMultiCallContractCaller(chain, header)
+	tempState, _ := backend.BlockChain().StateAt(header.Root)
+	caller, _ := NewMultiCallContractCaller(tempState, chain, header)
 	ret, err := caller.MultiCallStakingInfo(&bind.CallOpts{BlockNumber: header.Number})
 	assert.Nil(t, err)
 

--- a/common/refcntmap.go
+++ b/common/refcntmap.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"sync"
+)
+
+// RefCntMap is a map with reference counting.
+type RefCountingMap struct {
+	mu     sync.RWMutex
+	values map[interface{}]interface{}
+	counts map[interface{}]int
+}
+
+func NewRefCountingMap() *RefCountingMap {
+	return &RefCountingMap{
+		values: make(map[interface{}]interface{}),
+		counts: make(map[interface{}]int),
+	}
+}
+
+// Get returns the value associated with the given key.
+func (r *RefCountingMap) Get(key interface{}) (interface{}, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	value, ok := r.values[key]
+	return value, ok
+}
+
+// Add adds an element to the map and increments its reference count.
+func (r *RefCountingMap) Add(key interface{}, value interface{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.values[key] = value
+	r.counts[key]++
+}
+
+// Remove decrements the reference count of the element with the given key.
+func (r *RefCountingMap) Remove(key interface{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.counts[key] > 0 {
+		r.counts[key]--
+	}
+	if r.counts[key] == 0 {
+		delete(r.values, key)
+		delete(r.counts, key)
+	}
+}
+
+// Len returns the number of elements in the map.
+func (r *RefCountingMap) Len() int {
+	return len(r.values)
+}

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -143,6 +143,12 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 		database.TrieDB().ReferenceRoot(root)
 		if !common.EmptyHash(parent) {
 			database.TrieDB().Dereference(parent)
+			if current.Header().Root != root {
+				err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Header().Root, root)
+				// Logging here because something went wrong when the state roots disagree even if the execution was successful.
+				logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
+				return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
+			}
 		}
 		parent = root
 	}

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -116,7 +116,7 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 	for current.NumberU64() < origin {
 		// Print progress logs if long enough time elapsed
 		if report && time.Since(logged) > 8*time.Second {
-			logger.Info("Regenerating historical state", "block", current.NumberU64()+1, "target", origin, "remaining", origin-block.NumberU64()-1, "elapsed", time.Since(start))
+			logger.Info("Regenerating historical state", "block", current.NumberU64()+1, "target", origin, "remaining", origin-current.NumberU64()-1, "elapsed", time.Since(start))
 			logged = time.Now()
 		}
 		// Quit the state regeneration if time limit exceeds

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -432,6 +432,7 @@ func getStakingInfoFromCache(blockNum uint64) *StakingInfo {
 
 	if info, ok := stakingManager.preloadedInfo.Get(blockNum); ok {
 		info := info.(*StakingInfo)
+		logger.Debug("preloadedInfo hit.", "staking block number", blockNum, "stakingInfo", info)
 		// Fill in Gini coeff if not set. Modifies the cached object.
 		if err := fillMissingGiniCoefficient(info, blockNum); err != nil {
 			logger.Warn("Cannot fill in gini coefficient", "staking block number", blockNum, "err", err)

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -259,7 +259,7 @@ func PreloadStakingInfoWithState(header *types.Header, statedb *state.StateDB) e
 	}
 
 	num := header.Number.Uint64()
-	info, err := getStakingInfoFromMultiCallAtState(num, statedb.Copy(), header)
+	info, err := getStakingInfoFromMultiCallAtState(num, statedb, header)
 	if err != nil {
 		return fmt.Errorf("staking info preload failed. root err: %v", err)
 	}
@@ -334,17 +334,17 @@ func getStakingInfoFromMultiCall(blockNum uint64) (*StakingInfo, error) {
 		return nil, fmt.Errorf("failed to get header by number %d", blockNum)
 	}
 
-	tempState, err := stakingManager.blockchain.StateAt(header.Root)
+	statedb, err := stakingManager.blockchain.StateAt(header.Root)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get state at number %d. root err: %s", blockNum, err)
 	}
 
-	return getStakingInfoFromMultiCallAtState(blockNum, tempState, header)
+	return getStakingInfoFromMultiCallAtState(blockNum, statedb, header)
 }
 
-func getStakingInfoFromMultiCallAtState(blockNum uint64, tempState *state.StateDB, header *types.Header) (*StakingInfo, error) {
+func getStakingInfoFromMultiCallAtState(blockNum uint64, statedb *state.StateDB, header *types.Header) (*StakingInfo, error) {
 	// Get staking info from multicall contract
-	caller, err := system.NewMultiCallContractCaller(tempState, stakingManager.blockchain, header)
+	caller, err := system.NewMultiCallContractCaller(statedb, stakingManager.blockchain, header)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create multicall contract caller. root err: %s", err)
 	}

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -76,6 +76,13 @@ type StakingManager struct {
 	blockchain       blockChain
 	chainHeadChan    chan blockchain.ChainHeadEvent
 	chainHeadSub     event.Subscription
+
+	// Preloaded stakingInfos are fetched before the GetStakingInfo request.
+	// This is used when the state is available when preloaded, but not available
+	// when GetStakingInfo is called. e.g. reexec loop in stateAtBlock.
+	// Therefore preloaded staking infos must not be evicted,
+	// and it should be only used temporarily, hence a separate mapping.
+	preloadedInfo *common.RefCountingMap
 }
 
 var (
@@ -104,6 +111,7 @@ func NewStakingManager(bc blockChain, gh governanceHelper, db stakingInfoDB) *St
 				governanceHelper: gh,
 				blockchain:       bc,
 				chainHeadChan:    make(chan blockchain.ChainHeadEvent, chainHeadChanSize),
+				preloadedInfo:    common.NewRefCountingMap(),
 			}
 
 			// Before migration, staking information of current and before should be stored in DB.
@@ -234,6 +242,45 @@ func GetStakingInfoOnStakingBlock(stakingBlockNumber uint64) *StakingInfo {
 	return calcStakingInfo
 }
 
+// PreloadStakingInfoWithState fetches the stakingInfo based on the given state trie
+// and then stores it in the preloaded map. Because preloaded map does not have eviction policy,
+// it should be removed manually after use. Note that preloaded info is for the next block of the given header.
+func PreloadStakingInfoWithState(header *types.Header, statedb *state.StateDB) error {
+	if stakingManager == nil {
+		return ErrStakingManagerNotSet
+	}
+
+	if !isKaiaForkEnabled(header.Number.Uint64() + 1) {
+		return nil // no need to preload staking info before kaia fork because we have it in the database.
+	}
+
+	if header.Root != statedb.IntermediateRoot(false) { // Sanity check
+		return errors.New("must supply the statedb for the given header") // this should not happen
+	}
+
+	num := header.Number.Uint64()
+	info, err := getStakingInfoFromMultiCallAtState(num, statedb.Copy(), header)
+	if err != nil {
+		return fmt.Errorf("staking info preload failed. root err: %v", err)
+	}
+	if info != nil {
+		stakingManager.preloadedInfo.Add(num, info)
+	}
+	logger.Trace("preloaded staking info", "staking block number", num)
+	return nil
+}
+
+// UnloadStakingInfo removes a stakingInfo from the preloaded map.
+// Must be executed after PreloadStakingInfoWithState(Header{num}, state).
+func UnloadStakingInfo(num uint64) {
+	if stakingManager == nil {
+		logger.Error("unable to GetStakingInfo", "err", ErrStakingManagerNotSet)
+		return
+	}
+
+	stakingManager.preloadedInfo.Remove(num)
+}
+
 // updateKaiaStakingInfo updates kaia staking info in cache created from given block number.
 // From Kaia fork, not only the staking block number but also the calculation of staking amounts is changed,
 // so we need separate update function for kaia staking info.
@@ -287,8 +334,17 @@ func getStakingInfoFromMultiCall(blockNum uint64) (*StakingInfo, error) {
 		return nil, fmt.Errorf("failed to get header by number %d", blockNum)
 	}
 
+	tempState, err := stakingManager.blockchain.StateAt(header.Root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get state at number %d. root err: %s", blockNum, err)
+	}
+
+	return getStakingInfoFromMultiCallAtState(blockNum, tempState, header)
+}
+
+func getStakingInfoFromMultiCallAtState(blockNum uint64, tempState *state.StateDB, header *types.Header) (*StakingInfo, error) {
 	// Get staking info from multicall contract
-	caller, err := system.NewMultiCallContractCaller(stakingManager.blockchain, header)
+	caller, err := system.NewMultiCallContractCaller(tempState, stakingManager.blockchain, header)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create multicall contract caller. root err: %s", err)
 	}
@@ -372,6 +428,15 @@ func getStakingInfoFromCache(blockNum uint64) *StakingInfo {
 			logger.Warn("Cannot fill in gini coefficient", "staking block number", blockNum, "err", err)
 		}
 		return cachedStakingInfo.(*StakingInfo)
+	}
+
+	if info, ok := stakingManager.preloadedInfo.Get(blockNum); ok {
+		info := info.(*StakingInfo)
+		// Fill in Gini coeff if not set. Modifies the cached object.
+		if err := fillMissingGiniCoefficient(info, blockNum); err != nil {
+			logger.Warn("Cannot fill in gini coefficient", "staking block number", blockNum, "err", err)
+		}
+		return info
 	}
 
 	return nil
@@ -517,6 +582,7 @@ func SetTestStakingManagerWithChain(bc blockChain, gh governanceHelper, db staki
 		governanceHelper: gh,
 		blockchain:       bc,
 		chainHeadChan:    make(chan blockchain.ChainHeadEvent, chainHeadChanSize),
+		preloadedInfo:    common.NewRefCountingMap(),
 	})
 }
 
@@ -526,6 +592,7 @@ func SetTestStakingManagerWithDB(testDB stakingInfoDB) {
 	SetTestStakingManager(&StakingManager{
 		blockchain:    &blockchain.BlockChain{},
 		stakingInfoDB: testDB,
+		preloadedInfo: common.NewRefCountingMap(),
 	})
 }
 
@@ -537,6 +604,7 @@ func SetTestStakingManagerWithStakingInfoCache(testInfo *StakingInfo) {
 	SetTestStakingManager(&StakingManager{
 		blockchain:       &blockchain.BlockChain{},
 		stakingInfoCache: cache,
+		preloadedInfo:    common.NewRefCountingMap(),
 	})
 }
 
@@ -562,4 +630,8 @@ func SetTestAddressBookAddress(addr common.Address) {
 
 func TestGetStakingCacheSize() int {
 	return GetStakingManager().stakingInfoCache.Len()
+}
+
+func TestGetStakingPreloadSize() int {
+	return GetStakingManager().preloadedInfo.Len()
 }

--- a/tests/state_reexec_test.go
+++ b/tests/state_reexec_test.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/accounts/abi/bind"
+	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/system"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	testcontract "github.com/kaiachain/kaia/contracts/contracts/testing/reward"
+	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/reward"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test State Regeneration (reexecution) after pruning state trie nodes.
+// This test ensures that the state regeneration yields the exact same state as the block's stateRoot.
+// Post-Kaia engine.Finalize() relies on the state trie to calculate rewards, so the state regeneration
+// can be interfered. This test ensures that the state regeneration is robust against such interference.
+func TestStateReexec(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+
+	// Test parameters
+	var (
+		numNodes = 1
+		forkNum  = big.NewInt(4)
+		nodeId   = bind.NewKeyedTransactor(deriveTestAccount(0)).From
+		owner    = bind.NewKeyedTransactor(deriveTestAccount(5))
+
+		config = testStateReexec_config(forkNum)
+		alloc  = testStateReexec_alloc(t, owner, nodeId)
+	)
+
+	// Start the chain
+	ctx, err := newBlockchainTestContext(&blockchainTestOverrides{
+		numNodes:    numNodes,
+		numAccounts: 8,
+		config:      config,
+		alloc:       alloc,
+	})
+	require.Nil(t, err)
+	ctx.Subscribe(t, func(ev *blockchain.ChainEvent) {
+		b := ev.Block
+		t.Logf("block[%3d] stateRoot=%x", b.NumberU64(), b.Header().Root)
+	})
+	ctx.Start()
+	defer ctx.Cleanup()
+
+	ctx.WaitBlock(t, 6)
+
+	// Clear staking cache to force GetStakingInfo post-Kaia to utilize the state trie.
+	reward.PurgeStakingInfoCache()
+
+	// Delete state roots to force historical state regeneration
+	testStateReexec_prune(t, ctx.nodes[0], []uint64{2, 3, 4, 5})
+	testStateReexec_run(t, ctx.nodes[0], 3) // pre-kaia
+
+	testStateReexec_prune(t, ctx.nodes[0], []uint64{2, 3, 4, 5})
+	testStateReexec_run(t, ctx.nodes[0], 5) // post-kaia
+}
+
+func testStateReexec_config(forkNum *big.Int) *params.ChainConfig {
+	config := blockchainTestChainConfig.Copy()
+	config.LondonCompatibleBlock = common.Big0
+	config.IstanbulCompatibleBlock = common.Big0
+	config.EthTxTypeCompatibleBlock = common.Big0
+	config.MagmaCompatibleBlock = common.Big0
+	config.KoreCompatibleBlock = common.Big0
+	config.ShanghaiCompatibleBlock = common.Big0
+	config.CancunCompatibleBlock = common.Big0
+	config.KaiaCompatibleBlock = forkNum
+
+	// Use WeightedRandom to test reward distribution based on StakingInfo
+	config.Istanbul.ProposerPolicy = uint64(istanbul.WeightedRandom)
+	// Set the reward ratio so that reward distribution is different from the 'all to proposer' fallback.
+	// If the GetStakingInfo() fails during state regen, the regenerated state would just give all
+	// rewards to the proposer, deviating from the actual historical state.
+	config.Governance.Reward.Ratio = "34/54/12"
+	return config
+}
+
+// Create a genesis state with an AddressBookMock
+func testStateReexec_alloc(t *testing.T, owner *bind.TransactOpts, nodeId common.Address) blockchain.GenesisAlloc {
+	// Create a simulated state with the mock contract populated.
+	var (
+		abookAddr   = system.AddressBookAddr
+		abookCode   = common.FromHex(testcontract.AddressBookMockBinRuntime)
+		stakingAddr = common.HexToAddress("0x1000")
+		rewardAddr  = common.HexToAddress("0x2000")
+		fund1Addr   = common.HexToAddress("0xa000")
+		fund2Addr   = common.HexToAddress("0xb000")
+
+		alloc = blockchain.GenesisAlloc{
+			owner.From:             {Balance: big.NewInt(params.KAIA)},
+			system.AddressBookAddr: {Balance: common.Big0, Code: abookCode},
+		}
+		db          = database.NewMemoryDBManager()
+		backend     = backends.NewSimulatedBackendWithDatabase(db, alloc, &params.ChainConfig{})
+		contract, _ = testcontract.NewAddressBookMockTransactor(abookAddr, backend)
+	)
+	_, err := contract.ConstructContract(owner, []common.Address{owner.From}, common.Big1)
+	backend.Commit()
+	require.Nil(t, err)
+
+	_, err = contract.RegisterCnStakingContract(owner, nodeId, stakingAddr, rewardAddr)
+	require.Nil(t, err)
+	_, err = contract.UpdatePocContract(owner, fund1Addr, common.Big1)
+	require.Nil(t, err)
+	_, err = contract.UpdateKirContract(owner, fund2Addr, common.Big1)
+	backend.Commit()
+	require.Nil(t, err)
+
+	_, err = contract.ActivateAddressBook(owner)
+	backend.Commit()
+	require.Nil(t, err)
+
+	// Copy contract storage from the simulated state to the genesis account.
+	abookStorage := make(map[common.Hash]common.Hash)
+	stateDB, _ := backend.BlockChain().State()
+	stateDB.ForEachStorage(abookAddr, func(key common.Hash, value common.Hash) bool {
+		abookStorage[key] = value
+		return true
+	})
+	return blockchain.GenesisAlloc{
+		abookAddr: {
+			Balance: common.Big0,
+			Code:    abookCode,
+			Storage: abookStorage,
+		},
+		stakingAddr: {
+			Balance: new(big.Int).Mul(big.NewInt(params.KAIA), big.NewInt(5_000_000)),
+		},
+	}
+}
+
+func testStateReexec_prune(t *testing.T, node *blockchainTestNode, nums []uint64) {
+	db := node.cn.ChainDB()
+
+	for _, num := range nums {
+		block := node.cn.BlockChain().GetBlockByNumber(num)
+		root := block.Header().Root
+		db.DeleteTrieNode(root.ExtendZero())
+	}
+}
+
+func testStateReexec_run(t *testing.T, node *blockchainTestNode, num uint64) {
+	block := node.cn.BlockChain().GetBlockByNumber(num)
+
+	state, err := node.cn.APIBackend.StateAtBlock(context.Background(), block, 10, nil, false, false)
+	require.Nil(t, err)
+	root, err := state.Commit(false)
+	require.Nil(t, err)
+
+	// Regenerated state must match the stored block's stateRoot
+	assert.Equal(t, block.Header().Root, root)
+}

--- a/tests/testutil_blockchain_test.go
+++ b/tests/testutil_blockchain_test.go
@@ -56,6 +56,8 @@ type blockchainTestContext struct {
 	config       *params.ChainConfig
 	genesis      *blockchain.Genesis
 
+	savedStakingManager *reward.StakingManager
+
 	workspace string
 	nodes     []*blockchainTestNode
 }
@@ -261,6 +263,18 @@ func (ctx *blockchainTestContext) forEachNode(f func(*blockchainTestNode) error)
 }
 
 func (ctx *blockchainTestContext) Start() error {
+	// TODO: make StakingManager not singleton OR recreate new in cn.New()
+	// Manually re-wire StakingManager with the new blockchain.
+	// Because StakingManager is a singleton, it has to be part of one node. Here we use the first node.
+	ctx.savedStakingManager = reward.GetStakingManager()
+	reward.SetTestStakingManagerWithChain(
+		ctx.nodes[0].cn.BlockChain(),
+		ctx.nodes[0].cn.Governance(),
+		ctx.nodes[0].cn.ChainDB(),
+	)
+	reward.StakingManagerUnsubscribe()
+	reward.StakingManagerSubscribe() // re-subscribe to the new blockchain
+
 	return ctx.forEachNode(func(tn *blockchainTestNode) error {
 		return tn.cn.StartMining(false)
 	})
@@ -280,6 +294,7 @@ func (ctx *blockchainTestContext) Stop() error {
 	// other tests can use StakingManager as if it's fresh.
 	reward.PurgeStakingInfoCache()
 	blockchain.ClearMigrationPrerequisites()
+	reward.SetTestStakingManager(ctx.savedStakingManager)
 	return nil
 }
 


### PR DESCRIPTION
## Proposed changes

- Affects
  - `debug_trace*` APIs on full-mode nodes may have returned incorrect results if the traced transaction touches any validator reward address. e.g. interaction with PublicDelegation contracts. Archive-mode nodes are unaffected.

- Background
  - State regeneration (or reexec) is a process of generating the world state at a given block when the state is not in the database. It works by re-executing the transactions (and post-transaction state transitions by `Finalize()`), starting from the nearest block in which the state exists in the database.
  - State regen is primarily used in debug trace APIs. In those APIs, a block or a transaction is executed against a historic block state. To support this API even in full nodes, the block state is regenerated if not exist in the database.
  - During state regen, the `Finalize()` queries the staking info for the block to calculate rewards. Without the staking info, we cannot regenerate the correct state.
  - Since Kaia hardfork, the staking info is calculated from the previous block's state.

- Problem
  - During state regen, the staking info is supposed to be available because block states are sequentially generated. Suppose you want to regen from block 10 to 12 (block 10's state is in database)
    - Load state at 10.
    - Execute block 11 to regen state at 11. Staking info is from state at 10.
    - Execute block 12 to regen state at 12. Staking info is from state at 11.
  - But in reality, when executing block 12, StakingManager silently fails to read staking info from block 11 state.
    - Regenerated state is saved in an ephemeral database (https://github.com/kaiachain/kaia/blob/v1.0.1-rc.1/node/cn/state_accessor.go#L82-L84)
    - StakingManager reads from the *official* database (https://github.com/kaiachain/kaia/blob/v1.0.1-rc.1/node/cn/backend.go#L364)
    - So StakingManager fails at https://github.com/kaiachain/kaia/blob/v1.0.1-rc.1/blockchain/system/multicall.go#L79.

- Solution
  - During state regen, preload staking info from the ephemeral state.
    - Load state at 10. Preload staking info from state at 10.
    - Execute block 11 to regen state at 11. Use preloaded staking info. Preload staking info from state at 11.
    - Execute block 12 to regen state at 12. Use preloaded staking info. Preload staking info from state at 12.
    - Delete preloaded staking info because it's only for regen.
  - Because preloaded staking info can be concurrently used by multiple threads (e.g. concurrent debug API calls), it is implemented with a reference counting data structure.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
