### PR TITLE
Preload staking info only at startup

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -366,8 +366,8 @@ func (c *Clique) CreateSnapshot(chain consensus.ChainReader, number uint64, hash
 	return err
 }
 
-// GetHeadersToApply is not used for Clique engine
-func (c *Clique) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+// GetKaiaHeadersForSnapshotApply is not used for Clique engine
+func (c *Clique) GetKaiaHeadersForSnapshotApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
 	return nil, nil
 }
 

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -366,6 +366,11 @@ func (c *Clique) CreateSnapshot(chain consensus.ChainReader, number uint64, hash
 	return err
 }
 
+// GetHeadersToApply is not used for Clique engine
+func (c *Clique) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+	return nil, nil
+}
+
 // snapshot retrieves the authorization snapshot at a given point in time.
 func (c *Clique) snapshot(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, error) {
 	// Search for a snapshot in memory or on disk for checkpoints

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -124,6 +124,9 @@ type Engine interface {
 	// CreateSnapshot does not return a snapshot but creates a new snapshot if not exists at a given point in time.
 	CreateSnapshot(chain ChainReader, number uint64, hash common.Hash, parents []*types.Header) error
 
+	// GetHeadersToApply returns the headers need to be applied to calculate snapshot for the given block number.
+	GetHeadersToApply(chain ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error)
+
 	// GetConsensusInfo returns consensus information regarding the given block number.
 	GetConsensusInfo(block *types.Block) (ConsensusInfo, error)
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -124,8 +124,8 @@ type Engine interface {
 	// CreateSnapshot does not return a snapshot but creates a new snapshot if not exists at a given point in time.
 	CreateSnapshot(chain ChainReader, number uint64, hash common.Hash, parents []*types.Header) error
 
-	// GetHeadersToApply returns the headers need to be applied to calculate snapshot for the given block number.
-	GetHeadersToApply(chain ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error)
+	// GetKaiaHeadersForSnapshotApply returns the headers need to be applied to calculate snapshot for the given block number.
+	GetKaiaHeadersForSnapshotApply(chain ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error)
 
 	// GetConsensusInfo returns consensus information regarding the given block number.
 	GetConsensusInfo(block *types.Block) (ConsensusInfo, error)

--- a/consensus/gxhash/consensus.go
+++ b/consensus/gxhash/consensus.go
@@ -74,6 +74,11 @@ func (gxhash *Gxhash) CreateSnapshot(chain consensus.ChainReader, number uint64,
 	return nil
 }
 
+// GetHeadersToApply is not used for PoW engine.
+func (gxhash *Gxhash) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+	return nil, nil
+}
+
 // GetConsensusInfo is not used for PoW engine.
 func (gxhash *Gxhash) GetConsensusInfo(block *types.Block) (consensus.ConsensusInfo, error) {
 	return consensus.ConsensusInfo{}, nil

--- a/consensus/gxhash/consensus.go
+++ b/consensus/gxhash/consensus.go
@@ -74,8 +74,8 @@ func (gxhash *Gxhash) CreateSnapshot(chain consensus.ChainReader, number uint64,
 	return nil
 }
 
-// GetHeadersToApply is not used for PoW engine.
-func (gxhash *Gxhash) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+// GetKaiaHeadersForSnapshotApply is not used for PoW engine.
+func (gxhash *Gxhash) GetKaiaHeadersForSnapshotApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
 	return nil, nil
 }
 

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -594,7 +594,7 @@ func headerByRpcNumber(chain consensus.ChainReader, number *rpc.BlockNumber) (*t
 
 // Checks the all states for snapshot creation at the given block number
 func checkStatesForSnapshot(chain consensus.ChainReader, istBackend *backend, number uint64, hash common.Hash) error {
-	headers, err := istBackend.GetHeadersToApply(chain, number, hash, nil)
+	headers, err := istBackend.GetKaiaHeadersForSnapshotApply(chain, number, hash, nil)
 	if err != nil {
 		return err
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -516,12 +516,12 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 
 	// If sb.chain is nil, it means backend is not initialized yet.
 	if sb.chain != nil && !reward.IsRewardSimple(pset) {
-		// TODO-Kaia Let's redesign below logic and remove dependency between block reward and istanbul consensus.
-		lastHeader := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
-		valSet := sb.getValidators(lastHeader.Number.Uint64(), lastHeader.Hash())
-
 		// Determine and update Rewardbase when mining. When mining, state root is not yet determined and will be determined at the end of this Finalize below.
 		if common.EmptyHash(header.Root) {
+			// TODO-Kaia Let's redesign below logic and remove dependency between block reward and istanbul consensus.
+			lastHeader := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
+			valSet := sb.getValidators(lastHeader.Number.Uint64(), lastHeader.Hash())
+
 			var logMsg string
 			_, nodeValidator := valSet.GetByAddress(sb.address)
 			if nodeValidator == nil || (nodeValidator.RewardAddress() == common.Address{}) {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -517,8 +517,7 @@ func (sb *backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 	// If sb.chain is nil, it means backend is not initialized yet.
 	if sb.chain != nil && !reward.IsRewardSimple(pset) {
 		// TODO-Kaia Let's redesign below logic and remove dependency between block reward and istanbul consensus.
-
-		lastHeader := chain.CurrentHeader()
+		lastHeader := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
 		valSet := sb.getValidators(lastHeader.Number.Uint64(), lastHeader.Hash())
 
 		// Determine and update Rewardbase when mining. When mining, state root is not yet determined and will be determined at the end of this Finalize below.

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -930,12 +930,23 @@ func (sb *backend) prepareSnapshotApply(chain consensus.ChainReader, number uint
 	return snap, headers, nil
 }
 
+// GetHeadersToApply returns the headers need to be applied to calculate snapshot for the given block number.
+// Note that it only returns headers for kaia fork enabled blocks.
 func (sb *backend) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
 	_, headers, err := sb.prepareSnapshotApply(chain, number, hash, parents)
 	if err != nil {
 		return nil, err
 	}
-	return headers, nil
+
+	kaiaHeaders := []*types.Header{}
+	for i := 0; i < len(headers); i++ {
+		if chain.Config().IsKaiaForkEnabled(new(big.Int).Add(headers[i].Number, big.NewInt(1))) {
+			kaiaHeaders = headers[i:]
+			break
+		}
+	}
+
+	return kaiaHeaders, nil
 }
 
 // snapshot retrieves the state of the authorization voting at a given point in time.

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -885,10 +885,7 @@ func (sb *backend) InitSnapshot() {
 	sb.blsPubkeyProvider.ResetBlsCache()
 }
 
-// snapshot retrieves the state of the authorization voting at a given point in time.
-// There's in-memory snapshot and on-disk snapshot. On-disk snapshot is stored every checkpointInterval blocks.
-// Moreover, if the block has no in-memory or on-disk snapshot, before generating snapshot, it gathers the header and apply the vote in it.
-func (sb *backend) snapshot(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header, writable bool) (*Snapshot, error) {
+func (sb *backend) prepareSnapshotApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, []*types.Header, error) {
 	// Search for a snapshot in memory or on disk for checkpoints
 	var (
 		headers []*types.Header
@@ -913,13 +910,13 @@ func (sb *backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 		if number == 0 {
 			var err error
 			if snap, err = sb.initSnapshot(chain); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			break
 		}
 		// No snapshot for this header, gather the header and move backward
 		if header := getPrevHeaderAndUpdateParents(chain, number, hash, &parents); header == nil {
-			return nil, consensus.ErrUnknownAncestor
+			return nil, nil, consensus.ErrUnknownAncestor
 		} else {
 			headers = append(headers, header)
 			number, hash = number-1, header.ParentHash
@@ -929,7 +926,28 @@ func (sb *backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 	for i := 0; i < len(headers)/2; i++ {
 		headers[i], headers[len(headers)-1-i] = headers[len(headers)-1-i], headers[i]
 	}
-	pset, err := sb.governance.EffectiveParams(number)
+
+	return snap, headers, nil
+}
+
+func (sb *backend) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+	_, headers, err := sb.prepareSnapshotApply(chain, number, hash, parents)
+	if err != nil {
+		return nil, err
+	}
+	return headers, nil
+}
+
+// snapshot retrieves the state of the authorization voting at a given point in time.
+// There's in-memory snapshot and on-disk snapshot. On-disk snapshot is stored every checkpointInterval blocks.
+// Moreover, if the block has no in-memory or on-disk snapshot, before generating snapshot, it gathers the header and apply the vote in it.
+func (sb *backend) snapshot(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header, writable bool) (*Snapshot, error) {
+	snap, headers, err := sb.prepareSnapshotApply(chain, number, hash, parents)
+	if err != nil {
+		return nil, err
+	}
+
+	pset, err := sb.governance.EffectiveParams(snap.Number)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -885,6 +885,8 @@ func (sb *backend) InitSnapshot() {
 	sb.blsPubkeyProvider.ResetBlsCache()
 }
 
+// prepareSnapshotApply is a helper function to prepare snapshot and headers for the given block number and hash.
+// It returns the snapshot, headers, and error if any.
 func (sb *backend) prepareSnapshotApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, []*types.Header, error) {
 	// Search for a snapshot in memory or on disk for checkpoints
 	var (
@@ -930,7 +932,7 @@ func (sb *backend) prepareSnapshotApply(chain consensus.ChainReader, number uint
 	return snap, headers, nil
 }
 
-// GetHeadersToApply returns the headers need to be applied to calculate snapshot for the given block number.
+// GetHeadersToApply returns the headers need to be applied to create snapshot for the given block number.
 // Note that it only returns headers for kaia fork enabled blocks.
 func (sb *backend) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
 	_, headers, err := sb.prepareSnapshotApply(chain, number, hash, parents)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -932,9 +932,9 @@ func (sb *backend) prepareSnapshotApply(chain consensus.ChainReader, number uint
 	return snap, headers, nil
 }
 
-// GetHeadersToApply returns the headers need to be applied to create snapshot for the given block number.
+// GetKaiaHeadersForSnapshotApply returns the headers need to be applied to create snapshot for the given block number.
 // Note that it only returns headers for kaia fork enabled blocks.
-func (sb *backend) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+func (sb *backend) GetKaiaHeadersForSnapshotApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
 	_, headers, err := sb.prepareSnapshotApply(chain, number, hash, parents)
 	if err != nil {
 		return nil, err

--- a/consensus/mocks/engine_mock.go
+++ b/consensus/mocks/engine_mock.go
@@ -140,6 +140,21 @@ func (mr *MockEngineMockRecorder) GetConsensusInfo(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsensusInfo", reflect.TypeOf((*MockEngine)(nil).GetConsensusInfo), arg0)
 }
 
+// GetHeadersToApply mocks base method.
+func (m *MockEngine) GetHeadersToApply(arg0 consensus.ChainReader, arg1 uint64, arg2 common.Hash, arg3 []*types.Header) ([]*types.Header, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeadersToApply", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]*types.Header)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHeadersToApply indicates an expected call of GetHeadersToApply.
+func (mr *MockEngineMockRecorder) GetHeadersToApply(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeadersToApply", reflect.TypeOf((*MockEngine)(nil).GetHeadersToApply), arg0, arg1, arg2, arg3)
+}
+
 // InitSnapshot mocks base method.
 func (m *MockEngine) InitSnapshot() {
 	m.ctrl.T.Helper()

--- a/consensus/mocks/engine_mock.go
+++ b/consensus/mocks/engine_mock.go
@@ -140,19 +140,19 @@ func (mr *MockEngineMockRecorder) GetConsensusInfo(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsensusInfo", reflect.TypeOf((*MockEngine)(nil).GetConsensusInfo), arg0)
 }
 
-// GetHeadersToApply mocks base method.
-func (m *MockEngine) GetHeadersToApply(arg0 consensus.ChainReader, arg1 uint64, arg2 common.Hash, arg3 []*types.Header) ([]*types.Header, error) {
+// GetKaiaHeadersForSnapshotApply mocks base method.
+func (m *MockEngine) GetKaiaHeadersForSnapshotApply(arg0 consensus.ChainReader, arg1 uint64, arg2 common.Hash, arg3 []*types.Header) ([]*types.Header, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHeadersToApply", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetKaiaHeadersForSnapshotApply", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]*types.Header)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetHeadersToApply indicates an expected call of GetHeadersToApply.
-func (mr *MockEngineMockRecorder) GetHeadersToApply(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// GetKaiaHeadersForSnapshotApply indicates an expected call of GetKaiaHeadersForSnapshotApply.
+func (mr *MockEngineMockRecorder) GetKaiaHeadersForSnapshotApply(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeadersToApply", reflect.TypeOf((*MockEngine)(nil).GetHeadersToApply), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKaiaHeadersForSnapshotApply", reflect.TypeOf((*MockEngine)(nil).GetKaiaHeadersForSnapshotApply), arg0, arg1, arg2, arg3)
 }
 
 // InitSnapshot mocks base method.

--- a/datasync/chaindatafetcher/kafka/repository.go
+++ b/datasync/chaindatafetcher/kafka/repository.go
@@ -79,7 +79,8 @@ func (r *repository) HandleChainEvent(event blockchain.ChainEvent, dataType type
 		if event.Block.NumberU64() > 0 {
 			err := checkStatesForSnapshot(r.blockchain, r.engine, event.Block.NumberU64()-1, event.Block.ParentHash())
 			if err != nil {
-				return err
+				logger.Warn("skip fetching block", "number", event.Block.NumberU64(), "err", err)
+				return nil
 			}
 		}
 		cInfo, err := r.engine.GetConsensusInfo(event.Block)

--- a/datasync/chaindatafetcher/kafka/repository.go
+++ b/datasync/chaindatafetcher/kafka/repository.go
@@ -106,7 +106,7 @@ func (r *repository) HandleChainEvent(event blockchain.ChainEvent, dataType type
 }
 
 func checkStatesForSnapshot(chain consensus.ChainReader, engine consensus.Engine, number uint64, hash common.Hash) error {
-	headers, err := engine.GetHeadersToApply(chain, number, hash, nil)
+	headers, err := engine.GetKaiaHeadersForSnapshotApply(chain, number, hash, nil)
 	if err != nil {
 		return err
 	}

--- a/governance/api.go
+++ b/governance/api.go
@@ -91,6 +91,11 @@ func (api *GovernanceKaiaAPI) GetRewards(num *rpc.BlockNumber) (*reward.RewardSp
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
+	// Check if the node has state to calculate the snapshot.
+	err := checkStateForStakingInfo(api.governance, blockNumber)
+	if err != nil {
+		return nil, err
+	}
 
 	header := api.chain.GetHeaderByNumber(blockNumber)
 	block := api.chain.GetBlock(header.Hash(), blockNumber)
@@ -339,7 +344,29 @@ func getStakingInfo(governance Engine, num *rpc.BlockNumber) (*reward.StakingInf
 	} else {
 		blockNumber = uint64(num.Int64())
 	}
+	// Check if the node has state to calculate the snapshot.
+	err := checkStateForStakingInfo(governance, blockNumber)
+	if err != nil {
+		return nil, err
+	}
+
 	return reward.GetStakingInfo(blockNumber), nil
+}
+
+// Checks the state of block for the given block number for staking info
+func checkStateForStakingInfo(governance Engine, blockNumber uint64) error {
+	if blockNumber == 0 {
+		return nil
+	}
+
+	// The staking info at blockNumber is calculated by the state of previous block
+	blockNumber--
+	if !governance.BlockChain().Config().IsKaiaForkEnabled(big.NewInt(int64(blockNumber + 1))) {
+		return nil
+	}
+
+	_, err := governance.BlockChain().StateAt(governance.BlockChain().GetHeaderByNumber(blockNumber).Root)
+	return err
 }
 
 func (api *GovernanceAPI) PendingChanges() map[string]interface{} {

--- a/governance/api.go
+++ b/governance/api.go
@@ -174,8 +174,9 @@ func (api *GovernanceAPI) GetRewardsAccumulated(first rpc.BlockNumber, last rpc.
 	mu := sync.Mutex{} // protect blockRewards
 
 	numWorkers := runtime.NumCPU()
-	reqCh := make(chan uint64, numWorkers)
-	errCh := make(chan error, numWorkers+1)
+	// TODO-api: Fix hanging issue when requested range is over numWorkers considering goroutine scheduling
+	reqCh := make(chan uint64, blockCount)
+	errCh := make(chan error, blockCount+1)
 	wg := sync.WaitGroup{}
 
 	// introduce the worker pattern to prevent resource exhaustion

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -374,7 +374,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		currBlock = cn.blockchain.CurrentBlock()
 		headers   []*types.Header
 	)
-	if headers, err = cn.Engine().GetHeadersToApply(cn.blockchain, currBlock.NumberU64(), currBlock.Hash(), nil); err != nil {
+	if headers, err = cn.Engine().GetKaiaHeadersForSnapshotApply(cn.blockchain, currBlock.NumberU64(), currBlock.Hash(), nil); err != nil {
 		logger.Error("Failed to get headers to apply", "err", err)
 	} else {
 		// Temporarily supply blockchain for `Finalize`.

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -370,6 +370,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	// By calling CreateSnapshot, it restores the gov state snapshots and apply the votes in it
 	// Particularly, the gov.changeSet is also restored here.
 	// Temporarily set chain since snapshot needs state since kaia hardfork
+	logger.Info("Start creating istanbul snapshot")
 	var (
 		currBlock = cn.blockchain.CurrentBlock()
 		headers   []*types.Header
@@ -393,6 +394,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	if err := cn.Engine().CreateSnapshot(cn.blockchain, currBlock.NumberU64(), currBlock.Hash(), headers); err != nil {
 		logger.Error("CreateSnapshot failed", "err", err)
 	}
+	logger.Info("Finished creating istanbul snapshot")
 
 	// set worker
 	if config.WorkerDisable {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -369,7 +369,28 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	// It disappears during the node restart, so restoration is needed before the sync starts
 	// By calling CreateSnapshot, it restores the gov state snapshots and apply the votes in it
 	// Particularly, the gov.changeSet is also restored here.
-	if err := cn.Engine().CreateSnapshot(cn.blockchain, cn.blockchain.CurrentBlock().NumberU64(), cn.blockchain.CurrentBlock().Hash(), nil); err != nil {
+	// Temporarily set chain since snapshot needs state since kaia hardfork
+	var (
+		currBlock = cn.blockchain.CurrentBlock()
+		headers   []*types.Header
+	)
+	if headers, err = cn.Engine().GetHeadersToApply(cn.blockchain, currBlock.NumberU64(), currBlock.Hash(), nil); err != nil {
+		logger.Error("Failed to get headers to apply", "err", err)
+	} else {
+		// Temporarily supply blockchain for `Finalize`.
+		cn.blockchain.Engine().(consensus.Istanbul).SetChain(cn.blockchain)
+		preloadNums, err := reward.PreloadStakingInfo(headers)
+		if err != nil {
+			logger.Error("Preload staking info failed", "err", err)
+		}
+		cn.blockchain.Engine().(consensus.Istanbul).SetChain(nil)
+		defer func() {
+			for _, num := range preloadNums {
+				reward.UnloadStakingInfo(num)
+			}
+		}()
+	}
+	if err := cn.Engine().CreateSnapshot(cn.blockchain, currBlock.NumberU64(), currBlock.Hash(), headers); err != nil {
 		logger.Error("CreateSnapshot failed", "err", err)
 	}
 

--- a/reward/staking_manager.go
+++ b/reward/staking_manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/system"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	contract "github.com/kaiachain/kaia/contracts/contracts/system_contracts/consensus"
 	"github.com/kaiachain/kaia/event"
@@ -65,6 +66,9 @@ type blockChain interface {
 	GetHeaderByNumber(number uint64) *types.Header
 	State() (*state.StateDB, error)
 	CurrentBlock() *types.Block
+
+	StateCache() state.Database
+	Processor() blockchain.Processor
 
 	blockchain.ChainContext
 }
@@ -240,6 +244,101 @@ func GetStakingInfoOnStakingBlock(stakingBlockNumber uint64) *StakingInfo {
 
 	logger.Debug("Get stakingInfo from header.", "staking block number", stakingBlockNumber, "stakingInfo", calcStakingInfo)
 	return calcStakingInfo
+}
+
+// PreloadStakingInfo preloads staking info for the given headers.
+// It first finds the first block that does not have state, and then
+// it regenerates the state from the nearest block that has state to the target block to preload staking info.
+// Note that the state is saved every 128 blocks to disk in full node.
+func PreloadStakingInfo(headers []*types.Header) ([]uint64, error) {
+	// If no headers to preload, do nothing
+	if len(headers) == 0 {
+		return nil, nil
+	}
+
+	if stakingManager == nil {
+		return nil, ErrStakingManagerNotSet
+	}
+
+	var (
+		current  *types.Block
+		database state.Database
+		target   = headers[len(headers)-1].Number.Uint64()
+		bc       = stakingManager.blockchain
+	)
+
+	database = state.NewDatabaseWithExistingCache(bc.StateCache().TrieDB().DiskDB(), bc.StateCache().TrieDB().TrieNodeCache())
+
+	// Find the first block that does not have state
+	i := 0
+	for i < len(headers) {
+		if _, err := state.New(headers[i].Root, database, nil, nil); err != nil {
+			break
+		}
+		i++
+	}
+	// Early return if all blocks have state
+	if i == len(headers) {
+		return nil, nil
+	}
+
+	// Find the nearest block that has state
+	origin := headers[i].Number.Uint64() - headers[i].Number.Uint64()%128
+	current = bc.GetBlockByNumber(origin)
+	if current == nil {
+		return nil, fmt.Errorf("block %d not found", origin)
+	}
+	statedb, err := state.New(current.Header().Root, database, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		parent                    common.Hash
+		preloadedStakingBlockNums = make([]uint64, 0, target-current.NumberU64())
+	)
+
+	// Include target since we want staking info at `target`, not for `target`.
+	for current.NumberU64() <= target {
+		// Preload StakingInfo from the current block and state.
+		preloadedStakingBlockNums = append(preloadedStakingBlockNums, current.NumberU64())
+		if err := PreloadStakingInfoWithState(current.Header(), statedb); err != nil {
+			return nil, fmt.Errorf("preloading staking info from block %d failed: %v", current.NumberU64(), err)
+		}
+		if current.NumberU64() == target {
+			break
+		}
+		// Retrieve the next block to regenerate and process it
+		next := current.NumberU64() + 1
+		if current = bc.GetBlockByNumber(next); current == nil {
+			return nil, fmt.Errorf("block #%d not found", next)
+		}
+		_, _, _, _, _, err := bc.Processor().Process(current, statedb, vm.Config{})
+		if err != nil {
+			return nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
+		}
+		// Finalize the state so any modifications are written to the trie
+		root, err := statedb.Commit(true)
+		if err != nil {
+			return nil, err
+		}
+		if err := statedb.Reset(root); err != nil {
+			return nil, fmt.Errorf("state reset after block %d failed: %v", current.NumberU64(), err)
+		}
+		database.TrieDB().ReferenceRoot(root)
+		if !common.EmptyHash(parent) {
+			database.TrieDB().Dereference(parent)
+		}
+		if current.Root() != root {
+			err = fmt.Errorf("mistmatching state root block expected %x reexecuted %x", current.Root(), root)
+			// Logging here because something went wrong when the state roots disagree even if the execution was successful.
+			logger.Error("incorrectly regenerated historical state", "block", current.NumberU64(), "err", err)
+			return nil, fmt.Errorf("incorrectly regenerated historical state for block %d: %v", current.NumberU64(), err)
+		}
+		parent = root
+	}
+
+	return preloadedStakingBlockNums, nil
 }
 
 // PreloadStakingInfoWithState fetches the stakingInfo based on the given state trie

--- a/reward/supply_manager_test.go
+++ b/reward/supply_manager_test.go
@@ -792,6 +792,10 @@ func (s *supplyTestEngine) CreateSnapshot(chain consensus.ChainReader, number ui
 	return nil
 }
 
+func (s *supplyTestEngine) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+	return nil, nil
+}
+
 func (s *supplyTestEngine) GetConsensusInfo(block *types.Block) (consensus.ConsensusInfo, error) {
 	return consensus.ConsensusInfo{}, nil
 }

--- a/reward/supply_manager_test.go
+++ b/reward/supply_manager_test.go
@@ -792,7 +792,7 @@ func (s *supplyTestEngine) CreateSnapshot(chain consensus.ChainReader, number ui
 	return nil
 }
 
-func (s *supplyTestEngine) GetHeadersToApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
+func (s *supplyTestEngine) GetKaiaHeadersForSnapshotApply(chain consensus.ChainReader, number uint64, hash common.Hash, parents []*types.Header) ([]*types.Header, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Proposed changes

This PR is similar with #46 except that it only regenerates and preloads staking info at node start up. The existing APIs will bubble up if user requests info at stateless block (or blocks).

How it differs from #46:
| | #46 | This PR |
|---|---|---|
| Startup | regen | regen |
| APIs | regen | bubble up missing state error ("missing trie node") |

<details>
<summary>APIs example</summary>

```
// No snapshot cache
> kaia.getCommittee("20")
Error: missing trie node d9c413d220797a666c786380e0f269b1f228304601cdc492c66eb40bdc2efc28 (path )
	at web3.js:6812:9(39)
	at send (web3.js:5223:62(29))
	at <eval>:1:18(3)

// No snapshot cache
> kaia.getBlockWithConsensusInfo
kaia.getBlockWithConsensusInfo kaia.getBlockWithConsensusInfoRange
> istanbul.getValidators(30)
Error: missing trie node d9c413d220797a666c786380e0f269b1f228304601cdc492c66eb40bdc2efc28 (path )
	at web3.js:6812:9(39)
	at send (web3.js:5223:62(29))
	at <eval>:1:23(3)

> kaia.getRewards("30")
Error: missing trie node 25b62b34e5d1f2b5ccc2349ff7da9a7f73abe7b154c6153ff3aa7459ba270800 (path )
	at web3.js:6812:9(39)
	at send (web3.js:5223:62(29))
	at <eval>:1:16(3)

> kaia.getStakingInfo("30")
Error: missing trie node 25b62b34e5d1f2b5ccc2349ff7da9a7f73abe7b154c6153ff3aa7459ba270800 (path )
	at web3.js:6812:9(39)
	at send (web3.js:5223:62(29))
	at <eval>:1:20(3)
```

</details>

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
