### PR TITLE
Skip nil validator for snapshot

### DIFF
--- a/consensus/istanbul/validator/weighted.go
+++ b/consensus/istanbul/validator/weighted.go
@@ -131,6 +131,8 @@ func RecoverWeightedCouncilProposer(valSet istanbul.ValidatorSet, proposerAddrs 
 		_, val := weightedCouncil.GetByAddress(proposerAddr)
 		if val == nil {
 			logger.Error("Proposer is not available now.", "proposer address", proposerAddr)
+			// The valSet.proposers hasn't been used since Randao HF.
+			continue
 		}
 		proposers = append(proposers, val)
 


### PR DESCRIPTION
## Proposed changes

This PR fixed not to touch nil validator pointer if found.

The `valSet` in snapshot might contain demoted proposers if the CN's total staking amount became lower than 5M KAIA but not removed from validators explicitly.

Even before Kaia HF, potential nil dereference pointer must be prevented.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
