### PR TITLE
statedb: Initialize dirty storage map correctly

### DIFF
--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -832,15 +832,16 @@ func (s *StateDB) ForEachStorage(addr common.Address, cb func(key, value common.
 func (s *StateDB) Copy() *StateDB {
 	// Copy all the basic fields, initialize the memory ones
 	state := &StateDB{
-		db:                s.db,
-		trie:              s.db.CopyTrie(s.trie),
-		stateObjects:      make(map[common.Address]*stateObject, len(s.journal.dirties)),
-		stateObjectsDirty: make(map[common.Address]struct{}, len(s.journal.dirties)),
-		refund:            s.refund,
-		logs:              make(map[common.Hash][]*types.Log, len(s.logs)),
-		logSize:           s.logSize,
-		preimages:         make(map[common.Hash][]byte),
-		journal:           newJournal(),
+		db:                       s.db,
+		trie:                     s.db.CopyTrie(s.trie),
+		stateObjects:             make(map[common.Address]*stateObject, len(s.journal.dirties)),
+		stateObjectsDirty:        make(map[common.Address]struct{}, len(s.journal.dirties)),
+		stateObjectsDirtyStorage: make(map[common.Address]struct{}),
+		refund:                   s.refund,
+		logs:                     make(map[common.Hash][]*types.Log, len(s.logs)),
+		logSize:                  s.logSize,
+		preimages:                make(map[common.Hash][]byte),
+		journal:                  newJournal(),
 	}
 	// Copy the dirty states, logs, and preimages
 	for addr := range s.journal.dirties {


### PR DESCRIPTION
## Proposed changes

In `statedb.Copy()`, the `stateObjectsDirtyStorage` map isn't initialized so it may lead to nil map error. This PR suggests to initialize the map correctly. Note that I didn't copy entries from journal since it's redundant.

This can be triggered when using copied state for `blockchain.ApplyTransaction()` which calls `statedb.Finalise(true, setStorageRoot=false)`. In `Finalise`, it tries to mark the `stateObjectsDirtyStorage` but will be panic since copied `statedb` holds nil map.

The exact panic point is: https://github.com/kaiachain/kaia/blob/dev/blockchain/state/state_object.go#L408

I checked the current code and it seems there's no affected part so far.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
