### PR TITLE
api: do not crash with unknown blocknumber input

### DIFF
--- a/governance/api.go
+++ b/governance/api.go
@@ -86,7 +86,7 @@ func (api *GovernanceKaiaAPI) NodeAddress() common.Address {
 // GetRewards returns detailed information of the block reward at a given block number.
 func (api *GovernanceKaiaAPI) GetRewards(num *rpc.BlockNumber) (*reward.RewardSpec, error) {
 	blockNumber := uint64(0)
-	if num == nil || *num == rpc.LatestBlockNumber {
+	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
 		blockNumber = api.chain.CurrentBlock().NumberU64()
 	} else {
 		blockNumber = uint64(num.Int64())
@@ -365,8 +365,11 @@ func checkStateForStakingInfo(governance Engine, blockNumber uint64) error {
 	if !governance.BlockChain().Config().IsKaiaForkEnabled(big.NewInt(int64(blockNumber + 1))) {
 		return nil
 	}
-
-	_, err := governance.BlockChain().StateAt(governance.BlockChain().GetHeaderByNumber(blockNumber).Root)
+	header := governance.BlockChain().GetHeaderByNumber(blockNumber)
+	if header == nil {
+		return errUnknownBlock
+	}
+	_, err := governance.BlockChain().StateAt(header.Root)
 	return err
 }
 


### PR DESCRIPTION
## Proposed changes
Next methods were crashed with "pending" or future block number.
* `kaia.getStakingInfo(99999999)`
* `kaia.getRewards(99999999)`, `kaia.getRewards("pending")`
```
> kaia.getRewards(99999999)
Error: method handler crashed
        at web3.js:6812:9(39)
        at send (web3.js:5223:62(29))
        at <eval>:1:16(3)
```
This PR fixes it, and now it returns `currentblock information`(pending) or `unknown block error`(future block).
```
> kaia.getRewards("pending")
{
  burntFee: 0,
  kef: 0,
  kif: 0,
  minted: 9600000000000000000,
  proposer: 9600000000000000000,
  rewards: {
    0xf19ebf7b5766528b190e4a1b8073a0f1b6901c8b: 9600000000000000000
  },
  stakers: 0,
  totalFee: 0
}

> kaia.getRewards(99999999)
Error: Unknown block
        at web3.js:6812:9(39)
        at send (web3.js:5223:62(29))
        at <eval>:1:16(3)
```
## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
