### PR TITLE
api: Remove `totalDifficulty` and `totalBlockScore` field in RPC output

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1290,17 +1290,16 @@ func (api *EthereumAPI) rpcMarshalHeader(head *types.Header, inclMiner bool) (ma
 		}
 	}
 	result := map[string]interface{}{
-		"number":          (*hexutil.Big)(head.Number),
-		"hash":            head.Hash(),
-		"parentHash":      head.ParentHash,
-		"nonce":           BlockNonce{},  // There is no block nonce concept in Kaia, so it must be empty.
-		"mixHash":         common.Hash{}, // Kaia does not use mixHash, so it must be empty.
-		"sha3Uncles":      common.HexToHash(EmptySha3Uncles),
-		"logsBloom":       head.Bloom,
-		"stateRoot":       head.Root,
-		"miner":           proposer,
-		"difficulty":      (*hexutil.Big)(head.BlockScore),
-		"totalDifficulty": (*hexutil.Big)(b.GetTd(head.Hash())),
+		"number":     (*hexutil.Big)(head.Number),
+		"hash":       head.Hash(),
+		"parentHash": head.ParentHash,
+		"nonce":      BlockNonce{},  // There is no block nonce concept in Kaia, so it must be empty.
+		"mixHash":    common.Hash{}, // Kaia does not use mixHash, so it must be empty.
+		"sha3Uncles": common.HexToHash(EmptySha3Uncles),
+		"logsBloom":  head.Bloom,
+		"stateRoot":  head.Root,
+		"miner":      proposer,
+		"difficulty": (*hexutil.Big)(head.BlockScore),
 		// extraData always return empty Bytes because actual value of extraData in Kaia header cannot be used as meaningful way because
 		// we cannot provide original header of Kaia and this field is used as consensus info which is encoded value of validators addresses, validators signatures, and proposer signature in Kaia.
 		"extraData": hexutil.Bytes{},

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -289,7 +289,6 @@ func testGetHeader(t *testing.T, testAPIName string, config *params.ChainConfig)
 		"size": "0x244",
 		"stateRoot": "0xad31c32942fa033166e4ef588ab973dbe26657c594de4ba98192108becf0fec9",
 		"timestamp": "0x61d53854",
-		"totalDifficulty": "0x5",
 		"transactionsRoot": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
 	}`), &expected))
 
@@ -391,7 +390,6 @@ func testGetBlock(t *testing.T, testAPIName string, fullTxs bool) {
         "size": "0xe44",
         "stateRoot": "0xad31c32942fa033166e4ef588ab973dbe26657c594de4ba98192108becf0fec9",
         "timestamp": "0x61d53854",
-        "totalDifficulty": "0x5",
         "transactions": [
             {
               "blockHash": "0xc74d8c04d4d2f2e4ed9cd1731387248367cea7f149731b7a015371b220ffa0fb",
@@ -793,7 +791,6 @@ func testGetBlock(t *testing.T, testAPIName string, fullTxs bool) {
         "size": "0xe44",
         "stateRoot": "0xad31c32942fa033166e4ef588ab973dbe26657c594de4ba98192108becf0fec9",
         "timestamp": "0x61d53854",
-        "totalDifficulty": "0x5",
         "transactions": [
             "0x6231f24f79d28bb5b8425ce577b3b77cd9c1ab766fcfc5233358a2b1c2f4ff70",
             "0xf146858415c060eae65a389cbeea8aeadc79461038fbee331ffd97b41279dd63",

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -536,7 +536,7 @@ func FormatLogs(timeout time.Duration, logs []vm.StructLog) ([]StructLogRes, err
 
 // For kaia_getBlockByNumber, kaia_getBlockByHash, kaia_getBlockWithconsensusInfoByNumber, kaia_getBlockWithconsensusInfoByHash APIs
 // and Kafka chaindatafetcher.
-func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
+func RpcOutputBlock(b *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
@@ -546,7 +546,6 @@ func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool, confi
 		"stateRoot":        head.Root,
 		"reward":           head.Rewardbase,
 		"blockScore":       (*hexutil.Big)(head.BlockScore),
-		"totalBlockScore":  (*hexutil.Big)(td),
 		"extraData":        hexutil.Bytes(head.Extra),
 		"governanceData":   hexutil.Bytes(head.Governance),
 		"voteData":         hexutil.Bytes(head.Vote),
@@ -600,7 +599,7 @@ func RpcOutputBlock(b *types.Block, td *big.Int, inclTx bool, fullTx bool, confi
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
 func (s *PublicBlockChainAPI) rpcOutputBlock(b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
-	return RpcOutputBlock(b, s.b.GetTd(b.Hash()), inclTx, fullTx, s.b.ChainConfig())
+	return RpcOutputBlock(b, inclTx, fullTx, s.b.ChainConfig())
 }
 
 func getFrom(tx *types.Transaction) common.Address {

--- a/api/backend.go
+++ b/api/backend.go
@@ -77,7 +77,6 @@ type Backend interface {
 	GetBlockReceipts(ctx context.Context, blockHash common.Hash) types.Receipts
 	GetTxLookupInfoAndReceipt(ctx context.Context, hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt)
 	GetTxAndLookupInfo(hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64)
-	GetTd(blockHash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error)
 	SubscribeChainEvent(ch chan<- blockchain.ChainEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- blockchain.ChainHeadEvent) event.Subscription

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -309,11 +309,7 @@ func (api *APIExtension) makeRPCBlockOutput(b *types.Block,
 	head := b.Header() // copies the header once
 	hash := head.Hash()
 
-	td := big.NewInt(0)
-	if bc, ok := api.chain.(*blockchain.BlockChain); ok {
-		td = bc.GetTd(hash, b.NumberU64())
-	}
-	r, err := kaiaApi.RpcOutputBlock(b, td, false, false, api.chain.Config())
+	r, err := kaiaApi.RpcOutputBlock(b, false, false, api.chain.Config())
 	if err != nil {
 		logger.Error("failed to RpcOutputBlock", "err", err)
 		return nil

--- a/datasync/chaindatafetcher/kafka/utils.go
+++ b/datasync/chaindatafetcher/kafka/utils.go
@@ -68,8 +68,7 @@ func makeBlockGroupOutput(blockchain *blockchain.BlockChain, block *types.Block,
 	head := block.Header() // copies the header once
 	hash := head.Hash()
 
-	td := blockchain.GetTd(hash, block.NumberU64())
-	r, _ := kaiaApi.RpcOutputBlock(block, td, false, false, blockchain.Config())
+	r, _ := kaiaApi.RpcOutputBlock(block, false, false, blockchain.Config())
 
 	// make transactions
 	transactions := block.Transactions()

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -235,10 +235,6 @@ func (b *CNAPIBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*type
 	return b.cn.blockchain.GetLogsByHash(hash), nil
 }
 
-func (b *CNAPIBackend) GetTd(blockHash common.Hash) *big.Int {
-	return b.cn.blockchain.GetTdByHash(blockHash)
-}
-
 func (b *CNAPIBackend) GetEVM(ctx context.Context, msg blockchain.Message, state *state.StateDB, header *types.Header, vmCfg vm.Config) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -546,17 +546,6 @@ func TestCNAPIBackend_GetLogs(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCNAPIBackend_GetTd(t *testing.T) {
-	mockCtrl, mockBlockChain, _, api := newCNAPIBackend(t)
-	defer mockCtrl.Finish()
-
-	td := big.NewInt(123)
-	hash := hashes[0]
-	mockBlockChain.EXPECT().GetTdByHash(hash).Return(td).Times(1)
-
-	assert.Equal(t, td, api.GetTd(hash))
-}
-
 func TestCNAPIBackend_SubscribeEvents(t *testing.T) {
 	mockCtrl, mockBlockChain, _, api := newCNAPIBackend(t)
 	mockTxPool := mocks.NewMockTxPool(mockCtrl)


### PR DESCRIPTION
## Proposed changes

This PR removes `totalDifficulty`(`eth` namespace) and `totalBlockScore`(`kaia` namespace) according to https://github.com/ethereum/execution-apis/pull/570

As-Is:
```
> eth.getHeaderByNumber(kaia.blockNumber)
{
  baseFeePerGas: "0x5d21dba00",
  ...
  ...
  timestamp: "0x673e7f0f",
  totalDifficulty: "0x10294",
  transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
}
```

This PR:
```
> eth.getHeaderByNumber(kaia.blockNumber)
{
  baseFeePerGas: "0x5d21dba00",
  ...
  ...
  timestamp: "0x673e8215",
  transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
