### PR TITLE
Set the EOA CodeInfo correctly

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -2373,7 +2373,7 @@ func TestEIP7702(t *testing.T) {
 	if !bytes.Equal(code, want) {
 		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(want))
 	}
-	if vmVersion, ok := state.GetVmVersion(addr1); vmVersion != params.VmVersion1 || !ok {
+	if vmVersion, ok := state.GetVmVersion(addr1); !(vmVersion == params.VmVersion1 && ok) {
 		t.Fatalf("addr1 code info incorrect: got %v, want %v", vmVersion, params.VmVersion1)
 	}
 
@@ -2381,7 +2381,7 @@ func TestEIP7702(t *testing.T) {
 	if !bytes.Equal(code, want) {
 		t.Fatalf("addr2 code incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(want))
 	}
-	if vmVersion, ok := state.GetVmVersion(addr2); vmVersion != params.VmVersion1 || !ok {
+	if vmVersion, ok := state.GetVmVersion(addr2); !(vmVersion == params.VmVersion1 && ok) {
 		t.Fatalf("addr2 code info incorrect: got %v, want %v", vmVersion, params.VmVersion1)
 	}
 
@@ -2446,7 +2446,7 @@ func TestEIP7702(t *testing.T) {
 	if !bytes.Equal(state.GetCode(addr1), nil) {
 		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(want))
 	}
-	if vmVersion, ok := state.GetVmVersion(addr1); vmVersion != params.VmVersion0 || ok {
+	if vmVersion, ok := state.GetVmVersion(addr1); !(vmVersion == params.VmVersion0 && !ok) {
 		t.Fatalf("addr1 code info incorrect: got %v, want %v", vmVersion, params.VmVersion1)
 	}
 }

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -2373,10 +2373,18 @@ func TestEIP7702(t *testing.T) {
 	if !bytes.Equal(code, want) {
 		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(want))
 	}
+	if vmVersion, ok := state.GetVmVersion(addr1); vmVersion != params.VmVersion1 || !ok {
+		t.Fatalf("addr1 code info incorrect: got %v, want %v", vmVersion, params.VmVersion1)
+	}
+
 	code, want = state.GetCode(addr2), types.AddressToDelegation(auth2.Address)
 	if !bytes.Equal(code, want) {
 		t.Fatalf("addr2 code incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(want))
 	}
+	if vmVersion, ok := state.GetVmVersion(addr2); vmVersion != params.VmVersion1 || !ok {
+		t.Fatalf("addr2 code info incorrect: got %v, want %v", vmVersion, params.VmVersion1)
+	}
+
 	// Verify delegation executed the correct code.
 	var (
 		fortyTwo = common.BytesToHash([]byte{0x42})
@@ -2407,6 +2415,39 @@ func TestEIP7702(t *testing.T) {
 		// It only checks whether the transaction is successful.
 		err = applyTransaction(chain, state, tx, addr1)
 		assert.Equal(t, nil, err)
+	}
+
+	// Set 0x0000000000000000000000000000000000000000000 test
+	{
+		authForEmpty, _ := types.SignAuth(&types.Authorization{
+			ChainID: gspec.Config.ChainID.Uint64(),
+			Address: common.Address{},
+			Nonce:   state.GetNonce(addr1) + 1,
+		}, key1)
+
+		authorizationList := []types.Authorization{*authForEmpty}
+		intrinsicGas, err := types.IntrinsicGas(nil, nil, authorizationList, false, params.TestRules)
+		if err != nil {
+			t.Fatalf("failed to run intrinsic gas: %v", err)
+		}
+
+		tx, err := types.SignTx(types.NewMessage(addr1, &addr1, state.GetNonce(addr1), nil, 500000, nil, newGkei(50),
+			big.NewInt(20), nil, false, intrinsicGas, nil, authorizationList), signer, key1)
+		if err != nil {
+			t.Fatalf("failed to sign tx: %v", err)
+		}
+		err = applyTransaction(chain, state, tx, addr1)
+		assert.Equal(t, nil, err)
+
+		state.GetCode(addr1)
+	}
+
+	// Checks whether code and codeInfo are initialized.
+	if !bytes.Equal(state.GetCode(addr1), nil) {
+		t.Fatalf("addr1 code incorrect: got %s, want %s", common.Bytes2Hex(code), common.Bytes2Hex(want))
+	}
+	if vmVersion, ok := state.GetVmVersion(addr1); vmVersion != params.VmVersion0 || ok {
+		t.Fatalf("addr1 code info incorrect: got %v, want %v", vmVersion, params.VmVersion1)
 	}
 }
 

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -398,7 +398,7 @@ func (s *StateDB) IsValidCodeFormat(addr common.Address) bool {
 	return false
 }
 
-// GetVmVersion return false when getStateObject(addr) or GetProgramAccount(stateObject.account) fails and the account is EOA without code.
+// GetVmVersion returns true when the address is an SCA or an EOA with code.
 func (s *StateDB) GetVmVersion(addr common.Address) (params.VmVersion, bool) {
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -372,7 +372,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if msg.AuthorizationList() != nil {
 		// SetCode sender nonce increment should be done before set code process.
 		st.state.IncNonce(msg.ValidatedSender())
-		st.processAuthorizationList(msg.AuthorizationList(), *msg.To())
+		st.processAuthorizationList(msg.AuthorizationList(), *msg.To(), rules)
 	}
 
 	// Check whether the init code size has been exceeded.
@@ -524,7 +524,7 @@ func (st *StateTransition) gasUsed() uint64 {
 	return st.initialGas - st.gas
 }
 
-func (st *StateTransition) processAuthorizationList(authList types.AuthorizationList, to common.Address) {
+func (st *StateTransition) processAuthorizationList(authList types.AuthorizationList, to common.Address, rules params.Rules) {
 	for _, auth := range authList {
 		// Verify chain ID is 0 or equal to current chain ID.
 		if auth.ChainID != uint64(0) && auth.ChainID != st.evm.ChainConfig().ChainID.Uint64() {
@@ -568,7 +568,7 @@ func (st *StateTransition) processAuthorizationList(authList types.Authorization
 
 		// We treat EOA and SCA as separate objects and therefore need to use
 		// distinct methods.
-		st.state.SetCodeToEOA(authority, delegation)
+		st.state.SetCodeToEOA(authority, delegation, rules)
 
 		// Usually the transaction destination and delegation target are added to
 		// the access list in statedb.Prepare(..), however if the delegation is in

--- a/blockchain/state_transition_test.go
+++ b/blockchain/state_transition_test.go
@@ -123,7 +123,7 @@ func TestStateTransition_processAuthorizationList(t *testing.T) {
 				m.EXPECT().GetNonce(authority).Return(uint64(1))
 				m.EXPECT().Exist(authority).Return(false)
 				m.EXPECT().IncNonce(authority)
-				m.EXPECT().SetCodeToEOA(authority, types.AddressToDelegation(aa))
+				m.EXPECT().SetCodeToEOA(authority, types.AddressToDelegation(aa), params.TestRules)
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestStateTransition_processAuthorizationList(t *testing.T) {
 				m.EXPECT().GetKey(authority).Return(accountkey.NewAccountKeyLegacy())
 				m.EXPECT().AddRefund(params.CallNewAccountGas - params.TxAuthTupleGas)
 				m.EXPECT().IncNonce(authority)
-				m.EXPECT().SetCodeToEOA(authority, types.AddressToDelegation(aa))
+				m.EXPECT().SetCodeToEOA(authority, types.AddressToDelegation(aa), params.TestRules)
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestStateTransition_processAuthorizationList(t *testing.T) {
 				m.EXPECT().GetNonce(authority).Return(uint64(1))
 				m.EXPECT().Exist(authority).Return(false)
 				m.EXPECT().IncNonce(authority)
-				m.EXPECT().SetCodeToEOA(authority, []byte{})
+				m.EXPECT().SetCodeToEOA(authority, []byte{}, params.TestRules)
 			},
 		},
 		{
@@ -188,7 +188,7 @@ func TestStateTransition_processAuthorizationList(t *testing.T) {
 				m.EXPECT().GetNonce(authority).Return(uint64(1))
 				m.EXPECT().Exist(authority).Return(false)
 				m.EXPECT().IncNonce(authority)
-				m.EXPECT().SetCodeToEOA(authority, types.AddressToDelegation(aa))
+				m.EXPECT().SetCodeToEOA(authority, types.AddressToDelegation(aa), params.TestRules)
 				m.EXPECT().AddAddressToAccessList(aa)
 			},
 		},
@@ -214,7 +214,7 @@ func TestStateTransition_processAuthorizationList(t *testing.T) {
 				m.EXPECT().GetNonce(notAuthority).Return(uint64(1))
 				m.EXPECT().Exist(notAuthority).Return(false)
 				m.EXPECT().IncNonce(notAuthority)
-				m.EXPECT().SetCodeToEOA(notAuthority, types.AddressToDelegation(bb))
+				m.EXPECT().SetCodeToEOA(notAuthority, types.AddressToDelegation(bb), params.TestRules)
 			},
 		},
 		// Cases: fail to set code
@@ -340,7 +340,7 @@ func TestStateTransition_processAuthorizationList(t *testing.T) {
 			evm := vm.NewEVM(blockContext, txContext, mockStateDB, params.TestChainConfig, &vm.Config{Debug: true})
 
 			// Verify that the expected mockStateDB's calls are being made.
-			NewStateTransition(evm, tt.msg).processAuthorizationList(authList, *tt.msg.To())
+			NewStateTransition(evm, tt.msg).processAuthorizationList(authList, *tt.msg.To(), params.TestRules)
 		})
 	}
 }

--- a/blockchain/vm/interface.go
+++ b/blockchain/vm/interface.go
@@ -50,7 +50,7 @@ type StateDB interface {
 	GetCodeHash(common.Address) common.Hash
 	GetCode(common.Address) []byte
 	SetCode(common.Address, []byte) error
-	SetCodeToEOA(common.Address, []byte) error
+	SetCodeToEOA(common.Address, []byte, params.Rules) error
 	GetCodeSize(common.Address) int
 	GetVmVersion(common.Address) (params.VmVersion, bool)
 

--- a/blockchain/vm/mocks/statedb_mock.go
+++ b/blockchain/vm/mocks/statedb_mock.go
@@ -567,17 +567,17 @@ func (mr *MockStateDBMockRecorder) SetCode(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // SetCodeToEOA mocks base method.
-func (m *MockStateDB) SetCodeToEOA(arg0 common.Address, arg1 []byte) error {
+func (m *MockStateDB) SetCodeToEOA(arg0 common.Address, arg1 []byte, arg2 params.Rules) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCodeToEOA", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetCodeToEOA", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCodeToEOA indicates an expected call of SetCodeToEOA.
-func (mr *MockStateDBMockRecorder) SetCodeToEOA(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStateDBMockRecorder) SetCodeToEOA(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCodeToEOA", reflect.TypeOf((*MockStateDB)(nil).SetCodeToEOA), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCodeToEOA", reflect.TypeOf((*MockStateDB)(nil).SetCodeToEOA), arg0, arg1, arg2)
 }
 
 // SetNonce mocks base method.


### PR DESCRIPTION
## Proposed changes

- KIP228 has newly clarified the `CodeInfo`, so we will follow up on that.
  - https://github.com/kaiachain/kips/pull/32
- `GetVmVersion` should always return (0, false) or (1, true) when the account is EOA.
- In `SetCodeToEOA`, we also have to change state of `CodeInfo`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
