### PR TITLE
Improve error message for upstream request

### DIFF
--- a/networks/rpc/handler.go
+++ b/networks/rpc/handler.go
@@ -476,7 +476,7 @@ func requestUpstream(ctx context.Context, msg *jsonrpcMessage, args []reflect.Va
 	}
 
 	rpcErrorResponsesCounter.Inc(1)
-	return msg.errorResponse(fmt.Errorf("from upstream archive en: %w", err))
+	return msg.errorResponse(fmt.Errorf("from upstream rpc endpoint: %w", err))
 }
 
 // unsubscribe is the callback function for all *_unsubscribe calls.

--- a/networks/rpc/handler.go
+++ b/networks/rpc/handler.go
@@ -476,7 +476,7 @@ func requestUpstream(ctx context.Context, msg *jsonrpcMessage, args []reflect.Va
 	}
 
 	rpcErrorResponsesCounter.Inc(1)
-	return msg.errorResponse(err)
+	return msg.errorResponse(fmt.Errorf("from upstream archive en: %w", err))
 }
 
 // unsubscribe is the callback function for all *_unsubscribe calls.


### PR DESCRIPTION
## Proposed changes

This PR suggests to show the error comes from the upstream archive EN, not itself.

```
// Before
> kaia.getBalance("0x0d019776cf279ba6a0d93bf63c83ab1104287008", "23")
Error: the header does not exist (block number: 23)
	at web3.js:6814:9(39)
	at send (web3.js:5225:62(29))
	at <eval>:1:16(4)
```

```
// After
> kaia.getBalance("0x0d019776cf279ba6a0d93bf63c83ab1104287008", "23")
Error: from upstream archive en: the header does not exist (block number: 23)
	at web3.js:6814:9(39)
	at send (web3.js:5225:62(29))
	at <eval>:1:16(4) (edited) 
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
