### PR TITLE
kaiax/gov: Add ChainConfig fallback

### DIFF
--- a/kaiax/gov/contractgov/interface.go
+++ b/kaiax/gov/contractgov/interface.go
@@ -5,7 +5,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/gov"
 )
 
-//go:generate mockgen -destination=kaiax/gov/contractgov/mock/contractgov_mock.go github.com/kaiachain/kaia/kaiax/gov/contractgov ContractGovModule
+//go:generate mockgen -destination=mock/contractgov_mock.go github.com/kaiachain/kaia/kaiax/gov/contractgov ContractGovModule
 type ContractGovModule interface {
 	kaiax.BaseModule
 	kaiax.JsonRpcModule

--- a/kaiax/gov/headergov/impl/execution_test.go
+++ b/kaiax/gov/headergov/impl/execution_test.go
@@ -81,11 +81,11 @@ func TestVote(t *testing.T) {
 	)
 
 	for i := 0; i < n; i++ {
-		h.AddVote(uint64(i%epoch), uint64(i), v)
+		h.AddVote(calcEpochIdx(uint64(i), uint64(epoch)), uint64(i), v)
 	}
 
 	assert.Equal(t, n, len(h.VoteBlockNums()))
-	assert.Equal(t, n/epoch, len(h.groupedVotes))
+	assert.Equal(t, 4, len(h.groupedVotes)) // ceil(n/epoch)
 }
 
 func TestGov(t *testing.T) {

--- a/kaiax/gov/headergov/impl/getter.go
+++ b/kaiax/gov/headergov/impl/getter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/gov"
+	"golang.org/x/exp/maps" // TODO: use "maps"
 )
 
 func (h *headerGovModule) EffectiveParamSet(blockNum uint64) gov.ParamSet {
@@ -44,14 +45,7 @@ func (h *headerGovModule) VoteBlockNums() []uint64 {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	// TODO: replace with maps.Keys(h.groupedVotes)
-	blockNums := make([]uint64, 0)
-	for _, group := range h.groupedVotes {
-		for num := range group {
-			blockNums = append(blockNums, num)
-		}
-	}
-
+	blockNums := maps.Keys(h.groupedVotes)
 	slices.Sort(blockNums)
 	return blockNums
 }
@@ -60,12 +54,7 @@ func (h *headerGovModule) GovBlockNums() []uint64 {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	// TODO: replace with maps.Keys(h.Govs())
-	blockNums := make([]uint64, 0)
-	for num := range h.governances {
-		blockNums = append(blockNums, num)
-	}
-
+	blockNums := maps.Keys(h.governances)
 	slices.Sort(blockNums)
 	return blockNums
 }

--- a/kaiax/gov/headergov/impl/getter.go
+++ b/kaiax/gov/headergov/impl/getter.go
@@ -45,7 +45,11 @@ func (h *headerGovModule) VoteBlockNums() []uint64 {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
-	blockNums := maps.Keys(h.groupedVotes)
+	blockNums := []uint64{}
+	for _, votes := range h.groupedVotes {
+		blockNums = append(blockNums, maps.Keys(votes)...)
+	}
+
 	slices.Sort(blockNums)
 	return blockNums
 }

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -33,7 +33,7 @@ type InitOpts struct {
 	NodeAddress common.Address
 }
 
-//go:generate mockgen -destination=kaiax/headergov/mocks/headergov_mock.go github.com/kaiachain/kaia/kaiax/headergov HeaderGovModule
+//go:generate mockgen -destination=mocks/headergov_mock.go github.com/kaiachain/kaia/kaiax/headergov HeaderGovModule
 type headerGovModule struct {
 	ChainKv     database.Database
 	ChainConfig *params.ChainConfig

--- a/kaiax/gov/headergov/interface.go
+++ b/kaiax/gov/headergov/interface.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/gov"
 )
 
-//go:generate mockgen -destination=kaiax/gov/headergov/mock/headergov_mock.go github.com/kaiachain/kaia/kaiax/gov/headergov HeaderGovModule
+//go:generate mockgen -destination=mock/headergov_mock.go github.com/kaiachain/kaia/kaiax/gov/headergov HeaderGovModule
 type HeaderGovModule interface {
 	kaiax.BaseModule
 	kaiax.JsonRpcModule

--- a/kaiax/gov/impl/getter.go
+++ b/kaiax/gov/impl/getter.go
@@ -5,6 +5,11 @@ import "github.com/kaiachain/kaia/kaiax/gov"
 func (m *GovModule) EffectiveParamSet(blockNum uint64) gov.ParamSet {
 	ret := gov.GetDefaultGovernanceParamSet()
 
+	p0 := m.Fallback
+	for k, v := range p0 {
+		ret.Set(k, v)
+	}
+
 	p1 := m.Hgm.EffectiveParamsPartial(blockNum)
 	for k, v := range p1 {
 		ret.Set(k, v)

--- a/kaiax/gov/impl/getter.go
+++ b/kaiax/gov/impl/getter.go
@@ -1,6 +1,8 @@
 package impl
 
-import "github.com/kaiachain/kaia/kaiax/gov"
+import (
+	"github.com/kaiachain/kaia/kaiax/gov"
+)
 
 func (m *GovModule) EffectiveParamSet(blockNum uint64) gov.ParamSet {
 	ret := gov.GetDefaultGovernanceParamSet()

--- a/kaiax/gov/impl/getter_test.go
+++ b/kaiax/gov/impl/getter_test.go
@@ -29,11 +29,12 @@ func newGovModuleMock(t *testing.T, config *params.ChainConfig) (*headergov_mock
 	chain := blockchain_mock.NewMockBlockChain(gomock.NewController(t))
 	chain.EXPECT().Config().Return(config).AnyTimes()
 	m := NewGovModule()
-	m.Init(&InitOpts{
-		Hgm:   hgm,
-		Cgm:   cgm,
-		Chain: chain,
-	})
+
+	// don't use Init, we need to use mock Hgm and Cgm.
+	m.Chain = chain
+	m.ChainConfig = config
+	m.Hgm = hgm
+	m.Cgm = cgm
 	return hgm, cgm, m
 }
 

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -105,8 +105,9 @@ func ChainConfigFallback(chainConfig *params.ChainConfig) gov.PartialParamSet {
 	candidates := maps.Keys(gov.Params)
 
 	// on Mainnet/Kairos, fallback candidates are only the initial params specified in `params.{Mainnet,Kairos}ChainConfig`.
-	if chainConfig.ChainID.Cmp(params.MainnetChainConfig.ChainID) == 0 ||
-		chainConfig.ChainID.Cmp(params.KairosChainConfig.ChainID) == 0 {
+	if chainId := chainConfig.ChainID; chainId != nil &&
+		(chainId.Cmp(params.MainnetChainConfig.ChainID) == 0 ||
+			chainId.Cmp(params.KairosChainConfig.ChainID) == 0) {
 		candidates = []gov.ParamName{
 			gov.GovernanceDeriveShaImpl, gov.GovernanceGoverningNode, gov.GovernanceGovernanceMode, gov.RewardMintingAmount,
 			gov.RewardRatio, gov.RewardUseGiniCoeff, gov.RewardDeferredTxFee, gov.RewardStakingUpdateInterval,

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -39,8 +39,8 @@ type BlockChain interface {
 
 type GovModule struct {
 	Fallback    gov.PartialParamSet
-	Chain       BlockChain
 	ChainConfig *params.ChainConfig
+	Chain       BlockChain
 	Hgm         headergov.HeaderGovModule
 	Cgm         contractgov.ContractGovModule
 }
@@ -84,7 +84,14 @@ func (m *GovModule) Init(opts *InitOpts) error {
 		return err
 	}
 
-	m.Fallback = opts.Fallback
+	m.Fallback = make(gov.PartialParamSet)
+	for k, v := range opts.Fallback {
+		err := m.Fallback.Add(string(k), v)
+		if err != nil {
+			return err
+		}
+	}
+
 	m.Chain = opts.Chain
 	m.ChainConfig = opts.ChainConfig
 	m.Hgm = hgm

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -38,6 +38,7 @@ type BlockChain interface {
 }
 
 type GovModule struct {
+	Fallback    gov.PartialParamSet
 	Chain       BlockChain
 	ChainConfig *params.ChainConfig
 	Hgm         headergov.HeaderGovModule
@@ -45,6 +46,7 @@ type GovModule struct {
 }
 
 type InitOpts struct {
+	Fallback    gov.PartialParamSet
 	ChainConfig *params.ChainConfig
 	ChainKv     database.Database
 	Chain       BlockChain
@@ -82,6 +84,7 @@ func (m *GovModule) Init(opts *InitOpts) error {
 		return err
 	}
 
+	m.Fallback = opts.Fallback
 	m.Chain = opts.Chain
 	m.ChainConfig = opts.ChainConfig
 	m.Hgm = hgm

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -5,8 +5,6 @@ import (
 	"math/big"
 	"reflect"
 
-	"golang.org/x/exp/maps" // TODO: use "maps"
-
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -19,6 +17,7 @@ import (
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
+	"golang.org/x/exp/maps" // TODO: use "maps"
 )
 
 var (

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 	"reflect"
 
-	"golang.org/x/exp/maps"
+	"golang.org/x/exp/maps" // TODO: use "maps"
 
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/state"

--- a/kaiax/gov/impl/init_test.go
+++ b/kaiax/gov/impl/init_test.go
@@ -1,0 +1,94 @@
+package impl
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/gov"
+	"github.com/kaiachain/kaia/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChainConfigFallback(t *testing.T) {
+	tests := []struct {
+		desc     string
+		config   *params.ChainConfig
+		expected gov.PartialParamSet
+	}{
+		{
+			desc:     "nil config",
+			config:   nil,
+			expected: gov.PartialParamSet{},
+		},
+		{
+			desc:     "empty config",
+			config:   &params.ChainConfig{},
+			expected: gov.PartialParamSet{gov.GovernanceUnitPrice: uint64(0)},
+		},
+		{
+			desc: "config with non-default values",
+			config: &params.ChainConfig{
+				DeriveShaImpl: 1,
+				UnitPrice:     uint64(123456789),
+				Istanbul: &params.IstanbulConfig{
+					Epoch:          uint64(100),
+					ProposerPolicy: uint64(2),
+					SubGroupSize:   uint64(99),
+				},
+				Governance: &params.GovernanceConfig{
+					GovernanceMode:   "single",
+					GoverningNode:    common.HexToAddress("0x1234567890123456789012345678901234567890"),
+					GovParamContract: common.HexToAddress("0x2345678901234567890123456789012345678901"),
+					Reward: &params.RewardConfig{
+						MintingAmount:          big.NewInt(1e18),
+						Ratio:                  "34/33/33",
+						Kip82Ratio:             "50/50",
+						UseGiniCoeff:           true,
+						DeferredTxFee:          true,
+						StakingUpdateInterval:  uint64(12345),
+						ProposerUpdateInterval: uint64(6789),
+						MinimumStake:           big.NewInt(5000000),
+					},
+					KIP71: &params.KIP71Config{
+						LowerBoundBaseFee:         uint64(50000000000),
+						UpperBoundBaseFee:         uint64(500000000000),
+						GasTarget:                 uint64(40000000),
+						MaxBlockGasUsedForBaseFee: uint64(80000000),
+						BaseFeeDenominator:        uint64(25),
+					},
+				},
+			},
+			expected: gov.PartialParamSet{
+				gov.GovernanceDeriveShaImpl:        uint64(1),
+				gov.GovernanceUnitPrice:            uint64(123456789),
+				gov.IstanbulEpoch:                  uint64(100),
+				gov.IstanbulPolicy:                 uint64(2),
+				gov.IstanbulCommitteeSize:          uint64(99),
+				gov.GovernanceGovernanceMode:       "single",
+				gov.GovernanceGoverningNode:        common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				gov.GovernanceGovParamContract:     common.HexToAddress("0x2345678901234567890123456789012345678901"),
+				gov.RewardMintingAmount:            big.NewInt(1e18),
+				gov.RewardRatio:                    "34/33/33",
+				gov.RewardKip82Ratio:               "50/50",
+				gov.RewardUseGiniCoeff:             true,
+				gov.RewardDeferredTxFee:            true,
+				gov.RewardStakingUpdateInterval:    uint64(12345),
+				gov.RewardProposerUpdateInterval:   uint64(6789),
+				gov.RewardMinimumStake:             big.NewInt(5000000),
+				gov.Kip71LowerBoundBaseFee:         uint64(50000000000),
+				gov.Kip71UpperBoundBaseFee:         uint64(500000000000),
+				gov.Kip71GasTarget:                 uint64(40000000),
+				gov.Kip71MaxBlockGasUsedForBaseFee: uint64(80000000),
+				gov.Kip71BaseFeeDenominator:        uint64(25),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			fallback := ChainConfigFallback(tc.config)
+			assert.Equal(t, tc.expected, fallback)
+		})
+	}
+}

--- a/kaiax/gov/impl/mock/blockchain_mock.go
+++ b/kaiax/gov/impl/mock/blockchain_mock.go
@@ -11,6 +11,7 @@ import (
 	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
+	consensus "github.com/kaiachain/kaia/consensus"
 	params "github.com/kaiachain/kaia/params"
 )
 
@@ -65,6 +66,20 @@ func (mr *MockBlockChainMockRecorder) CurrentBlock() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentBlock", reflect.TypeOf((*MockBlockChain)(nil).CurrentBlock))
 }
 
+// Engine mocks base method.
+func (m *MockBlockChain) Engine() consensus.Engine {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Engine")
+	ret0, _ := ret[0].(consensus.Engine)
+	return ret0
+}
+
+// Engine indicates an expected call of Engine.
+func (mr *MockBlockChainMockRecorder) Engine() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Engine", reflect.TypeOf((*MockBlockChain)(nil).Engine))
+}
+
 // GetBlock mocks base method.
 func (m *MockBlockChain) GetBlock(arg0 common.Hash, arg1 uint64) *types.Block {
 	m.ctrl.T.Helper()
@@ -77,6 +92,20 @@ func (m *MockBlockChain) GetBlock(arg0 common.Hash, arg1 uint64) *types.Block {
 func (mr *MockBlockChainMockRecorder) GetBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlock", reflect.TypeOf((*MockBlockChain)(nil).GetBlock), arg0, arg1)
+}
+
+// GetHeader mocks base method.
+func (m *MockBlockChain) GetHeader(arg0 common.Hash, arg1 uint64) *types.Header {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeader", arg0, arg1)
+	ret0, _ := ret[0].(*types.Header)
+	return ret0
+}
+
+// GetHeader indicates an expected call of GetHeader.
+func (mr *MockBlockChainMockRecorder) GetHeader(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeader", reflect.TypeOf((*MockBlockChain)(nil).GetHeader), arg0, arg1)
 }
 
 // GetHeaderByNumber mocks base method.
@@ -105,6 +134,21 @@ func (m *MockBlockChain) GetReceiptsByBlockHash(arg0 common.Hash) types.Receipts
 func (mr *MockBlockChainMockRecorder) GetReceiptsByBlockHash(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiptsByBlockHash", reflect.TypeOf((*MockBlockChain)(nil).GetReceiptsByBlockHash), arg0)
+}
+
+// State mocks base method.
+func (m *MockBlockChain) State() (*state.StateDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "State")
+	ret0, _ := ret[0].(*state.StateDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// State indicates an expected call of State.
+func (mr *MockBlockChainMockRecorder) State() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockBlockChain)(nil).State))
 }
 
 // StateAt mocks base method.

--- a/kaiax/gov/interface.go
+++ b/kaiax/gov/interface.go
@@ -4,7 +4,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax"
 )
 
-//go:generate mockgen -destination=kaiax/gov/mock/govmodule_mock.go github.com/kaiachain/kaia/kaiax/gov GovModule
+//go:generate mockgen -destination=mock/govmodule_mock.go github.com/kaiachain/kaia/kaiax/gov GovModule
 type GovModule interface {
 	kaiax.BaseModule
 	kaiax.JsonRpcModule

--- a/kaiax/gov/param_test.go
+++ b/kaiax/gov/param_test.go
@@ -13,6 +13,7 @@ func TestParam(t *testing.T) {
 	for name, param := range Params {
 		assert.NotEmpty(t, param.Canonicalizer, name)
 		assert.NotEmpty(t, param.FormatChecker, name)
+		assert.NotEmpty(t, param.ChainConfigValue, name)
 	}
 }
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -47,8 +47,6 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/governance"
 	"github.com/kaiachain/kaia/kaiax"
-	contractgov_impl "github.com/kaiachain/kaia/kaiax/gov/contractgov/impl"
-	headergov_impl "github.com/kaiachain/kaia/kaiax/gov/headergov/impl"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
 	reward_impl "github.com/kaiachain/kaia/kaiax/reward/impl"
 	"github.com/kaiachain/kaia/kaiax/staking"
@@ -535,12 +533,10 @@ func (s *CN) SetupKaiaxModules() error {
 	// Declare modules
 
 	var (
-		mStaking     = staking_impl.NewStakingModule()
-		mReward      = reward_impl.NewRewardModule()
-		mSupply      = supply_impl.NewSupplyModule()
-		mHeaderGov   = headergov_impl.NewHeaderGovModule()
-		mContractGov = contractgov_impl.NewContractGovModule()
-		mGov         = gov_impl.NewGovModule()
+		mStaking = staking_impl.NewStakingModule()
+		mReward  = reward_impl.NewRewardModule()
+		mSupply  = supply_impl.NewSupplyModule()
+		mGov     = gov_impl.NewGovModule()
 	)
 
 	// Initialize modules
@@ -562,21 +558,11 @@ func (s *CN) SetupKaiaxModules() error {
 			Chain:        s.blockchain,
 			RewardModule: mReward,
 		}),
-		mHeaderGov.Init(&headergov_impl.InitOpts{
-			ChainKv:     s.chainDB.GetMiscDB(),
+		mGov.Init(&gov_impl.InitOpts{
 			ChainConfig: s.chainConfig,
+			ChainKv:     s.chainDB.GetMiscDB(),
 			Chain:       s.blockchain,
 			NodeAddress: s.nodeAddress,
-		}),
-		mContractGov.Init(&contractgov_impl.InitOpts{
-			ChainConfig: s.chainConfig,
-			Chain:       s.blockchain,
-			Hgm:         mHeaderGov,
-		}),
-		mGov.Init(&gov_impl.InitOpts{
-			Hgm:   mHeaderGov,
-			Cgm:   mContractGov,
-			Chain: s.blockchain,
 		}),
 	)
 	if err != nil {

--- a/tests/gov_test.go
+++ b/tests/gov_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/blockchain"
-	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/governance"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
@@ -43,7 +42,6 @@ func TestMainnetGenesisGovernance(t *testing.T) {
 	// Get params from GovModule
 	govModule := gov_impl.NewGovModule()
 	err = govModule.Init(&gov_impl.InitOpts{
-		Fallback:    map[gov.ParamName]interface{}{gov.GovernanceDeriveShaImpl: uint64(types.ImplDeriveShaConcat)},
 		Chain:       chain,
 		ChainConfig: config,
 		ChainKv:     dbm.GetMemDB(),

--- a/tests/gov_test.go
+++ b/tests/gov_test.go
@@ -1,0 +1,69 @@
+package tests
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/governance"
+	"github.com/kaiachain/kaia/kaiax/gov"
+	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
+	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMainnetGenesisGovernance is a regression test for genesis parameters.
+// TODO-kaiax: replace mixedEngine with fixed genesis parameters values.
+func TestMainnetGenesisGovernance(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
+	config := params.MainnetChainConfig.Copy()
+	genesis := blockchain.DefaultGenesisBlock()
+	genesis.Config = config
+	genesis.Governance = blockchain.SetGenesisGovernance(genesis)
+
+	fullNode, node, _, _, workspace := newBlockchain(t, config, genesis)
+	chain := node.BlockChain().(*blockchain.BlockChain)
+	defer os.RemoveAll(workspace)
+	defer fullNode.Stop()
+
+	// Create MixedEngine
+	dbm := database.NewMemoryDBManager()
+	mixed := governance.NewMixedEngine(config, dbm)
+
+	// Get params from MixedEngine
+	blockNum := uint64(0)
+	mixedParams, err := mixed.EffectiveParams(blockNum)
+	assert.NoError(t, err)
+
+	// Get params from GovModule
+	govModule := gov_impl.NewGovModule()
+	err = govModule.Init(&gov_impl.InitOpts{
+		Fallback:    map[gov.ParamName]interface{}{gov.GovernanceDeriveShaImpl: uint64(types.ImplDeriveShaConcat)},
+		Chain:       chain,
+		ChainConfig: config,
+		ChainKv:     dbm.GetMemDB(),
+	})
+	require.NoError(t, err)
+	govParams := govModule.EffectiveParamSet(blockNum)
+
+	// Compare all parameter values
+	mixedMap := mixedParams.StrMap()
+	govMap := govParams.ToMap()
+	assert.Equal(t, len(mixedMap), len(govMap))
+
+	for key, mixedVal := range mixedMap {
+		govVal, exists := govMap[gov.ParamName(key)]
+		assert.True(t, exists, "Key %s missing from GovModule params at block %d", key, blockNum)
+		switch key {
+		case string(gov.RewardMintingAmount), string(gov.RewardMinimumStake):
+			assert.Equal(t, mixedVal, govVal.(*big.Int).String())
+		default:
+			assert.Equal(t, mixedVal, govVal, "Key %s mismatch", key)
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a fallback to kaiax/gov, so the fallback chain is ContractGov -> HeaderGov -> ChainConfig (`m.Fallback`) -> Default values.

See further comments regarding why ChainConfig fallback is necessary.

This PR also fix some bugs; fix deadlock at rewind, use relative path for go:generate.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments


### Cases when ChainConfig fallback is required

If all below conditions are true, ChainConfig fallback is required:
- a parameter is not in `Genesis header`'s Governance.
- a parameter's value of `Genesis ChainConfig` is different from the `Default Value`.

On Mainnet/Kairos, DeriveShaImpl satisfies all the condition.

On Private net, new parameters can satisfy all the condition, when `Magma hardfork block > 0` and/or `Kore hardfork block > 0` and ChainConfig of `genesis.json` contains non-default value.

<details>

<summary>Details</summary>

![image](https://github.com/user-attachments/assets/ce077898-445a-4023-b4b0-bed48deab072)

### Definition

- Initial params: the initial 13 governance parameters. [link](https://github.com/kaiachain/kaia/blob/e9fc051923c2c31877f7680a6fefeda9476f60f0/blockchain/genesis.go#L467-L479)
- New params: newly introduced at hardforks; KIP-71 parameters at Magma Hardfork, KIP-82 ratio, GovParam Contract, DeriveShaImpl at Kore Hardfork.

### Mainnet/Kairos

- Initial params: ContractGov → **HeaderGov** → DefaultValue
  - Parameters before vote: ContractGov → HeaderGov → **DefaultValue**
    - Because DefaultValue is equal to ChainConfig, ChainConfig can be omitted.
  - Parameters after vote:  ContractGov → **HeaderGov** → DefaultValue
- New params (except DeriveShaImpl): 
  - Parameters before vote: ContractGov → HeaderGov → **DefaultValue**
  - Parameters after vote:  ContractGov → **HeaderGov** → DefaultValue
  - Thus, ChainConfig can be omitted.
- DeriveShaImpl
  - DeriveShaImpl before vote: ContractGov → HeaderGov → **ChainConfig (2)** → DefaultValue (0)
    - ChainConfig **cannot** be omitted. This is because (a) DeriveShaImpl is not in HeaderGov, and (b) the value from ChainConfig and DefaultValue are different.
  - DeriveShaImpl after vote: ContractGov → **HeaderGov (0)** → ChainConfig (2) → DefaultValue (0)
    - ChainConfig can omitted.
 
### Private net
- Initial params: ContractGov → HeaderGov → DefaultValue
  - Parameters before vote: ContractGov → HeaderGov → **DefaultValue**
    - Because DefaultValue is equal to ChainConfig, ChainConfig can be omitted.
  - Parameters after vote:  ContractGov → **HeaderGov** → DefaultValue
- New params
  - All parameters from ChainConfig of `genesis.json` are stored in DB ChainConfig.
  - Some of them are stored in DB Genesis header, while some are not. It depends on the genesis block's hardfork.
    e.g.) If Genesis is Magma, KIP-71 parameteres are stored in DB Genesis header. Otherwise, they're not stored.
  - For parameters stored in DB Genesis header, ChainConfig can be ommtted from the fallback chain
    e.g.) lowerboundbasefee: ContractGov → **HeaderGov (0gkei)** → ChainConfig (0gkei) → DefaultValue (25gkei)
  - However, if not stored in DB Genesis header, ChainConfig **cannot** be omiitted:
     e.g.) lowerboundbasefee: ContractGov → HeaderGov (nil) → **ChainConfig (0gkei)** → DefaultValue (25gkei)

</details>
