### PR TITLE
blockchain: Add PragueSigner and EIP-7702 SetCode transaction

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -152,7 +152,7 @@ func (b *BlockchainContractBackend) callContract(call kaia.CallMsg, block *types
 		call.Gas = uint64(3e8) // enough gas for ordinary contract calls
 	}
 
-	intrinsicGas, err := types.IntrinsicGas(call.Data, nil, call.To == nil, b.bc.Config().Rules(block.Number()))
+	intrinsicGas, err := types.IntrinsicGas(call.Data, nil, nil, call.To == nil, b.bc.Config().Rules(block.Number()))
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -496,7 +496,7 @@ func (b *SimulatedBackend) callContract(_ context.Context, call kaia.CallMsg, bl
 	from.SetBalance(math.MaxBig256)
 	// Execute the call.
 	nonce := from.Nonce()
-	intrinsicGas, _ := types.IntrinsicGas(call.Data, nil, call.To == nil, b.config.Rules(block.Number()))
+	intrinsicGas, _ := types.IntrinsicGas(call.Data, nil, nil, call.To == nil, b.config.Rules(block.Number()))
 
 	var accessList types.AccessList
 	if call.AccessList != nil {

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1413,7 +1413,7 @@ func EthDoCall(ctx context.Context, b Backend, args EthTransactionArgs, blockNrO
 	} else {
 		baseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
 	}
-	intrinsicGas, err := types.IntrinsicGas(args.data(), nil, args.To == nil, b.ChainConfig().Rules(header.Number))
+	intrinsicGas, err := types.IntrinsicGas(args.data(), nil, nil, args.To == nil, b.ChainConfig().Rules(header.Number))
 	if err != nil {
 		return nil, err
 	}
@@ -1570,7 +1570,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	precompiles := vm.ActivePrecompiles(rules)
 
 	toMsg := func() (*types.Transaction, error) {
-		intrinsicGas, err := types.IntrinsicGas(args.data(), nil, args.To == nil, rules)
+		intrinsicGas, err := types.IntrinsicGas(args.data(), nil, nil, args.To == nil, rules)
 		if err != nil {
 			return nil, err
 		}

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -771,7 +771,7 @@ type ethTxJSON struct {
 	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
 	AccessList *types.AccessList `json:"accessList,omitempty"`
 
-	// Authorization list transaction (SetCodeTx) fields:
+	// Set code transaction fields:
 	AuthorizationList *types.AuthorizationList `json:"authorizationList,omitempty"`
 
 	// Only used for encoding:

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -722,25 +722,26 @@ func (api *EthereumAPI) GetBlockTransactionCountByHash(ctx context.Context, bloc
 // RPCTransaction in go-ethereum has been renamed to EthRPCTransaction.
 // RPCTransaction is defined in go-ethereum's internal package, so RPCTransaction is redefined here as EthRPCTransaction.
 type EthRPCTransaction struct {
-	BlockHash        *common.Hash      `json:"blockHash"`
-	BlockNumber      *hexutil.Big      `json:"blockNumber"`
-	From             common.Address    `json:"from"`
-	Gas              hexutil.Uint64    `json:"gas"`
-	GasPrice         *hexutil.Big      `json:"gasPrice"`
-	GasFeeCap        *hexutil.Big      `json:"maxFeePerGas,omitempty"`
-	GasTipCap        *hexutil.Big      `json:"maxPriorityFeePerGas,omitempty"`
-	Hash             common.Hash       `json:"hash"`
-	Input            hexutil.Bytes     `json:"input"`
-	Nonce            hexutil.Uint64    `json:"nonce"`
-	To               *common.Address   `json:"to"`
-	TransactionIndex *hexutil.Uint64   `json:"transactionIndex"`
-	Value            *hexutil.Big      `json:"value"`
-	Type             hexutil.Uint64    `json:"type"`
-	Accesses         *types.AccessList `json:"accessList,omitempty"`
-	ChainID          *hexutil.Big      `json:"chainId,omitempty"`
-	V                *hexutil.Big      `json:"v"`
-	R                *hexutil.Big      `json:"r"`
-	S                *hexutil.Big      `json:"s"`
+	BlockHash        *common.Hash             `json:"blockHash"`
+	BlockNumber      *hexutil.Big             `json:"blockNumber"`
+	From             common.Address           `json:"from"`
+	Gas              hexutil.Uint64           `json:"gas"`
+	GasPrice         *hexutil.Big             `json:"gasPrice"`
+	GasFeeCap        *hexutil.Big             `json:"maxFeePerGas,omitempty"`
+	GasTipCap        *hexutil.Big             `json:"maxPriorityFeePerGas,omitempty"`
+	Hash             common.Hash              `json:"hash"`
+	Input            hexutil.Bytes            `json:"input"`
+	Nonce            hexutil.Uint64           `json:"nonce"`
+	To               *common.Address          `json:"to"`
+	TransactionIndex *hexutil.Uint64          `json:"transactionIndex"`
+	Value            *hexutil.Big             `json:"value"`
+	Type             hexutil.Uint64           `json:"type"`
+	Accesses         *types.AccessList        `json:"accessList,omitempty"`
+	Authorizations   *types.AuthorizationList `json:"authorizationList,omitempty"`
+	ChainID          *hexutil.Big             `json:"chainId,omitempty"`
+	V                *hexutil.Big             `json:"v"`
+	R                *hexutil.Big             `json:"r"`
+	S                *hexutil.Big             `json:"s"`
 }
 
 // ethTxJSON is the JSON representation of Ethereum transaction.
@@ -767,8 +768,9 @@ type ethTxJSON struct {
 	To                   *common.Address `json:"to"`
 
 	// Access list transaction fields:
-	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
-	AccessList *types.AccessList `json:"accessList,omitempty"`
+	ChainID           *hexutil.Big             `json:"chainId,omitempty"`
+	AccessList        *types.AccessList        `json:"accessList,omitempty"`
+	AuthorizationList *types.AuthorizationList `json:"authorizationList,omitempty"`
 
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
@@ -863,6 +865,20 @@ func newEthRPCTransaction(block *types.Block, tx *types.Transaction, blockHash c
 			// transaction is not processed yet
 			result.GasPrice = (*hexutil.Big)(tx.EffectiveGasPrice(nil, nil))
 		}
+	case types.TxTypeEthereumSetCode:
+		al := tx.AccessList()
+		aul := tx.AuthorizationList()
+		result.Accesses = &al
+		result.Authorizations = &aul
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
+		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
+		if block != nil {
+			result.GasPrice = (*hexutil.Big)(tx.EffectiveGasPrice(block.Header(), config))
+		} else {
+			// transaction is not processed yet
+			result.GasPrice = (*hexutil.Big)(tx.EffectiveGasPrice(nil, nil))
+		}
 	}
 	return result
 }
@@ -915,6 +931,14 @@ func formatTxToEthTxJSON(tx *types.Transaction) *ethTxJSON {
 	case types.TxTypeEthereumDynamicFee:
 		al := tx.AccessList()
 		enc.AccessList = &al
+		enc.ChainID = (*hexutil.Big)(tx.ChainId())
+		enc.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
+		enc.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())
+	case types.TxTypeEthereumSetCode:
+		al := tx.AccessList()
+		aul := tx.AuthorizationList()
+		enc.AccessList = &al
+		enc.AuthorizationList = &aul
 		enc.ChainID = (*hexutil.Big)(tx.ChainId())
 		enc.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		enc.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -770,6 +770,8 @@ type ethTxJSON struct {
 	// Access list transaction fields:
 	ChainID           *hexutil.Big             `json:"chainId,omitempty"`
 	AccessList        *types.AccessList        `json:"accessList,omitempty"`
+
+	// Authorization list transaction (SetCodeTx) fields:
 	AuthorizationList *types.AuthorizationList `json:"authorizationList,omitempty"`
 
 	// Only used for encoding:

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -768,8 +768,8 @@ type ethTxJSON struct {
 	To                   *common.Address `json:"to"`
 
 	// Access list transaction fields:
-	ChainID           *hexutil.Big             `json:"chainId,omitempty"`
-	AccessList        *types.AccessList        `json:"accessList,omitempty"`
+	ChainID    *hexutil.Big      `json:"chainId,omitempty"`
+	AccessList *types.AccessList `json:"accessList,omitempty"`
 
 	// Authorization list transaction (SetCodeTx) fields:
 	AuthorizationList *types.AuthorizationList `json:"authorizationList,omitempty"`

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -319,7 +319,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	// this makes sure resources are cleaned up.
 	defer cancel()
 
-	intrinsicGas, err := types.IntrinsicGas(args.InputData(), nil, args.To == nil, b.ChainConfig().Rules(header.Number))
+	intrinsicGas, err := types.IntrinsicGas(args.InputData(), nil, nil, args.To == nil, b.ChainConfig().Rules(header.Number))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -635,7 +635,7 @@ func newRPCTransaction(header *types.Header, tx *types.Transaction, blockHash co
 	output["from"] = getFrom(tx)
 	output["hash"] = tx.Hash()
 	output["transactionIndex"] = hexutil.Uint(index)
-	if tx.Type() == types.TxTypeEthereumDynamicFee {
+	if tx.Type() == types.TxTypeEthereumDynamicFee || tx.Type() == types.TxTypeEthereumSetCode {
 		if header != nil {
 			output["gasPrice"] = (*hexutil.Big)(tx.EffectiveGasPrice(header, config))
 		} else {

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -178,11 +178,11 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	}
 
 	// For the transaction that do not use the gasPrice field, the default value of gasPrice is not set.
-	if args.Price == nil && *args.TypeInt != types.TxTypeEthereumDynamicFee {
+	if args.Price == nil && (*args.TypeInt != types.TxTypeEthereumDynamicFee && *args.TypeInt != types.TxTypeEthereumSetCode) {
 		args.Price = (*hexutil.Big)(price)
 	}
 
-	if *args.TypeInt == types.TxTypeEthereumDynamicFee {
+	if *args.TypeInt == types.TxTypeEthereumDynamicFee || *args.TypeInt == types.TxTypeEthereumSetCode {
 		if args.MaxPriorityFeePerGas == nil {
 			args.MaxPriorityFeePerGas = (*hexutil.Big)(tip)
 		}
@@ -263,8 +263,8 @@ func (args *SendTxArgs) genTxValuesMap() map[types.TxValueKeyType]interface{} {
 	if args.TypeInt == nil || args.AccountNonce == nil || args.GasLimit == nil {
 		return values
 	}
-	// GasPrice can be an optional tx filed for TxTypeEthereumDynamicFee
-	if args.Price == nil && *args.TypeInt != types.TxTypeEthereumDynamicFee {
+	// GasPrice can be an optional tx filed for TxTypeEthereumDynamicFee or TxTypeEthereumSetCode.
+	if args.Price == nil && (*args.TypeInt != types.TxTypeEthereumDynamicFee && *args.TypeInt != types.TxTypeEthereumSetCode) {
 		return values
 	}
 

--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -111,7 +111,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
-		gas, _ := types.IntrinsicGas(data, nil, false, params.TestChainConfig.Rules(big.NewInt(0)))
+		gas, _ := types.IntrinsicGas(data, nil, nil, false, params.TestChainConfig.Rules(big.NewInt(0)))
 		signer := types.LatestSignerForChainID(params.TestChainConfig.ChainID)
 		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(benchRootAddr), toaddr, big.NewInt(1), gas, nil, data), signer, benchRootKey)
 		gen.AddTx(tx)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1459,7 +1459,7 @@ func TestAccessListTx(t *testing.T) {
 			b.SetRewardbase(common.Address{1})
 
 			// One transaction to 0xAAAA
-			intrinsicGas, _ := types.IntrinsicGas([]byte{}, list, false, gspec.Config.Rules(block.Number()))
+			intrinsicGas, _ := types.IntrinsicGas([]byte{}, list, nil, false, gspec.Config.Rules(block.Number()))
 			tx, _ := types.SignTx(types.NewMessage(senderAddr, &contractAddr, senderNonce, big.NewInt(0), 30000, big.NewInt(1), []byte{}, false, intrinsicGas, list), signer, senderKey)
 			b.AddTx(tx)
 		})

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -147,4 +147,11 @@ var (
 
 	// ErrGasPriceBelowBaseFee is returned if gas price of transaction is lower than gas unit price.
 	ErrGasPriceBelowBaseFee = errors.New("invalid gas price. It must be set to value greater than or equal to baseFee")
+
+	// ErrEmptyAuthList is returned if a set code transaction has an empty auth list.
+	ErrEmptyAuthList = errors.New("set code transaction with empty auth list")
+
+	// ErrAuthSignatureVeryHigh is returned if a set code transaction has a
+	// signature with R or S larger than 2^256-1.
+	ErrAuthSignatureVeryHigh = errors.New("set code transaction has authorization with R or S value greater than 2^256 - 1")
 )

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -399,13 +399,16 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			if exists := st.state.Exist(authority); exists {
 				st.state.AddRefund(params.CallNewAccountGas - params.TxAuthTupleGas)
 			}
-			st.state.SetNonce(authority, auth.Nonce+1)
+			st.state.IncNonce(authority)
 			delegation := types.AddressToDelegation(auth.Address)
 			if auth.Address == common.ZeroAddress {
 				// If the delegation is for the zero address, completely clear all
 				// delegations from the account.
 				delegation = []byte{}
 			}
+			// TODO: Change to a method that adds code to EOA
+			// This is currently expected to be an error. This will be addressed in a PR that adds a code hash field to the EOA.
+			// https://github.com/kaiachain/kaia/blob/v1.0.3/blockchain/state/state_object.go#L542
 			st.state.SetCode(authority, delegation)
 
 			// Usually the transaction destination and delegation target are added to

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -410,7 +410,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 				// delegations from the account.
 				delegation = []byte{}
 			}
-			// TODO: Change to a method that adds code to EOA
+			// TODO-7702: Change to a method that adds code to EOA
 			// This is currently expected to be an error. This will be addressed in a PR that adds a code hash field to the EOA.
 			// https://github.com/kaiachain/kaia/blob/v1.0.3/blockchain/state/state_object.go#L542
 			st.state.SetCode(authority, delegation)

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -123,6 +123,7 @@ type Message interface {
 	Execute(vm types.VM, stateDB types.StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) ([]byte, uint64, error)
 
 	AccessList() types.AccessList
+	AuthorizationList() types.AuthorizationList
 }
 
 // ExecutionResult includes all output after executing given evm
@@ -291,6 +292,16 @@ func (st *StateTransition) preCheck() error {
 			return ErrNonceTooLow
 		}
 	}
+
+	// Check that EIP-7702 authorization list signatures are well formed.
+	for i, auth := range st.msg.AuthorizationList() {
+		switch {
+		case auth.R.BitLen() > 256:
+			return fmt.Errorf("%w: address %v, authorization %d", ErrAuthSignatureVeryHigh, st.msg.ValidatedSender(), i)
+		case auth.S.BitLen() > 256:
+			return fmt.Errorf("%w: address %v, authorization %d", ErrAuthSignatureVeryHigh, st.msg.ValidatedSender(), i)
+		}
+	}
 	return st.buyGas()
 }
 
@@ -347,10 +358,64 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
 
+	// Verify authorization list is not empty.
+	if msg.AuthorizationList() != nil && len(msg.AuthorizationList()) == 0 {
+		return nil, fmt.Errorf("%w: address %v", ErrEmptyAuthList, msg.ValidatedSender())
+	}
+
 	// Execute the preparatory steps for state transition which includes:
 	// - prepare accessList(post-berlin)
 	// - reset transient storage(eip 1153)
 	st.state.Prepare(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Context.Coinbase, msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
+
+	// Check authorizations list validity.
+	if msg.AuthorizationList() != nil {
+		for _, auth := range msg.AuthorizationList() {
+			// Verify chain ID is 0 or equal to current chain ID.
+			if auth.ChainID != big.NewInt(0) && st.evm.ChainConfig().ChainID != auth.ChainID {
+				continue
+			}
+			// Limit nonce to 2^64-1 per EIP-2681.
+			if auth.Nonce+1 < auth.Nonce {
+				continue
+			}
+			// Validate signature values and recover authority.
+			authority, err := auth.Authority()
+			if err != nil {
+				continue
+			}
+			// Check the authority account 1) doesn't have code or has exisiting
+			// delegation 2) matches the auth's nonce
+			st.state.AddAddressToAccessList(authority)
+			code := st.state.GetCode(authority)
+			if _, ok := types.ParseDelegation(code); len(code) != 0 && !ok {
+				continue
+			}
+			if have := st.state.GetNonce(authority); have != auth.Nonce {
+				continue
+			}
+			// If the account already exists in state, refund the new account cost
+			// charged in the initrinsic calculation.
+			if exists := st.state.Exist(authority); exists {
+				st.state.AddRefund(params.CallNewAccountGas - params.TxAuthTupleGas)
+			}
+			st.state.SetNonce(authority, auth.Nonce+1)
+			delegation := types.AddressToDelegation(auth.Address)
+			if auth.Address == common.ZeroAddress {
+				// If the delegation is for the zero address, completely clear all
+				// delegations from the account.
+				delegation = []byte{}
+			}
+			st.state.SetCode(authority, delegation)
+
+			// Usually the transaction destination and delegation target are added to
+			// the access list in statedb.Prepare(..), however if the delegation is in
+			// the same transaction we need add here as Prepare already happened.
+			if *msg.To() == authority {
+				st.state.AddAddressToAccessList(auth.Address)
+			}
+		}
+	}
 
 	// Check whether the init code size has been exceeded.
 	if rules.IsShanghai && msg.To() == nil && len(st.data) > params.MaxInitCodeSize {

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -405,7 +405,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			}
 			st.state.IncNonce(authority)
 			delegation := types.AddressToDelegation(auth.Address)
-			if auth.Address == common.ZeroAddress {
+			if common.EmptyAddress(auth.Address) {
 				// If the delegation is for the zero address, completely clear all
 				// delegations from the account.
 				delegation = []byte{}

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -397,6 +397,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			// If the account already exists in state, refund the new account cost
 			// charged in the initrinsic calculation.
 			if exists := st.state.Exist(authority); exists {
+				// If the account is not AccountKeyTypeLegacy, setcode is not allowed.
+				if !st.state.GetKey(authority).Type().IsLegacyAccountKey() {
+					continue
+				}
 				st.state.AddRefund(params.CallNewAccountGas - params.TxAuthTupleGas)
 			}
 			st.state.IncNonce(authority)

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -675,7 +675,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 		return ErrTxTypeNotSupported
 	}
 	// Reject dynamic fee transactions until EIP-1559 activates.
-	if !pool.rules.IsEthTxType && tx.Type() == types.TxTypeEthereumDynamicFee {
+	if !pool.rules.IsEthTxType && (tx.Type() == types.TxTypeEthereumDynamicFee || tx.Type() == types.TxTypeEthereumSetCode) {
 		return ErrTxTypeNotSupported
 	}
 
@@ -691,7 +691,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 
 	// NOTE-Kaia Drop transactions with unexpected gasPrice
 	// If the transaction type is DynamicFee tx, Compare transaction's GasFeeCap(MaxFeePerGas) and GasTipCap with tx pool's gasPrice to check to have same value.
-	if tx.Type() == types.TxTypeEthereumDynamicFee {
+	if tx.Type() == types.TxTypeEthereumDynamicFee || tx.Type() == types.TxTypeEthereumSetCode {
 		// Sanity check for extremely large numbers
 		if tx.GasTipCap().BitLen() > 256 {
 			return ErrTipVeryHigh

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -285,7 +285,7 @@ func (tx *Transaction) setDecoded(inner TxInternalData, size int) {
 func (tx *Transaction) Gas() uint64        { return tx.data.GetGasLimit() }
 func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.GetPrice()) }
 func (tx *Transaction) GasTipCap() *big.Int {
-	if tx.Type() == TxTypeEthereumDynamicFee {
+	if tx.Type() == TxTypeEthereumDynamicFee || tx.Type() == TxTypeEthereumSetCode {
 		te := tx.GetTxInternalData().(TxInternalDataBaseFee)
 		return te.GetGasTipCap()
 	}
@@ -294,7 +294,7 @@ func (tx *Transaction) GasTipCap() *big.Int {
 }
 
 func (tx *Transaction) GasFeeCap() *big.Int {
-	if tx.Type() == TxTypeEthereumDynamicFee {
+	if tx.Type() == TxTypeEthereumDynamicFee || tx.Type() == TxTypeEthereumSetCode {
 		te := tx.GetTxInternalData().(TxInternalDataBaseFee)
 		return te.GetGasFeeCap()
 	}

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -333,6 +333,14 @@ func (tx *Transaction) AccessList() AccessList {
 	return nil
 }
 
+func (tx *Transaction) AuthorizationList() AuthorizationList {
+	if tx.Type() == TxTypeEthereumSetCode {
+		te := tx.GetTxInternalData().(*TxInternalDataEthereumSetCode)
+		return te.GetAuthorizationList()
+	}
+	return nil
+}
+
 func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.data.GetAmount()) }
 func (tx *Transaction) Nonce() uint64   { return tx.data.GetAccountNonce() }
 func (tx *Transaction) CheckNonce() bool {

--- a/blockchain/types/transaction_signing.go
+++ b/blockchain/types/transaction_signing.go
@@ -58,8 +58,10 @@ type sigCachePubkey struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 
-	if config.IsEthTxTypeForkEnabled(blockNumber) {
+	if config.IsPragueForkEnabled(blockNumber) {
 		signer = NewPragueSigner(config.ChainID)
+	} else if config.IsEthTxTypeForkEnabled(blockNumber) {
+		signer = NewLondonSigner(config.ChainID)
 	} else {
 		signer = NewEIP155Signer(config.ChainID)
 	}
@@ -75,10 +77,12 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 // Use this in transaction-handling code where the current block number is unknown. If you
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
-	// Be aware that it checks whether EthTxTypeCompatibleBlock is set,
+	// Be aware that it checks whether EthTxTypeCompatibleBlock or PragueCompatible is set,
 	// but doesn't check whether it is enabled on a specific block number.
-	if config.EthTxTypeCompatibleBlock != nil {
+	if config.PragueCompatibleBlock != nil {
 		return NewPragueSigner(config.ChainID)
+	} else if config.EthTxTypeCompatibleBlock != nil {
+		return NewLondonSigner(config.ChainID)
 	}
 
 	return NewEIP155Signer(config.ChainID)

--- a/blockchain/types/transaction_signing.go
+++ b/blockchain/types/transaction_signing.go
@@ -315,7 +315,6 @@ func (s pragueSigner) SenderPubkey(tx *Transaction) ([]*ecdsa.PublicKey, error) 
 // SenderFeePayer returns the public key derived from tx signature and txhash.
 func (s pragueSigner) SenderFeePayer(tx *Transaction) ([]*ecdsa.PublicKey, error) {
 	// EIP-7702(Set code transaction) tx don't supported fee-delegation.
-	// EIP-1559(Dynamic fee transaction) tx don't supported fee-delegation.
 	return s.londonSigner.SenderFeePayer(tx)
 }
 

--- a/blockchain/types/transaction_signing_test.go
+++ b/blockchain/types/transaction_signing_test.go
@@ -55,7 +55,7 @@ func TestPragueSigning(t *testing.T) {
 			GasLimit:          100,
 			AccessList:        accessList,
 			AuthorizationList: authorizationList,
-			Recipient:         &addr,
+			Recipient:         addr,
 		})},
 		{"WithChainID", NewTx(&TxInternalDataEthereumSetCode{
 			AccountNonce:      1,
@@ -65,7 +65,7 @@ func TestPragueSigning(t *testing.T) {
 			GasLimit:          100,
 			AccessList:        accessList,
 			AuthorizationList: authorizationList,
-			Recipient:         &addr,
+			Recipient:         addr,
 			ChainID:           big.NewInt(10),
 		})},
 		{"WithNoBitChainID", NewTx(&TxInternalDataEthereumSetCode{
@@ -76,7 +76,7 @@ func TestPragueSigning(t *testing.T) {
 			GasLimit:          100,
 			AccessList:        accessList,
 			AuthorizationList: authorizationList,
-			Recipient:         &addr,
+			Recipient:         addr,
 			ChainID:           new(big.Int),
 		})},
 	}

--- a/blockchain/types/transaction_signing_test.go
+++ b/blockchain/types/transaction_signing_test.go
@@ -37,6 +37,89 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPragueSigningWithoutChainID(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	accessList := AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
+	authorizationList := AuthorizationList{{ChainID: big.NewInt(10), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: big.NewInt(0), R: big.NewInt(0), S: big.NewInt(0)}}
+
+	signer := NewPragueSigner(big.NewInt(10))
+	tx, err := SignTx(NewTx(&TxInternalDataEthereumSetCode{
+		AccountNonce:      1,
+		Amount:            big.NewInt(10),
+		GasFeeCap:         big.NewInt(10),
+		GasTipCap:         big.NewInt(10),
+		GasLimit:          100,
+		AccessList:        accessList,
+		AuthorizationList: authorizationList,
+		Recipient:         &addr,
+	}), signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	from, err := Sender(signer, tx)
+	if from != addr {
+		t.Errorf("exected from and address to be equal. Got %x want %x", from, addr)
+	}
+}
+
+func TestPragueSigningWithChainID(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	accessList := AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
+	authorizationList := AuthorizationList{{ChainID: big.NewInt(10), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: big.NewInt(0), R: big.NewInt(0), S: big.NewInt(0)}}
+
+	signer := NewPragueSigner(big.NewInt(10))
+	tx, err := SignTx(NewTx(&TxInternalDataEthereumSetCode{
+		AccountNonce:      1,
+		Amount:            big.NewInt(10),
+		GasFeeCap:         big.NewInt(10),
+		GasTipCap:         big.NewInt(10),
+		GasLimit:          100,
+		AccessList:        accessList,
+		AuthorizationList: authorizationList,
+		Recipient:         &addr,
+		ChainID:           big.NewInt(10),
+	}), signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	from, err := Sender(signer, tx)
+	if from != addr {
+		t.Errorf("exected from and address to be equal. Got %x want %x", from, addr)
+	}
+}
+
+func TestPragueSigningWithNoBitChainID(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	accessList := AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
+	authorizationList := AuthorizationList{{ChainID: big.NewInt(10), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: big.NewInt(0), R: big.NewInt(0), S: big.NewInt(0)}}
+
+	signer := NewPragueSigner(big.NewInt(10))
+	tx, err := SignTx(NewTx(&TxInternalDataEthereumSetCode{
+		AccountNonce:      1,
+		Amount:            big.NewInt(10),
+		GasFeeCap:         big.NewInt(10),
+		GasTipCap:         big.NewInt(10),
+		GasLimit:          100,
+		AccessList:        accessList,
+		AuthorizationList: authorizationList,
+		Recipient:         &addr,
+		ChainID:           new(big.Int),
+	}), signer, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	from, err := Sender(signer, tx)
+	if from != addr {
+		t.Errorf("exected from and address to be equal. Got %x want %x", from, addr)
+	}
+}
+
 func TestLondonSigningWithoutChainID(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -625,19 +625,19 @@ func TestIntrinsicGas(t *testing.T) {
 		data, err = hex.DecodeString(tc.inputString) // decode input string to hex data
 		assert.Equal(t, nil, err)
 
-		gas, err = IntrinsicGas(data, nil, false, params.Rules{IsIstanbul: false})
+		gas, err = IntrinsicGas(data, nil, nil, false, params.Rules{IsIstanbul: false})
 		assert.Equal(t, tc.expectGas1, gas)
 		assert.Equal(t, nil, err)
 
-		gas, err = IntrinsicGas(data, nil, false, params.Rules{IsIstanbul: true})
+		gas, err = IntrinsicGas(data, nil, nil, false, params.Rules{IsIstanbul: true})
 		assert.Equal(t, tc.expectGas2, gas)
 		assert.Equal(t, nil, err)
 
-		gas, err = IntrinsicGas(data, nil, true, params.Rules{IsIstanbul: false})
+		gas, err = IntrinsicGas(data, nil, nil, true, params.Rules{IsIstanbul: false})
 		assert.Equal(t, tc.expectGas3, gas)
 		assert.Equal(t, nil, err)
 
-		gas, err = IntrinsicGas(data, nil, true, params.Rules{IsIstanbul: true})
+		gas, err = IntrinsicGas(data, nil, nil, true, params.Rules{IsIstanbul: true})
 		assert.Equal(t, tc.expectGas4, gas)
 		assert.Equal(t, nil, err)
 	}

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -839,7 +839,7 @@ func TestTransactionCoding(t *testing.T) {
 			txData = &TxInternalDataEthereumSetCode{
 				ChainID:           big.NewInt(1),
 				AccountNonce:      i,
-				Recipient:         &recipient,
+				Recipient:         recipient,
 				GasLimit:          123457,
 				GasFeeCap:         big.NewInt(10),
 				GasTipCap:         big.NewInt(10),

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -835,7 +835,7 @@ func TestTransactionCoding(t *testing.T) {
 				AccessList:   accesses,
 			}
 		case 8:
-			// Tx with non-zero authorization list.
+			// Tx with non-zero access list.
 			txData = &TxInternalDataEthereumSetCode{
 				ChainID:           big.NewInt(1),
 				AccountNonce:      i,
@@ -844,6 +844,17 @@ func TestTransactionCoding(t *testing.T) {
 				GasFeeCap:         big.NewInt(10),
 				GasTipCap:         big.NewInt(10),
 				AccessList:        accesses,
+				AuthorizationList: authorizations,
+			}
+		case 9:
+			// Tx with set code.
+			txData = &TxInternalDataEthereumSetCode{
+				ChainID:           big.NewInt(1),
+				AccountNonce:      i,
+				Recipient:         recipient,
+				GasLimit:          123457,
+				GasFeeCap:         big.NewInt(10),
+				GasTipCap:         big.NewInt(10),
 				AuthorizationList: authorizations,
 			}
 		}

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -834,6 +834,18 @@ func TestTransactionCoding(t *testing.T) {
 				GasTipCap:    big.NewInt(10),
 				AccessList:   accesses,
 			}
+		case 8:
+			// Tx with non-zero authorization list.
+			txData = &TxInternalDataEthereumSetCode{
+				ChainID:           big.NewInt(1),
+				AccountNonce:      i,
+				Recipient:         &recipient,
+				GasLimit:          123457,
+				GasFeeCap:         big.NewInt(10),
+				GasTipCap:         big.NewInt(10),
+				AccessList:        accesses,
+				AuthorizationList: authorizations,
+			}
 		}
 
 		transaction := Transaction{data: txData}

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -614,7 +614,7 @@ func IntrinsicGasPayloadLegacy(gas uint64, data []byte) (uint64, error) {
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.
-func IntrinsicGas(data []byte, accessList AccessList, contractCreation bool, r params.Rules) (uint64, error) {
+func IntrinsicGas(data []byte, accessList AccessList, authorizationList AuthorizationList, contractCreation bool, r params.Rules) (uint64, error) {
 	// Set the starting gas for the raw transaction
 	var gas uint64
 	if contractCreation {
@@ -641,6 +641,13 @@ func IntrinsicGas(data []byte, accessList AccessList, contractCreation bool, r p
 	if accessList != nil {
 		gasPayloadWithGas += uint64(len(accessList)) * params.TxAccessListAddressGas
 		gasPayloadWithGas += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
+	}
+
+	// We charge additional gas for the authorizationList:
+	// PER_EMPTY_ACCOUNT_COST : gas per address in authorizationList
+	// Since this is the same value as CallNewAccountGas, we will use this.
+	if authorizationList != nil {
+		gasPayloadWithGas += uint64(len(authorizationList)) * params.CallNewAccountGas
 	}
 
 	return gasPayloadWithGas, nil

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -58,8 +58,7 @@ const (
 	TxTypeKaiaLast, _, _
 	TxTypeEthereumAccessList = TxType(0x7801)
 	TxTypeEthereumDynamicFee = TxType(0x7802)
-	// Kaia has determined that BLOB_TX defined in EIP4844 is not necessary.
-	// https://github.com/ethereum/EIPs/blob/70471d02d48a81ca963407abe9c48706059dc8e8/EIPS/eip-4844.md
+	// EIP-4844 BLOB_TX_TYPE not supported in Kaia.
 	_                     = TxType(0x7803)
 	TxTypeEthereumSetCode = TxType(0x7804)
 	TxTypeEthereumLast    = TxType(0x7805)

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -60,9 +60,9 @@ const (
 	TxTypeEthereumDynamicFee = TxType(0x7802)
 	// Kaia has determined that BLOB_TX defined in EIP4844 is not necessary.
 	// https://github.com/ethereum/EIPs/blob/70471d02d48a81ca963407abe9c48706059dc8e8/EIPS/eip-4844.md
-	_ = TxType(0x7803)
-	TxTypeEthereumSetCode    = TxType(0x7804)
-	TxTypeEthereumLast       = TxType(0x7805)
+	_                     = TxType(0x7803)
+	TxTypeEthereumSetCode = TxType(0x7804)
+	TxTypeEthereumLast    = TxType(0x7805)
 )
 
 type TxValueKeyType uint

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -58,7 +58,8 @@ const (
 	TxTypeKaiaLast, _, _
 	TxTypeEthereumAccessList = TxType(0x7801)
 	TxTypeEthereumDynamicFee = TxType(0x7802)
-	TxTypeEthereumLast       = TxType(0x7803)
+	TxTypeEthereumSetCode    = TxType(0x7803)
+	TxTypeEthereumLast       = TxType(0x7804)
 )
 
 type TxValueKeyType uint
@@ -83,6 +84,7 @@ const (
 	TxValueKeyChainID
 	TxValueKeyGasTipCap
 	TxValueKeyGasFeeCap
+	TxValueKeyAuthorizationList
 )
 
 type TxTypeMask uint8
@@ -115,6 +117,7 @@ var (
 	errValueKeyFeeRatioMustUint8         = errors.New("FeeRatio must be a type of uint8")
 	errValueKeyCodeFormatInvalid         = errors.New("The smart contract code format is invalid")
 	errValueKeyAccessListInvalid         = errors.New("AccessList must be a type of AccessList")
+	errValueKeyAuthorizationListInvalid  = errors.New("AuthorizationList must be a type of AuthorizationList")
 	errValueKeyChainIDInvalid            = errors.New("ChainID must be a type of ChainID")
 	errValueKeyGasTipCapMustBigInt       = errors.New("GasTipCap must be a type of *big.Int")
 	errValueKeyGasFeeCapMustBigInt       = errors.New("GasFeeCap must be a type of *big.Int")
@@ -164,6 +167,8 @@ func (t TxValueKeyType) String() string {
 		return "TxValueKeyGasTipCap"
 	case TxValueKeyGasFeeCap:
 		return "TxValueKeyGasFeeCap"
+	case TxValueKeyAuthorizationList:
+		return "TxValueKeyAuthorizationList"
 	}
 
 	return "UndefinedTxValueKeyType"
@@ -223,6 +228,8 @@ func (t TxType) String() string {
 		return "TxTypeEthereumAccessList"
 	case TxTypeEthereumDynamicFee:
 		return "TxTypeEthereumDynamicFee"
+	case TxTypeEthereumSetCode:
+		return "TxTypeEthereumSetCode"
 	}
 
 	return "UndefinedTxType"
@@ -481,6 +488,8 @@ func NewTxInternalData(t TxType) (TxInternalData, error) {
 		return newTxInternalDataEthereumAccessList(), nil
 	case TxTypeEthereumDynamicFee:
 		return newTxInternalDataEthereumDynamicFee(), nil
+	case TxTypeEthereumSetCode:
+		return newTxInternalDataEthereumSetCode(), nil
 	}
 
 	return nil, errUndefinedTxType
@@ -538,6 +547,8 @@ func NewTxInternalDataWithMap(t TxType, values map[TxValueKeyType]interface{}) (
 		return newTxInternalDataEthereumAccessListWithMap(values)
 	case TxTypeEthereumDynamicFee:
 		return newTxInternalDataEthereumDynamicFeeWithMap(values)
+	case TxTypeEthereumSetCode:
+		return newTxInternalDataEthereumSetCodeWithMap(values)
 	}
 
 	return nil, errUndefinedTxType

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -58,8 +58,11 @@ const (
 	TxTypeKaiaLast, _, _
 	TxTypeEthereumAccessList = TxType(0x7801)
 	TxTypeEthereumDynamicFee = TxType(0x7802)
-	TxTypeEthereumSetCode    = TxType(0x7803)
-	TxTypeEthereumLast       = TxType(0x7804)
+	// Kaia has determined that BLOB_TX defined in EIP4844 is not necessary.
+	// https://github.com/ethereum/EIPs/blob/70471d02d48a81ca963407abe9c48706059dc8e8/EIPS/eip-4844.md
+	_ = TxType(0x7803)
+	TxTypeEthereumSetCode    = TxType(0x7804)
+	TxTypeEthereumLast       = TxType(0x7805)
 )
 
 type TxValueKeyType uint

--- a/blockchain/types/tx_internal_data_ethereum_access_list.go
+++ b/blockchain/types/tx_internal_data_ethereum_access_list.go
@@ -294,7 +294,7 @@ func (t *TxInternalDataEthereumAccessList) RecoverPubkey(txhash common.Hash, hom
 }
 
 func (t *TxInternalDataEthereumAccessList) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
-	return IntrinsicGas(t.Payload, t.AccessList, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	return IntrinsicGas(t.Payload, t.AccessList, nil, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 }
 
 func (t *TxInternalDataEthereumAccessList) setSignatureValues(chainID, v, r, s *big.Int) {

--- a/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
+++ b/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
@@ -289,7 +289,7 @@ func (t *TxInternalDataEthereumDynamicFee) RecoverPubkey(txhash common.Hash, hom
 }
 
 func (t *TxInternalDataEthereumDynamicFee) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
-	return IntrinsicGas(t.Payload, t.AccessList, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	return IntrinsicGas(t.Payload, t.AccessList, nil, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 }
 
 func (t *TxInternalDataEthereumDynamicFee) ChainId() *big.Int {

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -1,20 +1,18 @@
-// Modifications Copyright 2024 The Kaia Authors
-// Copyright 2019 The klaytn Authors
-// This file is part of the klaytn library.
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
 //
-// The klaytn library is free software: you can redistribute it and/or modify
+// The Kaia library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The klaytn library is distributed in the hope that it will be useful,
+// The Kaia library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
-// Modified and improved for the Kaia development.
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
 package types
 

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -306,8 +306,7 @@ func (t *TxInternalDataEthereumSetCode) Equal(a TxInternalData) bool {
 }
 
 func (t *TxInternalDataEthereumSetCode) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
-	gas, err := IntrinsicGas(t.Payload, t.AccessList, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
-	return gas + uint64(len(t.AuthorizationList))*params.CallNewAccountGas, err
+	return IntrinsicGas(t.Payload, t.AccessList, t.AuthorizationList, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 }
 
 func (t *TxInternalDataEthereumSetCode) SerializeForSign() []interface{} {

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -1,0 +1,542 @@
+// Modifications Copyright 2024 The Kaia Authors
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+// Modified and improved for the Kaia development.
+
+package types
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/kaiachain/kaia/blockchain/types/accountkey"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/fork"
+	"github.com/kaiachain/kaia/kerrors"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/rlp"
+)
+
+// DelegationPrefix is used by code to denote the account is delegating to
+// another account.
+var DelegationPrefix = []byte{0xef, 0x01, 0x00}
+
+// ParseDelegation tries to parse the address from a delegation slice.
+func ParseDelegation(b []byte) (common.Address, bool) {
+	if len(b) != 23 || !bytes.HasPrefix(b, DelegationPrefix) {
+		return common.Address{}, false
+	}
+	var addr common.Address
+	copy(addr[:], b[len(DelegationPrefix):])
+	return addr, true
+}
+
+// AddressToDelegation adds the delegation prefix to the specified address.
+func AddressToDelegation(addr common.Address) []byte {
+	return append(DelegationPrefix, addr.Bytes()...)
+}
+
+// TxInternalDataEthereumSetCode represents a set code transaction.
+type TxInternalDataEthereumSetCode struct {
+	ChainID           *big.Int
+	AccountNonce      uint64
+	GasTipCap         *big.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap         *big.Int // a.k.a. maxFeePerGas
+	GasLimit          uint64
+	Recipient         *common.Address `rlp:"nil"` // nil means contract creation
+	Amount            *big.Int
+	Payload           []byte
+	AccessList        AccessList
+	AuthorizationList AuthorizationList
+
+	// Signature values
+	V *big.Int `json:"v" gencodec:"required"`
+	R *big.Int `json:"r" gencodec:"required"`
+	S *big.Int `json:"s" gencodec:"required"`
+
+	// This is only used when marshaling to JSON.
+	Hash *common.Hash `json:"hash" rlp:"-"`
+}
+
+type TxInternalDataEthereumSetCodeJSON struct {
+	Type                 TxType            `json:"typeInt"`
+	TypeStr              string            `json:"type"`
+	ChainID              *hexutil.Big      `json:"chainId"`
+	AccountNonce         hexutil.Uint64    `json:"nonce"`
+	MaxPriorityFeePerGas *hexutil.Big      `json:"maxPriorityFeePerGas"`
+	MaxFeePerGas         *hexutil.Big      `json:"maxFeePerGas"`
+	GasLimit             hexutil.Uint64    `json:"gas"`
+	Recipient            *common.Address   `json:"to"`
+	Amount               *hexutil.Big      `json:"value"`
+	Payload              hexutil.Bytes     `json:"input"`
+	AccessList           AccessList        `json:"accessList"`
+	AuthorizationList    AuthorizationList `json:"authorizationList"`
+	TxSignatures         TxSignaturesJSON  `json:"signatures"`
+	Hash                 *common.Hash      `json:"hash"`
+}
+
+func newTxInternalDataEthereumSetCode() *TxInternalDataEthereumSetCode {
+	h := common.Hash{}
+
+	return &TxInternalDataEthereumSetCode{
+		Hash: &h,
+	}
+}
+
+func newTxInternalDataEthereumSetCodeWithMap(values map[TxValueKeyType]interface{}) (*TxInternalDataEthereumSetCode, error) {
+	d := newTxInternalDataEthereumSetCode()
+
+	if v, ok := values[TxValueKeyChainID].(*big.Int); ok {
+		d.ChainID.Set(v)
+		delete(values, TxValueKeyChainID)
+	} else {
+		return nil, errValueKeyChainIDInvalid
+	}
+
+	if v, ok := values[TxValueKeyNonce].(uint64); ok {
+		d.AccountNonce = v
+		delete(values, TxValueKeyNonce)
+	} else {
+		return nil, errValueKeyNonceMustUint64
+	}
+
+	if v, ok := values[TxValueKeyTo].(*common.Address); ok {
+		d.Recipient = v
+		delete(values, TxValueKeyTo)
+	} else {
+		return nil, errValueKeyToMustAddressPointer
+	}
+
+	if v, ok := values[TxValueKeyAmount].(*big.Int); ok {
+		d.Amount.Set(v)
+		delete(values, TxValueKeyAmount)
+	} else {
+		return nil, errValueKeyAmountMustBigInt
+	}
+
+	if v, ok := values[TxValueKeyData].([]byte); ok {
+		d.Payload = common.CopyBytes(v)
+		delete(values, TxValueKeyData)
+	} else {
+		return nil, errValueKeyDataMustByteSlice
+	}
+
+	if v, ok := values[TxValueKeyGasLimit].(uint64); ok {
+		d.GasLimit = v
+		delete(values, TxValueKeyGasLimit)
+	} else {
+		return nil, errValueKeyGasLimitMustUint64
+	}
+
+	if v, ok := values[TxValueKeyGasFeeCap].(*big.Int); ok {
+		d.GasFeeCap.Set(v)
+		delete(values, TxValueKeyGasFeeCap)
+	} else {
+		return nil, errValueKeyGasFeeCapMustBigInt
+	}
+	if v, ok := values[TxValueKeyGasTipCap].(*big.Int); ok {
+		d.GasTipCap.Set(v)
+		delete(values, TxValueKeyGasTipCap)
+	} else {
+		return nil, errValueKeyGasTipCapMustBigInt
+	}
+	if v, ok := values[TxValueKeyAccessList].(AccessList); ok {
+		d.AccessList = make(AccessList, len(v))
+		copy(d.AccessList, v)
+		delete(values, TxValueKeyAccessList)
+	} else {
+		return nil, errValueKeyAccessListInvalid
+	}
+	if v, ok := values[TxValueKeyAuthorizationList].(AuthorizationList); ok {
+		d.AuthorizationList = make(AuthorizationList, len(v))
+		copy(d.AuthorizationList, v)
+		delete(values, TxValueKeyAuthorizationList)
+	} else {
+		return nil, errValueKeyAuthorizationListInvalid
+	}
+
+	if len(values) != 0 {
+		for k := range values {
+			logger.Warn("unnecessary key", k.String())
+		}
+		return nil, errUndefinedKeyRemains
+	}
+
+	return d, nil
+}
+
+func (t *TxInternalDataEthereumSetCode) Type() TxType {
+	return TxTypeEthereumSetCode
+}
+
+func (t *TxInternalDataEthereumSetCode) GetAccountNonce() uint64 {
+	return t.AccountNonce
+}
+
+func (t *TxInternalDataEthereumSetCode) GetPrice() *big.Int {
+	return t.GasFeeCap
+}
+
+func (t *TxInternalDataEthereumSetCode) GetGasLimit() uint64 {
+	return t.GasLimit
+}
+
+func (t *TxInternalDataEthereumSetCode) GetRecipient() *common.Address {
+	return t.Recipient
+}
+
+func (t *TxInternalDataEthereumSetCode) GetAmount() *big.Int {
+	return new(big.Int).Set(t.Amount)
+}
+
+func (t *TxInternalDataEthereumSetCode) GetPayload() []byte {
+	return t.Payload
+}
+
+func (t *TxInternalDataEthereumSetCode) GetAccessList() AccessList {
+	return t.AccessList
+}
+
+func (tx *TxInternalDataEthereumSetCode) GetAuthorizationList() AuthorizationList {
+	return tx.AuthorizationList
+}
+
+func (t *TxInternalDataEthereumSetCode) GetGasTipCap() *big.Int {
+	return t.GasTipCap
+}
+
+func (t *TxInternalDataEthereumSetCode) GetGasFeeCap() *big.Int {
+	return t.GasFeeCap
+}
+
+func (t *TxInternalDataEthereumSetCode) GetHash() *common.Hash {
+	return t.Hash
+}
+
+func (t *TxInternalDataEthereumSetCode) SetHash(h *common.Hash) {
+	t.Hash = h
+}
+
+func (t *TxInternalDataEthereumSetCode) SetSignature(signatures TxSignatures) {
+	if len(signatures) != 1 {
+		logger.Crit("TxTypeSetCode can receive only single signature!")
+	}
+
+	t.V = signatures[0].V
+	t.R = signatures[0].R
+	t.S = signatures[0].S
+}
+
+func (t *TxInternalDataEthereumSetCode) RawSignatureValues() TxSignatures {
+	return TxSignatures{&TxSignature{t.V, t.R, t.S}}
+}
+
+func (t *TxInternalDataEthereumSetCode) ValidateSignature() bool {
+	v := byte(t.V.Uint64())
+	return crypto.ValidateSignatureValues(v, t.R, t.S, false)
+}
+
+func (t *TxInternalDataEthereumSetCode) RecoverAddress(txhash common.Hash, homestead bool, vfunc func(*big.Int) *big.Int) (common.Address, error) {
+	V := vfunc(t.V)
+	return recoverPlain(txhash, t.R, t.S, V, homestead)
+}
+
+func (t *TxInternalDataEthereumSetCode) RecoverPubkey(txhash common.Hash, homestead bool, vfunc func(*big.Int) *big.Int) ([]*ecdsa.PublicKey, error) {
+	V := vfunc(t.V)
+
+	pk, err := recoverPlainPubkey(txhash, t.R, t.S, V, homestead)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*ecdsa.PublicKey{pk}, nil
+}
+
+func (t *TxInternalDataEthereumSetCode) ChainId() *big.Int {
+	return t.ChainID
+}
+
+func (t *TxInternalDataEthereumSetCode) Equal(a TxInternalData) bool {
+	ta, ok := a.(*TxInternalDataEthereumSetCode)
+	if !ok {
+		return false
+	}
+
+	return t.ChainID.Cmp(ta.ChainID) == 0 &&
+		t.AccountNonce == ta.AccountNonce &&
+		t.GasFeeCap.Cmp(ta.GasFeeCap) == 0 &&
+		t.GasTipCap.Cmp(ta.GasTipCap) == 0 &&
+		t.GasLimit == ta.GasLimit &&
+		equalRecipient(t.Recipient, ta.Recipient) &&
+		t.Amount.Cmp(ta.Amount) == 0 &&
+		reflect.DeepEqual(t.AccessList, ta.AccessList) &&
+		reflect.DeepEqual(t.AuthorizationList, ta.AuthorizationList) &&
+		t.V.Cmp(ta.V) == 0 &&
+		t.R.Cmp(ta.R) == 0 &&
+		t.S.Cmp(ta.S) == 0
+}
+
+func (t *TxInternalDataEthereumSetCode) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
+	gas, err := IntrinsicGas(t.Payload, t.AccessList, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	return gas + uint64(len(t.AuthorizationList))*params.CallNewAccountGas, err
+}
+
+func (t *TxInternalDataEthereumSetCode) SerializeForSign() []interface{} {
+	// If the chainId has nil or empty value, It will be set signer's chainId.
+	return []interface{}{
+		t.ChainID,
+		t.AccountNonce,
+		t.GasTipCap,
+		t.GasFeeCap,
+		t.GasLimit,
+		t.Recipient,
+		t.Amount,
+		t.Payload,
+		t.AccessList,
+		t.AuthorizationList,
+	}
+}
+
+func (t *TxInternalDataEthereumSetCode) SenderTxHash() common.Hash {
+	return prefixedRlpHash(byte(t.Type()), []interface{}{
+		t.ChainID,
+		t.AccountNonce,
+		t.GasTipCap,
+		t.GasFeeCap,
+		t.GasLimit,
+		t.Recipient,
+		t.Amount,
+		t.Payload,
+		t.AccessList,
+		t.AuthorizationList,
+		t.V,
+		t.R,
+		t.S,
+	})
+}
+
+func (t *TxInternalDataEthereumSetCode) Validate(stateDB StateDB, currentBlockNumber uint64) error {
+	if t.Recipient != nil {
+		if common.IsPrecompiledContractAddress(*t.Recipient) {
+			return kerrors.ErrPrecompiledContractAddress
+		}
+	}
+	return t.ValidateMutableValue(stateDB, currentBlockNumber)
+}
+
+func (t *TxInternalDataEthereumSetCode) ValidateMutableValue(stateDB StateDB, currentBlockNumber uint64) error {
+	return nil
+}
+
+func (t *TxInternalDataEthereumSetCode) IsLegacyTransaction() bool {
+	return false
+}
+
+func (t *TxInternalDataEthereumSetCode) GetRoleTypeForValidation() accountkey.RoleType {
+	return accountkey.RoleTransaction
+}
+
+func (t *TxInternalDataEthereumSetCode) String() string {
+	var from, to string
+	tx := &Transaction{data: t}
+
+	v, r, s := t.V, t.R, t.S
+	if v != nil {
+		signer := LatestSignerForChainID(t.ChainId())
+		if f, err := Sender(signer, tx); err != nil { // derive but don't cache
+			from = "[invalid sender: invalid sig]"
+		} else {
+			from = fmt.Sprintf("%x", f[:])
+		}
+	} else {
+		from = "[invalid sender: nil V field]"
+	}
+
+	if t.GetRecipient() == nil {
+		to = "[contract creation]"
+	} else {
+		to = fmt.Sprintf("%x", t.GetRecipient().Bytes())
+	}
+	enc, _ := rlp.EncodeToBytes(tx)
+	return fmt.Sprintf(`
+		TX(%x)
+		Contract: %v
+		Chaind:   %#x
+		From:     %s
+		To:       %s
+		Nonce:    %v
+		GasTipCap: %#x
+		GasFeeCap: %#x
+		GasLimit  %#x
+		Value:    %#x
+		Data:     0x%x
+		AccessList: %x
+		AuthorizationList: %x
+		V:        %#x
+		R:        %#x
+		S:        %#x
+		Hex:      %x
+	`,
+		tx.Hash(),
+		t.GetRecipient() == nil,
+		t.ChainId(),
+		from,
+		to,
+		t.GetAccountNonce(),
+		t.GetGasTipCap(),
+		t.GetGasFeeCap(),
+		t.GetGasLimit(),
+		t.GetAmount(),
+		t.GetPayload(),
+		t.AccessList,
+		t.AuthorizationList,
+		v,
+		r,
+		s,
+		enc,
+	)
+}
+
+func (t *TxInternalDataEthereumSetCode) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
+	///////////////////////////////////////////////////////
+	// OpcodeComputationCostLimit: The below code is commented and will be usd for debugging purposes.
+	//start := time.Now()
+	//defer func() {
+	//	elapsed := time.Since(start)
+	//	logger.Debug("[TxInternalDataLegacy] EVM execution done", "elapsed", elapsed)
+	//}()
+	///////////////////////////////////////////////////////
+	if t.Recipient == nil {
+		// Sender's nonce will be increased in '`vm.Create()`
+		ret, _, usedGas, err = vm.Create(sender, t.Payload, gas, value, params.CodeFormatEVM)
+	} else {
+		stateDB.IncNonce(sender.Address())
+		ret, usedGas, err = vm.Call(sender, *t.Recipient, t.Payload, gas, value)
+	}
+	return ret, usedGas, err
+}
+
+func (t *TxInternalDataEthereumSetCode) MakeRPCOutput() map[string]interface{} {
+	return map[string]interface{}{
+		"typeInt":              t.Type(),
+		"type":                 t.Type().String(),
+		"chainId":              (*hexutil.Big)(t.ChainId()),
+		"nonce":                hexutil.Uint64(t.AccountNonce),
+		"maxPriorityFeePerGas": (*hexutil.Big)(t.GasTipCap),
+		"maxFeePerGas":         (*hexutil.Big)(t.GasFeeCap),
+		"gas":                  hexutil.Uint64(t.GasLimit),
+		"to":                   t.Recipient,
+		"input":                hexutil.Bytes(t.Payload),
+		"value":                (*hexutil.Big)(t.Amount),
+		"accessList":           t.AccessList,
+		"authorizationList":    t.AuthorizationList,
+		"signatures":           TxSignaturesJSON{&TxSignatureJSON{(*hexutil.Big)(t.V), (*hexutil.Big)(t.R), (*hexutil.Big)(t.S)}},
+	}
+}
+
+func (t *TxInternalDataEthereumSetCode) MarshalJSON() ([]byte, error) {
+	return json.Marshal(TxInternalDataEthereumSetCodeJSON{
+		t.Type(),
+		t.Type().String(),
+		(*hexutil.Big)(t.ChainID),
+		(hexutil.Uint64)(t.AccountNonce),
+		(*hexutil.Big)(t.GasTipCap),
+		(*hexutil.Big)(t.GasFeeCap),
+		(hexutil.Uint64)(t.GasLimit),
+		t.Recipient,
+		(*hexutil.Big)(t.Amount),
+		t.Payload,
+		t.AccessList,
+		t.AuthorizationList,
+		TxSignaturesJSON{&TxSignatureJSON{(*hexutil.Big)(t.V), (*hexutil.Big)(t.R), (*hexutil.Big)(t.S)}},
+		t.Hash,
+	})
+}
+
+func (t *TxInternalDataEthereumSetCode) UnmarshalJSON(bytes []byte) error {
+	js := &TxInternalDataEthereumSetCodeJSON{}
+	if err := json.Unmarshal(bytes, js); err != nil {
+		return err
+	}
+
+	t.ChainID = (*big.Int)(js.ChainID)
+	t.AccountNonce = uint64(js.AccountNonce)
+	t.GasTipCap = (*big.Int)(js.MaxPriorityFeePerGas)
+	t.GasFeeCap = (*big.Int)(js.MaxFeePerGas)
+	t.GasLimit = uint64(js.GasLimit)
+	t.Recipient = js.Recipient
+	t.Amount = (*big.Int)(js.Amount)
+	t.Payload = js.Payload
+	t.AccessList = js.AccessList
+	t.AuthorizationList = js.AuthorizationList
+	t.V = (*big.Int)(js.TxSignatures[0].V)
+	t.R = (*big.Int)(js.TxSignatures[0].R)
+	t.S = (*big.Int)(js.TxSignatures[0].S)
+	t.Hash = js.Hash
+
+	return nil
+}
+
+// ------------- Authorization -------------
+type AuthorizationList []Authorization
+
+type Authorization struct {
+	ChainID *big.Int       `json:"chainId"`
+	Address common.Address `json:"address"`
+	Nonce   uint64         `json:"nonce"`
+	V       *big.Int       `json:"v"`
+	R       *big.Int       `json:"r"`
+	S       *big.Int       `json:"s"`
+}
+
+func (a Authorization) Authority() (common.Address, error) {
+	sighash := prefixedRlpHash(
+		0x05,
+		[]interface{}{
+			a.ChainID,
+			a.Address,
+			a.Nonce,
+		})
+
+	v := byte(a.V.Uint64())
+	if !crypto.ValidateSignatureValues(v, a.R, a.S, true) {
+		return common.Address{}, ErrInvalidSig
+	}
+	// encode the signature in uncompressed format
+	r, s := a.R.Bytes(), a.S.Bytes()
+	sig := make([]byte, crypto.SignatureLength)
+	copy(sig[32-len(r):32], r)
+	copy(sig[64-len(s):64], s)
+	sig[64] = v
+	// recover the public key from the signature
+	pub, err := crypto.Ecrecover(sighash[:], sig)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if len(pub) == 0 || pub[0] != 4 {
+		return common.Address{}, errors.New("invalid public key")
+	}
+	var addr common.Address
+	copy(addr[:], crypto.Keccak256(pub[1:])[12:])
+	return addr, nil
+}

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -21,6 +21,7 @@ package types
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -70,9 +71,9 @@ type TxInternalDataEthereumSetCode struct {
 	AuthorizationList AuthorizationList
 
 	// Signature values
-	V *big.Int `json:"v" gencodec:"required"`
-	R *big.Int `json:"r" gencodec:"required"`
-	S *big.Int `json:"s" gencodec:"required"`
+	V *big.Int `gencodec:"required" json:"v"`
+	R *big.Int `gencodec:"required" json:"r"`
+	S *big.Int `gencodec:"required" json:"s"`
 
 	// This is only used when marshaling to JSON.
 	Hash *common.Hash `json:"hash" rlp:"-"`
@@ -394,7 +395,7 @@ func (t *TxInternalDataEthereumSetCode) String() string {
 		if f, err := Sender(signer, tx); err != nil { // derive but don't cache
 			from = "[invalid sender: invalid sig]"
 		} else {
-			from = fmt.Sprintf("%x", f[:])
+			from = hex.EncodeToString(f[:])
 		}
 	} else {
 		from = "[invalid sender: nil V field]"
@@ -403,7 +404,7 @@ func (t *TxInternalDataEthereumSetCode) String() string {
 	if t.GetRecipient() == nil {
 		to = "[contract creation]"
 	} else {
-		to = fmt.Sprintf("%x", t.GetRecipient().Bytes())
+		to = hex.EncodeToString(t.GetRecipient().Bytes())
 	}
 	enc, _ := rlp.EncodeToBytes(tx)
 	return fmt.Sprintf(`

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -96,10 +96,20 @@ type TxInternalDataEthereumSetCodeJSON struct {
 }
 
 func newTxInternalDataEthereumSetCode() *TxInternalDataEthereumSetCode {
-	h := common.Hash{}
-
 	return &TxInternalDataEthereumSetCode{
-		Hash: &h,
+		ChainID:           new(big.Int),
+		AccountNonce:      0,
+		GasTipCap:         new(big.Int),
+		GasFeeCap:         new(big.Int),
+		GasLimit:          0,
+		Recipient:         nil,
+		Amount:            new(big.Int),
+		Payload:           []byte{},
+		AccessList:        AccessList{},
+		AuthorizationList: AuthorizationList{},
+		V:                 new(big.Int),
+		R:                 new(big.Int),
+		S:                 new(big.Int),
 	}
 }
 
@@ -239,7 +249,7 @@ func (t *TxInternalDataEthereumSetCode) SetHash(h *common.Hash) {
 
 func (t *TxInternalDataEthereumSetCode) SetSignature(signatures TxSignatures) {
 	if len(signatures) != 1 {
-		logger.Crit("TxTypeSetCode can receive only single signature!")
+		logger.Crit("TxTypeEthereum can receive only single signature!")
 	}
 
 	t.V = signatures[0].V
@@ -315,6 +325,24 @@ func (t *TxInternalDataEthereumSetCode) SerializeForSign() []interface{} {
 		t.AccessList,
 		t.AuthorizationList,
 	}
+}
+
+func (t *TxInternalDataEthereumSetCode) TxHash() common.Hash {
+	return prefixedRlpHash(byte(t.Type()), []interface{}{
+		t.ChainID,
+		t.AccountNonce,
+		t.GasTipCap,
+		t.GasFeeCap,
+		t.GasLimit,
+		t.Recipient,
+		t.Amount,
+		t.Payload,
+		t.AccessList,
+		t.AuthorizationList,
+		t.V,
+		t.R,
+		t.S,
+	})
 }
 
 func (t *TxInternalDataEthereumSetCode) SenderTxHash() common.Hash {
@@ -495,6 +523,10 @@ func (t *TxInternalDataEthereumSetCode) UnmarshalJSON(bytes []byte) error {
 	t.Hash = js.Hash
 
 	return nil
+}
+
+func (t *TxInternalDataEthereumSetCode) setSignatureValues(chainID, v, r, s *big.Int) {
+	t.ChainID, t.V, t.R, t.S = chainID, v, r, s
 }
 
 // ------------- Authorization -------------

--- a/blockchain/types/tx_internal_data_legacy.go
+++ b/blockchain/types/tx_internal_data_legacy.go
@@ -236,7 +236,7 @@ func (t *TxInternalDataLegacy) RecoverPubkey(txhash common.Hash, homestead bool,
 }
 
 func (t *TxInternalDataLegacy) IntrinsicGas(currentBlockNumber uint64) (uint64, error) {
-	return IntrinsicGas(t.Payload, nil, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
+	return IntrinsicGas(t.Payload, nil, nil, t.Recipient == nil, *fork.Rules(big.NewInt(int64(currentBlockNumber))))
 }
 
 func (t *TxInternalDataLegacy) SerializeForSign() []interface{} {

--- a/blockchain/types/tx_internal_data_sender_hash_test.go
+++ b/blockchain/types/tx_internal_data_sender_hash_test.go
@@ -60,6 +60,7 @@ func TestTransactionSenderTxHash(t *testing.T) {
 		{"FeeDelegatedCancelWithRatio", genFeeDelegatedCancelWithRatioTransaction()},
 		{"AccessList", genAccessListTransaction()},
 		{"DynamicFee", genDynamicFeeTransaction()},
+		{"SetCode", genSetCodeTransaction()},
 	}
 
 	testcases := []struct {
@@ -459,6 +460,30 @@ func testTransactionSenderTxHash(t *testing.T, tx TxInternalData) {
 			v.Amount,
 			v.Payload,
 			v.AccessList,
+			v.V,
+			v.R,
+			v.S,
+		})
+
+		h := common.Hash{}
+
+		hw.Sum(h[:0])
+		senderTxHash := rawTx.GetTxInternalData().SenderTxHash()
+		assert.Equal(t, h, senderTxHash)
+	case *TxInternalDataEthereumSetCode:
+		hw := sha3.NewKeccak256()
+		rlp.Encode(hw, byte(rawTx.Type()))
+		rlp.Encode(hw, []interface{}{
+			v.ChainID,
+			v.AccountNonce,
+			v.GasTipCap,
+			v.GasFeeCap,
+			v.GasLimit,
+			v.Recipient,
+			v.Amount,
+			v.Payload,
+			v.AccessList,
+			v.AuthorizationList,
 			v.V,
 			v.R,
 			v.S,

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -292,7 +292,7 @@ func genDynamicFeeTransaction() TxInternalData {
 func genSetCodeTransaction() TxInternalData {
 	tx, err := NewTxInternalDataWithMap(TxTypeEthereumSetCode, map[TxValueKeyType]interface{}{
 		TxValueKeyNonce:             nonce,
-		TxValueKeyTo:                &to,
+		TxValueKeyTo:                to,
 		TxValueKeyAmount:            amount,
 		TxValueKeyGasLimit:          gasLimit,
 		TxValueKeyGasFeeCap:         gasFeeCap,

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -32,16 +32,17 @@ import (
 )
 
 var (
-	to        = common.HexToAddress("7b65B75d204aBed71587c9E519a89277766EE1d0")
-	key, from = defaultTestKey()
-	feePayer  = common.HexToAddress("5A0043070275d9f6054307Ee7348bD660849D90f")
-	nonce     = uint64(1234)
-	amount    = big.NewInt(10)
-	gasLimit  = uint64(1000000)
-	gasPrice  = big.NewInt(25)
-	gasTipCap = big.NewInt(25)
-	gasFeeCap = big.NewInt(25)
-	accesses  = AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
+	to             = common.HexToAddress("7b65B75d204aBed71587c9E519a89277766EE1d0")
+	key, from      = defaultTestKey()
+	feePayer       = common.HexToAddress("5A0043070275d9f6054307Ee7348bD660849D90f")
+	nonce          = uint64(1234)
+	amount         = big.NewInt(10)
+	gasLimit       = uint64(1000000)
+	gasPrice       = big.NewInt(25)
+	gasTipCap      = big.NewInt(25)
+	gasFeeCap      = big.NewInt(25)
+	accesses       = AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
+	authorizations = AuthorizationList{{ChainID: big.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: big.NewInt(0), R: big.NewInt(0), S: big.NewInt(0)}}
 )
 
 // TestTransactionSerialization tests RLP/JSON serialization for TxInternalData
@@ -74,6 +75,7 @@ func TestTransactionSerialization(t *testing.T) {
 		{"FeeDelegatedCancelWithRatio", genFeeDelegatedCancelWithRatioTransaction()},
 		{"AccessList", genAccessListTransaction()},
 		{"DynamicFee", genDynamicFeeTransaction()},
+		{"SetCode", genSetCodeTransaction()},
 	}
 
 	testcases := []struct {
@@ -279,6 +281,26 @@ func genDynamicFeeTransaction() TxInternalData {
 		TxValueKeyData:       []byte("1234"),
 		TxValueKeyAccessList: accesses,
 		TxValueKeyChainID:    big.NewInt(2),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return tx
+}
+
+func genSetCodeTransaction() TxInternalData {
+	tx, err := NewTxInternalDataWithMap(TxTypeEthereumSetCode, map[TxValueKeyType]interface{}{
+		TxValueKeyNonce:             nonce,
+		TxValueKeyTo:                &to,
+		TxValueKeyAmount:            amount,
+		TxValueKeyGasLimit:          gasLimit,
+		TxValueKeyGasFeeCap:         gasFeeCap,
+		TxValueKeyGasTipCap:         gasTipCap,
+		TxValueKeyData:              []byte("1234"),
+		TxValueKeyAccessList:        accesses,
+		TxValueKeyAuthorizationList: authorizations,
+		TxValueKeyChainID:           big.NewInt(2),
 	})
 	if err != nil {
 		panic(err)

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -55,6 +55,8 @@ func EnableEIP(eipNum int, jt *JumpTable) error {
 		enable1344(jt)
 	case 1153:
 		enable1153(jt)
+	case 7702:
+		enable7702(jt)
 	default:
 		return fmt.Errorf("undefined eip %d", eipNum)
 	}
@@ -377,4 +379,28 @@ func enableCancunComputationCostModification(jt *JumpTable) {
 	jt[LOG2].computationCost = params.Log2ComputationCostCancun
 	jt[LOG3].computationCost = params.Log3ComputationCostCancun
 	jt[LOG4].computationCost = params.Log4ComputationCostCancun
+}
+
+// enable7702 the EIP-7702 changes to support delegation designators.
+func enable7702(jt *JumpTable) {
+	jt[EXTCODECOPY].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODECOPY].dynamicGas = gasExtCodeCopyEIP7702
+
+	jt[EXTCODESIZE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODESIZE].dynamicGas = gasEip7702CodeCheck
+
+	jt[EXTCODEHASH].constantGas = params.WarmStorageReadCostEIP2929
+	jt[EXTCODEHASH].dynamicGas = gasEip7702CodeCheck
+
+	jt[CALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[CALL].dynamicGas = gasCallEIP7702
+
+	jt[CALLCODE].constantGas = params.WarmStorageReadCostEIP2929
+	jt[CALLCODE].dynamicGas = gasCallCodeEIP7702
+
+	jt[STATICCALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[STATICCALL].dynamicGas = gasStaticCallEIP7702
+
+	jt[DELEGATECALL].constantGas = params.WarmStorageReadCostEIP2929
+	jt[DELEGATECALL].dynamicGas = gasDelegateCallEIP7702
 }

--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -36,8 +36,6 @@ var (
 	ErrTotalTimeLimitReached             = errors.New("reached the total execution time limit for txs in a block")
 	ErrOpcodeComputationCostLimitReached = errors.New("reached the opcode computation cost limit")
 	ErrFailedOnSetCode                   = errors.New("failed on setting code to an account")
-	ErrOutOfGas                          = errors.New("out of gas")
-	ErrGasUintOverflow                   = errors.New("gas uint64 overflow")
 
 	// EVM internal errors
 	ErrWriteProtection       = errors.New("evm: write protection")

--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -36,6 +36,8 @@ var (
 	ErrTotalTimeLimitReached             = errors.New("reached the total execution time limit for txs in a block")
 	ErrOpcodeComputationCostLimitReached = errors.New("reached the opcode computation cost limit")
 	ErrFailedOnSetCode                   = errors.New("failed on setting code to an account")
+	ErrOutOfGas                          = errors.New("out of gas")
+	ErrGasUintOverflow                   = errors.New("gas uint64 overflow")
 
 	// EVM internal errors
 	ErrWriteProtection       = errors.New("evm: write protection")

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -284,7 +284,7 @@ func (evm *EVM) Call(caller types.ContractRef, addr common.Address, input []byte
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		contract := NewContract(caller, to, value, gas)
-		contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
+		contract.SetCallCode(&addr, evm.StateDB.ResolveCodeHash(addr), evm.StateDB.ResolveCode(addr))
 		ret, err = run(evm, contract, input)
 		gas = contract.Gas
 	}
@@ -346,7 +346,7 @@ func (evm *EVM) CallCode(caller types.ContractRef, addr common.Address, input []
 	// Initialise a new contract and set the code that is to be used by the EVM.
 	// The contract is a scoped environment for this execution context only.
 	contract := NewContract(caller, to, value, gas)
-	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
+	contract.SetCallCode(&addr, evm.StateDB.ResolveCodeHash(addr), evm.StateDB.ResolveCode(addr))
 
 	ret, err = run(evm, contract, input)
 	if err != nil {
@@ -396,7 +396,7 @@ func (evm *EVM) DelegateCall(caller types.ContractRef, addr common.Address, inpu
 
 	// Initialise a new contract and make initialise the delegate values
 	contract := NewContract(caller, to, nil, gas).AsDelegate()
-	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
+	contract.SetCallCode(&addr, evm.StateDB.ResolveCodeHash(addr), evm.StateDB.ResolveCode(addr))
 
 	ret, err = run(evm, contract, input)
 	if err != nil {
@@ -449,7 +449,7 @@ func (evm *EVM) StaticCall(caller types.ContractRef, addr common.Address, input 
 	// Initialise a new contract and set the code that is to be used by the EVM.
 	// The contract is a scoped environment for this execution context only.
 	contract := NewContract(caller, to, new(big.Int), gas)
-	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
+	contract.SetCallCode(&addr, evm.StateDB.ResolveCodeHash(addr), evm.StateDB.ResolveCode(addr))
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
@@ -512,7 +512,7 @@ func (evm *EVM) create(caller types.ContractRef, codeAndHash *codeAndHash, gas u
 	}
 
 	// Ensure there's no existing contract already at the designated address
-	contractHash := evm.StateDB.GetCodeHash(address)
+	contractHash := evm.StateDB.ResolveCodeHash(address)
 
 	// The early Kaia design tried to support the account creation with a user selected address,
 	// so the account overwriting was restricted.

--- a/blockchain/vm/instructions.go
+++ b/blockchain/vm/instructions.go
@@ -348,7 +348,7 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
-	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20())))
+	slot.SetUint64(uint64(len(interpreter.evm.StateDB.ResolveCode(slot.Bytes20()))))
 	return nil, nil
 }
 
@@ -388,7 +388,7 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 		uint64CodeOffset = 0xffffffffffffffff
 	}
 	addr := common.Address(a.Bytes20())
-	codeCopy := getData(interpreter.evm.StateDB.GetCode(addr), uint64CodeOffset, length.Uint64())
+	codeCopy := getData(interpreter.evm.StateDB.ResolveCode(addr), uint64CodeOffset, length.Uint64())
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 
 	return nil, nil
@@ -396,7 +396,7 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 
 // opExtCodeHash returns the code hash of a specified account.
 // There are several cases when the function is called, while we can relay everything
-// to `state.GetCodeHash` function to ensure the correctness.
+// to `state.ResolveCodeHash` function to ensure the correctness.
 //
 //  1. Caller tries to get the code hash of a normal contract account, state
 //     should return the relative code hash and set it as the result.
@@ -426,7 +426,7 @@ func opExtCodeHash1052(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCont
 	if interpreter.evm.StateDB.Empty(address) {
 		slot.Clear()
 	} else {
-		slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(address).Bytes())
+		slot.SetBytes(interpreter.evm.StateDB.ResolveCodeHash(address).Bytes())
 	}
 	return nil, nil
 }
@@ -436,7 +436,7 @@ func opExtCodeHash1052(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCont
 func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
 	address := common.Address(slot.Bytes20())
-	slot.SetBytes(interpreter.evm.StateDB.GetCodeHash(address).Bytes())
+	slot.SetBytes(interpreter.evm.StateDB.ResolveCodeHash(address).Bytes())
 	return nil, nil
 }
 

--- a/blockchain/vm/interface.go
+++ b/blockchain/vm/interface.go
@@ -52,6 +52,9 @@ type StateDB interface {
 	GetCodeSize(common.Address) int
 	GetVmVersion(common.Address) (params.VmVersion, bool)
 
+	ResolveCodeHash(common.Address) common.Hash
+	ResolveCode(common.Address) []byte
+
 	AddRefund(uint64)
 	SubRefund(uint64)
 	GetRefund() uint64

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -77,6 +77,7 @@ func newCancunInstructionSet() JumpTable {
 	enable1153(&instructionSet) // EIP-1153 TLOAD, TSTORE opcode
 	enable1052(&instructionSet) // EIP-1052 EXTCODEHASH fix
 	enableCancunComputationCostModification(&instructionSet)
+	enable7702(&instructionSet)
 	return instructionSet
 }
 

--- a/blockchain/vm/operations_acl.go
+++ b/blockchain/vm/operations_acl.go
@@ -265,7 +265,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 			// Charge the remaining difference here already, to correctly calculate available
 			// gas for call
 			if !contract.UseGas(coldCost) {
-				return 0, ErrOutOfGas
+				return 0, kerrors.ErrOutOfGas
 			}
 		}
 
@@ -279,7 +279,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 				cost += params.ColdAccountAccessCostEIP2929
 			}
 			if !contract.UseGas(cost) {
-				return 0, ErrOutOfGas
+				return 0, kerrors.ErrOutOfGas
 			}
 			coldCost += cost
 		}
@@ -300,7 +300,7 @@ func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
 
 		var overflow bool
 		if gas, overflow = math.SafeAdd(gas, coldCost); overflow {
-			return 0, ErrGasUintOverflow
+			return 0, errGasUintOverflow
 		}
 		return gas, nil
 	}
@@ -332,12 +332,12 @@ func gasExtCodeCopyEIP7702(evm *EVM, contract *Contract, stack *Stack, mem *Memo
 		var overflow bool
 		if evm.StateDB.AddressInAccessList(addr) {
 			if gas, overflow = math.SafeAdd(gas, params.WarmStorageReadCostEIP2929); overflow {
-				return 0, ErrGasUintOverflow
+				return 0, errGasUintOverflow
 			}
 		} else {
 			evm.StateDB.AddAddressToAccessList(addr)
 			if gas, overflow = math.SafeAdd(gas, params.ColdAccountAccessCostEIP2929); overflow {
-				return 0, ErrGasUintOverflow
+				return 0, errGasUintOverflow
 			}
 		}
 	}

--- a/blockchain/vm/operations_acl.go
+++ b/blockchain/vm/operations_acl.go
@@ -314,12 +314,10 @@ func gasEip7702CodeCheck(evm *EVM, contract *Contract, stack *Stack, mem *Memory
 		if evm.StateDB.AddressInAccessList(addr) {
 			cost += params.WarmStorageReadCostEIP2929
 		} else {
-			// fmt.Println("adding ", addr, "to acl")
 			evm.StateDB.AddAddressToAccessList(addr)
 			cost += params.ColdAccountAccessCostEIP2929
 		}
 	}
-	// fmt.Println("cost is", cost)
 	return cost, nil
 }
 

--- a/blockchain/vm/operations_acl.go
+++ b/blockchain/vm/operations_acl.go
@@ -19,6 +19,7 @@ package vm
 import (
 	"errors"
 
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/math"
 	"github.com/kaiachain/kaia/kerrors"
@@ -242,4 +243,105 @@ func makeSelfdestructGasFn(refundsEnabled bool) gasFunc {
 		return gas, nil
 	}
 	return gasFunc
+}
+
+var (
+	gasCallEIP7702         = makeCallVariantGasCallEIP7702(gasCall)
+	gasDelegateCallEIP7702 = makeCallVariantGasCallEIP7702(gasDelegateCall)
+	gasStaticCallEIP7702   = makeCallVariantGasCallEIP7702(gasStaticCall)
+	gasCallCodeEIP7702     = makeCallVariantGasCallEIP7702(gasCallCode)
+)
+
+func makeCallVariantGasCallEIP7702(oldCalculator gasFunc) gasFunc {
+	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+		addr := common.Address(stack.Back(1).Bytes20())
+		// Check slot presence in the access list
+		warmAccess := evm.StateDB.AddressInAccessList(addr)
+		// The WarmStorageReadCostEIP2929 (100) is already deducted in the form of a constant cost, so
+		// the cost to charge for cold access, if any, is Cold - Warm
+		coldCost := params.ColdAccountAccessCostEIP2929 - params.WarmStorageReadCostEIP2929
+		if !warmAccess {
+			evm.StateDB.AddAddressToAccessList(addr)
+			// Charge the remaining difference here already, to correctly calculate available
+			// gas for call
+			if !contract.UseGas(coldCost) {
+				return 0, ErrOutOfGas
+			}
+		}
+
+		// Check if code is a delegation and if so, charge for resolution.
+		if addr, ok := types.ParseDelegation(evm.StateDB.GetCode(addr)); ok {
+			var cost uint64
+			if evm.StateDB.AddressInAccessList(addr) {
+				cost += params.WarmStorageReadCostEIP2929
+			} else {
+				evm.StateDB.AddAddressToAccessList(addr)
+				cost += params.ColdAccountAccessCostEIP2929
+			}
+			if !contract.UseGas(cost) {
+				return 0, ErrOutOfGas
+			}
+			coldCost += cost
+		}
+		// Now call the old calculator, which takes into account
+		// - create new account
+		// - transfer value
+		// - memory expansion
+		// - 63/64ths rule
+		gas, err := oldCalculator(evm, contract, stack, mem, memorySize)
+		if warmAccess || err != nil {
+			return gas, err
+		}
+		// In case of a cold access, we temporarily add the cold charge back, and also
+		// add it to the returned gas. By adding it to the return, it will be charged
+		// outside of this function, as part of the dynamic gas, and that will make it
+		// also become correctly reported to tracers.
+		contract.Gas += coldCost
+
+		var overflow bool
+		if gas, overflow = math.SafeAdd(gas, coldCost); overflow {
+			return 0, ErrGasUintOverflow
+		}
+		return gas, nil
+	}
+}
+
+func gasEip7702CodeCheck(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	cost, _ := gasEip2929AccountCheck(evm, contract, stack, mem, memorySize)
+	// Check if code is a delegation and if so, charge for resolution
+	addr := common.Address(stack.peek().Bytes20())
+	if addr, ok := types.ParseDelegation(evm.StateDB.GetCode(addr)); ok {
+		if evm.StateDB.AddressInAccessList(addr) {
+			cost += params.WarmStorageReadCostEIP2929
+		} else {
+			// fmt.Println("adding ", addr, "to acl")
+			evm.StateDB.AddAddressToAccessList(addr)
+			cost += params.ColdAccountAccessCostEIP2929
+		}
+	}
+	// fmt.Println("cost is", cost)
+	return cost, nil
+}
+
+func gasExtCodeCopyEIP7702(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	gas, err := gasExtCodeCopyEIP2929(evm, contract, stack, mem, memorySize)
+	if err != nil {
+		return 0, err
+	}
+	// Check if code is a delegation and if so, charge for resolution
+	addr := common.Address(stack.peek().Bytes20())
+	if addr, ok := types.ParseDelegation(evm.StateDB.GetCode(addr)); ok {
+		var overflow bool
+		if evm.StateDB.AddressInAccessList(addr) {
+			if gas, overflow = math.SafeAdd(gas, params.WarmStorageReadCostEIP2929); overflow {
+				return 0, ErrGasUintOverflow
+			}
+		} else {
+			evm.StateDB.AddAddressToAccessList(addr)
+			if gas, overflow = math.SafeAdd(gas, params.ColdAccountAccessCostEIP2929); overflow {
+				return 0, ErrGasUintOverflow
+			}
+		}
+	}
+	return gas, nil
 }

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -136,6 +136,7 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewInt64Flag(kip160CompatibleBlockNumberFlag),
 	altsrc.NewStringFlag(kip160ContractAddressFlag),
 	altsrc.NewInt64Flag(randaoCompatibleBlockNumberFlag),
+	altsrc.NewInt64Flag(pragueCompatibleBlockNumberFlag),
 	altsrc.NewStringFlag(kip113ProxyAddressFlag),
 	altsrc.NewStringFlag(kip113LogicAddressFlag),
 	altsrc.NewBoolFlag(kip113MockFlag),
@@ -788,6 +789,7 @@ func Gen(ctx *cli.Context) error {
 	genesisJson.Config.Kip160ContractAddress = common.HexToAddress(ctx.String(kip160ContractAddressFlag.Name))
 
 	genesisJson.Config.RandaoCompatibleBlock = big.NewInt(ctx.Int64(randaoCompatibleBlockNumberFlag.Name))
+	genesisJson.Config.PragueCompatibleBlock = big.NewInt(ctx.Int64(pragueCompatibleBlockNumberFlag.Name))
 
 	genesisJsonBytes, _ = json.MarshalIndent(genesisJson, "", "    ")
 	genValidatorKeystore(privKeys)

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -554,6 +554,13 @@ var (
 		Aliases: []string{"genesis.hardfork.randao-compatible-blocknumber"},
 	}
 
+	pragueCompatibleBlockNumberFlag = &cli.Int64Flag{
+		Name:    "prague-compatible-blocknumber",
+		Usage:   "pragueCompatible blockNumber",
+		Value:   0,
+		Aliases: []string{"genesis.hardfork.prague-compatible-blocknumber"},
+	}
+
 	kip113ProxyAddressFlag = &cli.StringFlag{
 		Name:    "kip113-proxy-contract-address",
 		Usage:   "kip113 proxy contract address",

--- a/common/types.go
+++ b/common/types.go
@@ -49,6 +49,8 @@ var (
 	hashT    = reflect.TypeOf(Hash{})
 	extHashT = reflect.TypeOf(ExtHash{})
 	addressT = reflect.TypeOf(Address{})
+	// ZeroAddress represents the zero address value.
+	ZeroAddress = Address{}
 )
 
 var (

--- a/common/types.go
+++ b/common/types.go
@@ -49,8 +49,6 @@ var (
 	hashT    = reflect.TypeOf(Hash{})
 	extHashT = reflect.TypeOf(ExtHash{})
 	addressT = reflect.TypeOf(Address{})
-	// ZeroAddress represents the zero address value.
-	ZeroAddress = Address{}
 )
 
 var (

--- a/governance/api.go
+++ b/governance/api.go
@@ -490,6 +490,7 @@ func getChainConfig(governance Engine, num *rpc.BlockNumber) *params.ChainConfig
 	config.Kip160CompatibleBlock = latestConfig.Kip160CompatibleBlock
 	config.Kip160ContractAddress = latestConfig.Kip160ContractAddress
 	config.RandaoCompatibleBlock = latestConfig.RandaoCompatibleBlock
+	config.PragueCompatibleBlock = latestConfig.PragueCompatibleBlock
 
 	// To avoid confusion, override some parameters that are deprecated after hardforks.
 	// e.g., stakingupdateinterval is shown as 86400 but actually irrelevant (i.e. updated every block)

--- a/kerrors/kerrors.go
+++ b/kerrors/kerrors.go
@@ -35,6 +35,7 @@ var (
 	ErrNotProgramAccount          = errors.New("not a program account (e.g., an account having code and storage)")
 	ErrPrecompiledContractAddress = errors.New("the address is reserved for pre-compiled contracts")
 	ErrInvalidCodeFormat          = errors.New("smart contract code format is invalid")
+	ErrEmptyRecipient             = errors.New("this type transaction cannot be sent to nil")
 
 	// Error codes related to account keys.
 	ErrAccountAlreadyExists                 = errors.New("account already exists")

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -898,7 +898,7 @@ func (api *CommonAPI) TraceCall(ctx context.Context, args kaiaapi.CallArgs, bloc
 	defer release()
 
 	// Execute the trace
-	intrinsicGas, err := types.IntrinsicGas(args.InputData(), nil, args.To == nil, api.backend.ChainConfig().Rules(block.Number()))
+	intrinsicGas, err := types.IntrinsicGas(args.InputData(), nil, nil, args.To == nil, api.backend.ChainConfig().Rules(block.Number()))
 	if err != nil {
 		return nil, err
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -216,7 +216,7 @@ type ChainConfig struct {
 	ShanghaiCompatibleBlock  *big.Int `json:"shanghaiCompatibleBlock,omitempty"`  // ShanghaiCompatible switch block (nil = no fork, 0 already on shanghai)
 	CancunCompatibleBlock    *big.Int `json:"cancunCompatibleBlock,omitempty"`    // CancunCompatible switch block (nil = no fork, 0 already on Cancun)
 	KaiaCompatibleBlock      *big.Int `json:"kaiaCompatibleBlock,omitempty"`      // KaiaCompatible switch block (nil = no fork, 0 already on Kaia)
-	PragueCompatibleBlock    *big.Int `json:"pragueCompatibleBlock,omitempty"`    // PragueCompatibl activate block (nil = no fork)
+	PragueCompatibleBlock    *big.Int `json:"pragueCompatibleBlock,omitempty"`    // PragueCompatibl switch block (nil = no fork)
 
 	// Kip103 is a special purpose hardfork feature that can be executed only once
 	// Both Kip103CompatibleBlock and Kip103ContractAddress should be specified to enable KIP103
@@ -433,8 +433,8 @@ func (c *ChainConfig) IsRandaoForkEnabled(num *big.Int) bool {
 	return isForked(c.RandaoCompatibleBlock, num)
 }
 
-// IsPragueForkEnabeld returns whether num is either equal to the prague block or greater.
-func (c *ChainConfig) IsPragueForkEnabeld(num *big.Int) bool {
+// IsPragueForkEnabled returns whether num is either equal to the prague block or greater.
+func (c *ChainConfig) IsPragueForkEnabled(num *big.Int) bool {
 	return isForked(c.PragueCompatibleBlock, num)
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -216,6 +216,7 @@ type ChainConfig struct {
 	ShanghaiCompatibleBlock  *big.Int `json:"shanghaiCompatibleBlock,omitempty"`  // ShanghaiCompatible switch block (nil = no fork, 0 already on shanghai)
 	CancunCompatibleBlock    *big.Int `json:"cancunCompatibleBlock,omitempty"`    // CancunCompatible switch block (nil = no fork, 0 already on Cancun)
 	KaiaCompatibleBlock      *big.Int `json:"kaiaCompatibleBlock,omitempty"`      // KaiaCompatible switch block (nil = no fork, 0 already on Kaia)
+	PragueCompatibleBlock    *big.Int `json:"pragueCompatibleBlock,omitempty"`    // PragueCompatibl activate block (nil = no fork)
 
 	// Kip103 is a special purpose hardfork feature that can be executed only once
 	// Both Kip103CompatibleBlock and Kip103ContractAddress should be specified to enable KIP103
@@ -231,8 +232,6 @@ type ChainConfig struct {
 	// RandaoCompatibleBlock, RandaoRegistryRecords and RandaoRegistryOwner all must be specified to enable Randao
 	RandaoCompatibleBlock *big.Int        `json:"randaoCompatibleBlock,omitempty"` // RandaoCompatible activate block (nil = no fork)
 	RandaoRegistry        *RegistryConfig `json:"randaoRegistry,omitempty"`        // Registry initial states
-
-	PragueCompatibleBlock *big.Int `json:"pragueCompatibleBlock,omitempty"` // PragueCompatibl activate block (nil = no fork)
 
 	// Various consensus engines
 	Gxhash   *GxhashConfig   `json:"gxhash,omitempty"` // (deprecated) not supported engine
@@ -434,7 +433,7 @@ func (c *ChainConfig) IsRandaoForkEnabled(num *big.Int) bool {
 	return isForked(c.RandaoCompatibleBlock, num)
 }
 
-// IsPragueForkEnabeld returns whether num is either equal to the randao block or greater.
+// IsPragueForkEnabeld returns whether num is either equal to the prague block or greater.
 func (c *ChainConfig) IsPragueForkEnabeld(num *big.Int) bool {
 	return isForked(c.PragueCompatibleBlock, num)
 }
@@ -501,7 +500,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "cancunBlock", block: c.CancunCompatibleBlock},
 		{name: "randaoBlock", block: c.RandaoCompatibleBlock, optional: true},
 		{name: "kaiaBlock", block: c.KaiaCompatibleBlock},
-		{name: "pragueBlock", block: c.PragueCompatibleBlock, optional: true},
+		{name: "pragueBlock", block: c.PragueCompatibleBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number

--- a/params/config.go
+++ b/params/config.go
@@ -216,7 +216,7 @@ type ChainConfig struct {
 	ShanghaiCompatibleBlock  *big.Int `json:"shanghaiCompatibleBlock,omitempty"`  // ShanghaiCompatible switch block (nil = no fork, 0 already on shanghai)
 	CancunCompatibleBlock    *big.Int `json:"cancunCompatibleBlock,omitempty"`    // CancunCompatible switch block (nil = no fork, 0 already on Cancun)
 	KaiaCompatibleBlock      *big.Int `json:"kaiaCompatibleBlock,omitempty"`      // KaiaCompatible switch block (nil = no fork, 0 already on Kaia)
-	PragueCompatibleBlock    *big.Int `json:"pragueCompatibleBlock,omitempty"`    // PragueCompatibl switch block (nil = no fork)
+	PragueCompatibleBlock    *big.Int `json:"pragueCompatibleBlock,omitempty"`    // PragueCompatible switch block (nil = no fork)
 
 	// Kip103 is a special purpose hardfork feature that can be executed only once
 	// Both Kip103CompatibleBlock and Kip103ContractAddress should be specified to enable KIP103
@@ -714,7 +714,7 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsCancun:    c.IsCancunForkEnabled(num),
 		IsKaia:      c.IsKaiaForkEnabled(num),
 		IsRandao:    c.IsRandaoForkEnabled(num),
-		IsPrague:    c.IsPragueForkEnabeld(num),
+		IsPrague:    c.IsPragueForkEnabled(num),
 	}
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -59,6 +59,7 @@ var (
 			},
 			Owner: common.HexToAddress("0x04992a2B7E7CE809d409adE32185D49A96AAa32d"),
 		},
+		PragueCompatibleBlock: nil, // TODO-Kaia-Prague: set Cypress PragueCompatibleBlock
 		Kip103CompatibleBlock: big.NewInt(119750400),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),
 		Kip160CompatibleBlock: big.NewInt(162900480),
@@ -104,6 +105,7 @@ var (
 			},
 			Owner: common.HexToAddress("0x04992a2B7E7CE809d409adE32185D49A96AAa32d"),
 		},
+		PragueCompatibleBlock: nil, // TODO-Kaia-Prague: set Kairos PragueCompatibleBlock
 		Kip103CompatibleBlock: big.NewInt(119145600),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),
 		Kip160CompatibleBlock: big.NewInt(156660000),
@@ -230,6 +232,8 @@ type ChainConfig struct {
 	RandaoCompatibleBlock *big.Int        `json:"randaoCompatibleBlock,omitempty"` // RandaoCompatible activate block (nil = no fork)
 	RandaoRegistry        *RegistryConfig `json:"randaoRegistry,omitempty"`        // Registry initial states
 
+	PragueCompatibleBlock *big.Int `json:"pragueCompatibleBlock,omitempty"` // PragueCompatibl activate block (nil = no fork)
+
 	// Various consensus engines
 	Gxhash   *GxhashConfig   `json:"gxhash,omitempty"` // (deprecated) not supported engine
 	Clique   *CliqueConfig   `json:"clique,omitempty"`
@@ -337,7 +341,7 @@ func (c *ChainConfig) String() string {
 	kip160 := fmt.Sprintf("KIP160CompatibleBlock: %v KIP160ContractAddress %s", c.Kip160CompatibleBlock, c.Kip160ContractAddress.String())
 
 	if c.Istanbul != nil {
-		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v MagmaCompatibleBlock: %v KoreCompatibleBlock: %v ShanghaiCompatibleBlock: %v CancunCompatibleBlock: %v KaiaCompatibleBlock: %v RandaoCompatibleBlock: %v %s %s SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d Engine: %v}",
+		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v MagmaCompatibleBlock: %v KoreCompatibleBlock: %v ShanghaiCompatibleBlock: %v CancunCompatibleBlock: %v KaiaCompatibleBlock: %v RandaoCompatibleBlock: %v PragueCompatibleBlock: %v %s %s SubGroupSize: %d UnitPrice: %d DeriveShaImpl: %d Engine: %v}",
 			c.ChainID,
 			c.IstanbulCompatibleBlock,
 			c.LondonCompatibleBlock,
@@ -348,6 +352,7 @@ func (c *ChainConfig) String() string {
 			c.CancunCompatibleBlock,
 			c.KaiaCompatibleBlock,
 			c.RandaoCompatibleBlock,
+			c.PragueCompatibleBlock,
 			kip103,
 			kip160,
 			c.Istanbul.SubGroupSize,
@@ -356,7 +361,7 @@ func (c *ChainConfig) String() string {
 			engine,
 		)
 	} else {
-		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v MagmaCompatibleBlock: %v KoreCompatibleBlock: %v ShanghaiCompatibleBlock: %v CancunCompatibleBlock: %v KaiaCompatibleBlock: %v RandaoCompatibleBlock: %v %s %s UnitPrice: %d DeriveShaImpl: %d Engine: %v }",
+		return fmt.Sprintf("{ChainID: %v IstanbulCompatibleBlock: %v LondonCompatibleBlock: %v EthTxTypeCompatibleBlock: %v MagmaCompatibleBlock: %v KoreCompatibleBlock: %v ShanghaiCompatibleBlock: %v CancunCompatibleBlock: %v KaiaCompatibleBlock: %v RandaoCompatibleBlock: %v PragueCompatibleBlock: %v %s %s UnitPrice: %d DeriveShaImpl: %d Engine: %v }",
 			c.ChainID,
 			c.IstanbulCompatibleBlock,
 			c.LondonCompatibleBlock,
@@ -367,6 +372,7 @@ func (c *ChainConfig) String() string {
 			c.CancunCompatibleBlock,
 			c.KaiaCompatibleBlock,
 			c.RandaoCompatibleBlock,
+			c.PragueCompatibleBlock,
 			kip103,
 			kip160,
 			c.UnitPrice,
@@ -426,6 +432,11 @@ func (c *ChainConfig) IsKaiaForkEnabled(num *big.Int) bool {
 // IsRandaoForkEnabled returns whether num is either equal to the randao block or greater.
 func (c *ChainConfig) IsRandaoForkEnabled(num *big.Int) bool {
 	return isForked(c.RandaoCompatibleBlock, num)
+}
+
+// IsPragueForkEnabeld returns whether num is either equal to the randao block or greater.
+func (c *ChainConfig) IsPragueForkEnabeld(num *big.Int) bool {
+	return isForked(c.PragueCompatibleBlock, num)
 }
 
 // IsKIP103ForkBlock returns whether num is equal to the kip103 block.
@@ -490,6 +501,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "cancunBlock", block: c.CancunCompatibleBlock},
 		{name: "randaoBlock", block: c.RandaoCompatibleBlock, optional: true},
 		{name: "kaiaBlock", block: c.KaiaCompatibleBlock},
+		{name: "pragueBlock", block: c.PragueCompatibleBlock, optional: true},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -541,6 +553,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.RandaoCompatibleBlock, newcfg.RandaoCompatibleBlock, head) {
 		return newCompatError("Randao Block", c.RandaoCompatibleBlock, newcfg.RandaoCompatibleBlock)
+	}
+	if isForkIncompatible(c.PragueCompatibleBlock, newcfg.PragueCompatibleBlock, head) {
+		return newCompatError("Prague Block", c.PragueCompatibleBlock, newcfg.PragueCompatibleBlock)
 	}
 	return nil
 }
@@ -680,6 +695,7 @@ type Rules struct {
 	IsCancun    bool
 	IsKaia      bool
 	IsRandao    bool
+	IsPrague    bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -699,6 +715,7 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsCancun:    c.IsCancunForkEnabled(num),
 		IsKaia:      c.IsKaiaForkEnabled(num),
 		IsRandao:    c.IsRandaoForkEnabled(num),
+		IsPrague:    c.IsPragueForkEnabeld(num),
 	}
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -185,6 +185,8 @@ const (
 	TxAccessListAddressGas    uint64 = 2400 // Per address specified in EIP 2930 access list
 	TxAccessListStorageKeyGas uint64 = 1900 // Per storage key specified in EIP 2930 access list
 
+	TxAuthTupleGas uint64 = 12500 // Per auth tuple code specified in EIP-7702
+
 	// ZeroBaseFee exists for supporting Ethereum compatible data structure.
 	ZeroBaseFee uint64 = 0
 )

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -150,6 +150,9 @@ func generateDefaultTx(sender *TestAccountType, recipient *TestAccountType, txTy
 	dataCode := common.FromHex(code)
 	values := map[types.TxValueKeyType]interface{}{}
 
+	// Default authorization list
+	authorizationList := types.AuthorizationList{{ChainID: big.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: big.NewInt(0), R: big.NewInt(0), S: big.NewInt(0)}}
+
 	switch txType {
 	case types.TxTypeValueTransfer:
 		values[types.TxValueKeyNonce] = sender.Nonce
@@ -341,6 +344,17 @@ func generateDefaultTx(sender *TestAccountType, recipient *TestAccountType, txTy
 		values[types.TxValueKeyChainID] = big.NewInt(1)
 		values[types.TxValueKeyData] = dataCode
 		values[types.TxValueKeyAccessList] = types.AccessList{}
+	case types.TxTypeEthereumSetCode:
+		values[types.TxValueKeyNonce] = sender.Nonce
+		values[types.TxValueKeyTo] = &recipient.Addr
+		values[types.TxValueKeyAmount] = amount
+		values[types.TxValueKeyGasLimit] = gasLimit
+		values[types.TxValueKeyGasFeeCap] = gasFeeCap
+		values[types.TxValueKeyGasTipCap] = gasTipCap
+		values[types.TxValueKeyChainID] = big.NewInt(1)
+		values[types.TxValueKeyData] = dataCode
+		values[types.TxValueKeyAccessList] = types.AccessList{}
+		values[types.TxValueKeyAuthorizationList] = authorizationList
 	}
 
 	tx, err := types.NewTransactionWithMap(txType, values)

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -431,6 +431,7 @@ func TestDefaultTxsWithDefaultAccountKey(t *testing.T) {
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().PragueCompatibleBlock = big.NewInt(0)
 	prof.Profile("main_init_blockchain", time.Now().Sub(start))
 	defer bcdata.Shutdown()
 

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -346,7 +346,7 @@ func generateDefaultTx(sender *TestAccountType, recipient *TestAccountType, txTy
 		values[types.TxValueKeyAccessList] = types.AccessList{}
 	case types.TxTypeEthereumSetCode:
 		values[types.TxValueKeyNonce] = sender.Nonce
-		values[types.TxValueKeyTo] = &recipient.Addr
+		values[types.TxValueKeyTo] = recipient.Addr
 		values[types.TxValueKeyAmount] = amount
 		values[types.TxValueKeyGasLimit] = gasLimit
 		values[types.TxValueKeyGasFeeCap] = gasFeeCap

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -274,7 +274,7 @@ func (tx *stTransaction) toMessage(ps stPostState, r params.Rules) (blockchain.M
 		return nil, fmt.Errorf("invalid tx data %q", dataHex)
 	}
 
-	intrinsicGas, err := types.IntrinsicGas(data, nil, to == nil, r)
+	intrinsicGas, err := types.IntrinsicGas(data, nil, nil, to == nil, r)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -61,6 +61,7 @@ func TestGasCalculation(t *testing.T) {
 		{"LegacyTransaction", genLegacyTransaction},
 		{"AccessListTransaction", genAccessListTransaction},
 		{"DynamicFeeTransaction", genDynamicFeeTransaction},
+		{"SetCodeTransaction", genSetCodeTransaction},
 
 		{"ValueTransfer", genValueTransfer},
 		{"ValueTransferWithMemo", genValueTransferWithMemo},
@@ -245,7 +246,7 @@ func TestGasCalculation(t *testing.T) {
 			senderRole := accountkey.RoleTransaction
 
 			// LegacyTransaction can be used only by the KaiaAccount with AccountKeyLegacy.
-			if sender.Type != "KaiaLegacy" && (strings.Contains(f.Name, "Legacy") || strings.Contains(f.Name, "Access") || strings.Contains(f.Name, "Dynamic")) {
+			if sender.Type != "KaiaLegacy" && (strings.Contains(f.Name, "Legacy") || strings.Contains(f.Name, "Access") || strings.Contains(f.Name, "Dynamic") || strings.Contains(f.Name, "SetCode")) {
 				continue
 			}
 
@@ -316,6 +317,17 @@ func genAccessListTransaction(t *testing.T, signer types.Signer, from TestAccoun
 func genDynamicFeeTransaction(t *testing.T, signer types.Signer, from TestAccount, to TestAccount, payer TestAccount, gasPrice *big.Int) (*types.Transaction, uint64) {
 	values, intrinsic := genMapForDynamicFeeTransaction(from, to, gasPrice, types.TxTypeEthereumDynamicFee)
 	tx, err := types.NewTransactionWithMap(types.TxTypeEthereumDynamicFee, values)
+	assert.Equal(t, nil, err)
+
+	err = tx.SignWithKeys(signer, from.GetTxKeys())
+	assert.Equal(t, nil, err)
+
+	return tx, intrinsic
+}
+
+func genSetCodeTransaction(t *testing.T, signer types.Signer, from TestAccount, to TestAccount, payer TestAccount, gasPrice *big.Int) (*types.Transaction, uint64) {
+	values, intrinsic := genMapForSetCodeTransaction(from, to, gasPrice, types.TxTypeEthereumSetCode)
+	tx, err := types.NewTransactionWithMap(types.TxTypeEthereumSetCode, values)
 	assert.Equal(t, nil, err)
 
 	err = tx.SignWithKeys(signer, from.GetTxKeys())
@@ -736,6 +748,34 @@ func genMapForDynamicFeeTransaction(from TestAccount, to TestAccount, gasPrice *
 	return values, intrinsic + gasPayload
 }
 
+func genMapForSetCodeTransaction(from TestAccount, to TestAccount, gasPrice *big.Int, txType types.TxType) (map[types.TxValueKeyType]interface{}, uint64) {
+	intrinsic := getIntrinsicGas(txType)
+	amount := big.NewInt(100000)
+	data := []byte{0x11, 0x22}
+	gasPayload := uint64(len(data)) * params.TxDataGas
+	accessList := types.AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
+	authorizationList := types.AuthorizationList{{ChainID: big.NewInt(1), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: 1, V: big.NewInt(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	toAddress := to.GetAddr()
+
+	gasPayload += uint64(len(accessList)) * params.TxAccessListAddressGas
+	gasPayload += uint64(accessList.StorageKeys()) * params.TxAccessListStorageKeyGas
+	gasPayload += uint64(len(authorizationList)) * params.CallNewAccountGas
+
+	values := map[types.TxValueKeyType]interface{}{
+		types.TxValueKeyNonce:             from.GetNonce(),
+		types.TxValueKeyTo:                &toAddress,
+		types.TxValueKeyAmount:            amount,
+		types.TxValueKeyData:              data,
+		types.TxValueKeyGasLimit:          gasLimit,
+		types.TxValueKeyGasFeeCap:         gasPrice,
+		types.TxValueKeyGasTipCap:         gasPrice,
+		types.TxValueKeyAccessList:        accessList,
+		types.TxValueKeyAuthorizationList: authorizationList,
+		types.TxValueKeyChainID:           big.NewInt(1),
+	}
+	return values, intrinsic + gasPayload
+}
+
 func genMapForValueTransfer(from TestAccount, to TestAccount, gasPrice *big.Int, txType types.TxType) (map[types.TxValueKeyType]interface{}, uint64) {
 	intrinsic := getIntrinsicGas(txType)
 	amount := big.NewInt(100000)
@@ -1044,6 +1084,8 @@ func getIntrinsicGas(txType types.TxType) uint64 {
 	case types.TxTypeEthereumAccessList:
 		intrinsic = params.TxGas
 	case types.TxTypeEthereumDynamicFee:
+		intrinsic = params.TxGas
+	case types.TxTypeEthereumSetCode:
 		intrinsic = params.TxGas
 	case types.TxTypeValueTransfer:
 		intrinsic = params.TxGasValueTransfer

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -111,6 +111,7 @@ func TestGasCalculation(t *testing.T) {
 	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().KoreCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().ShanghaiCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().PragueCompatibleBlock = big.NewInt(0)
 	prof.Profile("main_init_blockchain", time.Now().Sub(start))
 
 	defer bcdata.Shutdown()

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -764,7 +764,7 @@ func genMapForSetCodeTransaction(from TestAccount, to TestAccount, gasPrice *big
 
 	values := map[types.TxValueKeyType]interface{}{
 		types.TxValueKeyNonce:             from.GetNonce(),
-		types.TxValueKeyTo:                &toAddress,
+		types.TxValueKeyTo:                toAddress,
 		types.TxValueKeyAmount:            amount,
 		types.TxValueKeyData:              data,
 		types.TxValueKeyGasLimit:          gasLimit,

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -397,6 +397,7 @@ func TestValidationBlockTx(t *testing.T) {
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().PragueCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification
@@ -1217,6 +1218,7 @@ func TestInvalidBalanceBlockTx(t *testing.T) {
 	bcdata.bc.Config().IstanbulCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().LondonCompatibleBlock = big.NewInt(0)
 	bcdata.bc.Config().EthTxTypeCompatibleBlock = big.NewInt(0)
+	bcdata.bc.Config().PragueCompatibleBlock = big.NewInt(0)
 	defer bcdata.Shutdown()
 
 	// Initialize address-balance map for verification

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -96,6 +96,10 @@ func genMapForTxTypes(from TestAccount, to TestAccount, txType types.TxType) (tx
 		valueMap, gas = genMapForDynamicFeeTransaction(from, to, gasPrice, txType)
 	}
 
+	if txType == types.TxTypeEthereumSetCode {
+		valueMap, gas = genMapForSetCodeTransaction(from, to, gasPrice, txType)
+	}
+
 	return valueMap, gas
 }
 

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -495,7 +495,7 @@ func decreaseNonce(txType types.TxType, values txValueMap, contract common.Addre
 // decreaseGasPrice changes gasPrice to 12345678
 func decreaseGasPrice(txType types.TxType, values txValueMap, contract common.Address) (txValueMap, error) {
 	var err error
-	if txType == types.TxTypeEthereumDynamicFee {
+	if txType == types.TxTypeEthereumDynamicFee || txType == types.TxTypeEthereumSetCode {
 		(*big.Int).SetUint64(values[types.TxValueKeyGasFeeCap].(*big.Int), 12345678)
 		(*big.Int).SetUint64(values[types.TxValueKeyGasTipCap].(*big.Int), 12345678)
 		err = blockchain.ErrInvalidGasTipCap
@@ -511,7 +511,7 @@ func decreaseGasPrice(txType types.TxType, values txValueMap, contract common.Ad
 // decreaseGasPrice changes gasPrice to 12345678 and return an error with magma policy
 func decreaseGasPriceMagma(txType types.TxType, values txValueMap, contract common.Address) (txValueMap, error) {
 	var err error
-	if txType == types.TxTypeEthereumDynamicFee {
+	if txType == types.TxTypeEthereumDynamicFee || txType == types.TxTypeEthereumSetCode {
 		(*big.Int).SetUint64(values[types.TxValueKeyGasFeeCap].(*big.Int), 12345678)
 		(*big.Int).SetUint64(values[types.TxValueKeyGasTipCap].(*big.Int), 12345678)
 		err = blockchain.ErrFeeCapBelowBaseFee


### PR DESCRIPTION
## Proposed changes

- Define the `TxTypeEthereumSetCode` to set the code for EOA.
- Serialization changes with the addition of `TxTypeEthereumSetCode`
- Add PragueSigner
  - Although it has been newly created, the process is no different from that of existing signers.
- Add test case for gas cost calculation of `TxTypeEthereumSetCode`
- Add set code processing to state_transition
  - This isn't perfect yet, there is a PR to add a code hash field to EOA that will get it working perfectly, see the comments.
- This PR is adapting the ongoing go-eth PR for kaia.
  - https://github.com/ethereum/go-ethereum/pull/30078

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #106 

## Further comments

The responsibilities of this PR are to add SetCodeTxType and PragueSigner, and to add the expected processing of SetCodeTxType to state_transition (Functional testing is not possible yet because the code field has not been added to EOA).
We are planning to submit three additional PRs later.
- Add code hash field to EOA
- Add a method to set code for EOA and functional test of SetCodeTxType
- Integrate test