### PR TITLE
[StateMigration] Mark the completion mark once deletion is done

### DIFF
--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -822,7 +822,7 @@ func (dbm *databaseManager) CreateMigrationDBAndSetStatus(blockNum uint64) error
 
 // FinishStateMigration updates stateTrieDB and removes the old one.
 // The function should be called only after when state trie migration is finished.
-// It returns a channel that closes when removeDB is finished.
+// It returns a channel that closes when removeOldDB is finished.
 func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 	// lock to prevent from a conflict of reading state DB and changing state DB
 	dbm.lockInMigration.Lock()
@@ -844,8 +844,6 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 	dbm.setDBDir(StateTrieDB, dbDirToBeUsed)
 	dbm.dbs[StateTrieDB] = dbToBeUsed
 
-	dbm.setStateTrieMigrationStatus(0)
-
 	dbm.dbs[StateTrieMigrationDB] = nil
 	dbm.setDBDir(StateTrieMigrationDB, "")
 
@@ -853,11 +851,14 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 	dbToBeRemoved.Close()
 
 	endCheck := make(chan struct{})
-	go removeDB(dbPathToBeRemoved, endCheck)
+	go dbm.removeOldDB(dbPathToBeRemoved, endCheck)
+
+	// Used only for testing. Closing it takes time due to the large size of the database
 	return endCheck
 }
 
-func removeDB(dbPath string, endCheck chan struct{}) {
+// Remove old database. This is called once migration(copy) is done.
+func (dbm *databaseManager) removeOldDB(dbPath string, endCheck chan struct{}) {
 	defer func() {
 		if endCheck != nil {
 			close(endCheck)
@@ -868,6 +869,8 @@ func removeDB(dbPath string, endCheck chan struct{}) {
 		return
 	}
 	logger.Info("Successfully removed database", "path", dbPath)
+	// Set the completion mark if old database is completely removed
+	dbm.setStateTrieMigrationStatus(0)
 }
 
 func (dbm *databaseManager) GetStateTrieDB() Database {

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -860,6 +860,8 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 // Remove old database. This is called once migration(copy) is done.
 func (dbm *databaseManager) removeOldDB(dbPath string, endCheck chan struct{}) {
 	defer func() {
+		// Set the completion mark if old database is completely removed (possibly not be removed if error occurs)
+		dbm.setStateTrieMigrationStatus(0)
 		if endCheck != nil {
 			close(endCheck)
 		}
@@ -869,8 +871,6 @@ func (dbm *databaseManager) removeOldDB(dbPath string, endCheck chan struct{}) {
 		return
 	}
 	logger.Info("Successfully removed database", "path", dbPath)
-	// Set the completion mark if old database is completely removed
-	dbm.setStateTrieMigrationStatus(0)
 }
 
 func (dbm *databaseManager) GetStateTrieDB() Database {


### PR DESCRIPTION
## Proposed changes

Resolve https://github.com/klaytn/klaytn/issues/1412

As-Is
```
do state migration (copy database)
mark the completion
remove old database
```

To-Be
```
do state migration (copy database)
remove old database
mark the completion
```

During the database deletion process, failures may occur due to common errors with os.RemoveAll(). The function marks the operation as complete regardless of whether the deletion was successful or not.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
