### PR TITLE
governance: APIs override deprecated parameters

### DIFF
--- a/governance/api.go
+++ b/governance/api.go
@@ -331,7 +331,32 @@ func getParams(governance Engine, num *rpc.BlockNumber) (map[string]interface{},
 	if err != nil {
 		return nil, err
 	}
-	return pset.StrMap(), nil
+	sm := pset.StrMap()
+
+	// To avoid confusion, override some parameters that are deprecated after hardforks.
+	// e.g., stakingupdateinterval is shown as 86400 but actually irrelevant (i.e. updated every block)
+	rule := governance.BlockChain().Config().Rules(new(big.Int).SetUint64(blockNumber))
+	if rule.IsKore {
+		// Gini option deprecated since Kore, as All committee members have an equal chance
+		// of being elected block proposers.
+		if _, ok := sm["reward.useginicoeff"]; ok {
+			sm["reward.useginicoeff"] = false
+		}
+	}
+	if rule.IsRandao {
+		// Block proposer is randomly elected at every block with Randao,
+		// no more precalculated proposer list.
+		if _, ok := sm["reward.proposerupdateinterval"]; ok {
+			sm["reward.proposerupdateinterval"] = 1
+		}
+	}
+	if rule.IsKaia {
+		// Staking information updated every block since Kaia.
+		if _, ok := sm["reward.stakingupdateinterval"]; ok {
+			sm["reward.stakingupdateinterval"] = 1
+		}
+	}
+	return sm, nil
 }
 
 func (api *GovernanceAPI) GetStakingInfo(num *rpc.BlockNumber) (*reward.StakingInfo, error) {
@@ -448,6 +473,7 @@ func getChainConfig(governance Engine, num *rpc.BlockNumber) *params.ChainConfig
 		return nil
 	}
 
+	// Fill in the non-governance-parameter fields of ChainConfig
 	latestConfig := governance.BlockChain().Config()
 	config := pset.ToChainConfig()
 	config.ChainID = latestConfig.ChainID
@@ -464,6 +490,24 @@ func getChainConfig(governance Engine, num *rpc.BlockNumber) *params.ChainConfig
 	config.Kip160CompatibleBlock = latestConfig.Kip160CompatibleBlock
 	config.Kip160ContractAddress = latestConfig.Kip160ContractAddress
 	config.RandaoCompatibleBlock = latestConfig.RandaoCompatibleBlock
+
+	// To avoid confusion, override some parameters that are deprecated after hardforks.
+	// e.g., stakingupdateinterval is shown as 86400 but actually irrelevant (i.e. updated every block)
+	rule := governance.BlockChain().Config().Rules(new(big.Int).SetUint64(blocknum))
+	if rule.IsKore {
+		// Gini option deprecated since Kore, as All committee members have an equal chance
+		// of being elected block proposers.
+		config.Governance.Reward.UseGiniCoeff = false
+	}
+	if rule.IsRandao {
+		// Block proposer is randomly elected at every block with Randao,
+		// no more precalculated proposer list.
+		config.Governance.Reward.ProposerUpdateInterval = 1
+	}
+	if rule.IsKaia {
+		// Staking information updated every block since Kaia.
+		config.Governance.Reward.StakingUpdateInterval = 1
+	}
 
 	return config
 }


### PR DESCRIPTION
## Proposed changes

`kaia_getParams`, `governance_getParams`, `kaia_getChainConfig`, `governance_getChainConfig` APIs to override deprecated parameters depending on hardfork level. Namely,
- since Kore, `reward.useginicoeff` is `false` as All committee members have an equal chance of being elected block proposers https://github.com/klaytn/klaytn/pull/1655
- since Randao, `reward.proposerupdateinterval` is `1` as proposer list is no longer used, rather proposers are selected every block at random. (https://github.com/klaytn/klaytn/pull/2030)
- since Kaia, `reward.stakingupdateinterval` is `1` as staking information is updated every block, effectively deprecating the interval. (https://github.com/klaytn/klaytn/pull/2154)

Though these fields could be deleted later as in #91, we first return the close-to-reality values to avoid confusion.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

Example

- `kaia_getParams`, `governance_getParams`
	```js
	> kaia.getParams(0)
	{
      // ...
	  reward.proposerupdateinterval: 3600,
	  reward.ratio: "34/54/12",
	  reward.stakingupdateinterval: 86400,
	  reward.useginicoeff: true
	}
	```
	```js
	> kaia.getParams("latest")
	{
      // ...
	  reward.proposerupdateinterval: 1,
	  reward.ratio: "50/25/25",
	  reward.stakingupdateinterval: 1,
	  reward.useginicoeff: false
	}
	```
- `kaia_getChainConfig`, `governance_getChainConfig`
	```js
	> kaia.getChainConfig(0)
	{
	  // ...
	     reward: {
	      deferredTxFee: true,
	      kip82ratio: "20/80",
	      minimumStake: 5000000,
	      mintingAmount: 9600000000000000000,
	      proposerUpdateInterval: 3600,
	      ratio: "34/54/12",
	      stakingUpdateInterval: 86400,
	      useGiniCoeff: true
	    }
	  // ...
	}
	```
	```js
	> kaia.getChainConfig("latest")
	{
	  // ...
	    reward: {
	      deferredTxFee: true,
	      kip82ratio: "20/80",
	      minimumStake: 5000000,
	      mintingAmount: 9600000000000000000,
	      proposerUpdateInterval: 1,
	      ratio: "50/25/25",
	      stakingUpdateInterval: 1,
	      useGiniCoeff: false
	    }
	  },
	  // ...
	}
	```