### PR TITLE
p2p: Warn when none of bn,static,trusted nodes are given

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -195,6 +195,12 @@ func (n *Node) Start() error {
 	if n.serverConfig.NodeDatabase == "" {
 		n.serverConfig.NodeDatabase = n.config.NodeDB()
 	}
+	if len(n.serverConfig.BootstrapNodes) == 0 && len(n.serverConfig.StaticNodes) == 0 && len(n.serverConfig.TrustedNodes) == 0 {
+		// Still there are possibilities such as (1) NodeDB has some content (2) Other node connecting to this node,
+		// so we cannot definitely say this node will be isolated. But having none of them could indicate a configuration mistake
+		// especially for mainnet or kairos nodes where there should be some bootnode.
+		logger.Warn("no p2p bootnodes, static or trusted nodes are configured; This node may fail to connect to any peers")
+	}
 
 	p2pServer := p2p.NewServer(n.serverConfig)
 	n.logger.Info("Starting peer-to-peer node", "instance", n.serverConfig.Name)


### PR DESCRIPTION
## Proposed changes

A node may find other peers from bootnode (when discovery enabled), static-nodes, trusted-nodes, and contents of nodeDB (i.e. DATA_DIR/klay/nodes). When none of those are given, this node cannot connect to any node, failing to download blocks.

A common mistake is to run a node with `ken --networkid 8217`, where the node launches in private net mode. This node 
will be given no bootnodes, thus no connection to any peers. In this particular example, the correct way is to using `ken --mainnet`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
