### PR TITLE
Update build tags for static link

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -215,6 +215,9 @@ func buildFlags(env build.Environment) (flags []string) {
 		// Pass the static link flag to the external linker.
 		// By default, cmd/link will use external linking mode when non-standard cgo packages are involved.
 		ld = append(ld, "-linkmode", "external", "-extldflags", "-static")
+		// Even if the binary is statically linked, some glibc features (e.g., libnss) can have dependencies on
+		// specific version of glibc. So we should try to avoid using them.
+		flags = append(flags, "-tags", "osusergo,netgo")
 	}
 	if env.IsKaiaRaceDetectionOn {
 		flags = append(flags, "-race")


### PR DESCRIPTION
## Proposed changes

- This PR adds build tags for building statically linked kaia binaries
   - Some glibc features (e.g., libnss) can cause dependencies on specific version of glibc.
   - To avoid using such features, we can add build tags to guide go compiler (and linker) to use Golang implementation (as an alternative to the related glibc feature)
   - This is a [known](https://go-review.googlesource.com/c/go/+/92456) [issue](https://github.com/golang/go/issues/26492) in Golang, and also a mitigation adopted in [geth](https://github.com/ethereum/go-ethereum/blob/ec69830b6f4520c0d847cad3cf61d8a4da9db178/build/ci.go#L265)

The following build method now produces a fully static binary.
```sh
KAIA_STATIC_LINK=1 make ken
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

