### PR TITLE
kaia: change package name of interfaces.go

### DIFF
--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -27,7 +27,7 @@ import (
 	"errors"
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 )

--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/state"

--- a/accounts/abi/bind/backends/blockchain_test.go
+++ b/accounts/abi/bind/backends/blockchain_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/bloombits"

--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain"

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"sync"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"

--- a/accounts/abi/bind/base_test.go
+++ b/accounts/abi/bind/base_test.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"testing"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/accounts/abi/bind/template.go
+++ b/accounts/abi/bind/template.go
@@ -99,7 +99,7 @@ import (
 	"strings"
 	"errors"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/common"

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -25,7 +25,7 @@ package accounts
 import (
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/event"

--- a/accounts/keystore/keystore_wallet.go
+++ b/accounts/keystore/keystore_wallet.go
@@ -25,7 +25,7 @@ package keystore
 import (
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts"
 	"github.com/kaiachain/kaia/blockchain/types"
 )

--- a/api/backend.go
+++ b/api/backend.go
@@ -27,7 +27,7 @@ import (
 	"math/big"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/state"

--- a/api/mocks/backend_mock.go
+++ b/api/mocks/backend_mock.go
@@ -11,7 +11,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	accounts "github.com/kaiachain/kaia/accounts"
 	blockchain "github.com/kaiachain/kaia/blockchain"
 	state "github.com/kaiachain/kaia/blockchain/state"

--- a/blockchain/system/multicall.go
+++ b/blockchain/system/multicall.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/state"

--- a/blockchain/system/rebalance.go
+++ b/blockchain/system/rebalance.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"

--- a/client/bridge_client.go
+++ b/client/bridge_client.go
@@ -27,7 +27,7 @@ import (
 	"errors"
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"

--- a/client/kaia_client.go
+++ b/client/kaia_client.go
@@ -29,7 +29,7 @@ import (
 	"fmt"
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/api"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"

--- a/client/kaia_client_test.go
+++ b/client/kaia_client_test.go
@@ -22,7 +22,7 @@
 
 package client
 
-import kaia "github.com/kaiachain/kaia"
+import "github.com/kaiachain/kaia"
 
 // Verify that Client implements the Kaia interfaces.
 var (

--- a/contracts/contracts/libs/kip13/InterfaceIdentifier.go
+++ b/contracts/contracts/libs/kip13/InterfaceIdentifier.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/service_chain/bridge/Bridge.go
+++ b/contracts/contracts/service_chain/bridge/Bridge.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/consensus/Kip163.go
+++ b/contracts/contracts/system_contracts/consensus/Kip163.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/consensus/consensus.go
+++ b/contracts/contracts/system_contracts/consensus/consensus.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/gov/GovParam.go
+++ b/contracts/contracts/system_contracts/gov/GovParam.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/kip113/SimpleBlsRegistry.go
+++ b/contracts/contracts/system_contracts/kip113/SimpleBlsRegistry.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/kip149/Registry.go
+++ b/contracts/contracts/system_contracts/kip149/Registry.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/multicall/MultiCallContract.go
+++ b/contracts/contracts/system_contracts/multicall/MultiCallContract.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/proxy/proxy.go
+++ b/contracts/contracts/system_contracts/proxy/proxy.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/system_contracts/rebalance/all.go
+++ b/contracts/contracts/system_contracts/rebalance/all.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/testing/extbridge/ext_bridge.go
+++ b/contracts/contracts/testing/extbridge/ext_bridge.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/testing/reward/all.go
+++ b/contracts/contracts/testing/reward/all.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/testing/sc_erc20/sc_token.go
+++ b/contracts/contracts/testing/sc_erc20/sc_token.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/testing/sc_erc721/sc_nft.go
+++ b/contracts/contracts/testing/sc_erc721/sc_nft.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/testing/sc_erc721_no_uri/sc_nft_no_uri.go
+++ b/contracts/contracts/testing/sc_erc721_no_uri/sc_nft_no_uri.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/contracts/contracts/testing/system_contracts/all.go
+++ b/contracts/contracts/testing/system_contracts/all.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"strings"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/datasync/chaindatafetcher/kas/contract_caller.go
+++ b/datasync/chaindatafetcher/kas/contract_caller.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/api"
 	"github.com/kaiachain/kaia/blockchain"

--- a/datasync/downloader/api.go
+++ b/datasync/downloader/api.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"sync"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/networks/rpc"
 )

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -30,7 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/event"

--- a/datasync/downloader/downloader_fake.go
+++ b/datasync/downloader/downloader_fake.go
@@ -21,7 +21,7 @@ package downloader
 import (
 	"math/big"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/node/cn/snap"

--- a/interfaces.go
+++ b/interfaces.go
@@ -20,8 +20,8 @@
 // Modified and improved for the klaytn development.
 // Modified and improved for the Kaia development.
 
-// Package Kaia defines interfaces for interacting with Kaia.
-package klaytn
+// Package kaia defines interfaces for interacting with Kaia.
+package kaia
 
 import (
 	"context"

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -28,7 +28,7 @@ import (
 	"math/big"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/bloombits"

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts"
 	"github.com/kaiachain/kaia/api"
 	"github.com/kaiachain/kaia/blockchain"

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"

--- a/node/cn/filters/filter_system.go
+++ b/node/cn/filters/filter_system.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"

--- a/node/cn/filters/filter_system_test.go
+++ b/node/cn/filters/filter_system_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/bloombits"
 	"github.com/kaiachain/kaia/blockchain/types"

--- a/node/cn/mocks/downloader_mock.go
+++ b/node/cn/mocks/downloader_mock.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
 	downloader "github.com/kaiachain/kaia/datasync/downloader"

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -28,7 +28,7 @@ import (
 	"math/big"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/datasync/downloader"

--- a/node/sc/remote_backend.go
+++ b/node/sc/remote_backend.go
@@ -24,7 +24,7 @@ import (
 	"net"
 	"time"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"

--- a/tests/randao_fork_test.go
+++ b/tests/randao_fork_test.go
@@ -20,7 +20,7 @@ import (
 	"math/big"
 	"testing"
 
-	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"


### PR DESCRIPTION
## Proposed changes

- This PR changes the package name of interfaces.go.( klaytn -> kaia)
- It is an interface for kaia, so name should be kaia.
- It will be referenced as below.
```
import (
        ...
	"github.com/kaiachain/kaia"
        ...
)
        
	callMsg := kaia.CallMsg{ ... }

```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
