### PR TITLE
params: Add default BN addresses for PNs

### DIFF
--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -36,7 +36,11 @@ var MainnetBootnodes = map[common.ConnType]bootnodesByTypes{
 		[]string{},
 	},
 	common.PROXYNODE: {
-		[]string{},
+		[]string{
+			"kni://18b36118cce093673499fc6e9aa196f047fe17a0de35b6f2a76a4557802f6abf9f89aa5e7330e93c9014b714b9df6378393611efe39aec9d3d831d6aa9d617ae@ston65.node.kaia.io:32323?ntype=bn",
+			"kni://63f1c96874da85140ecca3ce24875cb5ef28fa228bc3572e16f690db4a48fc8067502d2f6e8f0c66fb558276a5ada1e4906852c7ae42b0003e9f9f25d1e123b1@ston873.node.kaia.io:32323?ntype=bn",
+			"kni://94cc15e2014b86584908707de55800c0a2ea8a24dc5550dcb507043e4cf18ff04f21dc86ed17757dc63b1fa85bb418b901e5e24e4197ad4bbb0d96cd9389ed98@ston106.node.kaia.io:32323?ntype=bn",
+		},
 	},
 	common.ENDPOINTNODE: {
 		[]string{
@@ -53,7 +57,9 @@ var KairosBootnodes = map[common.ConnType]bootnodesByTypes{
 		[]string{},
 	},
 	common.PROXYNODE: {
-		[]string{},
+		[]string{
+			"kni://779d766628247ebda5f3e108e9303bd8efdb8eba9fd8d6c529e2614aec7207ebf6614fe7e61d0d99b75e8b23dd3a679b112fd0de7e4e71a7008f0718710da48f@ston45-kairos.node.kaia.io:32323?ntype=bn",
+		},
 	},
 	common.ENDPOINTNODE: {
 		[]string{


### PR DESCRIPTION
## Proposed changes

- Let PNs have the BN address by default, eliminating the need of `BOOTNODES=` setting in kpnd.conf.
- The BN addresses are identical to ENBNs because we don't operate separate PNBNs.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
