### PR TITLE
kaiax/supply: Expect Initialize to be called by mock (Fix CI)

### DIFF
--- a/kaiax/supply/impl/testutil_test.go
+++ b/kaiax/supply/impl/testutil_test.go
@@ -279,6 +279,7 @@ func setupMockEngine(engine *consensus_mock.MockEngine, chain *blockchain.BlockC
 	engine.EXPECT().Author(gomock.Any()).Return(addrProposer, nil).AnyTimes()
 	engine.EXPECT().CalcBlockScore(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.Big0).AnyTimes()
 	engine.EXPECT().CanVerifyHeadersConcurrently().Return(false).AnyTimes()
+	engine.EXPECT().Initialize(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	engine.EXPECT().PreprocessHeaderVerification(gomock.Any()).DoAndReturn(
 		func(headers []*types.Header) (chan<- struct{}, <-chan error) {


### PR DESCRIPTION
## Proposed changes

Fix CI failures such as [this](https://app.circleci.com/pipelines/github/kaiachain/kaia/989/workflows/73066f11-3082-4392-bd05-a1e491430276/jobs/4840)

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
