### PR TITLE
console: Sanitization in inputBlockNumberFormatter

### DIFF
--- a/console/jsre/deps/web3.js
+++ b/console/jsre/deps/web3.js
@@ -3848,7 +3848,7 @@ var inputBlockNumberFormatter = function (blockNumber) {
         return undefined;
     } else if (isPredefinedBlockNumber(blockNumber)) {
         return blockNumber;
-    } else if (/^-?\d+$/.test(blockNumber)) {
+    } else if (/^\d+$/.test(blockNumber) || /^0x[0-9a-fA-F]+$/.test(blockNumber)) { // test if input is decmial or hex
       return utils.toHex(blockNumber);
     }
     throw new Error(`input block number(${blockNumber}) is invalid`);

--- a/console/jsre/deps/web3.js
+++ b/console/jsre/deps/web3.js
@@ -3848,8 +3848,10 @@ var inputBlockNumberFormatter = function (blockNumber) {
         return undefined;
     } else if (isPredefinedBlockNumber(blockNumber)) {
         return blockNumber;
+    } else if (/^-?\d+$/.test(blockNumber)) {
+      return utils.toHex(blockNumber);
     }
-    return utils.toHex(blockNumber);
+    throw new Error(`input block number(${blockNumber}) is invalid`);
 };
 
 var inputEmptyFormatter = function (a) {


### PR DESCRIPTION
## Proposed changes

As-is
```
> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "latest2")
Error: the header does not exist (block number: 30506450030916658)
        at web3.js:6812:9(39)
        at send (web3.js:5223:62(29))
        at <eval>:1:13(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "www")
"0x"
> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "wwwwqnfqwfnkn")
Error: invalid argument 1: hex number > 64 bits
        at web3.js:6812:9(39)
        at send (web3.js:5223:62(29))
        at <eval>:1:13(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "wwwwqnfqwfn^C
> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "wwwwqnfqwfnkn")
Error: invalid argument 1: hex number > 64 bits
        at web3.js:6812:9(39)
        at send (web3.js:5223:62(29))
        at <eval>:1:13(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "www")
"0x"
> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "askndkzx?")
Error: invalid argument 1: hex number > 64 bits
        at web3.js:6812:9(39)
        at send (web3.js:5223:62(29))
        at <eval>:1:13(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "latest2")
Error: the header does not exist (block number: 30506450030916658)
        at web3.js:6812:9(39)
        at send (web3.js:5223:62(29))
        at <eval>:1:13(4)
```

To-be
```
>  klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "latest2")
Error: input block number(latest2) is invalid
        at inputBlockNumberFormatter (web3.js:3854:11(32))
        at inputDefaultBlockNumberFormatter (web3.js:3843:37(11))
        at web3.js:5169:37(8)
        at map (native)
        at web3.js:5168:35(12)
        at web3.js:5194:34(15)
        at send (web3.js:5219:39(11))
        at <eval>:1:14(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "www")
Error: input block number(www) is invalid
        at inputBlockNumberFormatter (web3.js:3854:11(32))
        at inputDefaultBlockNumberFormatter (web3.js:3843:37(11))
        at web3.js:5169:37(8)
        at map (native)
        at web3.js:5168:35(12)
        at web3.js:5194:34(15)
        at send (web3.js:5219:39(11))
        at <eval>:1:13(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "wwwwqnfqwfnkn")
Error: input block number(wwwwqnfqwfnkn) is invalid
        at inputBlockNumberFormatter (web3.js:3854:11(32))
        at inputDefaultBlockNumberFormatter (web3.js:3843:37(11))
        at web3.js:5169:37(8)
        at map (native)
        at web3.js:5168:35(12)
        at web3.js:5194:34(15)
        at send (web3.js:5219:39(11))
        at <eval>:1:13(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "askndkzx?")
Error: input block number(askndkzx?) is invalid
        at inputBlockNumberFormatter (web3.js:3854:11(32))
        at inputDefaultBlockNumberFormatter (web3.js:3843:37(11))
        at web3.js:5169:37(8)
        at map (native)
        at web3.js:5168:35(12)
        at web3.js:5194:34(15)
        at send (web3.js:5219:39(11))
        at <eval>:1:13(4)

> klay.getCode("0x98f4aB2c97eFff367827777e2fd96c536f38df1d", "latest2")
Error: input block number(latest2) is invalid
        at inputBlockNumberFormatter (web3.js:3854:11(32))
        at inputDefaultBlockNumberFormatter (web3.js:3843:37(11))
        at web3.js:5169:37(8)
        at map (native)
        at web3.js:5168:35(12)
        at web3.js:5194:34(15)
        at send (web3.js:5219:39(11))
        at <eval>:1:13(4)
```

This PR adds explicit error handling for invalid inputs, ensuring that the input must be either `latest`, `pending`, `earliest`, or a valid number.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
