### PR TITLE
kaiax/gov: Add exhaustive linter & remove reflect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,14 +230,14 @@ commands:
       - run:
           name: "Create pull request"
           command: |
-              version=$(hub pr list -s open -L 10 -f "%H%n")
-              echo $version
-              if [[ $version == *"release/${CIRCLE_TAG%-*}"* ]]; then
-                echo "PR already exist"
-              else
-                echo "hub pull-request -m "[Main] release/$CIRCLE_TAG QA Signoff" -b $CIRCLE_PROJECT_USERNAME:master -h $CIRCLE_PROJECT_USERNAME:${CIRCLE_TAG%-*}"
-                echo -e "[Main] release/${CIRCLE_TAG%-*} QA Sign-off\n\nThis PR is automatically created by CI to release a new official version of $CIRCLE_PROJECT_REPONAME.\n\nWhen this PR is approved by QA team, a new version will be released." | hub pull-request -b $CIRCLE_PROJECT_USERNAME:main -h $CIRCLE_PROJECT_USERNAME:release/${CIRCLE_TAG%-*} -r $GITHUB_reviewer -l circleci -F-
-              fi
+            version=$(hub pr list -s open -L 10 -f "%H%n")
+            echo $version
+            if [[ $version == *"release/${CIRCLE_TAG%-*}"* ]]; then
+              echo "PR already exist"
+            else
+              echo "hub pull-request -m "[Main] release/$CIRCLE_TAG QA Signoff" -b $CIRCLE_PROJECT_USERNAME:master -h $CIRCLE_PROJECT_USERNAME:${CIRCLE_TAG%-*}"
+              echo -e "[Main] release/${CIRCLE_TAG%-*} QA Sign-off\n\nThis PR is automatically created by CI to release a new official version of $CIRCLE_PROJECT_REPONAME.\n\nWhen this PR is approved by QA team, a new version will be released." | hub pull-request -b $CIRCLE_PROJECT_USERNAME:main -h $CIRCLE_PROJECT_USERNAME:release/${CIRCLE_TAG%-*} -r $GITHUB_reviewer -l circleci -F-
+            fi
       - run:
           name: "build announce"
           command: .circleci/scripts/build_announce.sh
@@ -300,14 +300,14 @@ commands:
     steps:
       - run:
           name: "notify slack when job success"
-          command : |
+          command: |
             curl --data '{"text": "✅ Job *'$CIRCLE_JOB'* succeeded on *'$CIRCLE_BRANCH''$CIRCLE_TAG'*. Please see '$CIRCLE_BUILD_URL' for details."}' "$SLACK_WEBHOOK_URL"
           when: on_success
   notify-failure:
     steps:
       - run:
           name: "notify slack when job fail"
-          command : |
+          command: |
             curl --data '{"text": "❌ Job *'$CIRCLE_JOB'* failed on *'$CIRCLE_BRANCH'*. Please see '$CIRCLE_BUILD_URL' for details."}' "$SLACK_WEBHOOK_URL"
           when: on_fail
   run-rpc:
@@ -348,7 +348,11 @@ jobs:
       - run:
           name: "Run golangci-lint"
           no_output_timeout: 30m
-          command: go run build/ci.go lint -v --new-from-rev=dev
+          command: go run build/ci.go lint -v
+      - run:
+          name: "Run exhaustive golangci-lint on kaiax"
+          no_output_timeout: 30m
+          command: go run build/ci.go lint -c build/linter/golangci-exhaustive.yml -v kaiax/...
 
   test-datasync:
     executor: linux-others-executor
@@ -454,7 +458,7 @@ jobs:
           command: |
             make lint-try
             mkdir -p /tmp/linter_reports
-            cp linter_report.txt /tmp/linter_reports/
+            cp linter_report.html /tmp/linter_reports/
       - notify-failure
       - notify-success
       - store_artifacts:
@@ -598,7 +602,7 @@ workflows:
               only: dev
           requires:
             - pass-tests
-          extra_build_args: '--platform=linux/amd64'
+          extra_build_args: "--platform=linux/amd64"
           image: kaiachain/kaia
           tag: dev
           executor: docker/docker
@@ -614,7 +618,7 @@ workflows:
               ignore: /.*/
           requires:
             - pass-tests
-          extra_build_args: '--platform=linux/amd64'
+          extra_build_args: "--platform=linux/amd64"
           image: kaiachain/kaia
           tag: latest,$CIRCLE_TAG
           executor: docker/docker

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ lint:
 	$(GORUN) build/ci.go lint
 
 lint-try:
-	$(GORUN) build/ci.go lint-try
+	$(GORUN) build/ci.go lint-try -c build/linter/golangci-try.yml
 
 clean:
 	env GO111MODULE=on go clean -cache

--- a/build/Dockerfile-go1.20.6-solc0.8.13-ubuntu
+++ b/build/Dockerfile-go1.20.6-solc0.8.13-ubuntu
@@ -37,4 +37,4 @@ COPY --from=go_builder /usr/local/go /usr/local
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0

--- a/build/Dockerfile-ubuntu-18.04-go1.20.6-solc0.8.13
+++ b/build/Dockerfile-ubuntu-18.04-go1.20.6-solc0.8.13
@@ -26,4 +26,4 @@ RUN mkdir /usr/bin/solc && wget -q https://github.com/ethereum/solidity/releases
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0

--- a/build/ci.go
+++ b/build/ci.go
@@ -951,7 +951,7 @@ func installLinter() string {
 		fmt.Println("Installing golangci-lint.")
 
 		cmdCurl := exec.Command("curl", "-sSfL", "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh")
-		cmdSh := exec.Command("sh", "-s", "--", "-b", filepath.Join(build.GOPATH(), "bin"), "v1.52.0")
+		cmdSh := exec.Command("sh", "-s", "--", "-b", filepath.Join(build.GOPATH(), "bin"), "v1.61.0")
 		cmdSh.Stdin, err = cmdCurl.StdoutPipe()
 		if err != nil {
 			log.Fatal(err)

--- a/build/linter/golangci-exhaustive.yml
+++ b/build/linter/golangci-exhaustive.yml
@@ -1,0 +1,11 @@
+linters:
+  disable-all: true
+  enable:
+    - exhaustive
+
+run:
+  timeout: 10m
+  tests: true
+
+issues:
+  new-from-rev: dev

--- a/build/linter/golangci-try.yml
+++ b/build/linter/golangci-try.yml
@@ -1,0 +1,26 @@
+linters:
+  disable-all: true
+  enable:
+    - misspell
+    - goconst
+    - dupl
+    - errcheck
+    - ineffassign
+    - unparam
+    - unused
+    - unconvert
+    - gosimple
+    - staticcheck
+    - gocyclo
+
+run:
+  timeout: 10m
+  tests: true
+
+issues:
+  new-from-rev: dev
+
+output:
+  formats:
+    - format: html
+      path: linter_report.html

--- a/build/linter/golangci.yml
+++ b/build/linter/golangci.yml
@@ -1,0 +1,12 @@
+linters:
+  disable-all: true
+  presets:
+    - format
+    - performance
+
+run:
+  timeout: 10m
+  tests: true
+
+issues:
+  new-from-rev: dev

--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -116,6 +116,7 @@ func (h *headerGovModule) VerifyGov(header *types.Header) error {
 }
 
 func (h *headerGovModule) checkConsistency(blockNum uint64, vote headergov.VoteData) error {
+	//nolint:exhaustive
 	switch vote.Name() {
 	case gov.GovernanceGoverningNode:
 		// TODO: check in valset

--- a/kaiax/gov/param.go
+++ b/kaiax/gov/param.go
@@ -12,9 +12,8 @@ import (
 type canonicalizerT func(v any) (any, error)
 
 type Param struct {
-	ParamSetFieldName string
-	Canonicalizer     canonicalizerT
-	FormatChecker     func(cv any) bool // validation on canonical value.
+	Canonicalizer canonicalizerT
+	FormatChecker func(cv any) bool // validation on canonical value.
 
 	DefaultValue  any
 	VoteForbidden bool
@@ -159,8 +158,7 @@ const (
 
 var Params = map[ParamName]*Param{
 	GovernanceDeriveShaImpl: {
-		ParamSetFieldName: "DeriveShaImpl",
-		Canonicalizer:     uint64Canonicalizer,
+		Canonicalizer: uint64Canonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(uint64)
 			if !ok {
@@ -172,8 +170,7 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: false,
 	},
 	GovernanceGovernanceMode: {
-		ParamSetFieldName: "GovernanceMode",
-		Canonicalizer:     stringCanonicalizer,
+		Canonicalizer: stringCanonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(string)
 			if !ok {
@@ -188,8 +185,7 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: true,
 	},
 	GovernanceGoverningNode: {
-		ParamSetFieldName: "GoverningNode",
-		Canonicalizer:     addressCanonicalizer,
+		Canonicalizer: addressCanonicalizer,
 		FormatChecker: func(cv any) bool {
 			_, ok := cv.(common.Address)
 			return ok
@@ -198,8 +194,7 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: false,
 	},
 	GovernanceGovParamContract: {
-		ParamSetFieldName: "GovParamContract",
-		Canonicalizer:     addressCanonicalizer,
+		Canonicalizer: addressCanonicalizer,
 		FormatChecker: func(cv any) bool {
 			_, ok := cv.(common.Address)
 			return ok
@@ -208,15 +203,13 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: false,
 	},
 	GovernanceUnitPrice: {
-		ParamSetFieldName: "UnitPrice",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(250e9),
-		VoteForbidden:     false,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(250e9),
+		VoteForbidden: false,
 	},
 	IstanbulCommitteeSize: {
-		ParamSetFieldName: "CommitteeSize",
-		Canonicalizer:     uint64Canonicalizer,
+		Canonicalizer: uint64Canonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(uint64)
 			if !ok {
@@ -228,15 +221,13 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: false,
 	},
 	IstanbulEpoch: {
-		ParamSetFieldName: "Epoch",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(604800),
-		VoteForbidden:     true,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(604800),
+		VoteForbidden: true,
 	},
 	IstanbulPolicy: {
-		ParamSetFieldName: "ProposerPolicy",
-		Canonicalizer:     uint64Canonicalizer,
+		Canonicalizer: uint64Canonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(uint64)
 			if !ok {
@@ -248,8 +239,7 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: true,
 	},
 	Kip71BaseFeeDenominator: {
-		ParamSetFieldName: "BaseFeeDenominator",
-		Canonicalizer:     uint64Canonicalizer,
+		Canonicalizer: uint64Canonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(uint64)
 			return ok && v != 0
@@ -258,43 +248,37 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: false,
 	},
 	Kip71GasTarget: {
-		ParamSetFieldName: "GasTarget",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(30000000),
-		VoteForbidden:     false,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(30000000),
+		VoteForbidden: false,
 	},
 	Kip71LowerBoundBaseFee: {
-		ParamSetFieldName: "LowerBoundBaseFee",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(25000000000),
-		VoteForbidden:     false,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(25000000000),
+		VoteForbidden: false,
 	},
 	Kip71MaxBlockGasUsedForBaseFee: {
-		ParamSetFieldName: "MaxBlockGasUsedForBaseFee",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(60000000),
-		VoteForbidden:     false,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(60000000),
+		VoteForbidden: false,
 	},
 	Kip71UpperBoundBaseFee: {
-		ParamSetFieldName: "UpperBoundBaseFee",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(750000000000),
-		VoteForbidden:     false,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(750000000000),
+		VoteForbidden: false,
 	},
 	RewardDeferredTxFee: {
-		ParamSetFieldName: "DeferredTxFee",
-		Canonicalizer:     boolCanonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      false,
-		VoteForbidden:     true,
+		Canonicalizer: boolCanonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  false,
+		VoteForbidden: true,
 	},
 	RewardKip82Ratio: {
-		ParamSetFieldName: "Kip82Ratio",
-		Canonicalizer:     stringCanonicalizer,
+		Canonicalizer: stringCanonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(string)
 			if !ok {
@@ -322,15 +306,13 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: false,
 	},
 	RewardMintingAmount: {
-		ParamSetFieldName: "MintingAmount",
-		Canonicalizer:     bigIntCanonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      big.NewInt(0),
-		VoteForbidden:     false,
+		Canonicalizer: bigIntCanonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  big.NewInt(0),
+		VoteForbidden: false,
 	},
 	RewardMinimumStake: {
-		ParamSetFieldName: "MinimumStake",
-		Canonicalizer:     bigIntCanonicalizer,
+		Canonicalizer: bigIntCanonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(*big.Int)
 			if !ok {
@@ -342,15 +324,13 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: true,
 	},
 	RewardProposerUpdateInterval: {
-		ParamSetFieldName: "ProposerUpdateInterval",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(3600),
-		VoteForbidden:     true,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(3600),
+		VoteForbidden: true,
 	},
 	RewardRatio: {
-		ParamSetFieldName: "Ratio",
-		Canonicalizer:     stringCanonicalizer,
+		Canonicalizer: stringCanonicalizer,
 		FormatChecker: func(cv any) bool {
 			v, ok := cv.(string)
 			if !ok {
@@ -378,18 +358,16 @@ var Params = map[ParamName]*Param{
 		VoteForbidden: false,
 	},
 	RewardStakingUpdateInterval: {
-		ParamSetFieldName: "StakingUpdateInterval",
-		Canonicalizer:     uint64Canonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      uint64(86400),
-		VoteForbidden:     true,
+		Canonicalizer: uint64Canonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  uint64(86400),
+		VoteForbidden: true,
 	},
 	RewardUseGiniCoeff: {
-		ParamSetFieldName: "UseGiniCoeff",
-		Canonicalizer:     boolCanonicalizer,
-		FormatChecker:     noopFormatChecker,
-		DefaultValue:      false,
-		VoteForbidden:     true,
+		Canonicalizer: boolCanonicalizer,
+		FormatChecker: noopFormatChecker,
+		DefaultValue:  false,
+		VoteForbidden: true,
 	},
 }
 

--- a/kaiax/gov/param_test.go
+++ b/kaiax/gov/param_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestParam(t *testing.T) {
 	for name, param := range Params {
-		assert.NotEmpty(t, param.ParamSetFieldName, name)
 		assert.NotEmpty(t, param.Canonicalizer, name)
 		assert.NotEmpty(t, param.FormatChecker, name)
 	}

--- a/kaiax/gov/paramset_test.go
+++ b/kaiax/gov/paramset_test.go
@@ -2,7 +2,6 @@ package gov
 
 import (
 	"math/big"
-	"reflect"
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
@@ -53,11 +52,4 @@ func TestParametersSetAndAdd(t *testing.T) {
 func TestGetDefaultGovernanceParamSet(t *testing.T) {
 	ps := GetDefaultGovernanceParamSet()
 	assert.NotNil(t, ps)
-	for name, param := range Params {
-		t.Run(string(name), func(t *testing.T) {
-			fieldName := param.ParamSetFieldName
-			fieldValue := reflect.ValueOf(ps).Elem().FieldByName(fieldName).Interface()
-			assert.Equal(t, param.DefaultValue, fieldValue, "Mismatch for %s", name)
-		})
-	}
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces an exhaustive linter for enums. It prevents mistakes when adding a new element to enum.

Also, refactor `build/ci.go` to use config files like [geth](https://github.com/ethereum/go-ethereum/blob/master/build/ci.go#L481-L498).
- Now, circle CI additionally runs `golangci-lint` command (i.e., exhaustive linter on `kaiax`) during `test-linters` job.
- Before, `lint-try` executed `golangci-lint` 6 times. Now, it runs all flags in a batch and executes just `golangci-lint` once.
- Before, `lint-try` produced output to `linter_report.txt`. Now it outputs `linter_report.html` based on `build/linter/golangci-try.yml`.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


## Further comments

If an enum is missing from switch statement, linter outputs an error:

```
kaiax/gov/paramset.go:128:3: missing cases in switch of type gov.ParamName: gov.GovernanceDeriveShaImpl (exhaustive)
                switch name {
                ^
```
