### PR TITLE
Lower log level of vrank

### DIFF
--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -155,7 +155,7 @@ func (v *Vrank) Log() {
 
 	v.updateMetrics()
 
-	logger.Info("VRank", "seq", v.view.Sequence.Int64(),
+	logger.Debug("VRank", "seq", v.view.Sequence.Int64(),
 		"round", v.view.Round.Int64(),
 		"bitmap", v.Bitmap(),
 		"late", encodeDurationBatch(lateCommits),


### PR DESCRIPTION
## Proposed changes

Vrank logs are not currently being collected due to datadog issue, so lower the log level for reducing log file size.

## Types of changes

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
