### PR TITLE
vm: InternalTxTrace JSON includes revertReason

### DIFF
--- a/blockchain/vm/internaltx_trace_json.go
+++ b/blockchain/vm/internaltx_trace_json.go
@@ -51,7 +51,8 @@ func (i InternalTxTrace) MarshalJSON() ([]byte, error) {
 		Time  *string            `json:"time,omitempty"`
 		Calls []*InternalTxTrace `json:"calls,omitempty"`
 
-		Reverted *RevertedInfo `json:"reverted,omitempty"`
+		RevertReason string        `json:"revertReason,omitempty"`
+		Reverted     *RevertedInfo `json:"reverted,omitempty"`
 	}
 
 	var enc internalTxTrace
@@ -84,6 +85,7 @@ func (i InternalTxTrace) MarshalJSON() ([]byte, error) {
 		enc.Time = &timeStr
 	}
 	enc.Calls = i.Calls
+	enc.RevertReason = i.RevertReason
 	enc.Reverted = i.Reverted
 
 	return json.Marshal(&enc)
@@ -106,7 +108,8 @@ func (i *InternalTxTrace) UnmarshalJSON(input []byte) error {
 		Time  *string            `json:"time,omitempty"`
 		Calls []*InternalTxTrace `json:"calls,omitempty"`
 
-		Reverted *RevertedInfo `json:"reverted,omitempty"`
+		RevertReason string        `json:"revertReason,omitempty"`
+		Reverted     *RevertedInfo `json:"reverted,omitempty"`
 	}
 	var dec internalTxTrace
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -145,6 +148,7 @@ func (i *InternalTxTrace) UnmarshalJSON(input []byte) error {
 		i.Time = t
 	}
 	i.Calls = dec.Calls
+	i.RevertReason = dec.RevertReason
 	i.Reverted = dec.Reverted
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

- Fixes chaindatafetcher trace output to include the new `revertReason` field

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
