### PR TITLE
console: kaia.getTotalSupply accepts second optional param

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -1161,8 +1161,8 @@ var klayMethods = [
 	new web3._extend.Method({
 		name: 'getTotalSupply',
 		call: 'klay_getTotalSupply',
-		params: 1,
-		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		params: 2,
+		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, function (val) { return !!val; }]
 	}),
 	new web3._extend.Method({
 		name: 'getProof',


### PR DESCRIPTION
## Proposed changes

- JS console supports the parameter introduced by #58.
```
// all of them supported
kaia.getTotalSupply(0x19c4e00)
kaia.getTotalSupply(0x19c4e00, false)
kaia.getTotalSupply(0x19c4e00, true)
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
