### PR TITLE
Kaiax/gov: use both old and new DB schema

### DIFF
--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -173,12 +173,14 @@ func (h *headerGovModule) getVotesInEpoch(epochIdx uint64) map[uint64]headergov.
 	lastInsertedBlock := *lastInsertedBlockPtr
 
 	if lastInsertedBlock <= epochIdx*h.epoch {
+		logger.Info("scanning votes fastpath")
 		votes := make(map[uint64]headergov.VoteData)
 		for blockNum, vote := range h.cache.GroupedVotes()[epochIdx] {
 			votes[blockNum] = vote
 		}
 		return votes
 	} else {
+		logger.Info("scanning votes slowpath")
 		return h.scanAllVotesInHeader(epochIdx)
 	}
 }

--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -172,7 +172,7 @@ func (h *headerGovModule) getVotesInEpoch(epochIdx uint64) map[uint64]headergov.
 	}
 	lastInsertedBlock := *lastInsertedBlockPtr
 
-	if lastInsertedBlock <= epochIdx*h.epoch {
+	if lastInsertedBlock <= calcEpochStartBlock(epochIdx, h.epoch) {
 		logger.Info("scanning votes fastpath")
 		votes := make(map[uint64]headergov.VoteData)
 		for blockNum, vote := range h.cache.GroupedVotes()[epochIdx] {
@@ -181,6 +181,6 @@ func (h *headerGovModule) getVotesInEpoch(epochIdx uint64) map[uint64]headergov.
 		return votes
 	} else {
 		logger.Info("scanning votes slowpath")
-		return h.scanAllVotesInHeader(epochIdx)
+		return h.scanAllVotesInEpoch(epochIdx)
 	}
 }

--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -166,13 +166,13 @@ func (h *headerGovModule) getExpectedGovernance(blockNum uint64) headergov.GovDa
 }
 
 func (h *headerGovModule) getVotesInEpoch(epochIdx uint64) map[uint64]headergov.VoteData {
-	lastInsertedBlockPtr := ReadLastInsertedBlock(h.ChainKv)
-	if lastInsertedBlockPtr == nil {
-		panic("last inserted block must exist")
+	lowestVoteScannedBlockNumPtr := ReadLowestVoteScannedBlockNum(h.ChainKv)
+	if lowestVoteScannedBlockNumPtr == nil {
+		panic("lowest vote scanned block num must exist")
 	}
-	lastInsertedBlock := *lastInsertedBlockPtr
+	lowestVoteScannedBlockNum := *lowestVoteScannedBlockNumPtr
 
-	if lastInsertedBlock <= calcEpochStartBlock(epochIdx, h.epoch) {
+	if lowestVoteScannedBlockNum <= calcEpochStartBlock(epochIdx, h.epoch) {
 		logger.Info("scanning votes fastpath")
 		votes := make(map[uint64]headergov.VoteData)
 		for blockNum, vote := range h.cache.GroupedVotes()[epochIdx] {

--- a/kaiax/gov/headergov/impl/error.go
+++ b/kaiax/gov/headergov/impl/error.go
@@ -3,9 +3,9 @@ package impl
 import "errors"
 
 var (
-	ErrZeroEpoch                 = errors.New("epoch cannot be zero")
-	ErrInitNil                   = errors.New("cannot init headergov module because of nil")
-	ErrLastInsertedBlockNotFound = errors.New("last inserted block not found")
+	ErrZeroEpoch                      = errors.New("epoch cannot be zero")
+	ErrInitNil                        = errors.New("cannot init headergov module because of nil")
+	ErrLowestVoteScannedBlockNotFound = errors.New("lowest vote scanned block not found")
 
 	ErrVotePermissionDenied = errors.New("you don't have the right to vote")
 	ErrInvalidKeyValue      = errors.New("your vote couldn't be placed. Please check your vote's key and value")

--- a/kaiax/gov/headergov/impl/error.go
+++ b/kaiax/gov/headergov/impl/error.go
@@ -3,8 +3,9 @@ package impl
 import "errors"
 
 var (
-	ErrZeroEpoch = errors.New("epoch cannot be zero")
-	ErrInitNil   = errors.New("cannot init headergov module because of nil")
+	ErrZeroEpoch                 = errors.New("epoch cannot be zero")
+	ErrInitNil                   = errors.New("cannot init headergov module because of nil")
+	ErrLastInsertedBlockNotFound = errors.New("last inserted block not found")
 
 	ErrVotePermissionDenied = errors.New("you don't have the right to vote")
 	ErrInvalidKeyValue      = errors.New("your vote couldn't be placed. Please check your vote's key and value")

--- a/kaiax/gov/headergov/impl/execution.go
+++ b/kaiax/gov/headergov/impl/execution.go
@@ -40,10 +40,10 @@ func (h *headerGovModule) PostInsertBlock(b *types.Block) error {
 }
 
 func (h *headerGovModule) HandleVote(blockNum uint64, vote headergov.VoteData) error {
-	h.cache.AddVote(calcEpochIdx(blockNum, h.epoch), blockNum, vote)
-
-	var data StoredUint64Array = h.cache.VoteBlockNums()
-	WriteVoteDataBlockNums(h.ChainKv, &data)
+	if vote.Name() != "governance.addvalidator" && vote.Name() != "governance.removevalidator" {
+		h.cache.AddVote(calcEpochIdx(blockNum, h.epoch), blockNum, vote)
+		InsertVoteDataBlockNum(h.ChainKv, blockNum)
+	}
 
 	// if the vote was mine, remove it.
 	for i, myvote := range h.myVotes {

--- a/kaiax/gov/headergov/impl/getter.go
+++ b/kaiax/gov/headergov/impl/getter.go
@@ -17,13 +17,15 @@ func (h *headerGovModule) EffectiveParamSet(blockNum uint64) gov.ParamSet {
 }
 
 func (h *headerGovModule) EffectiveParamsPartial(blockNum uint64) gov.PartialParamSet {
+	prevEpochStart := PrevEpochStart(blockNum, h.epoch, h.isKoreHF(blockNum))
 	ret := make(gov.PartialParamSet)
+
+	// merge all governance sets before num's prevEpochStart.
 	for _, num := range h.cache.GovBlockNums() {
-		if num > blockNum {
-			break
-		}
-		for name, value := range h.cache.Govs()[num].Items() {
-			ret[name] = value
+		if num <= prevEpochStart {
+			for name, value := range h.cache.Govs()[num].Items() {
+				ret[name] = value
+			}
 		}
 	}
 

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -113,12 +113,12 @@ func (h *headerGovModule) Init(opts *InitOpts) error {
 func (h *headerGovModule) Start() error {
 	logger.Info("HeaderGovModule started")
 
-	lastInsertedBlockPtr := ReadLastInsertedBlock(h.ChainKv)
-	if lastInsertedBlockPtr == nil {
-		return ErrLastInsertedBlockNotFound
+	lowestVoteScannedBlockNumPtr := ReadLowestVoteScannedBlockNum(h.ChainKv)
+	if lowestVoteScannedBlockNumPtr == nil {
+		return ErrLowestVoteScannedBlockNotFound
 	}
 
-	epochIdxIter := calcEpochIdx(*lastInsertedBlockPtr, h.epoch)
+	epochIdxIter := calcEpochIdx(*lowestVoteScannedBlockNumPtr, h.epoch)
 	if epochIdxIter == 0 {
 		return nil
 	}
@@ -132,7 +132,7 @@ func (h *headerGovModule) Start() error {
 				InsertVoteDataBlockNum(h.ChainKv, blockNum)
 			}
 
-			WriteLastInsertedBlock(h.ChainKv, calcEpochStartBlock(epochIdxIter, h.epoch))
+			WriteLowestVoteScannedBlockNum(h.ChainKv, calcEpochStartBlock(epochIdxIter, h.epoch))
 			logger.Info("Scanned votes in header", "num", calcEpochStartBlock(epochIdxIter, h.epoch))
 
 			epochIdxIter -= 1

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -162,7 +162,7 @@ func (h *headerGovModule) scanAllVotesInEpoch(epochIdx uint64) map[uint64]header
 	votes := make(map[uint64]headergov.VoteData)
 	for blockNum := rangeStart; blockNum < rangeEnd; blockNum++ {
 		header := h.Chain.GetHeaderByNumber(blockNum)
-		if len(header.Vote) == 0 {
+		if header == nil || len(header.Vote) == 0 {
 			continue
 		}
 

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -115,14 +115,7 @@ func (h *headerGovModule) Start() error {
 
 	lastInsertedBlockPtr := ReadLastInsertedBlock(h.ChainKv)
 	if lastInsertedBlockPtr == nil {
-		// TODO-kaiax: must panic, but commented for unit tests.
-		// panic("last inserted block must exist")
-
-		curr := h.Chain.CurrentBlock().NumberU64()
-		curr = curr - curr%h.epoch
-		lastInsertedBlockPtr = &curr
-
-		WriteLastInsertedBlock(h.ChainKv, curr)
+		return ErrLastInsertedBlockNotFound
 	}
 
 	epochIdxIter := calcEpochIdx(*lastInsertedBlockPtr, h.epoch)

--- a/kaiax/gov/headergov/impl/init_test.go
+++ b/kaiax/gov/headergov/impl/init_test.go
@@ -49,6 +49,7 @@ func newHeaderGovModule(t *testing.T, config *params.ChainConfig) *headerGovModu
 		ChainConfig: config,
 	})
 	require.NoError(t, err)
+	WriteLastInsertedBlock(db, 0)
 	h.Start()
 
 	return h

--- a/kaiax/gov/headergov/impl/init_test.go
+++ b/kaiax/gov/headergov/impl/init_test.go
@@ -49,6 +49,7 @@ func newHeaderGovModule(t *testing.T, config *params.ChainConfig) *headerGovModu
 		ChainConfig: config,
 	})
 	require.NoError(t, err)
+	h.Start()
 
 	return h
 }

--- a/kaiax/gov/headergov/impl/init_test.go
+++ b/kaiax/gov/headergov/impl/init_test.go
@@ -49,7 +49,7 @@ func newHeaderGovModule(t *testing.T, config *params.ChainConfig) *headerGovModu
 		ChainConfig: config,
 	})
 	require.NoError(t, err)
-	WriteLastInsertedBlock(db, 0)
+	WriteLowestVoteScannedBlockNum(db, 0)
 	h.Start()
 
 	return h

--- a/kaiax/gov/headergov/impl/init_test.go
+++ b/kaiax/gov/headergov/impl/init_test.go
@@ -35,7 +35,12 @@ func newHeaderGovModule(t *testing.T, config *params.ChainConfig) *headerGovModu
 		Governance: gov,
 	}
 	dbm.WriteHeader(genesisHeader)
-	chain.EXPECT().GetHeaderByNumber(uint64(0)).Return(genesisHeader)
+
+	// mock accumulateVotesInEpoch
+	chain.EXPECT().GetHeaderByNumber(uint64(0)).Return(genesisHeader).AnyTimes()
+	for i := uint64(1); i < config.Istanbul.Epoch; i++ {
+		chain.EXPECT().GetHeaderByNumber(i).Return(&types.Header{Number: big.NewInt(int64(i))})
+	}
 
 	cachingDb := state.NewDatabase(dbm)
 	statedb, _ := state.New(common.Hash{}, cachingDb, nil, nil)

--- a/kaiax/gov/headergov/impl/schema.go
+++ b/kaiax/gov/headergov/impl/schema.go
@@ -10,10 +10,10 @@ import (
 )
 
 var (
-	voteDataBlockNumsKey = []byte("governanceVoteDataBlockNums")
-	govDataBlockNumsKey  = []byte("governanceDataBlockNums")
-	lastInsertedBlockKey = []byte("governanceLastInsertedBlock") // grows downwards
-	mu                   = &sync.RWMutex{}
+	voteDataBlockNumsKey         = []byte("governanceVoteDataBlockNums")
+	govDataBlockNumsKey          = []byte("governanceDataBlockNums")
+	lowestVoteScannedBlockNumKey = []byte("governanceLowestVoteScannedBlockNum") // grows downwards
+	mu                           = &sync.RWMutex{}
 )
 
 type StoredUint64Array []uint64
@@ -101,17 +101,17 @@ func WriteGovDataBlockNums(db database.Database, govDataBlockNums *StoredUint64A
 	writeStoredUint64Array(db, govDataBlockNumsKey, govDataBlockNums)
 }
 
-func ReadLastInsertedBlock(db database.Database) *uint64 {
+func ReadLowestVoteScannedBlockNum(db database.Database) *uint64 {
 	mu.RLock()
 	defer mu.RUnlock()
 
-	b, err := db.Get(lastInsertedBlockKey)
+	b, err := db.Get(lowestVoteScannedBlockNumKey)
 	if err != nil || len(b) == 0 {
 		return nil
 	}
 
 	if len(b) != 8 {
-		logger.Error("Invalid lastInsertedBlock data length", "length", len(b))
+		logger.Error("Invalid lowestVoteScannedBlockNum data length", "length", len(b))
 		return nil
 	}
 
@@ -119,11 +119,11 @@ func ReadLastInsertedBlock(db database.Database) *uint64 {
 	return &ret
 }
 
-func WriteLastInsertedBlock(db database.Database, lastInsertedBlock uint64) {
+func WriteLowestVoteScannedBlockNum(db database.Database, lowestVoteScannedBlockNum uint64) {
 	mu.Lock()
 	defer mu.Unlock()
 
 	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, lastInsertedBlock)
-	db.Put(lastInsertedBlockKey, b)
+	binary.BigEndian.PutUint64(b, lowestVoteScannedBlockNum)
+	db.Put(lowestVoteScannedBlockNumKey, b)
 }

--- a/kaiax/gov/headergov/impl/schema.go
+++ b/kaiax/gov/headergov/impl/schema.go
@@ -1,7 +1,9 @@
 package impl
 
 import (
+	"encoding/binary"
 	"encoding/json"
+	"sort"
 	"sync"
 
 	"github.com/kaiachain/kaia/storage/database"
@@ -10,6 +12,7 @@ import (
 var (
 	voteDataBlockNumsKey = []byte("governanceVoteDataBlockNums")
 	govDataBlockNumsKey  = []byte("governanceDataBlockNums")
+	lastInsertedBlockKey = []byte("governanceLastInsertedBlock") // grows downwards
 	mu                   = &sync.RWMutex{}
 )
 
@@ -55,10 +58,61 @@ func WriteVoteDataBlockNums(db database.Database, voteDataBlockNums *StoredUint6
 	writeStoredUint64Array(db, voteDataBlockNumsKey, voteDataBlockNums)
 }
 
+func InsertVoteDataBlockNum(db database.Database, blockNum uint64) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	blockNums := ReadVoteDataBlockNums(db)
+	if blockNums == nil {
+		blockNums = new(StoredUint64Array)
+	}
+
+	// Check if blockNum already exists in the array
+	for _, num := range *blockNums {
+		if num == blockNum {
+			return
+		}
+	}
+
+	*blockNums = append(*blockNums, blockNum)
+	// Sort the block numbers in ascending order
+	sort.Slice(*blockNums, func(i, j int) bool {
+		return (*blockNums)[i] < (*blockNums)[j]
+	})
+
+	writeStoredUint64Array(db, voteDataBlockNumsKey, blockNums)
+}
+
 func ReadGovDataBlockNums(db database.Database) *StoredUint64Array {
 	return readStoredUint64Array(db, govDataBlockNumsKey)
 }
 
 func WriteGovDataBlockNums(db database.Database, govDataBlockNums *StoredUint64Array) {
 	writeStoredUint64Array(db, govDataBlockNumsKey, govDataBlockNums)
+}
+
+func ReadLastInsertedBlock(db database.Database) *uint64 {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	b, err := db.Get(lastInsertedBlockKey)
+	if err != nil || len(b) == 0 {
+		return nil
+	}
+
+	if len(b) != 8 {
+		logger.Error("Invalid lastInsertedBlock data length", "length", len(b))
+		return nil
+	}
+
+	ret := binary.BigEndian.Uint64(b)
+	return &ret
+}
+
+func WriteLastInsertedBlock(db database.Database, lastInsertedBlock uint64) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	binary.BigEndian.PutUint64(lastInsertedBlockKey, lastInsertedBlock)
+	db.Put(lastInsertedBlockKey, lastInsertedBlockKey)
 }

--- a/kaiax/gov/headergov/impl/schema.go
+++ b/kaiax/gov/headergov/impl/schema.go
@@ -35,15 +35,14 @@ func readStoredUint64ArrayNoLock(db database.Database, key []byte) *StoredUint64
 
 // writeStoredUint64ArrayNoLock should be called only when the caller holds the lock.
 func writeStoredUint64ArrayNoLock(db database.Database, key []byte, data *StoredUint64Array) {
-	b, err := db.Get(key)
-	if err != nil || len(b) == 0 {
+	b, err := json.Marshal(data)
+	if err != nil {
+		logger.Error("Failed to marshal voteDataBlocks", "err", err)
 		return
 	}
 
-	ret := new(StoredUint64Array)
-	if err := json.Unmarshal(b, ret); err != nil {
-		logger.Error("Invalid voteDataBlocks JSON", "err", err)
-		return
+	if err := db.Put(key, b); err != nil {
+		logger.Crit("Failed to write voteDataBlocks", "err", err)
 	}
 }
 

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -71,6 +71,8 @@ func (m *GovModule) Start() error {
 
 func (m *GovModule) Stop() {
 	logger.Info("GovModule stopped")
+	m.hgm.Stop()
+	m.cgm.Stop()
 }
 
 func (m *GovModule) isKoreHF(num uint64) bool {

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/kaiachain/kaia/blockchain/state"
@@ -62,7 +63,10 @@ func (m *GovModule) Init(opts *InitOpts) error {
 
 func (m *GovModule) Start() error {
 	logger.Info("GovModule started")
-	return nil
+	return errors.Join(
+		m.hgm.Start(),
+		m.cgm.Start(),
+	)
 }
 
 func (m *GovModule) Stop() {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -462,6 +462,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 			headergov_impl.InsertVoteDataBlockNum(cn.chainDB.GetMiscDB(), blockNum)
 		}
 		headergov_impl.WriteLastInsertedBlock(cn.chainDB.GetMiscDB(), currentEpochStart)
+		logger.Info("Initialized last inserted block", "num", currentEpochStart)
 	}
 
 	// Setup kaiax Modules

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -442,6 +442,15 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	cn.addComponent(cn.ChainDB())
 	cn.addComponent(cn.engine)
 
+	// migrate gov DB
+	govIndices, err := chainDB.ReadRecentGovernanceIdx(0)
+	if err != nil {
+		panic("Failed to read recent governance idx")
+	}
+	govIndicesStoredArray := headergov_impl.StoredUint64Array(govIndices)
+	headergov_impl.WriteGovDataBlockNums(cn.chainDB.GetMiscDB(), &govIndicesStoredArray)
+
+	// migrate vote DB for the current epoch
 	currentEpochStart := cn.blockchain.CurrentBlock().NumberU64() % pset.Epoch()
 	lastInsertedBlockPtr := headergov_impl.ReadLastInsertedBlock(cn.chainDB.GetMiscDB())
 	if lastInsertedBlockPtr == nil {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -442,7 +442,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	cn.addComponent(cn.ChainDB())
 	cn.addComponent(cn.engine)
 
-	// migrate vote DB for the current epoch
+	// migrate vote DB for the current epoch. Gov module requires votes for current epoch.
 	currentEpochStart := currBlock.NumberU64() / pset.Epoch() * pset.Epoch()
 	lastInsertedBlockPtr := headergov_impl.ReadLastInsertedBlock(cn.chainDB.GetMiscDB())
 	if lastInsertedBlockPtr == nil {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -442,14 +442,6 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	cn.addComponent(cn.ChainDB())
 	cn.addComponent(cn.engine)
 
-	// migrate gov DB
-	govIndices, err := chainDB.ReadRecentGovernanceIdx(0)
-	if err != nil {
-		panic("Failed to read recent governance idx")
-	}
-	govIndicesStoredArray := headergov_impl.StoredUint64Array(govIndices)
-	headergov_impl.WriteGovDataBlockNums(cn.chainDB.GetMiscDB(), &govIndicesStoredArray)
-
 	// migrate vote DB for the current epoch
 	currentEpochStart := cn.blockchain.CurrentBlock().NumberU64() % pset.Epoch()
 	lastInsertedBlockPtr := headergov_impl.ReadLastInsertedBlock(cn.chainDB.GetMiscDB())


### PR DESCRIPTION
## Proposed changes

This PR introduces an "anchor" block number (`governanceLowestVoteScannedBlockNum` in code), which indicates that the block numbers larger than the anchor has been scanned and saved into `governanceVoteDataBlockNums` DB.
The anchor is decremented by an epoch after scanning all the headers to record all blocks with votes.
Therefore, the retrieval logic is different depending on whether the blocks in a given epoch are greater than anchor or not. See `getVotesInEpoch`.

```
                        lowestVoteScannedBlock                     HEAD
0                                  V                                 V
|..................................|.................................|
    votes not saved                     votes saved in DB/memory
    header scan required
```

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist
- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Service log
```
INFO[10/22,17:36:57 +09] [41|node/cn/backend.go:471]                    Initialized lowest vote scanned block     num=210
...
INFO[10/22,17:36:57 +09] [59|kaiax/gov/headergov/impl/init.go:143]      Scanned votes in header                   num=180
INFO[10/22,17:36:57 +09] [59|kaiax/gov/headergov/impl/init.go:143]      Scanned votes in header                   num=150
INFO[10/22,17:36:57 +09] [44|reward/supply_manager.go:315]              Total supply big step catchup             last=128 head=220 minted=200000000000000000000000000001228800000000000000000 burntFee=0
INFO[10/22,17:36:57 +09] [59|kaiax/gov/headergov/impl/init.go:143]      Scanned votes in header                   num=120
INFO[10/22,17:36:57 +09] [59|kaiax/gov/headergov/impl/init.go:143]      Scanned votes in header                   num=90
INFO[10/22,17:36:57 +09] [59|kaiax/gov/headergov/impl/init.go:143]      Scanned votes in header                   num=60
INFO[10/22,17:36:57 +09] [59|kaiax/gov/headergov/impl/init.go:143]      Scanned votes in header                   num=30
INFO[10/22,17:36:57 +09] [59|kaiax/gov/headergov/impl/init.go:143]      Scanned votes in header                   num=0
```