### PR TITLE
reward: SupplyManager correctly handles block rewinds

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -611,6 +611,11 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 			// to low, so it's safe the update in-memory markers directly.
 			bc.currentFastBlock.Store(newHeadFastBlock)
 		}
+
+		// Rewind the supply checkpoint
+		newLastSupplyCheckpointNumber := header.Number.Uint64() - (header.Number.Uint64() % params.SupplyCheckpointInterval)
+		bc.db.WriteLastSupplyCheckpointNumber(newLastSupplyCheckpointNumber)
+
 		return bc.CurrentBlock().Number().Uint64(), nil
 	}
 
@@ -629,6 +634,7 @@ func (bc *BlockChain) setHeadBeyondRoot(head uint64, root common.Hash, repair bo
 		if bc.Config().Istanbul.ProposerPolicy == params.WeightedRandom && !bc.Config().IsKaiaForkEnabled(new(big.Int).SetUint64(num)) && params.IsStakingUpdateInterval(num) {
 			bc.db.DeleteStakingInfo(num)
 		}
+		bc.db.DeleteSupplyCheckpoint(num)
 	}
 
 	// If SetHead was only called as a chain reparation method, try to skip

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -100,6 +100,8 @@ func (b *CNAPIBackend) SetHead(number uint64) error {
 	b.cn.protocolManager.Downloader().Cancel()
 	b.cn.protocolManager.SetSyncStop(true)
 	defer b.cn.protocolManager.SetSyncStop(false)
+	b.cn.supplyManager.Stop()
+	defer b.cn.supplyManager.Start()
 	return doSetHead(b.cn.blockchain, b.cn.engine, b.cn.governance, b.gpo, number)
 }
 

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -173,6 +173,18 @@ func testGov() *governance.MixedEngine {
 	return governance.NewMixedEngine(config, db)
 }
 
+type testSupplyManager struct{}
+
+func (sm *testSupplyManager) Start() {
+}
+
+func (sm *testSupplyManager) Stop() {
+}
+
+func (sm *testSupplyManager) GetTotalSupply(num uint64) (*reward.TotalSupply, error) {
+	return &reward.TotalSupply{}, nil
+}
+
 func TestCNAPIBackend_SetHead(t *testing.T) {
 	mockCtrl, mockBlockChain, _, api := newCNAPIBackend(t)
 	defer mockCtrl.Finish()
@@ -183,6 +195,7 @@ func TestCNAPIBackend_SetHead(t *testing.T) {
 	api.cn.protocolManager = pm
 	api.cn.engine = gxhash.NewFullFaker()
 	api.cn.governance = testGov()
+	api.cn.supplyManager = &testSupplyManager{}
 	api.gpo = gasprice.NewOracle(api, gasprice.Config{}, nil, api.cn.governance)
 
 	number := uint64(123)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -363,9 +363,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		// NewStakingManager is called with proper non-nil parameters
 		reward.NewStakingManager(cn.blockchain, governance, cn.chainDB)
 	}
-	// Note: archive nodes might have TrieBlockInterval == 128, then SupplyManager will store checkpoints every 128 blocks.
-	// Still it is not a problem since SupplyManager can re-accumulate from the nearest checkpoint.
-	cn.supplyManager = reward.NewSupplyManager(cn.blockchain, cn.governance, cn.chainDB, config.TrieBlockInterval)
+	cn.supplyManager = reward.NewSupplyManager(cn.blockchain, cn.governance, cn.chainDB)
 
 	// Governance states which are not yet applied to the db remains at in-memory storage
 	// It disappears during the node restart, so restoration is needed before the sync starts

--- a/params/governance_params.go
+++ b/params/governance_params.go
@@ -38,7 +38,8 @@ const (
 	// The prefix for governance cache
 	GovernanceCachePrefix = "governance"
 
-	CheckpointInterval = 1024
+	CheckpointInterval       = 1024 // For Istanbul snapshot
+	SupplyCheckpointInterval = 128  // for SupplyManager tracking native token supply
 )
 
 const (

--- a/reward/supply_manager.go
+++ b/reward/supply_manager.go
@@ -342,16 +342,18 @@ func (sm *supplyManager) catchup() {
 		case head := <-sm.chainHeadChan:
 			headNum = head.Block.NumberU64()
 
-			supply, err := sm.accumulateReward(lastNum, headNum, lastCheckpoint, true)
-			if err != nil {
-				if err != errSupplyManagerQuit {
-					logger.Error("Total supply accumulate failed", "from", lastNum, "to", headNum, "err", err)
+			if lastNum < headNum {
+				supply, err := sm.accumulateReward(lastNum, headNum, lastCheckpoint, true)
+				if err != nil {
+					if err != errSupplyManagerQuit {
+						logger.Error("Total supply accumulate failed", "from", lastNum, "to", headNum, "err", err)
+					}
+					return
 				}
-				return
-			}
 
-			lastNum = headNum
-			lastCheckpoint = supply
+				lastNum = headNum
+				lastCheckpoint = supply
+			}
 		}
 	}
 }

--- a/reward/supply_manager_test.go
+++ b/reward/supply_manager_test.go
@@ -240,9 +240,14 @@ func (s *SupplyTestSuite) TestCatchupRewind() {
 	s.insertBlocks()                   // block is inserted after the catchup started
 	s.waitCatchup()                    // catchup to block 400
 
-	// Rewind to 200, and re-insert blocks.
-	// The catchup thread should correctly handle ChainHeadEvents less than 400.
+	// Rewind to 200; relevant data must have been deleted.
 	s.chain.SetHead(200)
+	assert.Equal(t, uint64(128), s.db.ReadLastSupplyCheckpointNumber())
+	assert.NotNil(t, s.db.ReadSupplyCheckpoint(128))
+	assert.Nil(t, s.db.ReadSupplyCheckpoint(256))
+
+	// Re-insert blocks.
+	// The catchup thread should correctly handle ChainHeadEvents less than 400.
 	s.insertBlocks()
 
 	testcases := s.testcases()

--- a/reward/supply_manager_test.go
+++ b/reward/supply_manager_test.go
@@ -93,6 +93,7 @@ type SupplyTestSuite struct {
 	db      database.DBManager
 	genesis *types.Block
 	chain   *blockchain.BlockChain
+	blocks  []*types.Block
 	sm      *supplyManager
 }
 
@@ -103,11 +104,11 @@ func TestSupplyManager(t *testing.T) {
 // ----------------------------------------------------------------------------
 // Test cases
 
-// Tests totalSupplyFromState as well as the setupHistory() itself.
-// This accounts for (AccMinted - AccBurntFee - kip103Burn - kip160Burn) but not (- zeroBurn - deadBurn).
+// Tests totalSupplyFromState as well as the insertBlocks() itself.
+// totalSupplyFromState accounts for (AccMinted - AccBurntFee - kip103Burn - kip160Burn) but not (- zeroBurn - deadBurn).
 func (s *SupplyTestSuite) TestFromState() {
 	t := s.T()
-	s.setupHistory()
+	s.insertBlocks()
 	s.sm.Start() // start catchup
 
 	testcases := s.testcases()
@@ -126,7 +127,7 @@ func (s *SupplyTestSuite) TestFromState() {
 // Test reading canonical burn amounts from the state.
 func (s *SupplyTestSuite) TestCanonicalBurn() {
 	t := s.T()
-	s.setupHistory()
+	s.insertBlocks()
 
 	// Delete state at 199
 	root := s.db.ReadBlockByNumber(199).Root()
@@ -148,7 +149,7 @@ func (s *SupplyTestSuite) TestCanonicalBurn() {
 // Test reading rebalance memo from the contract.
 func (s *SupplyTestSuite) TestRebalanceMemo() {
 	t := s.T()
-	s.setupHistory()
+	s.insertBlocks()
 
 	// rebalance not configured
 	amount, err := s.sm.GetRebalanceBurn(199, nil, common.Address{})
@@ -177,7 +178,7 @@ func (s *SupplyTestSuite) TestRebalanceMemo() {
 
 // Tests sm.Stop() does not block.
 func (s *SupplyTestSuite) TestStop() {
-	s.setupHistory() // head block is already 400
+	s.insertBlocks() // head block is already 400
 	s.sm.Start()     // start catchup, enters big-step mode
 
 	endCh := make(chan struct{})
@@ -198,7 +199,7 @@ func (s *SupplyTestSuite) TestStop() {
 // Tests the insertBlock -> go catchup, where the catchup enters the big-step mode.
 func (s *SupplyTestSuite) TestCatchupBigStep() {
 	t := s.T()
-	s.setupHistory() // head block is already 400
+	s.insertBlocks() // head block is already 400
 	s.sm.Start()     // start catchup
 	defer s.sm.Stop()
 	s.waitCatchup() // Wait for catchup to finish
@@ -217,8 +218,8 @@ func (s *SupplyTestSuite) TestCatchupEventSubscription() {
 	t := s.T()
 	s.sm.Start() // start catchup
 	defer s.sm.Stop()
-	time.Sleep(10 * time.Millisecond) // yield to the catchup goroutine to start
-	s.setupHistory()                  // block is inserted after the catchup started
+	time.Sleep(100 * time.Millisecond) // yield to the catchup goroutine to start
+	s.insertBlocks()                   // block is inserted after the catchup started
 	s.waitCatchup()
 
 	testcases := s.testcases()
@@ -233,7 +234,7 @@ func (s *SupplyTestSuite) TestCatchupEventSubscription() {
 // Tests all supply components.
 func (s *SupplyTestSuite) TestTotalSupply() {
 	t := s.T()
-	s.setupHistory()
+	s.insertBlocks()
 	s.sm.Start()
 	defer s.sm.Stop()
 	s.waitCatchup()
@@ -259,7 +260,7 @@ func (s *SupplyTestSuite) TestTotalSupply() {
 // Test that when some data are missing, GetTotalSupply leaves some fields nil and returns an error.
 func (s *SupplyTestSuite) TestTotalSupplyPartialInfo() {
 	t := s.T()
-	s.setupHistory()
+	s.insertBlocks()
 	s.sm.Start()
 	s.waitCatchup()
 	s.sm.Stop()
@@ -314,7 +315,7 @@ func (s *SupplyTestSuite) TestTotalSupplyPartialInfo() {
 // Test that when SupplyCheckpoint are missing, GetTotalSupply will re-accumulate from the nearest stored SupplyCheckpoint.
 func (s *SupplyTestSuite) TestTotalSupplyReaccumulate() {
 	t := s.T()
-	s.setupHistory()
+	s.insertBlocks()
 	s.sm.Start()
 	defer s.sm.Stop()
 	s.waitCatchup()
@@ -350,14 +351,12 @@ func (s *SupplyTestSuite) TestTotalSupplyReaccumulate() {
 
 func (s *SupplyTestSuite) waitCatchup() {
 	for i := 0; i < 1000; i++ { // wait 10 seconds until catchup complete
-		if s.db.ReadLastSupplyCheckpointNumber() >= 400 {
-			break
+		if s.sm.checkpointCache.Contains(uint64(400)) {
+			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if s.db.ReadLastSupplyCheckpointNumber() < 400 {
-		s.T().Fatal("Catchup not finished in time")
-	}
+	s.T().Fatal("Catchup not finished in time")
 }
 
 // ----------------------------------------------------------------------------
@@ -485,12 +484,6 @@ func (s *SupplyTestSuite) SetupTest() {
 	require.NoError(t, err)
 	s.chain = chain
 
-	s.sm = NewSupplyManager(s.chain, s.gov, s.db, 1) // 1 interval for testing
-}
-
-func (s *SupplyTestSuite) setupHistory() {
-	t := s.T()
-
 	var ( // Generate blocks with 1 tx per block. Send 1 kei from Genesis4 to Genesis3.
 		signer   = types.LatestSignerForChainID(s.config.ChainID)
 		key      = keyGenesis4
@@ -516,13 +509,22 @@ func (s *SupplyTestSuite) setupHistory() {
 			}
 		}
 	)
-	blocks, _ := blockchain.GenerateChain(s.config, s.genesis, s.engine, s.db, 400, genFunc)
-	require.NotEmpty(t, blocks)
+	s.blocks, _ = blockchain.GenerateChain(s.config, s.genesis, s.engine, s.db, 400, genFunc)
+	require.NotEmpty(t, s.blocks)
 
-	// Insert s.chain
-	_, err := s.chain.InsertChain(blocks)
-	require.NoError(t, err)
-	expected := blocks[len(blocks)-1]
+	s.sm = NewSupplyManager(s.chain, s.gov, s.db, 1) // 1 interval for testing
+}
+
+func (s *SupplyTestSuite) insertBlocks() {
+	t := s.T()
+
+	// Insert blocks to chain. Note that duplicating blocks will automatically be ignored.
+	// ChainHeadEvent will be published after each block insertion.
+	for _, block := range s.blocks {
+		_, err := s.chain.InsertChain([]*types.Block{block})
+		require.NoError(t, err)
+	}
+	expected := s.blocks[len(s.blocks)-1]
 	actual := s.chain.CurrentBlock()
 	assert.Equal(t, expected.Hash(), actual.Hash())
 }

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -132,8 +132,8 @@ var (
 
 	stakingInfoPrefix = []byte("stakingInfo")
 
-	supplyCheckpointPrefix        = []byte("accReward")
-	lastSupplyCheckpointNumberKey = []byte("lastAccRewardBlockNumber")
+	supplyCheckpointPrefix        = []byte("supplyCheckpoint")
+	lastSupplyCheckpointNumberKey = []byte("lastSupplyCheckpointNumber")
 
 	chaindatafetcherCheckpointKey = []byte("chaindatafetcherCheckpoint")
 )


### PR DESCRIPTION
## Proposed changes

- The GetTotalSupply API had a bug that over-accumulates TotalMinted and TotalBurnt after a manual block rewinding via `debug_setHead`. See https://app.circleci.com/pipelines/github/kaiachain/kaia/355/workflows/a330fe31-08f5-4771-bd3a-3459d4849a70/jobs/1776 and `reward/supply_manager_test.go:TestCatchupRewind` for the test reproducing it.

1. SupplyManager catchup thread is guarded against out-of-order ChainHeadEvent that might be emitted after block rewind (i.e. debug_setHead)
2. Block rewind (i.e. BlockChain.setHeadBeyondRoot) involves deletion of SupplyCheckpoints, and restarting the catchup thread.
3. Invalidate existing supply checkpoints (dubbed "accRewards"), triggers every node upgrading to v1.0.2 re-accumulate from the genesis. Because of the bug, nodes v1.0.1 or earlier which undergone setHead at least once might have corrupt accRewards data.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
