### PR TITLE
p2p: Relaxed Bond pingpong condition

### DIFF
--- a/networks/p2p/discover/table.go
+++ b/networks/p2p/discover/table.go
@@ -644,11 +644,13 @@ func (tab *Table) Bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16
 		return nil, errors.New("still initializing")
 	}
 	// Start bonding if we haven't seen this node for a while or if it failed findnode too often.
+	// db.node: nil if never bonded or program exited before writing (via copyBondedNodes) to db.
+	// db.findFails: 0 if never tried or never failed.
+	// db.bondTime: 0 if never bonded, in which case age becomes very big.
 	node, fails := tab.db.node(id), tab.db.findFails(id)
 	age := time.Since(tab.db.bondTime(id))
 	var result error
-	// A Bootnode always add node(cn, pn, en) to table.
-	if fails > 0 || age > nodeDBNodeExpiration || (node == nil && tab.self.NType == NodeTypeBN) {
+	if node == nil || fails > 0 || age > nodeDBNodeExpiration {
 		tab.localLogger.Trace("Bond - Starting bonding ping/pong", "id", id, "known", node != nil, "failcount", fails, "age", age)
 
 		tab.bondmu.Lock()


### PR DESCRIPTION
## Proposed changes

Suppose a program bonds to a node once and exits before committing to the database via tab.copyBondedNodes or db.updateNode. Next time this program launches and tries to tab.Bond a node, it will receive db.node(id) = nil, then never bonding to the node. This patch can recover from such absence of database entry.

It has to do with following three NodeDB schemas:
- db.node(id): Node information. Periodically committed by the [`copyBondedNode` loop](https://github.com/kaiachain/kaia/blob/c1f9ef577b7066cd0f3503fae64523a3f574f481/networks/p2p/discover/table.go#L472-L473), [every 30 seconds](https://github.com/kaiachain/kaia/blob/c1f9ef577b7066cd0f3503fae64523a3f574f481/networks/p2p/discover/table.go#L435).
- db.findFails(id): Number of times the node failed to respond to `findnode` request. Incremented [whenever `findnode` fails](https://github.com/kaiachain/kaia/blob/c1f9ef577b7066cd0f3503fae64523a3f574f481/networks/p2p/discover/table.go#L246).
- db.bondTime(id): Timestamp of the last ping-pong. [Updated whenever pinged the node](https://github.com/kaiachain/kaia/blob/c1f9ef577b7066cd0f3503fae64523a3f574f481/networks/p2p/discover/table.go#L725).

Under specific conditions, an inconsistency where the `db.nodes(id)` is not written but `db.bondTime(id)` is written, happens:
- First `ken` run
  - In `findNewNode()`, receive PN IDs from BN via `findnode`.
  - In `tab.bondall()` and `tab.Bond()`, for each PN,
    - `db.node(id) = nil, db.findFails(id) = 0, db.bondTime(id) = 0`.
    - The if statement passes because `(age = time.Since(0)) > nodeDBNodeExpiration`.
    - Proceeds to `tab.pingpong()`. 
  - Kill the `ken` before 30 seconds so `copyBondedNode` never executes.
- Second `ken` run
  - In `findNewNode()`, receive PN IDs from BN via `findnode`.
  - In `tab.bondall()` and `tab.Bond()`, for each PN,
    - `db.node(id) = nil, db.findFails(id) = 0, db.bondTime(id) = (recent timestamp)`.
    - The if statement fails because `fails == 0 && age < 24h && self.type != BN`
    - The node is never ping-ponged.
    - `tab.Bond()` returns the `node` which is still `nil`.
  - Therefore `findNewNode(type=PN)` never returns any data.

The previous remedy for the EN-PN connection was to delete `DATA_DIR/klay/nodes` directory and restart. With this fix, users won't need such an obscure manual intervention.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
