### PR TITLE
api: Fix recoverFromTransaction with Legacy type

### DIFF
--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -592,7 +592,7 @@ func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, e
 	if err != nil {
 		return common.Address{}, err
 	}
-	return tx.From()
+	return types.Sender(signer, tx)
 }
 
 // RecoverFromMessage validates that the message is signed by one of the keys in the given account.


### PR DESCRIPTION
## Proposed changes

- `kaia_recoverFromTransaction` now works with Ethereum tx types (types 0,1,2).

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #70

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
