### PR TITLE
kaiax: Add module framework and dummy noop module

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/fork"
+	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/log"
 	kaiametrics "github.com/kaiachain/kaia/metrics"
 	"github.com/kaiachain/kaia/params"
@@ -215,6 +216,11 @@ type BlockChain struct {
 	quitWarmUp         chan struct{}
 
 	prefetchTxCh chan prefetchTx
+
+	// kaiax modules
+	executionModules  []kaiax.ExecutionModule
+	rewindableModules []kaiax.RewindableModule
+	// TODO-kaiax: Add individual modules such as gov, reward, etc.
 }
 
 // prefetchTx is used to prefetch transactions, when fetcher works.
@@ -596,6 +602,10 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 			// to low, so it's safe the update in-memory markers directly.
 			bc.currentBlock.Store(newHeadBlock)
 			headBlockNumberGauge.Update(int64(newHeadBlock.NumberU64()))
+
+			for _, module := range bc.rewindableModules {
+				module.RewindTo(newHeadBlock)
+			}
 		}
 
 		// Rewind the fast block in a simpleton way to the target head
@@ -637,6 +647,10 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 			bc.db.DeleteStakingInfo(num)
 		}
 		bc.db.DeleteSupplyCheckpoint(num)
+
+		for _, module := range bc.rewindableModules {
+			module.RewindDelete(hash, num)
+		}
 	}
 
 	// If SetHead was only called as a chain reparation method, try to skip
@@ -2138,6 +2152,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		cache, _, _ := bc.stateCache.TrieDB().Size()
 		stats.report(chain, i, cache)
 
+		for _, module := range bc.executionModules {
+			if err := module.PostInsertBlock(block); err != nil {
+				return i, events, coalescedLogs, err
+			}
+		}
+
 		// update governance CurrentSet if it is at an epoch block
 		if bc.engine.CreateSnapshot(bc, block.NumberU64(), block.Hash(), nil) != nil {
 			return i, events, coalescedLogs, err
@@ -2788,6 +2808,28 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
 
 	return receipt, internalTrace, err
+}
+
+func (bc *BlockChain) RegisterExecutionModule(modules ...kaiax.ExecutionModule) {
+	bc.executionModules = append(bc.executionModules, modules...)
+}
+
+func (bc *BlockChain) RegisterRewindableModule(modules ...kaiax.RewindableModule) {
+	bc.rewindableModules = append(bc.rewindableModules, modules...)
+}
+
+// Stop modules before performing a SetHead while node is running, i.e. via debug_setHead.
+func (bc *BlockChain) StopRewindableModules() {
+	for _, module := range bc.rewindableModules {
+		module.Stop()
+	}
+}
+
+// Start modules after performing a SetHead while node is running, i.e. via debug_setHead.
+func (bc *BlockChain) StartRewindableModules() {
+	for _, module := range bc.rewindableModules {
+		module.Start()
+	}
 }
 
 func GetInternalTxTrace(tracer vm.Tracer) (*vm.InternalTxTrace, error) {

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kaiachain/kaia/crypto/bls"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/governance"
+	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/reward"
 	"github.com/kaiachain/kaia/storage/database"
@@ -147,6 +148,9 @@ type backend struct {
 	nodetype common.ConnType
 
 	isRestoringSnapshots atomic.Bool
+
+	// kaiax modules
+	consensusModules []kaiax.ConsensusModule
 }
 
 func (sb *backend) NodeType() common.ConnType {
@@ -449,4 +453,8 @@ func (sb *backend) HasBadProposal(hash common.Hash) bool {
 		return false
 	}
 	return sb.hasBadBlock(hash)
+}
+
+func (sb *backend) RegisterConsensusModule(module ...kaiax.ConsensusModule) {
+	sb.consensusModules = append(sb.consensusModules, module...)
 }

--- a/kaiax/README.md
+++ b/kaiax/README.md
@@ -1,0 +1,8 @@
+# kaiax modules
+
+A kaiax module is a collection of modfications to the base blockchain that implement a related set of features. Such a module can be about staking, governance, or reward distribution.
+
+## Modules list
+
+- [noop](./noop): A template module that does nothing.
+

--- a/kaiax/interface.go
+++ b/kaiax/interface.go
@@ -1,0 +1,121 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package kaiax
+
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
+	"github.com/kaiachain/kaia/networks/rpc"
+)
+
+// On top of below Module interfaces, every module must have these:
+//
+// Constructor: Initialize data structures such as maps and channels.
+// Try not to perform any application-specific initializations here.
+//   func NewAbc() (*Abc, error)
+//
+// Module-specific Init method: Pass in fields - config, other modules, db, etc.
+//   type AbcOpts struct { ... }
+//   func (*Abc) Init(*AbcOpts) error
+
+// BaseModule must be implemented by every kaiax module
+type BaseModule interface {
+	Start() error
+	Stop()
+}
+
+// A module can optionally implement below interfaces.
+
+// JsonRpcModule adds JSON-RPC APIs.
+type JsonRpcModule interface {
+	// Exposes the module-specific APIs like governance_ namespace.
+	// Or expose a general-purpose APIs like kaia_ namespace, in which case
+	// the module is likely an API-only module.
+	APIs() []rpc.API
+}
+
+// ConsensusModule consensus deals with states before block confirmation.
+// Therefore these methods MUST NOT modify any persistent states.
+// e.g. VerifyHeader shall not actually record the governance change.
+type ConsensusModule interface {
+	// Additional checks to perform at the end of header verification.
+	VerifyHeader(*types.Header) error
+
+	// Additional changes to the new header that is being created.
+	PrepareHeader(*types.Header) (*types.Header, error)
+
+	// Additional state transitions after block txs have been executed.
+	FinalizeBlock(b *types.Block) (*types.Block, error)
+}
+
+// ExecutionModule deals with execution of confirmed blocks.
+// These methods MAY modify persistent states.
+// e.g. PostInsertBlock() may record the governance change.
+type ExecutionModule interface {
+	// Additional actions to perform after inserting a block.
+	PostInsertBlock(*types.Block) error
+}
+
+// TxProcessModule intervenes how transactions are executed.
+// Tx processing can happen on temporary states (e.g. eth_call),
+// or run on states before confirmation (e.g. miner),
+// therefore these methods MUST NOT modify any persistent states.
+type TxProcessModule interface {
+	// Additional actions to perform before EVM execution.
+	// Optionally transform the tx to a regular Eth tx.
+	// Optionally populate VM envs e.g. feepayer
+	PreRunTx(*vm.EVM, *types.Transaction) (*types.Transaction, error)
+
+	// Additional actions to perform after EVM execution.
+	PostRunTx(*vm.EVM, *types.Transaction) error
+}
+
+// UnwindableModule is a module that can erase its persistent data
+// associated to block numbers. If a module maintains block-number-dependent
+// data, the module should implement UnwindableModule.
+type RewindableModule interface {
+	// Actions to be taken when the header rewinds to given block number.
+	// e.g. Move the head pointer to `num`.
+	//
+	// Happens when "soft" rewind occurs such as --start-block-num or startup repair.
+	// and also when "hard" rewind occurs such as debug_setHead.
+	RewindToHeader(num uint64) error
+
+	// Actions to be taken when the block data should be deleted at given block number.
+	// This method should deal with exactly one block.
+	// e.g. Delete data associated with the block number `num`.
+	//
+	// Happens when "hard" rewind occurs such as debug_setHead.
+	RewindOneBlock(num uint64)
+}
+
+// TxPoolModule can intervene how the txpool handles transactions
+// from the inception (e.g. AddLocal) to termination (e.g. drop).
+type TxPoolModule interface {
+	// Additional actions to be taken when a new tx arrives at txpool
+	PreAddLocal(*types.Transaction) error
+	PreAddRemote(*types.Transaction) error
+}
+
+// A module can freely add more methods.
+// But try to follow the naming convention:
+//
+// Prefix 'Get' for read-only methods.
+//   GetXyz(..)
+//
+// Prefix 'Handle' for other non-getters not defined in the interface above.
+//   HandleXyz(...)

--- a/kaiax/noop/api.go
+++ b/kaiax/noop/api.go
@@ -14,11 +14,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
-package types
+package noop
 
-import "github.com/kaiachain/kaia/kaiax"
+import "github.com/kaiachain/kaia/networks/rpc"
 
-type NoopModule interface {
-	kaiax.BaseModule
-	kaiax.JsonRpcModule
+func (m *NoopModule) APIs() []rpc.API {
+	return []rpc.API{}
 }

--- a/kaiax/noop/api.go
+++ b/kaiax/noop/api.go
@@ -16,8 +16,33 @@
 
 package noop
 
-import "github.com/kaiachain/kaia/networks/rpc"
+import (
+	"context"
+
+	"github.com/kaiachain/kaia/networks/rpc"
+)
 
 func (m *NoopModule) APIs() []rpc.API {
-	return []rpc.API{}
+	return []rpc.API{
+		/*
+			{
+				Namespace: "noop",
+				Version:   "1.0",
+				Service:   NewNoopAPI(m),
+				Public:    true,
+			},
+		*/
+	}
+}
+
+type NoopAPI struct {
+	m *NoopModule
+}
+
+func NewNoopAPI(m *NoopModule) *NoopAPI {
+	return &NoopAPI{m: m}
+}
+
+func (api *NoopAPI) GetNoop(ctx context.Context) (string, error) {
+	return "noop", nil
 }

--- a/kaiax/noop/consensus.go
+++ b/kaiax/noop/consensus.go
@@ -14,12 +14,21 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
-package types
+package noop
 
-import "github.com/kaiachain/kaia/kaiax"
+import (
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+)
 
-type NoopModule interface {
-	kaiax.BaseModule
-	kaiax.JsonRpcModule
-	kaiax.ConsensusModule
+func (m *NoopModule) VerifyHeader(header *types.Header) error {
+	return nil
+}
+
+func (m *NoopModule) PrepareHeader(header *types.Header) error {
+	return nil
+}
+
+func (m *NoopModule) FinalizeHeader(header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) error {
+	return nil
 }

--- a/kaiax/noop/execution.go
+++ b/kaiax/noop/execution.go
@@ -14,15 +14,19 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
-package types
+package noop
 
-import "github.com/kaiachain/kaia/kaiax"
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+)
 
-type NoopModule interface {
-	kaiax.BaseModule
-	kaiax.JsonRpcModule
-	kaiax.ConsensusModule
-	kaiax.ExecutionModule
-	kaiax.RewindableModule
-	kaiax.TxProcessModule
+func (m *NoopModule) PostInsertBlock(block *types.Block) error {
+	return nil
+}
+
+func (m *NoopModule) RewindTo(block *types.Block) {
+}
+
+func (m *NoopModule) RewindDelete(hash common.Hash, num uint64) {
 }

--- a/kaiax/noop/init.go
+++ b/kaiax/noop/init.go
@@ -27,8 +27,7 @@ var (
 	logger = log.NewModuleLogger(log.KaiaxMeta)
 )
 
-type NoopModule struct {
-}
+type NoopModule struct{}
 
 func NewNoopModule() *NoopModule {
 	return &NoopModule{}

--- a/kaiax/noop/init.go
+++ b/kaiax/noop/init.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package noop
+
+import (
+	noop_types "github.com/kaiachain/kaia/kaiax/noop/types"
+	"github.com/kaiachain/kaia/log"
+)
+
+var (
+	_ (noop_types.NoopModule) = (*NoopModule)(nil)
+
+	logger = log.NewModuleLogger(log.KaiaxMeta)
+)
+
+type NoopModule struct {
+}
+
+func NewNoopModule() *NoopModule {
+	return &NoopModule{}
+}
+
+func (m *NoopModule) Init() error {
+	logger.Info("NoopModule Init")
+	return nil
+}
+
+func (m *NoopModule) Start() error {
+	logger.Info("NoopModule Start")
+	return nil
+}
+
+func (m *NoopModule) Stop() {
+	logger.Info("NoopModule Stop")
+}

--- a/kaiax/noop/txprocess.go
+++ b/kaiax/noop/txprocess.go
@@ -14,15 +14,17 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
-package types
+package noop
 
-import "github.com/kaiachain/kaia/kaiax"
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
+)
 
-type NoopModule interface {
-	kaiax.BaseModule
-	kaiax.JsonRpcModule
-	kaiax.ConsensusModule
-	kaiax.ExecutionModule
-	kaiax.RewindableModule
-	kaiax.TxProcessModule
+func (m *NoopModule) PreRunTx(evm *vm.EVM, tx *types.Transaction) (*types.Transaction, error) {
+	return tx, nil
+}
+
+func (m *NoopModule) PostRunTx(evm *vm.EVM, tx *types.Transaction) error {
+	return nil
 }

--- a/kaiax/noop/types/interface.go
+++ b/kaiax/noop/types/interface.go
@@ -1,0 +1,23 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import "github.com/kaiachain/kaia/kaiax"
+
+type NoopModule interface {
+	kaiax.BaseModule
+}

--- a/log/log_modules.go
+++ b/log/log_modules.go
@@ -128,6 +128,7 @@ const (
 	KAS
 	FORK
 	NodeCnGasPrice
+	KaiaxMeta
 
 	// ModuleNameLen should be placed at the end of the list.
 	ModuleNameLen
@@ -205,4 +206,5 @@ var moduleNames = [ModuleNameLen]string{
 	"kas",
 	"fork",
 	"node/cn/gasprice",
+	"kaiax",
 }

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/governance"
+	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/node/cn/gasprice"
 	"github.com/kaiachain/kaia/node/cn/tracers"
@@ -103,6 +104,10 @@ func (b *CNAPIBackend) SetHead(number uint64) error {
 	defer b.cn.protocolManager.SetSyncStop(false)
 	b.cn.supplyManager.Stop()
 	defer b.cn.supplyManager.Start()
+
+	b.cn.blockchain.(kaiax.RewindableModuleHost).StopRewindableModules()
+	defer b.cn.blockchain.(kaiax.RewindableModuleHost).StartRewindableModules()
+
 	return doSetHead(b.cn.blockchain, b.cn.engine, b.cn.governance, b.gpo, number)
 }
 

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -200,6 +200,8 @@ func TestCNAPIBackend_SetHead(t *testing.T) {
 
 	number := uint64(123)
 	mockBlockChain.EXPECT().SetHead(number).Times(1)
+	mockBlockChain.EXPECT().StopRewindableModules().Times(1)
+	mockBlockChain.EXPECT().StartRewindableModules().Times(1)
 
 	api.SetHead(number)
 	block := newBlock(int(number))

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -141,6 +141,7 @@ type CN struct {
 	governance    governance.Engine
 	supplyManager reward.SupplyManager
 
+	// kaiax modules
 	baseModules    []kaiax.BaseModule
 	jsonRpcModules []kaiax.JsonRpcModule
 }
@@ -519,6 +520,8 @@ func (s *CN) SetupKaiaxModules() error {
 	s.RegisterBaseModules(mNoop)
 	// s.RegisterJsonRpcModules()
 	s.engine.(kaiax.ConsensusModuleHost).RegisterConsensusModule(mNoop)
+	s.blockchain.(kaiax.ExecutionModuleHost).RegisterExecutionModule(mNoop)
+	s.blockchain.(kaiax.RewindableModuleHost).RegisterRewindableModule(mNoop)
 
 	return nil
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -512,9 +512,7 @@ func (s *CN) SetComponents(component []interface{}) {
 
 func (s *CN) SetupKaiaxModules() error {
 	// Declare modules
-	var (
-		mNoop = noop.NewNoopModule()
-	)
+	mNoop := noop.NewNoopModule()
 
 	// Register modules to respective components
 	s.RegisterBaseModules(mNoop)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -517,8 +517,8 @@ func (s *CN) SetupKaiaxModules() error {
 
 	// Register modules to respective components
 	s.RegisterBaseModules(mNoop)
-
 	// s.RegisterJsonRpcModules()
+	s.engine.(kaiax.ConsensusModuleHost).RegisterConsensusModule(mNoop)
 
 	return nil
 }

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -17,6 +17,7 @@ import (
 	common "github.com/kaiachain/kaia/common"
 	consensus "github.com/kaiachain/kaia/consensus"
 	event "github.com/kaiachain/kaia/event"
+	kaiax "github.com/kaiachain/kaia/kaiax"
 	params "github.com/kaiachain/kaia/params"
 	rlp "github.com/kaiachain/kaia/rlp"
 	snapshot "github.com/kaiachain/kaia/snapshot"
@@ -705,6 +706,22 @@ func (mr *MockBlockChainMockRecorder) PrunableStateAt(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrunableStateAt", reflect.TypeOf((*MockBlockChain)(nil).PrunableStateAt), arg0, arg1)
 }
 
+// RegisterRewindableModule mocks base method.
+func (m *MockBlockChain) RegisterRewindableModule(arg0 ...kaiax.RewindableModule) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "RegisterRewindableModule", varargs...)
+}
+
+// RegisterRewindableModule indicates an expected call of RegisterRewindableModule.
+func (mr *MockBlockChainMockRecorder) RegisterRewindableModule(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterRewindableModule", reflect.TypeOf((*MockBlockChain)(nil).RegisterRewindableModule), arg0...)
+}
+
 // ResetWithGenesisBlock mocks base method.
 func (m *MockBlockChain) ResetWithGenesisBlock(arg0 *types.Block) error {
 	m.ctrl.T.Helper()
@@ -799,6 +816,18 @@ func (m *MockBlockChain) StartContractWarmUp(arg0 common.Address, arg1 uint) err
 func (mr *MockBlockChainMockRecorder) StartContractWarmUp(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartContractWarmUp", reflect.TypeOf((*MockBlockChain)(nil).StartContractWarmUp), arg0, arg1)
+}
+
+// StartRewindableModules mocks base method.
+func (m *MockBlockChain) StartRewindableModules() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StartRewindableModules")
+}
+
+// StartRewindableModules indicates an expected call of StartRewindableModules.
+func (mr *MockBlockChainMockRecorder) StartRewindableModules() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRewindableModules", reflect.TypeOf((*MockBlockChain)(nil).StartRewindableModules))
 }
 
 // StartStateMigration mocks base method.
@@ -933,6 +962,18 @@ func (m *MockBlockChain) Stop() {
 func (mr *MockBlockChainMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockChain)(nil).Stop))
+}
+
+// StopRewindableModules mocks base method.
+func (m *MockBlockChain) StopRewindableModules() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StopRewindableModules")
+}
+
+// StopRewindableModules indicates an expected call of StopRewindableModules.
+func (mr *MockBlockChainMockRecorder) StopRewindableModules() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopRewindableModules", reflect.TypeOf((*MockBlockChain)(nil).StopRewindableModules))
 }
 
 // StopStateMigration mocks base method.

--- a/work/work.go
+++ b/work/work.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/event"
+	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -264,6 +265,7 @@ type BlockChain interface {
 	SubscribeChainEvent(ch chan<- blockchain.ChainEvent) event.Subscription
 	SetHead(head uint64) error
 	Stop()
+	kaiax.RewindableModuleHost
 
 	SubscribeRemovedLogsEvent(ch chan<- blockchain.RemovedLogsEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- blockchain.ChainHeadEvent) event.Subscription


### PR DESCRIPTION
## Proposed changes

- Define "kaiax modules" similar to "x/modules" of Cosmos SDK. See kaiax/interface.go for the design.
- Add NoopModule as a template.
- A JsonRpcModule can be injected into the `CN` to expose its APIs
- A ConsensusModule can be injected into a `ConsensusModuleHost`; currently the only host is the Istanbul backend.
- An ExecutionModule can be injected into an `ExecutionModuleHost`; where the only host is BlockChain.
- A RewindableModule can be injected into an `RewindableModuleHost`; where the only host is BlockChain.
- TxProcessModule and TxPoolModule are left as future work.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
