### PR TITLE
ci: fix upload-packages-to-s3 script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,16 +174,20 @@ commands:
             source ~/.bashrc
             KAIA_VERSION=$(go run build/rpm/main.go version)
             PLATFORM_SUFFIX=$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)
-            for item in kcn kpn ken kgen kscn kbn kspn ksen homi; do
+                     
+            for item in kcn kpn ken kcn-kairos kpn-kairos ken-kairos kgen kscn kbn kspn ksen homi; do
               if [[ << parameters.package-type >> = "tar" ]]; then
-                  aws s3 cp packages/${item}-*.tar.gz s3://$FRONTEND_BUCKET/packages/kaia/$KAIA_VERSION/;
+                aws s3 cp packages/${item}-v*.tar.gz s3://$FRONTEND_BUCKET/packages/kaia/$KAIA_VERSION/
               elif [[ << parameters.package-type >> = "rpm" ]]; then
-                  TARGET_RPM=$(find $item-linux-x86_64/rpmbuild/RPMS/x86_64/ | awk -v pat="$item(d)?-(kairos-)?v" '$0~pat')
-                  aws s3 cp $TARGET_RPM s3://$FRONTEND_BUCKET/packages/rhel/7/kaia/
-                  aws s3 cp $TARGET_RPM s3://$FRONTEND_BUCKET/packages/kaia/$KAIA_VERSION/
-                  TARGET_RPM=$(find $item-linux-aarch64/rpmbuild/RPMS/aarch64/ | awk -v pat="$item(d)?-(kairos-)?v" '$0~pat')
-                  aws s3 cp $TARGET_RPM s3://$FRONTEND_BUCKET/packages/rhel/7/kaia/
-                  aws s3 cp $TARGET_RPM s3://$FRONTEND_BUCKET/packages/kaia/$KAIA_VERSION/
+                BINARY=$item
+                KAIROS=""
+                if [[ $BINARY = *-kairos ]]; then
+                  BINARY="${BINARY%-kairos}"
+                  KAIROS="-kairos"
+                fi
+                TARGET_RPM=$(find $BINARY-$PLATFORM_SUFFIX/rpmbuild/RPMS/$(uname -m)/ | awk -v pat="$BINARY(d)?$KAIROS-v" '$0~pat')
+                aws s3 cp $TARGET_RPM s3://$FRONTEND_BUCKET/packages/rhel/7/kaia/
+                aws s3 cp $TARGET_RPM s3://$FRONTEND_BUCKET/packages/kaia/$KAIA_VERSION/
               fi
             done
   createrepo-update:


### PR DESCRIPTION
## Proposed changes

- The upload packages to s3 repo is failing when tagging v1.0.3-rc.2. It is because s3 command cannot upload multiple files together.
- This PR makes aws s3 command handles one file at one time.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
