### PR TITLE
kaiax: Fix execution location

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1581,12 +1581,6 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		return status, err
 	}
 
-	for _, module := range bc.executionModules {
-		if err := module.PostInsertBlock(block); err != nil {
-			return WriteResult{Status: NonStatTy}, err
-		}
-	}
-
 	// Publish the committed block to the redis cache of stateDB.
 	// The cache uses the block to distinguish the latest state.
 	if bc.cacheConfig.TrieNodeCacheConfig.RedisPublishBlockEnable {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1581,6 +1581,12 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		return status, err
 	}
 
+	for _, module := range bc.executionModules {
+		if err := module.PostInsertBlock(block); err != nil {
+			return WriteResult{Status: NonStatTy}, err
+		}
+	}
+
 	// Publish the committed block to the redis cache of stateDB.
 	// The cache uses the block to distinguish the latest state.
 	if bc.cacheConfig.TrieNodeCacheConfig.RedisPublishBlockEnable {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -234,15 +234,15 @@ func (sb *backend) verifyHeader(chain consensus.ChainReader, header *types.Heade
 		return errInvalidBlockScore
 	}
 
-	// TODO-kaiax: further flatten the code inside
-	if err := sb.verifyCascadingFields(chain, header, parents); err != nil {
-		return err
-	}
-
 	for _, module := range sb.consensusModules {
 		if err := module.VerifyHeader(header); err != nil {
 			return err
 		}
+	}
+
+	// TODO-kaiax: further flatten the code inside
+	if err := sb.verifyCascadingFields(chain, header, parents); err != nil {
+		return err
 	}
 
 	return nil

--- a/kaiax/noop/consensus.go
+++ b/kaiax/noop/consensus.go
@@ -22,13 +22,16 @@ import (
 )
 
 func (m *NoopModule) VerifyHeader(header *types.Header) error {
+	logger.Info("NoopModule VerifyHeader")
 	return nil
 }
 
 func (m *NoopModule) PrepareHeader(header *types.Header) error {
+	logger.Info("NoopModule PrepareHeader")
 	return nil
 }
 
 func (m *NoopModule) FinalizeHeader(header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) error {
+	logger.Info("NoopModule FinalizeHeader")
 	return nil
 }

--- a/kaiax/noop/consensus.go
+++ b/kaiax/noop/consensus.go
@@ -22,16 +22,16 @@ import (
 )
 
 func (m *NoopModule) VerifyHeader(header *types.Header) error {
-	logger.Info("NoopModule VerifyHeader")
+	logger.Info("NoopModule VerifyHeader", "blockNum", header.Number.Uint64())
 	return nil
 }
 
 func (m *NoopModule) PrepareHeader(header *types.Header) error {
-	logger.Info("NoopModule PrepareHeader")
+	logger.Info("NoopModule PrepareHeader", "blockNum", header.Number.Uint64())
 	return nil
 }
 
 func (m *NoopModule) FinalizeHeader(header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) error {
-	logger.Info("NoopModule FinalizeHeader")
+	logger.Info("NoopModule FinalizeHeader", "blockNum", header.Number.Uint64())
 	return nil
 }

--- a/kaiax/noop/execution.go
+++ b/kaiax/noop/execution.go
@@ -22,14 +22,14 @@ import (
 )
 
 func (m *NoopModule) PostInsertBlock(block *types.Block) error {
-	logger.Info("NoopModule PostInsertBlock")
+	logger.Info("NoopModule PostInsertBlock", "blockNum", block.Header().Number.Uint64())
 	return nil
 }
 
 func (m *NoopModule) RewindTo(block *types.Block) {
-	logger.Info("NoopModule RewindTo")
+	logger.Info("NoopModule RewindTo", "blockNum", block.Header().Number.Uint64())
 }
 
 func (m *NoopModule) RewindDelete(hash common.Hash, num uint64) {
-	logger.Info("NoopModule RewindDelete")
+	logger.Info("NoopModule RewindDelete", "num", num)
 }

--- a/kaiax/noop/execution.go
+++ b/kaiax/noop/execution.go
@@ -22,11 +22,14 @@ import (
 )
 
 func (m *NoopModule) PostInsertBlock(block *types.Block) error {
+	logger.Info("NoopModule PostInsertBlock")
 	return nil
 }
 
 func (m *NoopModule) RewindTo(block *types.Block) {
+	logger.Info("NoopModule RewindTo")
 }
 
 func (m *NoopModule) RewindDelete(hash common.Hash, num uint64) {
+	logger.Info("NoopModule RewindDelete")
 }

--- a/kaiax/noop/txprocess.go
+++ b/kaiax/noop/txprocess.go
@@ -22,9 +22,11 @@ import (
 )
 
 func (m *NoopModule) PreRunTx(evm *vm.EVM, tx *types.Transaction) (*types.Transaction, error) {
+	logger.Info("NoopModule PreRunTx")
 	return tx, nil
 }
 
 func (m *NoopModule) PostRunTx(evm *vm.EVM, tx *types.Transaction) error {
+	logger.Info("NoopModule PostRunTx")
 	return nil
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -519,6 +519,7 @@ func (s *CN) SetupKaiaxModules() error {
 	// s.RegisterJsonRpcModules()
 	s.engine.(kaiax.ConsensusModuleHost).RegisterConsensusModule(mNoop)
 	s.blockchain.(kaiax.ExecutionModuleHost).RegisterExecutionModule(mNoop)
+	s.miner.(kaiax.ExecutionModuleHost).RegisterExecutionModule(mNoop)
 	s.blockchain.(kaiax.RewindableModuleHost).RegisterRewindableModule(mNoop)
 
 	return nil

--- a/work/work.go
+++ b/work/work.go
@@ -223,6 +223,10 @@ func (self *Miner) PendingBlock() *types.Block {
 	return self.worker.pendingBlock()
 }
 
+func (self *Miner) RegisterExecutionModule(modules ...kaiax.ExecutionModule) {
+	self.worker.RegisterExecutionModule(modules...)
+}
+
 // BlockChain is an interface of blockchain.BlockChain used by ProtocolManager.
 //
 //go:generate mockgen -destination=mocks/blockchain_mock.go -package=mocks github.com/kaiachain/kaia/work BlockChain


### PR DESCRIPTION
## Proposed changes

1. Fix in `VerifyHeader`: `sb.verifyCascadingFields` returns `errEmptyCommittedSeals` for 1 CN, so execute the module first. (This error is handled [here](https://github.com/kaiachain/kaia/blob/feat/kaiax/consensus/istanbul/backend/backend.go#L366))
2. Add in `writeBlockWithState`: because the proposer does not execute `insertChain`.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Proposer log

```
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:30]                 NoopModule PrepareHeader                  blockNum=2
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:35]                 NoopModule FinalizeHeader                 blockNum=2
INFO[09/20,11:55:13 +09] [51|work/worker.go:633]                         Commit new mining work                    number=2 hash=992222…c72086 txs=0 elapsed=5.211ms   commitTime=4.739ms   finalizeTime=466.5µs
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:25]                 NoopModule VerifyHeader                   blockNum=2
INFO[09/20,11:55:13 +09] [25|consensus/istanbul/core/vrank.go:158]       VRank                                     seq=1 round=0 bitmap=00 late=[]
INFO[09/20,11:55:13 +09] [25|consensus/istanbul/core/prepare.go:91]      received a quorum of the messages and change state to prepared  msgType=1 prepareMsgNum=2 commitMsgNum=0 valSet=2
INFO[09/20,11:55:13 +09] [24|consensus/istanbul/backend/backend.go:319]  Committed                                 number=2 hash=45e4a1…2ab091 address=0x70997970C51812dc3A010C7d01b50e0d17dc79C8
INFO[09/20,11:55:13 +09] [51|work/agent.go:119]                          Successfully sealed new block             number=2 hash=45e4a1…2ab091
INFO[09/20,11:55:13 +09] [44|reward/staking_manager.go:474]              The addressBook is not yet activated. Use empty stakingInfo 
INFO[09/20,11:55:13 +09] [58|kaiax/noop/execution.go:25]                 NoopModule PostInsertBlock                blockNum=2
INFO[09/20,11:55:13 +09] [51|work/worker.go:464]                         Successfully wrote mined block            num=2  hash=45e4a1…2ab091 txs=0 elapsed=223.167µs
```

Non-proposer log
```
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:30]                 NoopModule PrepareHeader                  blockNum=2
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:35]                 NoopModule FinalizeHeader                 blockNum=2
INFO[09/20,11:55:13 +09] [51|work/worker.go:633]                         Commit new mining work                    number=2 hash=19976b…10cc40 txs=0 elapsed=6.542ms   commitTime=5.549ms   finalizeTime=981.417µs
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:25]                 NoopModule VerifyHeader                   blockNum=2
INFO[09/20,11:55:13 +09] [25|consensus/istanbul/core/vrank.go:158]       VRank                                     seq=1 round=0 bitmap=00 late=[]
INFO[09/20,11:55:13 +09] [25|consensus/istanbul/core/prepare.go:91]      received a quorum of the messages and change state to prepared  msgType=1 prepareMsgNum=2 commitMsgNum=0 valSet=2
INFO[09/20,11:55:13 +09] [24|consensus/istanbul/backend/backend.go:319]  Committed                                 number=2 hash=45e4a1…2ab091 address=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:25]                 NoopModule VerifyHeader                   blockNum=2
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:25]                 NoopModule VerifyHeader                   blockNum=2
INFO[09/20,11:55:13 +09] [58|kaiax/noop/consensus.go:35]                 NoopModule FinalizeHeader                 blockNum=2
INFO[09/20,11:55:13 +09] [5|blockchain/blockchain.go:2119]              Inserted a new block                      number=2 hash=45e4a1…2ab091 txs=0 gas=0 elapsed=2.013ms   processTxs=292ns finalize=276.291µs validateState=53.084µs totalWrite=203.791µs trieWrite=127.208µs
INFO[09/20,11:55:13 +09] [58|kaiax/noop/execution.go:25]                 NoopModule PostInsertBlock                blockNum=2
```