### PR TITLE
Preload staking info

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -517,8 +517,7 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	// If sb.chain is nil, it means backend is not initialized yet.
 	if sb.chain != nil && !reward.IsRewardSimple(pset) {
 		// TODO-Kaia Let's redesign below logic and remove dependency between block reward and istanbul consensus.
-
-		lastHeader := chain.CurrentHeader()
+		lastHeader := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
 		valSet := sb.getValidators(lastHeader.Number.Uint64(), lastHeader.Hash())
 
 		// Determine and update Rewardbase when mining. When mining, state root is not yet determined and will be determined at the end of this Finalize below.

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -406,12 +406,12 @@ func preloadStakingInfo(headers []*types.Header, engine governance.HeaderEngine)
 		database.TrieDB().ReferenceRoot(root)
 		if !common.EmptyHash(parent) {
 			database.TrieDB().Dereference(parent)
-			if current.Root() != root {
-				err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Root(), root)
-				// Logging here because something went wrong when the state roots disagree even if the execution was successful.
-				logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
-				return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
-			}
+		}
+		if current.Root() != root {
+			err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Root(), root)
+			// Logging here because something went wrong when the state roots disagree even if the execution was successful.
+			logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
+			return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
 		}
 		parent = root
 	}

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -25,15 +25,19 @@ package backend
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"math/big"
 
+	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/consensus/istanbul/validator"
 	"github.com/kaiachain/kaia/governance"
 	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/reward"
 	"github.com/kaiachain/kaia/storage/database"
 )
 
@@ -153,6 +157,32 @@ func (s *Snapshot) apply(headers []*types.Header, gov governance.Engine, addr co
 	}
 	if headers[0].Number.Uint64() != s.Number+1 {
 		return nil, errInvalidVotingChain
+	}
+
+	// Find all kaia headers
+	kaiaHeaders := []*types.Header{}
+	for i := 0; i < len(headers); i++ {
+		if chain.Config().IsKaiaForkEnabled(new(big.Int).Add(headers[i].Number, big.NewInt(1))) {
+			kaiaHeaders = headers[i:]
+			break
+		}
+	}
+
+	if len(kaiaHeaders) > 0 {
+		sInfo := reward.GetStakingInfo(kaiaHeaders[0].Number.Uint64() + 1)
+		// The second condition is to make sure that the staking info is not already loaded
+		if len(kaiaHeaders) > 1 || (len(kaiaHeaders) == 1 && sInfo == nil) {
+			preloadNums, err := preloadStakingInfo(kaiaHeaders, gov.HeaderGov())
+			if err != nil {
+				return nil, err
+			}
+
+			defer func() {
+				for _, num := range preloadNums {
+					reward.UnloadStakingInfo(num)
+				}
+			}()
+		}
 	}
 
 	// Iterate through the headers and create a new snapshot
@@ -301,6 +331,92 @@ func sortValidatorArray(validators []common.Address) []common.Address {
 		}
 	}
 	return validators
+}
+
+// preloadStakingInfo preloads staking info for the given headers.
+// It first finds the first block that does not have state, and then
+// it regenerates the state from the nearest block that has state to the target block to preload staking info.
+// Note that the state is saved every 128 blocks to disk in full node.
+func preloadStakingInfo(headers []*types.Header, engine governance.HeaderEngine) ([]uint64, error) {
+	var (
+		current  *types.Block
+		database state.Database
+		target   = headers[len(headers)-1].Number.Uint64()
+		bc       = engine.BlockChain()
+	)
+
+	database = state.NewDatabaseWithExistingCache(engine.DB(), bc.StateCache().TrieDB().TrieNodeCache())
+
+	// Find the first block that does not have state
+	i := 0
+	for i < len(headers) {
+		if _, err := state.New(headers[i].Root, database, nil, nil); err != nil {
+			break
+		}
+		i++
+	}
+	// Early return if all blocks have state
+	if i == len(headers) {
+		return nil, nil
+	}
+
+	// Find the nearest block that has state
+	origin := headers[i].Number.Uint64() - headers[i].Number.Uint64()%128
+	current = bc.GetBlockByNumber(origin)
+	if current == nil {
+		return nil, fmt.Errorf("block %d not found", origin)
+	}
+	statedb, err := state.New(current.Header().Root, database, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		parent                    common.Hash
+		preloadedStakingBlockNums = make([]uint64, 0, target-current.NumberU64())
+	)
+
+	// Include target since we want staking info at `target`, not for `target`.
+	for current.NumberU64() <= target {
+		// Preload StakingInfo from the current block and state.
+		preloadedStakingBlockNums = append(preloadedStakingBlockNums, current.NumberU64())
+		if err := reward.PreloadStakingInfoWithState(current.Header(), statedb); err != nil {
+			return nil, fmt.Errorf("preloading staking info from block %d failed: %v", current.NumberU64(), err)
+		}
+		if current.NumberU64() == target {
+			break
+		}
+		// Retrieve the next block to regenerate and process it
+		next := current.NumberU64() + 1
+		if current = bc.GetBlockByNumber(next); current == nil {
+			return nil, fmt.Errorf("block #%d not found", next)
+		}
+		_, _, _, _, _, err := bc.Processor().Process(current, statedb, vm.Config{})
+		if err != nil {
+			return nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
+		}
+		// Finalize the state so any modifications are written to the trie
+		root, err := statedb.Commit(true)
+		if err != nil {
+			return nil, err
+		}
+		if err := statedb.Reset(root); err != nil {
+			return nil, fmt.Errorf("state reset after block %d failed: %v", current.NumberU64(), err)
+		}
+		database.TrieDB().ReferenceRoot(root)
+		if !common.EmptyHash(parent) {
+			database.TrieDB().Dereference(parent)
+			if current.Root() != root {
+				err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Root(), root)
+				// Logging here because something went wrong when the state roots disagree even if the execution was successful.
+				logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
+				return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
+			}
+		}
+		parent = root
+	}
+
+	return preloadedStakingBlockNums, nil
 }
 
 type snapshotJSON struct {

--- a/governance/api_test.go
+++ b/governance/api_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
@@ -323,6 +324,14 @@ func (bc *testBlockChain) StateAt(root common.Hash) (*state.StateDB, error) { re
 func (bc *testBlockChain) State() (*state.StateDB, error)                   { return nil, nil }
 func (bc *testBlockChain) Config() *params.ChainConfig {
 	return bc.config
+}
+
+func (bc *testBlockChain) Processor() blockchain.Processor {
+	return nil
+}
+
+func (bc *testBlockChain) StateCache() state.Database {
+	return nil
 }
 
 func (bc *testBlockChain) CurrentBlock() *types.Block {

--- a/governance/interface.go
+++ b/governance/interface.go
@@ -120,9 +120,13 @@ type blockChain interface {
 	CurrentHeader() *types.Header
 	GetHeaderByNumber(val uint64) *types.Header
 	GetBlock(hash common.Hash, number uint64) *types.Block
+	GetBlockByNumber(number uint64) *types.Block
 	GetReceiptsByBlockHash(blockHash common.Hash) types.Receipts
 	State() (*state.StateDB, error)
 	StateAt(root common.Hash) (*state.StateDB, error)
+
+	StateCache() state.Database
+	Processor() blockchain.Processor
 
 	CurrentBlock() *types.Block
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -369,9 +369,12 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	// It disappears during the node restart, so restoration is needed before the sync starts
 	// By calling CreateSnapshot, it restores the gov state snapshots and apply the votes in it
 	// Particularly, the gov.changeSet is also restored here.
+	// Temporarily set chain since snapshot needs state since kaia hardfork
+	cn.blockchain.Engine().(consensus.Istanbul).SetChain(cn.blockchain)
 	if err := cn.Engine().CreateSnapshot(cn.blockchain, cn.blockchain.CurrentBlock().NumberU64(), cn.blockchain.CurrentBlock().Hash(), nil); err != nil {
 		logger.Error("CreateSnapshot failed", "err", err)
 	}
+	cn.blockchain.Engine().(consensus.Istanbul).SetChain(nil)
 
 	// set worker
 	if config.WorkerDisable {

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -156,12 +156,12 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 		database.TrieDB().ReferenceRoot(root)
 		if !common.EmptyHash(parent) {
 			database.TrieDB().Dereference(parent)
-			if current.Header().Root != root {
-				err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Header().Root, root)
-				// Logging here because something went wrong when the state roots disagree even if the execution was successful.
-				logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
-				return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
-			}
+		}
+		if current.Header().Root != root {
+			err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Header().Root, root)
+			// Logging here because something went wrong when the state roots disagree even if the execution was successful.
+			logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
+			return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
 		}
 		parent = root
 	}

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/system"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	contract "github.com/kaiachain/kaia/contracts/contracts/system_contracts/consensus"
 	"github.com/kaiachain/kaia/event"
@@ -65,6 +66,9 @@ type blockChain interface {
 	GetHeaderByNumber(number uint64) *types.Header
 	State() (*state.StateDB, error)
 	CurrentBlock() *types.Block
+
+	StateCache() state.Database
+	Processor() blockchain.Processor
 
 	blockchain.ChainContext
 }
@@ -240,6 +244,97 @@ func GetStakingInfoOnStakingBlock(stakingBlockNumber uint64) *StakingInfo {
 
 	logger.Debug("Get stakingInfo from header.", "staking block number", stakingBlockNumber, "stakingInfo", calcStakingInfo)
 	return calcStakingInfo
+}
+
+// PreloadStakingInfo preloads staking info for the given headers.
+// It first finds the first block that does not have state, and then
+// it regenerates the state from the nearest block that has state to the target block to preload staking info.
+// Note that the state is saved every 128 blocks to disk in full node.
+func PreloadStakingInfo(headers []*types.Header) ([]uint64, error) {
+	// If no headers are given, do nothing
+	if len(headers) == 0 {
+		return nil, nil
+	}
+
+	var (
+		current  *types.Block
+		database state.Database
+		target   = headers[len(headers)-1].Number.Uint64()
+		bc       = stakingManager.blockchain
+	)
+
+	database = state.NewDatabaseWithExistingCache(bc.StateCache().TrieDB().DiskDB(), bc.StateCache().TrieDB().TrieNodeCache())
+
+	// Find the first block that does not have state
+	i := 0
+	for i < len(headers) {
+		if _, err := state.New(headers[i].Root, database, nil, nil); err != nil {
+			break
+		}
+		i++
+	}
+	// Early return if all blocks have state
+	if i == len(headers) {
+		return nil, nil
+	}
+
+	// Find the nearest block that has state
+	origin := headers[i].Number.Uint64() - headers[i].Number.Uint64()%128
+	current = bc.GetBlockByNumber(origin)
+	if current == nil {
+		return nil, fmt.Errorf("block %d not found", origin)
+	}
+	statedb, err := state.New(current.Header().Root, database, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		parent                    common.Hash
+		preloadedStakingBlockNums = make([]uint64, 0, target-current.NumberU64())
+	)
+
+	// Include target since we want staking info at `target`, not for `target`.
+	for current.NumberU64() <= target {
+		// Preload StakingInfo from the current block and state.
+		preloadedStakingBlockNums = append(preloadedStakingBlockNums, current.NumberU64())
+		if err := PreloadStakingInfoWithState(current.Header(), statedb); err != nil {
+			return nil, fmt.Errorf("preloading staking info from block %d failed: %v", current.NumberU64(), err)
+		}
+		if current.NumberU64() == target {
+			break
+		}
+		// Retrieve the next block to regenerate and process it
+		next := current.NumberU64() + 1
+		if current = bc.GetBlockByNumber(next); current == nil {
+			return nil, fmt.Errorf("block #%d not found", next)
+		}
+		_, _, _, _, _, err := bc.Processor().Process(current, statedb, vm.Config{})
+		if err != nil {
+			return nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
+		}
+		// Finalize the state so any modifications are written to the trie
+		root, err := statedb.Commit(true)
+		if err != nil {
+			return nil, err
+		}
+		if err := statedb.Reset(root); err != nil {
+			return nil, fmt.Errorf("state reset after block %d failed: %v", current.NumberU64(), err)
+		}
+		database.TrieDB().ReferenceRoot(root)
+		if !common.EmptyHash(parent) {
+			database.TrieDB().Dereference(parent)
+		}
+		if current.Root() != root {
+			err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Root(), root)
+			// Logging here because something went wrong when the state roots disagree even if the execution was successful.
+			logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
+			return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
+		}
+		parent = root
+	}
+
+	return preloadedStakingBlockNums, nil
 }
 
 // PreloadStakingInfoWithState fetches the stakingInfo based on the given state trie


### PR DESCRIPTION
## Proposed changes

The `reward.GetStakingInfo` has required a state at the `N-1` block to calculate staking information since Kaia HF. However, in a full node, it only has states of 128 interval blocks. It makes snapshot to be wrongly calculated when node start up and return `nil` for staking info related APIs.

This PR introduces `PreloadStakingInfo(headers)` that preloads all staking info at `headers` while regenerating all necessary states. In case of staking info, its maximum reexec will be 128, while snapshot is 1024.

<details>
<summary>e.g: getCommittee</summary>

```
// Before this PR:
// Before restarting CN#1
> kaia.getCommittee("61")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]
> kaia.getCommittee("62")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4"]
> kaia.getCommittee("81")
["0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4"]
> kaia.getCommittee("82")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]

// After restarting CN#1 (cached snapshot removed)
> kaia.getCommittee("61")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]
> kaia.getCommittee("62")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]
> kaia.getCommittee("81")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]
> kaia.getCommittee("82")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]

// CN#2 (not restarted, so still has cached)
> kaia.getCommittee("61")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]
> kaia.getCommittee("62")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4"]
> kaia.getCommittee("81")
["0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4"]
> kaia.getCommittee("82")
["0x5b20db15861f73cf689aeee439eed72915db4c95", "0x7239df9f44bed3080bce6e0d6a442988a4811fe3", "0xd5ce4082f013d8dbb77c15fd060d821b42cf12e4", "0xf962de1081ddc0fdc03c43e1b53ab408b0c31eee"]
```


```
// After this PR:
// Before restarting CN#1
> kaia.getCommittee("61")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389", "0x5953ad5d7131fbb3bfe8c055afc3429283e6bd9a", "0xe3c2c2fb0b089756bea453b93d983b3f2dc71fab", "0xf552b0ad62d701b2d2ee54e08c4a3d8a303a0e76"]
> kaia.getCommittee("62")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389", "0x5953ad5d7131fbb3bfe8c055afc3429283e6bd9a", "0xf552b0ad62d701b2d2ee54e08c4a3d8a303a0e76"]
> kaia.getCommittee("82")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389"]
> kaia.getCommittee("83")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389", "0x5953ad5d7131fbb3bfe8c055afc3429283e6bd9a", "0xe3c2c2fb0b089756bea453b93d983b3f2dc71fab", "0xf552b0ad62d701b2d2ee54e08c4a3d8a303a0e76"]

// After restarting CN#1 (cached snapshot removed, but re-generated snapshot correctly)
> kaia.getCommittee("61")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389", "0x5953ad5d7131fbb3bfe8c055afc3429283e6bd9a", "0xe3c2c2fb0b089756bea453b93d983b3f2dc71fab", "0xf552b0ad62d701b2d2ee54e08c4a3d8a303a0e76"]
> kaia.getCommittee("62")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389", "0x5953ad5d7131fbb3bfe8c055afc3429283e6bd9a", "0xf552b0ad62d701b2d2ee54e08c4a3d8a303a0e76"]
> kaia.getCommittee("82")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389"]
> kaia.getCommittee("83")
["0x2afebc32a705e5de8b07ff9ae96b8de241361389", "0x5953ad5d7131fbb3bfe8c055afc3429283e6bd9a", "0xe3c2c2fb0b089756bea453b93d983b3f2dc71fab", "0xf552b0ad62d701b2d2ee54e08c4a3d8a303a0e76"]
```
</details>


<details>
<summary>e.g: getStakingInfo</summary>

```
// Before this PR
> kaia.getStakingInfo("159435780")
null

// After this PR
> kaia.getStakingInfo("159435780")
{
  KIRAddr: "0x819d4b7245164e6a94341f4b5c2ae587372bb669",
  PoCAddr: "0x8436e5bd1a6d622c278c946e2f8988a26136a16f",
  blockNum: 159435779,
  councilNodeAddrs: ["0x99fb17d324fa0e07f23b49d09028ac0919414db6", "0x571e53df607be97431a5bbefca1dffe5aef56f4d", "0xb74ff9dea397fe9e231df545eb53fe2adf776cb2", "0x5cb1a7dccbd0dc446e3640898ede8820368554c8", "0xcb21b21b8948a26259775b88c14a7dda9eb09ce7", "0xa3b387b7b0dc914a4f106ad645a0ad079d70ebdc", "0x52c0f3654e9ac47ba5e64ffcb398be485718a74b", "0x20685d7bbcb07dddbd8dbdc824c31fe2bfb31c92", "0x7e4f6573fc67e334227b041ce90784533f0a0fe8", "0xa3903e0680ef44aaff474f4714bf2bc51c467285", "0x91fd07901bea2eddc9ef076e0ec4fcc2bab3cc60", "0xc1df096e6b907f4c20b449393b640dbcb77f717b", "0xda1e49f338cdea22edd68012f40617028ee93bae", "0x85992b5c1c1224f2582c4429babe429c16386a78", "0x248ca8fa2c670c645764364e9760f601171f15c5", "0x5704f555172b964719cdf858d22d5c722d784381", "0x0b5f888d7b48a8227e122a64814439dc4c6cb9c3", "0x85a65b24ae66790532806f52da61a154ab2bda54", "0xcae4466e1f19f025be3a0357914f5c411b475921", "0x2a9b841a08455f8ed333c94f0df1fe5607b4ad8e", "0x1651145859e30a2b1763612c18aea6f138b2cfbc", "0x993efc86499ff9a47e5770040a02f37ed9469911", "0x5d13e58574c6c6515678bcedb15cab9166ebb583", "0x6a7acac3634348222843066cdaa7d860bbf62eef", "0x93c9af04956e6f300d19f968559e063f3a859391", "0x060270b218ff16eae6cc877b838f1b6b6716deef", "0x55cf7ece098f172cc3170311d270ea28379a8916", "0xb9c84952da199e8046dfcc2f65974198ad2e5d08", "0x3470f35b916bf966c7cb0b9d4d67a3715020eed1", "0xc9d314f636e5b713dfc2404173b6f646c9bf9392", "0xbca148145fac7f14bde47f9a626c18535be09438"],
  councilRewardAddrs: ["0xb2bd3178affccd9f9f5189457f1cad7d17a01c9d", "0x6559a7b6248b342bc11fbcdf9343212bbc347edc", "0x82829a60c6eac4e3e9d6ed00891c69e88537fd4d", "0xf90675a56a03f836204d66c0f923e00500ddc90a", "0x583a5b5313279e442aec042e3c6771951b02a5bc", "0x662a2c18b36b06f21105b019a8795f8d5a38b5b4", "0xc8e7053dc17bce47d2317718734ef087be40a023", "0xfc37e31fe3b1019f5be58cb826e5d7b08f9b2e35", "0x4d7ff4251c1755fdc08d393a2aca2feaed9664a1", "0x4d7ff4251c1755fdc08d393a2aca2feaed9664a1", "0x52b5798bbef5c3c00abb3a7be71285874b20af10", "0x52b5798bbef5c3c00abb3a7be71285874b20af10", "0x21689e0b32e8c9bde382457b38c3af4b70b08997", "0x21689e0b32e8c9bde382457b38c3af4b70b08997", "0x85a4803c43f434eb8db149d2ea2e2f7b1568bb9f", "0x85a4803c43f434eb8db149d2ea2e2f7b1568bb9f", "0x88b08385c26bb06b88648c226d06b492ca82968d", "0x2bf231a2c3d49e86997a328596eaff9b37af06e0", "0xe59c0526a67e67e7ca35e2a6e7232e203771a00a", "0x5c2293e49682b82c66985673d813707723c845be", "0x88b08385c26bb06b88648c226d06b492ca82968d", "0xbc695a070d706bc26d33604d0233f8e1fa95b530", "0x1ed6eb5c7bdf5c04734d25f6e798d67c6b2e8114", "0x842ab31ab877b67a7636927580d83c5ee561c981", "0xf708a34dfae166043d45eb91ad76ad13204cb1b6", "0xb942d0c72073ab75d5654004625387e106d61ed1", "0x5bb2b2977a29ad85994f601f45802f514bb5e2a1", "0x9afa6b429e737edea3854cbdf32bda324563d3ac", "0x6419730389089e9cada08c5b202a8e15c0094343", "0xba950d20f65e2ec6daf9bbe4ec4381ae53328b04", "0x7faedd28992791316d2f5931d05e8f672ce1c561"],
  councilStakingAddrs: ["0x12fa1ab4c3e17c1c08c1b5a945c864c8e8bf707e", "0xfd56604f1a20268ff7a0eab2ab48e25ee1e0f653", "0x1e0f6aaa9baa6081dc4910a854eebf8854c262ab", "0x5e6988415ebe0f6b088f5a676003ba60f572875a", "0x8917ed4c6d687a1002d31b3a21cea331ba7742de", "0x588df37ed04f150617ed693a485b29b31c192434", "0xe70c8aa660d253fb0122a3890e32ea057f6a08f8", "0x7cae8c7120afab7fec9cda2022bab15a4b119715", "0xf36ba9426340bd13ca3440b7a8da62301bc2eff8", "0x49f1886e592129dfee129bf1baa6dd4d8bf9cd34", "0x6b15e4b9dac3fbaaec6c2fe94c51b060ca4a105e", "0x9a3ebcc1a479fc8050dbc83cde8ab5cd114fcb8f", "0x83754f56ee1238e9c090cbacf8cf650358864f4d", "0x27292935dec283f2a27f8e54bc81e0cd8f2ac8d5", "0xfde566fc3f87d17a7d30ee920b25c5f61218a634", "0x96e4b8c2a8a8932d5c71d7b1a03264c263005917", "0x1173f457bac58ab8700220375b5a9b05fa81a882", "0xdfd0767037be384232cafe32ba747808db49eb2a", "0xea383529501daddd72c9daff3eb5def03bd6e706", "0x6074ddfbaed37710d118885f930db2f3c311c7d8", "0x7253621629156d75fe97aa0d7cf1cee1910ea3dc", "0x55538b3b74d6a9e7a541dffc2a3e178ccb16d383", "0x42e7890aaca30c9038253d25522733194ce8c5d8", "0xa354f84a692dec449099fcf5aaf69e632cb114cc", "0x5c6f14ea90f6b6d756a8b0c1d3f16c1420574cde", "0x19eb3e2db706a760ae1627ccfe2e37b88a6de6e2", "0x5b7490375f47ba11b9702bbbaf4e545b65708961", "0xf532ac928f115cd9feea17f11197e74c7a7382a3", "0xe4fe2d1b9f24b8b470a9c71b0124152d8531642b", "0x1a6a1cd4da3f665f5703829888bd3274a17daa48", "0xa02248861f3c4393c867be697bdf53ea39693c6b"],
  councilStakingAmounts: [5000001, 15000000, 5000001, 5000000, 1, 1, 1, 1, 5000000, 16000000, 5000000, 5000000, 5000000, 50000000, 1, 14800000, 4900000, 19999900, 5000000, 6034308, 100001, 1, 1, 1, 5386716, 5245453, 5073588, 5053770, 1, 1, 1],
  gini: 0.44,
  kcfAddr: "0x819d4b7245164e6a94341f4b5c2ae587372bb669",
  kefAddr: "0x819d4b7245164e6a94341f4b5c2ae587372bb669",
  kffAddr: "0x8436e5bd1a6d622c278c946e2f8988a26136a16f",
  kifAddr: "0x8436e5bd1a6d622c278c946e2f8988a26136a16f",
  useGini: true
}

// Result of archive node
> kaia.getStakingInfo("159435780")
{
  KIRAddr: "0x819d4b7245164e6a94341f4b5c2ae587372bb669",
  PoCAddr: "0x8436e5bd1a6d622c278c946e2f8988a26136a16f",
  blockNum: 159435779,
  councilNodeAddrs: ["0x99fb17d324fa0e07f23b49d09028ac0919414db6", "0x571e53df607be97431a5bbefca1dffe5aef56f4d", "0xb74ff9dea397fe9e231df545eb53fe2adf776cb2", "0x5cb1a7dccbd0dc446e3640898ede8820368554c8", "0xcb21b21b8948a26259775b88c14a7dda9eb09ce7", "0xa3b387b7b0dc914a4f106ad645a0ad079d70ebdc", "0x52c0f3654e9ac47ba5e64ffcb398be485718a74b", "0x20685d7bbcb07dddbd8dbdc824c31fe2bfb31c92", "0x7e4f6573fc67e334227b041ce90784533f0a0fe8", "0xa3903e0680ef44aaff474f4714bf2bc51c467285", "0x91fd07901bea2eddc9ef076e0ec4fcc2bab3cc60", "0xc1df096e6b907f4c20b449393b640dbcb77f717b", "0xda1e49f338cdea22edd68012f40617028ee93bae", "0x85992b5c1c1224f2582c4429babe429c16386a78", "0x248ca8fa2c670c645764364e9760f601171f15c5", "0x5704f555172b964719cdf858d22d5c722d784381", "0x0b5f888d7b48a8227e122a64814439dc4c6cb9c3", "0x85a65b24ae66790532806f52da61a154ab2bda54", "0xcae4466e1f19f025be3a0357914f5c411b475921", "0x2a9b841a08455f8ed333c94f0df1fe5607b4ad8e", "0x1651145859e30a2b1763612c18aea6f138b2cfbc", "0x993efc86499ff9a47e5770040a02f37ed9469911", "0x5d13e58574c6c6515678bcedb15cab9166ebb583", "0x6a7acac3634348222843066cdaa7d860bbf62eef", "0x93c9af04956e6f300d19f968559e063f3a859391", "0x060270b218ff16eae6cc877b838f1b6b6716deef", "0x55cf7ece098f172cc3170311d270ea28379a8916", "0xb9c84952da199e8046dfcc2f65974198ad2e5d08", "0x3470f35b916bf966c7cb0b9d4d67a3715020eed1", "0xc9d314f636e5b713dfc2404173b6f646c9bf9392", "0xbca148145fac7f14bde47f9a626c18535be09438"],
  councilRewardAddrs: ["0xb2bd3178affccd9f9f5189457f1cad7d17a01c9d", "0x6559a7b6248b342bc11fbcdf9343212bbc347edc", "0x82829a60c6eac4e3e9d6ed00891c69e88537fd4d", "0xf90675a56a03f836204d66c0f923e00500ddc90a", "0x583a5b5313279e442aec042e3c6771951b02a5bc", "0x662a2c18b36b06f21105b019a8795f8d5a38b5b4", "0xc8e7053dc17bce47d2317718734ef087be40a023", "0xfc37e31fe3b1019f5be58cb826e5d7b08f9b2e35", "0x4d7ff4251c1755fdc08d393a2aca2feaed9664a1", "0x4d7ff4251c1755fdc08d393a2aca2feaed9664a1", "0x52b5798bbef5c3c00abb3a7be71285874b20af10", "0x52b5798bbef5c3c00abb3a7be71285874b20af10", "0x21689e0b32e8c9bde382457b38c3af4b70b08997", "0x21689e0b32e8c9bde382457b38c3af4b70b08997", "0x85a4803c43f434eb8db149d2ea2e2f7b1568bb9f", "0x85a4803c43f434eb8db149d2ea2e2f7b1568bb9f", "0x88b08385c26bb06b88648c226d06b492ca82968d", "0x2bf231a2c3d49e86997a328596eaff9b37af06e0", "0xe59c0526a67e67e7ca35e2a6e7232e203771a00a", "0x5c2293e49682b82c66985673d813707723c845be", "0x88b08385c26bb06b88648c226d06b492ca82968d", "0xbc695a070d706bc26d33604d0233f8e1fa95b530", "0x1ed6eb5c7bdf5c04734d25f6e798d67c6b2e8114", "0x842ab31ab877b67a7636927580d83c5ee561c981", "0xf708a34dfae166043d45eb91ad76ad13204cb1b6", "0xb942d0c72073ab75d5654004625387e106d61ed1", "0x5bb2b2977a29ad85994f601f45802f514bb5e2a1", "0x9afa6b429e737edea3854cbdf32bda324563d3ac", "0x6419730389089e9cada08c5b202a8e15c0094343", "0xba950d20f65e2ec6daf9bbe4ec4381ae53328b04", "0x7faedd28992791316d2f5931d05e8f672ce1c561"],
  councilStakingAddrs: ["0x12fa1ab4c3e17c1c08c1b5a945c864c8e8bf707e", "0xfd56604f1a20268ff7a0eab2ab48e25ee1e0f653", "0x1e0f6aaa9baa6081dc4910a854eebf8854c262ab", "0x5e6988415ebe0f6b088f5a676003ba60f572875a", "0x8917ed4c6d687a1002d31b3a21cea331ba7742de", "0x588df37ed04f150617ed693a485b29b31c192434", "0xe70c8aa660d253fb0122a3890e32ea057f6a08f8", "0x7cae8c7120afab7fec9cda2022bab15a4b119715", "0xf36ba9426340bd13ca3440b7a8da62301bc2eff8", "0x49f1886e592129dfee129bf1baa6dd4d8bf9cd34", "0x6b15e4b9dac3fbaaec6c2fe94c51b060ca4a105e", "0x9a3ebcc1a479fc8050dbc83cde8ab5cd114fcb8f", "0x83754f56ee1238e9c090cbacf8cf650358864f4d", "0x27292935dec283f2a27f8e54bc81e0cd8f2ac8d5", "0xfde566fc3f87d17a7d30ee920b25c5f61218a634", "0x96e4b8c2a8a8932d5c71d7b1a03264c263005917", "0x1173f457bac58ab8700220375b5a9b05fa81a882", "0xdfd0767037be384232cafe32ba747808db49eb2a", "0xea383529501daddd72c9daff3eb5def03bd6e706", "0x6074ddfbaed37710d118885f930db2f3c311c7d8", "0x7253621629156d75fe97aa0d7cf1cee1910ea3dc", "0x55538b3b74d6a9e7a541dffc2a3e178ccb16d383", "0x42e7890aaca30c9038253d25522733194ce8c5d8", "0xa354f84a692dec449099fcf5aaf69e632cb114cc", "0x5c6f14ea90f6b6d756a8b0c1d3f16c1420574cde", "0x19eb3e2db706a760ae1627ccfe2e37b88a6de6e2", "0x5b7490375f47ba11b9702bbbaf4e545b65708961", "0xf532ac928f115cd9feea17f11197e74c7a7382a3", "0xe4fe2d1b9f24b8b470a9c71b0124152d8531642b", "0x1a6a1cd4da3f665f5703829888bd3274a17daa48", "0xa02248861f3c4393c867be697bdf53ea39693c6b"],
  councilStakingAmounts: [5000001, 15000000, 5000001, 5000000, 1, 1, 1, 1, 5000000, 16000000, 5000000, 5000000, 5000000, 50000000, 1, 14800000, 4900000, 19999900, 5000000, 6034308, 100001, 1, 1, 1, 5386716, 5245453, 5073588, 5053770, 1, 1, 1],
  gini: 0.44,
  kcfAddr: "0x819d4b7245164e6a94341f4b5c2ae587372bb669",
  kefAddr: "0x819d4b7245164e6a94341f4b5c2ae587372bb669",
  kffAddr: "0x8436e5bd1a6d622c278c946e2f8988a26136a16f",
  kifAddr: "0x8436e5bd1a6d622c278c946e2f8988a26136a16f",
  useGini: true
}
```
</details>


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
