### PR TITLE
db: adjust pebbledb metric

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -96,7 +96,7 @@ var (
 	}
 	DbTypeFlag = &cli.StringFlag{
 		Name:     "dbtype",
-		Usage:    `Blockchain storage database type ("LevelDB", "BadgerDB", "MemoryDB", "DynamoDBS3")`,
+		Usage:    `Blockchain storage database type ("LevelDB", "BadgerDB", "MemoryDB", "DynamoDBS3", "PebbleDB")`,
 		Value:    "LevelDB",
 		Aliases:  []string{"db.type", "migration.src.dbtype"},
 		EnvVars:  []string{"KLAYTN_DBTYPE", "KAIA_DBTYPE"},

--- a/node/config.go
+++ b/node/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	// in the devp2p node identifier.
 	Version string `toml:"-"`
 
-	// key-value database type [LevelDB, RocksDB, BadgerDB, MemoryDB, DynamoDB]
+	// key-value database type [LevelDB, RocksDB, BadgerDB, MemoryDB, DynamoDB, PebbleDB]
 	DBType database.DBType
 
 	// DataDir is the file system folder the node should use for any data storage

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -563,6 +563,8 @@ func newDatabase(dbc *DBConfig, entryType DBEntryType) (Database, error) {
 		return NewLevelDB(dbc, entryType)
 	case RocksDB:
 		return NewRocksDB(dbc.Dir, dbc.RocksDBConfig)
+	case PebbleDB:
+		return NewPebbleDB(dbc, dbc.Dir)
 	case BadgerDB:
 		return NewBadgerDB(dbc.Dir)
 	case MemoryDB:


### PR DESCRIPTION
## Proposed changes

- This PR adds some level related pebbledb metrics. Also, it adds `PebbleDB` dbtype option since it was missing.
- Some metrics are not matched 100% between leveldb and pebbledb, so be pay attention when comparing those metrics.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments
For example, one of the level related pebbledb metric, `klaytn_klay_db_chaindata_statetrie_0levelN_size (N=0~6)` is now available in pebbleDB.

<img width="656" alt="image" src="https://github.com/user-attachments/assets/028d58e6-2092-42f5-b3c0-e26398bdee80">


