### PR TITLE
api: getTotalSupply can fall back to Upstream EN

### DIFF
--- a/api/api_public_klay.go
+++ b/api/api_public_klay.go
@@ -117,7 +117,9 @@ type TotalSupplyResult struct {
 	Kip160Burn  *hexutil.Big `json:"kip160Burn"`      // by KIP160 fork. Read from its memo.
 }
 
-func (s *PublicKaiaAPI) GetTotalSupply(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*TotalSupplyResult, error) {
+// If showPartial == nil or *showPartial == false, the regular use case, this API either delivers the full result or fails.
+// If showPartial == true, the advanced and debugging use case, this API delivers full or best effort partial result.
+func (s *PublicKaiaAPI) GetTotalSupply(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, showPartial *bool) (*TotalSupplyResult, error) {
 	block, err := s.b.BlockByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {
 		return nil, err
@@ -143,11 +145,13 @@ func (s *PublicKaiaAPI) GetTotalSupply(ctx context.Context, blockNrOrHash rpc.Bl
 		Kip103Burn:  (*hexutil.Big)(ts.Kip103Burn),
 		Kip160Burn:  (*hexutil.Big)(ts.Kip160Burn),
 	}
-	if err != nil {
+	if showPartial != nil && *showPartial && err != nil {
 		errStr := err.Error()
 		res.Error = &errStr
+		return res, nil
+	} else {
+		return res, err
 	}
-	return res, nil
 }
 
 // Syncing returns false in case the node is currently not syncing with the network. It can be up to date or has not

--- a/networks/rpc/handler.go
+++ b/networks/rpc/handler.go
@@ -25,6 +25,7 @@ package rpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -448,12 +449,10 @@ func (h *handler) runMethod(ctx context.Context, msg *jsonrpcMessage, callb *cal
 
 // shouldRequestUpstream is a function that determines whether must be requested upstream.
 func shouldRequestUpstream(err error) bool {
-	switch err.(type) {
-	case *statedb.MissingNodeError:
-		return true
-	default:
-		return false
-	}
+	// Checks if the error contains MissingNodeError in the wrapped error chain.
+	// MissingNodeError is a strong evidence that the node has no state and worth dialing the upstream.
+	var missingNodeError *statedb.MissingNodeError
+	return errors.As(err, &missingNodeError)
 }
 
 // requestUpstream is the function to request upstream archive en

--- a/reward/supply_manager.go
+++ b/reward/supply_manager.go
@@ -50,11 +50,11 @@ var (
 )
 
 func errNoCanonicalBurn(err error) error {
-	return fmt.Errorf("cannot determine canonical (0x0, 0xdead) burn amount: %v", err)
+	return fmt.Errorf("cannot determine canonical (0x0, 0xdead) burn amount: %w", err)
 }
 
 func errNoRebalanceBurn(err error) error {
-	return fmt.Errorf("cannot determine rebalance (kip103, kip160) burn amount: %v", err)
+	return fmt.Errorf("cannot determine rebalance (kip103, kip160) burn amount: %w", err)
 }
 
 // SupplyManager tracks the total supply of native tokens.


### PR DESCRIPTION
## Proposed changes

1. In the `kaia_getTotalSupply` API, add an optional `showPartial *bool` parameter that controls the error behavior.

- As-is: API returns...
  - (a) Return a full information or
  - (b) Return a partial information
- To-be: API returns..
  - **Regular use case**: If `showPartial == nil || *showPartial == false` (default)
    - (a) Return a full information or
    - (c) API Fails. If `--upstream-en` is configured and the error contains "missing trie node", retry with upstream.
  - **Advanced/Debugging use case**: If `*showPartial == true`
    - (a) Return a full information or
    - (b) Return a partial information

2. More generous `--upstream-en` criteria

- Updated `shouldRequestUpstream()` to recognize a wrapped error that contains "missing trie node" error.

#### Rationale

Regular users of this API are interested in the full information including the `totalSupply` field. For those uses, responses (b) and (c) are both unsatisfactory. But compared to (b), (c) is better because it can at least retry via `--upstream-en`.

#### Response example

- (a) Return a full information
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "number": "0x99c4ef3",
    "totalSupply": "0x446c3b15f9926687d2d40c284b29cb9e52ac96b5fe",
    "totalMinted": "0x446c3b15f9926687d2c87ebd0341151d6357f80000",
    "totalBurnt": "-0xb8d6b47e8b680ef549eb5fe",
    "burntFee": "0x9e7d0a18207b048528c5",
    "zeroBurn": "0x65c7159b3ef9a5c78e9",
    "deadBurn": "0x36345feb5921447741",
    "kip103Burn": "0x6a15eef7e3a354cf657913",
    "kip160Burn": "-0xbf82646906be407e42a4800"
  }
}
```
- (b) Return a partial information with the `result.error` field containing "missing trie node" error message.
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "number": "0x99c4ef3",
    "error": "cannot determine canonical (0x0, 0xdead) burn amount: missing trie node fa4aa0947dd9fbe527914ecafec8034766cf1a9873f90c2852f5f478900bcfed (path )",
    "totalSupply": null,
    "totalMinted": "0x446c3b15f9926687d2c87ebd0341151d6357f80000",
    "totalBurnt": null,
    "burntFee": "0x9e7d0a18207b048528c5",
    "zeroBurn": null,
    "deadBurn": null,
    "kip103Burn": "0x6a15eef7e3a354cf657913",
    "kip160Burn": "-0xbf82646906be407e42a4800"
  }
}
```

- (c) API Fails
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32000,
    "message": "cannot determine canonical (0x0, 0xdead) burn amount: missing trie node fa4aa0947dd9fbe527914ecafec8034766cf1a9873f90c2852f5f478900bcfed (path )"
  }
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
