### PR TITLE
kaiax/gov: Serialize/deserialize validator votes

### DIFF
--- a/kaiax/gov/headergov/impl/api_test.go
+++ b/kaiax/gov/headergov/impl/api_test.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kaiachain/kaia/params"
@@ -28,4 +29,28 @@ func TestLowerBoundBaseFeeSet(t *testing.T) {
 	s, err := api.Vote("kip71.lowerboundbasefee", uint64(1e18))
 	assert.Equal(t, ErrLowerBoundBaseFee, err)
 	assert.Equal(t, "", s)
+}
+
+func TestValidatorVotes(t *testing.T) {
+	testCases := []struct {
+		key         string
+		value       string
+		expectedErr error
+	}{
+		{key: "governance.addvalidator", value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{key: "governance.addvalidator", value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
+		{key: "governance.addvalidator", value: ",0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", expectedErr: ErrInvalidKeyValue},
+		{key: "governance.removevalidator", value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{key: "governance.removevalidator", value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
+		{key: "governance.removevalidator", value: ",0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", expectedErr: ErrInvalidKeyValue},
+	}
+
+	api := newHeaderGovAPI(t)
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			_, err := api.Vote(tc.key, tc.value)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
 }

--- a/kaiax/gov/headergov/impl/execution.go
+++ b/kaiax/gov/headergov/impl/execution.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"bytes"
+	"reflect"
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/kaiax/gov"
@@ -51,7 +52,7 @@ func (h *headerGovModule) HandleVote(blockNum uint64, vote headergov.VoteData) e
 	for i, myvote := range h.myVotes {
 		if bytes.Equal(myvote.Voter().Bytes(), vote.Voter().Bytes()) &&
 			myvote.Name() == vote.Name() &&
-			myvote.Value() == vote.Value() {
+			reflect.DeepEqual(myvote.Value(), vote.Value()) {
 			h.PopMyVotes(i)
 			break
 		}

--- a/kaiax/gov/headergov/impl/execution.go
+++ b/kaiax/gov/headergov/impl/execution.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 )
 
@@ -40,7 +41,8 @@ func (h *headerGovModule) PostInsertBlock(b *types.Block) error {
 }
 
 func (h *headerGovModule) HandleVote(blockNum uint64, vote headergov.VoteData) error {
-	if vote.Name() != "governance.addvalidator" && vote.Name() != "governance.removevalidator" {
+	// if governance vote (i.e., not validator vote), add to vote
+	if _, ok := gov.Params[vote.Name()]; ok {
 		h.AddVote(calcEpochIdx(blockNum, h.epoch), blockNum, vote)
 		InsertVoteDataBlockNum(h.ChainKv, blockNum)
 	}

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
@@ -154,8 +155,12 @@ func (h *headerGovModule) scanAllVotesInEpoch(epochIdx uint64) map[uint64]header
 			logger.Error("Failed to parse vote", "num", blockNum, "err", err)
 			continue
 		}
-		// TODO-kaiax: consider writing addval/removeval votes to validator DB.
-		if vote != nil && vote.Name() != "governance.addvalidator" && vote.Name() != "governance.removevalidator" {
+
+		if vote == nil {
+			continue
+		}
+
+		if _, ok := gov.Params[vote.Name()]; ok {
 			votes[blockNum] = vote
 		}
 	}

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -160,6 +160,7 @@ func (h *headerGovModule) scanAllVotesInEpoch(epochIdx uint64) map[uint64]header
 			continue
 		}
 
+		// Only governance params are collected. Validator params are ignored.
 		if _, ok := gov.Params[vote.Name()]; ok {
 			votes[blockNum] = vote
 		}

--- a/kaiax/gov/headergov/vote_test.go
+++ b/kaiax/gov/headergov/vote_test.go
@@ -49,14 +49,14 @@ func TestNewVoteData(t *testing.T) {
 		{name: gov.RewardRatio, value: "100/0/0"},
 		{name: gov.RewardRatio, value: "30/40/30"},
 		{name: gov.RewardRatio, value: "50/25/25"},
-		{name: gov.ParamName("governance.addvalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
-		{name: gov.ParamName("governance.addvalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
-		{name: gov.ParamName("governance.addvalidator"), value: common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")},
-		{name: gov.ParamName("governance.addvalidator"), value: []common.Address{common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")}},
-		{name: gov.ParamName("governance.removevalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
-		{name: gov.ParamName("governance.removevalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
-		{name: gov.ParamName("governance.removevalidator"), value: common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")},
-		{name: gov.ParamName("governance.removevalidator"), value: []common.Address{common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")}},
+		{name: gov.ParamName(gov.AddValidator), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{name: gov.ParamName(gov.AddValidator), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
+		{name: gov.ParamName(gov.AddValidator), value: common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")},
+		{name: gov.ParamName(gov.AddValidator), value: []common.Address{common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")}},
+		{name: gov.ParamName(gov.RemoveValidator), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{name: gov.ParamName(gov.RemoveValidator), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
+		{name: gov.ParamName(gov.RemoveValidator), value: common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")},
+		{name: gov.ParamName(gov.RemoveValidator), value: []common.Address{common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")}},
 	}
 
 	for _, tc := range goodVotes {
@@ -177,12 +177,12 @@ func TestNewVoteData(t *testing.T) {
 		{name: gov.RewardUseGiniCoeff, value: 1},
 		{name: gov.RewardUseGiniCoeff, value: false},
 		{name: gov.RewardUseGiniCoeff, value: true},
-		{name: gov.ParamName("governance.addvalidator"), value: "0x"},
-		{name: gov.ParamName("governance.addvalidator"), value: "0x1"},
-		{name: gov.ParamName("governance.addvalidator"), value: "0x1,0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
-		{name: gov.ParamName("governance.removevalidator"), value: "0x"},
-		{name: gov.ParamName("governance.removevalidator"), value: "0x1"},
-		{name: gov.ParamName("governance.removevalidator"), value: "0x1,0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{name: gov.ParamName(gov.AddValidator), value: "0x"},
+		{name: gov.ParamName(gov.AddValidator), value: "0x1"},
+		{name: gov.ParamName(gov.AddValidator), value: "0x1,0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{name: gov.ParamName(gov.RemoveValidator), value: "0x"},
+		{name: gov.ParamName(gov.RemoveValidator), value: "0x1"},
+		{name: gov.ParamName(gov.RemoveValidator), value: "0x1,0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
 	}
 
 	for _, tc := range badVotes {

--- a/kaiax/gov/headergov/vote_test.go
+++ b/kaiax/gov/headergov/vote_test.go
@@ -49,6 +49,14 @@ func TestNewVoteData(t *testing.T) {
 		{name: gov.RewardRatio, value: "100/0/0"},
 		{name: gov.RewardRatio, value: "30/40/30"},
 		{name: gov.RewardRatio, value: "50/25/25"},
+		{name: gov.ParamName("governance.addvalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{name: gov.ParamName("governance.addvalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
+		{name: gov.ParamName("governance.addvalidator"), value: common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")},
+		{name: gov.ParamName("governance.addvalidator"), value: []common.Address{common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")}},
+		{name: gov.ParamName("governance.removevalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{name: gov.ParamName("governance.removevalidator"), value: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266,0x70997970C51812dc3A010C7d01b50e0d17dc79C8"},
+		{name: gov.ParamName("governance.removevalidator"), value: common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")},
+		{name: gov.ParamName("governance.removevalidator"), value: []common.Address{common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"), common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")}},
 	}
 
 	for _, tc := range goodVotes {
@@ -56,11 +64,6 @@ func TestNewVoteData(t *testing.T) {
 			assert.NotNil(t, NewVoteData(common.Address{}, string(tc.name), tc.value))
 		})
 	}
-
-	t.Run("goodVote/validators", func(t *testing.T) {
-		assert.NotNil(t, NewVoteData(common.Address{}, "governance.addvalidator", common.Address{}))
-		assert.NotNil(t, NewVoteData(common.Address{}, "governance.removevalidator", common.Address{}))
-	})
 
 	badVotes := []struct {
 		name  gov.ParamName
@@ -174,6 +177,12 @@ func TestNewVoteData(t *testing.T) {
 		{name: gov.RewardUseGiniCoeff, value: 1},
 		{name: gov.RewardUseGiniCoeff, value: false},
 		{name: gov.RewardUseGiniCoeff, value: true},
+		{name: gov.ParamName("governance.addvalidator"), value: "0x"},
+		{name: gov.ParamName("governance.addvalidator"), value: "0x1"},
+		{name: gov.ParamName("governance.addvalidator"), value: "0x1,0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
+		{name: gov.ParamName("governance.removevalidator"), value: "0x"},
+		{name: gov.ParamName("governance.removevalidator"), value: "0x1"},
+		{name: gov.ParamName("governance.removevalidator"), value: "0x1,0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"},
 	}
 
 	for _, tc := range badVotes {
@@ -197,6 +206,7 @@ func TestVoteSerialization(t *testing.T) {
 		serializedVoteData string
 		blockNum           uint64
 		voteData           VoteData
+		noSerialize        bool
 	}{
 		///// all vote datas.
 		{serializedVoteData: "0xf8439452d41ca72af615a1ac3301b0a93efa222ecc754198676f7665726e616e63652e676f7665726e696e676e6f64659452d41ca72af615a1ac3301b0a93efa222ecc7541", blockNum: 1, voteData: NewVoteData(v1, "governance.governingnode", v1)},
@@ -221,6 +231,15 @@ func TestVoteSerialization(t *testing.T) {
 		{serializedVoteData: "0xed94c0cbe1c770fbce1eb7786bfba1ac2115d5c0a45696697374616e62756c2e636f6d6d697474656573697a6532", blockNum: 161809335, voteData: NewVoteData(v2, "istanbul.committeesize", uint64(50))},
 		{serializedVoteData: "0xf83e94c0cbe1c770fbce1eb7786bfba1ac2115d5c0a456947265776172642e6d696e74696e67616d6f756e749339363030303030303030303030303030303030", blockNum: 161809370, voteData: NewVoteData(v2, "reward.mintingamount", new(big.Int).SetUint64(9.6e18))},
 		{serializedVoteData: "0xeb94c0cbe1c770fbce1eb7786bfba1ac2115d5c0a4568c7265776172642e726174696f8835302f32352f3235", blockNum: 161809416, voteData: NewVoteData(v2, "reward.ratio", "50/25/25")},
+
+		// Real mainnet validator vote data.
+		{serializedVoteData: "0xf8459452d41ca72af615a1ac3301b0a93efa222ecc75419a676f7665726e616e63652e72656d6f766576616c696461746f7294a2ba8f7798649a778a1fd66d3035904949fec555", blockNum: 5505383, voteData: NewVoteData(v1, "governance.removevalidator", "0xa2ba8f7798649a778a1fd66d3035904949fec555")},
+
+		// Dummy validator vote data (multiple addresses).
+		{serializedVoteData: "0xf85994f39fd6e51aad88f6f4ce6ab8827279cfffb922669a676f7665726e616e63652e72656d6f766576616c696461746f72a83c44cdddb6a900fa2b585dd299e03d12fa4293bc90f79bf6eb2c4f870365e785982e1f101e93b906", blockNum: 123123, voteData: NewVoteData(common.HexToAddress("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"), "governance.removevalidator", "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc,0x90f79bf6eb2c4f870365e785982e1f101e93b906")},
+
+		// Real mainnet validator vote data with hex-encoded address (for backward compatibility). Deserialize test only.
+		{serializedVoteData: "0xf85b9452d41ca72af615a1ac3301b0a93efa222ecc75419a676f7665726e616e63652e72656d6f766576616c696461746f72aa307831366331393235383561306162323462353532373833623462663764386463396636383535633335", blockNum: 90915008, voteData: NewVoteData(v1, "governance.removevalidator", "0x16c192585a0ab24b552783b4bf7d8dc9f6855c35"), noSerialize: true},
 	}
 
 	for _, tc := range tcs {
@@ -231,10 +250,12 @@ func TestVoteSerialization(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.voteData, actual, "ToVoteData() failed")
 
-			// Test serialization
-			serialized, err := tc.voteData.ToVoteBytes()
-			assert.NoError(t, err)
-			assert.Equal(t, tc.serializedVoteData, hexutil.Encode(serialized), "voteData.Serialize() failed")
+			if !tc.noSerialize {
+				// Test serialization
+				serialized, err := tc.voteData.ToVoteBytes()
+				assert.NoError(t, err)
+				assert.Equal(t, tc.serializedVoteData, hexutil.Encode(serialized), "voteData.Serialize() failed")
+			}
 		})
 	}
 }

--- a/kaiax/gov/param.go
+++ b/kaiax/gov/param.go
@@ -165,8 +165,10 @@ func noopFormatChecker(cv any) bool {
 	return true
 }
 
-type ParamName string
-type ValidatorParamName string
+type (
+	ParamName          string
+	ValidatorParamName string
+)
 
 // alphabetically sorted. These are only used in-memory, so the order does not matter.
 const (

--- a/kaiax/gov/param.go
+++ b/kaiax/gov/param.go
@@ -40,7 +40,7 @@ var (
 		return nil, ErrCanonicalizeToAddress
 	}
 
-	validatorAddressCanonicalizer canonicalizerT = func(v any) (any, error) { // always canonicalizes to []address
+	validatorAddressListCanonicalizer canonicalizerT = func(v any) (any, error) {
 		stringToAddressList := func(v string) ([]common.Address, error) {
 			ret := []common.Address{}
 			for _, address := range strings.Split(v, ",") {
@@ -417,13 +417,13 @@ var Params = map[ParamName]*Param{
 
 var ValidatorParams = map[ValidatorParamName]*Param{
 	AddValidator: {
-		Canonicalizer: validatorAddressCanonicalizer,
+		Canonicalizer: validatorAddressListCanonicalizer,
 		FormatChecker: noopFormatChecker,
 		DefaultValue:  []common.Address{},
 		VoteForbidden: false,
 	},
 	RemoveValidator: {
-		Canonicalizer: validatorAddressCanonicalizer,
+		Canonicalizer: validatorAddressListCanonicalizer,
 		FormatChecker: noopFormatChecker,
 		DefaultValue:  []common.Address{},
 		VoteForbidden: false,

--- a/kaiax/gov/param_test.go
+++ b/kaiax/gov/param_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,23 +47,25 @@ func TestAddressCanonicalizer(t *testing.T) {
 	}
 }
 
-func TestAddressListCanonicalizer(t *testing.T) {
+func TestValidatorAddressCanonicalizer(t *testing.T) {
 	tcs := []struct {
 		desc          string
 		input         any
 		expected      []common.Address
 		expectedError error
 	}{
-		{desc: "Valid single address string", input: "0x1234567890123456789012345678901234567890", expected: []common.Address{common.HexToAddress("0x1234567890123456789012345678901234567890")}},
-		{desc: "Valid multiple address string", input: "0x1234567890123456789012345678901234567890,0x0987654321098765432109876543210987654321", expected: []common.Address{common.HexToAddress("0x1234567890123456789012345678901234567890"), common.HexToAddress("0x0987654321098765432109876543210987654321")}},
-		{desc: "Invalid address string", input: "0xinvalid", expectedError: ErrCanonicalizeStringToAddress},
-		{desc: "Valid byte slice", input: []byte("0x1234567890123456789012345678901234567890"), expected: []common.Address{common.HexToAddress("0x1234567890123456789012345678901234567890")}},
+		{desc: "Valid string, single address", input: "0x1234567890123456789012345678901234567890", expected: []common.Address{common.HexToAddress("0x1234567890123456789012345678901234567890")}},
+		{desc: "Valid string, multiple addresses", input: "0x1234567890123456789012345678901234567890,0x0987654321098765432109876543210987654321", expected: []common.Address{common.HexToAddress("0x1234567890123456789012345678901234567890"), common.HexToAddress("0x0987654321098765432109876543210987654321")}},
+		{desc: "Invalid string", input: "0xinvalid", expectedError: ErrCanonicalizeStringToAddress},
+		{desc: "Valid bytes, one address", input: hexutil.MustDecode("0x1212121212121212121212121212121212121212"), expected: []common.Address{common.HexToAddress("0x1212121212121212121212121212121212121212")}},
+		{desc: "Valid bytes, hex-encoded one address", input: hexutil.MustDecode("0x307831366331393235383561306162323462353532373833623462663764386463396636383535633335"), expected: []common.Address{common.HexToAddress("0x16c192585a0ab24b552783b4bf7d8dc9f6855c35")}},
+		{desc: "Valid bytes, two addresses", input: hexutil.MustDecode("0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc90f79bf6eb2c4f870365e785982e1f101e93b906"), expected: []common.Address{common.HexToAddress("0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc"), common.HexToAddress("0x90f79bf6eb2c4f870365e785982e1f101e93b906")}},
 		{desc: "Invalid type", input: 123, expectedError: ErrCanonicalizeToAddressList},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			result, err := addressListCanonicalizer(tc.input)
+			result, err := validatorAddressCanonicalizer(tc.input)
 			assert.Equal(t, tc.expectedError, err)
 			if tc.expectedError == nil {
 				assert.Equal(t, tc.expected, result.([]common.Address))

--- a/kaiax/gov/param_test.go
+++ b/kaiax/gov/param_test.go
@@ -65,7 +65,7 @@ func TestValidatorAddressCanonicalizer(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.desc, func(t *testing.T) {
-			result, err := validatorAddressCanonicalizer(tc.input)
+			result, err := validatorAddressListCanonicalizer(tc.input)
 			assert.Equal(t, tc.expectedError, err)
 			if tc.expectedError == nil {
 				assert.Equal(t, tc.expected, result.([]common.Address))


### PR DESCRIPTION
## Proposed changes

- Facilitates `governance_vote` to support validator votes (i.e., `governance.addvalidator`/`governance.removevalidator`).
  - Adds address-list encoding in `ToVoteBytes`.
  - Adds address-list canonicalizer `validatorAddressListCanonicalizer`.
- Adds `ValidatorParams` for checking validator-related votes.
- Adds testcases from real blocks: `TestVoteSerialization`.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist
- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This PR fixes encoding of multiple-address votes, because the previous scheme involves decoding RLP twice.
This data does not exist in any on-chain blocks, so there's no need to support backward compatibility.

```
// before this PR
rlp decode 0xf85b94f39fd6e51aad88f6f4ce6ab8827279cfffb922669a676f7665726e616e63652e72656d6f766576616c696461746f72ea943c44cdddb6a900fa2b585dd299e03d12fa4293bc9490f79bf6eb2c4f870365e785982e1f101e93b906
["f39fd6e51aad88f6f4ce6ab8827279cfffb92266","676f7665726e616e63652e72656d6f766576616c696461746f72",["3c44cdddb6a900fa2b585dd299e03d12fa4293bc","90f79bf6eb2c4f870365e785982e1f101e93b906"]]

// after this PR
rlp decode 0xf85994f39fd6e51aad88f6f4ce6ab8827279cfffb922669a676f7665726e616e63652e72656d6f766576616c696461746f72a83c44cdddb6a900fa2b585dd299e03d12fa4293bc90f79bf6eb2c4f870365e785982e1f101e93b906
["f39fd6e51aad88f6f4ce6ab8827279cfffb92266","676f7665726e616e63652e72656d6f766576616c696461746f72","3c44cdddb6a900fa2b585dd299e03d12fa4293bc90f79bf6eb2c4f870365e785982e1f101e93b906"]
```