### PR TITLE
reward: SupplyManager reaccumulates from nearest persisted AccReward

### DIFF
--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -363,6 +363,8 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		// NewStakingManager is called with proper non-nil parameters
 		reward.NewStakingManager(cn.blockchain, governance, cn.chainDB)
 	}
+	// Note: archive nodes might have TrieBlockInterval == 128, then SupplyManager will store checkpoints every 128 blocks.
+	// Still it is not a problem since SupplyManager can re-accumulate from the nearest checkpoint.
 	cn.supplyManager = reward.NewSupplyManager(cn.blockchain, cn.governance, cn.chainDB, config.TrieBlockInterval)
 
 	// Governance states which are not yet applied to the db remains at in-memory storage

--- a/reward/supply_manager.go
+++ b/reward/supply_manager.go
@@ -40,6 +40,7 @@ import (
 var (
 	supplyCacheSize   = 86400          // A day; Some total supply consumers might want daily supply.
 	supplyLogInterval = uint64(102400) // Periodic total supply log.
+	supplyReaccLimit  = uint64(1024)   // Re-accumulate from the last accumulated block.
 	zeroBurnAddress   = common.HexToAddress("0x0")
 	deadBurnAddress   = common.HexToAddress("0xdead")
 
@@ -143,9 +144,9 @@ func (sm *supplyManager) GetAccReward(num uint64) (*database.AccReward, error) {
 		return nil, errNoAccReward
 	}
 
-	accReward := sm.db.ReadAccReward(num)
-	if accReward == nil {
-		return nil, errNoAccReward
+	accReward, err := sm.getAccRewardUncached(num)
+	if err != nil {
+		return nil, err
 	}
 
 	sm.accRewardCache.Add(num, accReward.Copy())
@@ -318,7 +319,7 @@ func (sm *supplyManager) catchup() {
 	for lastNum < headNum {
 		logger.Info("Total supply big step catchup", "last", lastNum, "head", headNum, "minted", lastAccReward.Minted.String(), "burntFee", lastAccReward.BurntFee.String())
 
-		accReward, err := sm.accumulateReward(lastNum, headNum, lastAccReward)
+		accReward, err := sm.accumulateReward(lastNum, headNum, lastAccReward, true)
 		if err != nil {
 			if err != errSupplyManagerQuit {
 				logger.Error("Total supply accumulate failed", "from", lastNum, "to", headNum, "err", err)
@@ -341,7 +342,7 @@ func (sm *supplyManager) catchup() {
 		case head := <-sm.chainHeadChan:
 			headNum = head.Block.NumberU64()
 
-			supply, err := sm.accumulateReward(lastNum, headNum, lastAccReward)
+			supply, err := sm.accumulateReward(lastNum, headNum, lastAccReward, true)
 			if err != nil {
 				if err != errSupplyManagerQuit {
 					logger.Error("Total supply accumulate failed", "from", lastNum, "to", headNum, "err", err)
@@ -379,9 +380,35 @@ func (sm *supplyManager) totalSupplyFromState(num uint64) (*big.Int, error) {
 	return totalSupply, nil
 }
 
+func (sm *supplyManager) getAccRewardUncached(num uint64) (*database.AccReward, error) {
+	accReward := sm.db.ReadAccReward(num)
+	if accReward != nil {
+		return accReward, nil
+	}
+
+	// Trace back to the last stored accumulated reward.
+	var fromNum uint64
+	var fromAcc *database.AccReward
+	for i := uint64(1); i < supplyReaccLimit; i++ {
+		accReward = sm.db.ReadAccReward(num - i)
+		if accReward != nil {
+			fromNum = num - i
+			fromAcc = accReward
+			break
+		}
+	}
+	if fromAcc == nil {
+		return nil, errNoAccReward
+	}
+
+	logger.Trace("on-demand reaccumulating rewards", "from", fromNum, "to", num)
+	return sm.accumulateReward(fromNum, num, fromAcc, false)
+}
+
 // accumulateReward calculates the total supply from the last block to the current block.
 // Given supply at `from` is `fromSupply`, calculate the supply until `to`, inclusive.
-func (sm *supplyManager) accumulateReward(from, to uint64, fromAcc *database.AccReward) (*database.AccReward, error) {
+// If `write` is true, the result will be written to the database.
+func (sm *supplyManager) accumulateReward(from, to uint64, fromAcc *database.AccReward, write bool) (*database.AccReward, error) {
 	accReward := fromAcc.Copy() // make a copy because we're updating it in-place.
 
 	for num := from + 1; num <= to; num++ {
@@ -410,7 +437,7 @@ func (sm *supplyManager) accumulateReward(from, to uint64, fromAcc *database.Acc
 
 		// Store to database, print progress log.
 		sm.accRewardCache.Add(num, accReward.Copy())
-		if (num % sm.checkpointInterval) == 0 {
+		if write && (num%sm.checkpointInterval) == 0 {
 			sm.db.WriteAccReward(num, accReward)
 			sm.db.WriteLastAccRewardBlockNumber(num)
 		}


### PR DESCRIPTION
## Proposed changes

- Address the issue where an archive node not serving `kaia_getTotalSupply` for non-128-multiple blocks.
- Cause
  - SupplyManager writes `AccReward` every BlockInterval. The intention was to make full nodes write every `BlockInterval` whereas archive nodes write every `1` block.
  - In reality, archive nodes may set `BlockInterval == 128 (default)` because it didn't matter so far. The [writeStateTrie loop](https://github.com/kaiachain/kaia/blob/v1.0.1/blockchain/blockchain.go#L1363) ignores BlockInterval when gcmode is archive.
  - Therefore, SupplyManager didn't store `AccReward` every `1` block. Rather it stored every 128 blocks in archive nodes with default settings.
- Fix
  - Have SupplyManager calculate `AccReward` for any given block, by re-accumulating from the nearest persisted `AccReward`.
  - Note that the re-accumulation only requires blocks and receipts which should be available in an archive node.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

- Prepare a Kairos archive node
```js
> admin.nodeConfig.TrieBlockInterval
128
> num = 157740851
> num % 128
51
```
- Before PR (1afbbfb3)
```js
> eth.getBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", num)
49924765500000000000
> kaia.getTotalSupply(num)
Error: accumulated reward not stored
	at web3.js:6812:9(39)
	at send (web3.js:5223:62(29))
	at <eval>:1:20(3)
```
- After PR (ee14c8b)
```js
> eth.getBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", num)
49924765500000000000
> kaia.getTotalSupply(num)
{
  burntFee: "0x899be299255df6283350",
  deadBurn: "0x35a29f8b3e27ba28cd",
  kip103Burn: "0x6a15eef7e3a354cf657913",
  kip160Burn: "-0xbf82646906be407e42a4800",
  number: "0x966ef33",
  totalBurnt: "-0xb8d8029a1f5dc275c85f9f6",
  totalMinted: "0x446c3b15f9926687d2c87232559657244007b80000",
  totalSupply: "0x446c3b15f9926687d2d3ffb27f384d0067643df9f6",
  zeroBurn: "0x65c7159b3ef9a5c78da"
}
```