### PR TITLE
kaiax/gov: Replace remaining with gov

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -226,6 +226,7 @@ func (b *BlockchainContractBackend) SuggestGasPrice(ctx context.Context) (*big.I
 			return new(big.Int).Mul(b.bc.CurrentBlock().Header().BaseFee, big.NewInt(2)), nil
 		}
 	} else {
+		// This is used for sending txs, so it's ok to use the genesis value instead of the latest value from governance.
 		return new(big.Int).SetUint64(b.bc.Config().UnitPrice), nil
 	}
 }

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kaiachain/kaia/consensus/gxhash"
 	"github.com/kaiachain/kaia/consensus/mocks"
 	"github.com/kaiachain/kaia/crypto"
-	"github.com/kaiachain/kaia/governance"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -83,13 +82,8 @@ func TestEthereumAPI_Coinbase(t *testing.T) {
 
 // testNodeAddress generates nodeAddress and tests Etherbase and Coinbase.
 func testNodeAddress(t *testing.T, testAPIName string) {
-	gov := governance.NewMixedEngineNoInit(
-		dummyChainConfigForEthereumAPITest,
-		database.NewMemoryDBManager(),
-	)
 	key, _ := crypto.GenerateKey()
 	nodeAddress := crypto.PubkeyToAddress(key.PublicKey)
-	gov.SetNodeAddress(nodeAddress)
 
 	api := EthereumAPI{nodeAddress: nodeAddress}
 	results := reflect.ValueOf(&api).MethodByName(testAPIName).Call([]reflect.Value{})

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -440,14 +440,6 @@ func (bc *BlockChain) SetCanonicalBlock(blockNum uint64) {
 	logger.Info("successfully set the canonical block", "blockNum", blockNum)
 }
 
-func (bc *BlockChain) UseGiniCoeff() bool {
-	return bc.chainConfig.Governance.Reward.UseGiniCoeff
-}
-
-func (bc *BlockChain) ProposerPolicy() uint64 {
-	return bc.chainConfig.Istanbul.ProposerPolicy
-}
-
 func (bc *BlockChain) getProcInterrupt() bool {
 	return atomic.LoadInt32(&bc.procInterrupt) == 1
 }
@@ -1540,7 +1532,7 @@ func isCommitTrieRequired(bc *BlockChain, blockNum uint64) bool {
 	}
 
 	if bc.chainConfig.Istanbul != nil {
-		return bc.ProposerPolicy() == params.WeightedRandom &&
+		return bc.chainConfig.Istanbul.ProposerPolicy == params.WeightedRandom &&
 			params.IsStakingUpdateInterval(blockNum)
 	}
 	return false

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -391,6 +391,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	// Defer transferring Tx fee when DeferredTxFee is true
+	// DeferredTxFee has never been voted, so it's ok to use the genesis value instead of the latest value from governance.
 	if st.evm.ChainConfig().Governance == nil || !st.evm.ChainConfig().Governance.DeferredTxFee() {
 		if rules.IsMagma {
 			st.state.AddBalance(st.evm.Context.Rewardbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))

--- a/cmd/homi/genesis/options.go
+++ b/cmd/homi/genesis/options.go
@@ -281,15 +281,3 @@ func Clique(config *params.CliqueConfig) Option {
 		genesis.Config.Clique = config
 	}
 }
-
-func StakingInterval(interval uint64) Option {
-	return func(genesis *blockchain.Genesis) {
-		genesis.Config.Governance.Reward.StakingUpdateInterval = interval
-	}
-}
-
-func ProposerInterval(interval uint64) Option {
-	return func(genesis *blockchain.Genesis) {
-		genesis.Config.Governance.Reward.ProposerUpdateInterval = interval
-	}
-}

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -32,9 +32,9 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/cmd/utils"
 	"github.com/kaiachain/kaia/governance"
+	headergov_impl "github.com/kaiachain/kaia/kaiax/gov/headergov/impl"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
-	"github.com/kaiachain/kaia/rlp"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/urfave/cli/v2"
 )
@@ -128,14 +128,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 
 	// Set genesis.Governance and reward intervals
-	govSet := governance.GetGovernanceItemsFromChainConfig(genesis.Config)
-	govItemBytes, err := json.Marshal(govSet.Items())
-	if err != nil {
-		logger.Crit("Failed to json marshaling governance data", "err", err)
-	}
-	if genesis.Governance, err = rlp.EncodeToBytes(govItemBytes); err != nil {
-		logger.Crit("Failed to encode initial settings. Check your genesis.json", "err", err)
-	}
+	genesis.Governance = headergov_impl.GetGenesisGovBytes(genesis.Config)
 	params.SetStakingUpdateInterval(genesis.Config.Governance.Reward.StakingUpdateInterval)
 	params.SetProposerUpdateInterval(genesis.Config.Governance.Reward.ProposerUpdateInterval)
 

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -195,13 +195,6 @@ func initGenesis(ctx *cli.Context) error {
 			logger.Crit("Failed to write genesis block", "err", err)
 		}
 
-		// Write governance items to database
-		// If governance data already exist, it'll be skipped with an error log and will not return an error
-		gov := governance.NewMixedEngineNoInit(genesis.Config, chainDB)
-		if err := gov.WriteGovernance(0, govSet, governance.NewGovernanceSet()); err != nil {
-			logger.Crit("Failed to write governance items", "err", err)
-		}
-
 		// Write the live pruning flag to database
 		if livePruning {
 			logger.Info("Writing live pruning flag to database")

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -835,7 +835,6 @@ func newTestBackendWithConfig(chainConfig *params.ChainConfig, blockPeriod uint6
 		Governance:     g,
 		NodeType:       common.CONSENSUSNODE,
 	}).(*backend)
-	g.SetNodeAddress(backend.Address())
 	return backend
 }
 

--- a/consensus/istanbul/backend/testutil_test.go
+++ b/consensus/istanbul/backend/testutil_test.go
@@ -177,7 +177,6 @@ func newTestContext(numNodes int, config *params.ChainConfig, overrides *testOve
 		BlsPubkeyProvider: newMockBlsPubkeyProvider(nodeAddrs, nodeBlsKeys),
 		NodeType:          common.CONSENSUSNODE,
 	}).(*backend)
-	gov.SetNodeAddress(engine.Address())
 
 	// Create blockchain
 	cacheConfig := &blockchain.CacheConfig{
@@ -196,6 +195,7 @@ func newTestContext(numNodes int, config *params.ChainConfig, overrides *testOve
 		Chain:       chain,
 		ChainKv:     dbm.GetMiscDB(),
 		ChainConfig: config,
+		NodeAddress: engine.Address(),
 	})
 
 	// Start the engine

--- a/governance/default.go
+++ b/governance/default.go
@@ -1003,7 +1003,6 @@ func (gov *Governance) toJSON(num uint64) ([]byte, error) {
 		BlockNumber:     num,
 		ChainConfig:     gov.ChainConfig,
 		VoteMap:         gov.voteMap.Copy(),
-		NodeAddress:     gov.nodeAddress.Load().(common.Address),
 		GovernanceVotes: gov.GovernanceVotes.Copy(),
 		GovernanceTally: gov.GovernanceTallies.Copy(),
 		CurrentSet:      gov.currentSet.Items(),

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -285,9 +285,15 @@ func GetGenesisGovBytes(config *params.ChainConfig) headergov.GovBytes {
 	return ret
 }
 
+// getGenesisParamNames returns a subset of parameters to be included
+// in the genesis block header's Governance field.
+// The subset depends on genesis block's hardfork level and genesis chain config.
+// For backward compatibility, some fields may be intentionally omitted.
 func getGenesisParamNames(config *params.ChainConfig) []gov.ParamName {
 	genesisParamNames := make([]gov.ParamName, 0)
 
+	// DeriveShaImpl is excluded unless the genesis is Kore HF,
+	// even though it has been always included in the genesis chain config.
 	if config.Governance != nil {
 		genesisParamNames = append(genesisParamNames, []gov.ParamName{
 			gov.GovernanceGovernanceMode, gov.GovernanceGoverningNode, gov.GovernanceUnitPrice,

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -75,6 +75,9 @@ func (h *headerGovModule) Init(opts *InitOpts) error {
 	// 1. Init gov. If Gov DB is empty, migrate from legacy governance DB.
 	if ReadGovDataBlockNums(h.ChainKv) == nil {
 		legacyGovBlockNums := ReadLegacyIdxHistory(h.ChainKv)
+		if legacyGovBlockNums == nil {
+			legacyGovBlockNums = StoredUint64Array{0}
+		}
 		WriteGovDataBlockNums(h.ChainKv, legacyGovBlockNums)
 	}
 
@@ -209,11 +212,6 @@ func readVoteDataFromDB(chain chain, db database.Database) map[uint64]headergov.
 func readGovDataFromDB(chain chain, db database.Database) map[uint64]headergov.GovData {
 	govBlocks := ReadGovDataBlockNums(db)
 	govs := make(map[uint64]headergov.GovData)
-
-	// TODO: in production, govBlocks must not be nil. Remove this after implementing kcn init and data migration.
-	if govBlocks == nil {
-		govBlocks = StoredUint64Array{0}
-	}
 
 	for _, blockNum := range govBlocks {
 		header := chain.GetHeaderByNumber(blockNum)

--- a/kaiax/gov/headergov/impl/init_test.go
+++ b/kaiax/gov/headergov/impl/init_test.go
@@ -106,3 +106,16 @@ func TestReadGovDataFromDB(t *testing.T) {
 
 	assert.Equal(t, govs, readGovDataFromDB(chain, db))
 }
+
+func TestInitialDB(t *testing.T) {
+	config := params.TestChainConfig.Copy()
+	config.Istanbul = &params.IstanbulConfig{Epoch: 10}
+
+	h := newHeaderGovModule(t, config)
+	require.NotNil(t, h)
+
+	assert.Nil(t, ReadLegacyIdxHistory(h.ChainKv))
+	assert.Equal(t, StoredUint64Array{0}, ReadGovDataBlockNums(h.ChainKv))
+	assert.Nil(t, StoredUint64Array(nil), ReadVoteDataBlockNums(h.ChainKv))
+	assert.Equal(t, uint64(0), *ReadLowestVoteScannedBlockNum(h.ChainKv))
+}

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -35,7 +35,6 @@ type BlockChain interface {
 	GetHeaderByNumber(val uint64) *types.Header
 	State() (*state.StateDB, error)
 	StateAt(root common.Hash) (*state.StateDB, error)
-	GetReceiptsByBlockHash(blockHash common.Hash) types.Receipts
 	GetBlock(hash common.Hash, number uint64) *types.Block
 }
 

--- a/kaiax/staking/impl/api.go
+++ b/kaiax/staking/impl/api.go
@@ -66,5 +66,5 @@ func (api *stakingAPI) GetStakingInfo(num rpc.BlockNumber) (*staking.StakingInfo
 		useGini = api.s.useGiniCoeff
 	}
 	// Calculate Gini coefficient regardless of useGini flag
-	return si.ToResponse(useGini, api.s.stakingInterval), nil
+	return si.ToResponse(useGini, api.s.minimumStake.Uint64()), nil
 }

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -260,7 +260,6 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	// istanbul BFT. Derive and set node's address using nodekey
 	if cn.chainConfig.Istanbul != nil {
 		cn.nodeAddress = crypto.PubkeyToAddress(ctx.NodeKey().PublicKey)
-		governance.SetNodeAddress(cn.nodeAddress)
 	}
 
 	logger.Info("Initialising Klaytn protocol", "versions", cn.engine.Protocol().Versions, "network", config.NetworkId)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -396,7 +396,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		}
 	} else {
 		// TODO-Kaia improve to handle drop transaction on network traffic in PN and EN
-		cn.miner = work.New(cn, cn.chainConfig, cn.EventMux(), cn.engine, ctx.NodeType(), crypto.PubkeyToAddress(ctx.NodeKey().PublicKey), cn.config.TxResendUseLegacy)
+		cn.miner = work.New(cn, cn.chainConfig, cn.EventMux(), cn.engine, ctx.NodeType(), crypto.PubkeyToAddress(ctx.NodeKey().PublicKey), cn.config.TxResendUseLegacy, cn.govModule)
 	}
 
 	// istanbul BFT

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -25,7 +25,6 @@ package cn
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"os/exec"
 	"runtime"
 	"sync"
@@ -132,8 +131,7 @@ type CN struct {
 
 	APIBackend *CNAPIBackend
 
-	miner    Miner
-	gasPrice *big.Int
+	miner Miner
 
 	rewardbase  common.Address
 	nodeAddress common.Address
@@ -237,8 +235,6 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	governance := governance.NewMixedEngine(chainConfig, chainDB)
 	logger.Info("Initialised chain configuration", "config", chainConfig)
 
-	config.GasPrice = new(big.Int).SetUint64(chainConfig.UnitPrice)
-
 	mGov := gov_impl.NewGovModule()
 	cn := &CN{
 		config:            config,
@@ -248,7 +244,6 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		accountManager:    ctx.AccountManager,
 		engine:            CreateConsensusEngine(ctx, config, chainConfig, chainDB, governance, mGov, ctx.NodeType()),
 		networkId:         config.NetworkId,
-		gasPrice:          config.GasPrice,
 		rewardbase:        config.Rewardbase,
 		bloomRequests:     make(chan chan *bloombits.Retrieval),
 		bloomIndexer:      NewBloomIndexer(chainDB, params.BloomBitsBlocks),
@@ -410,10 +405,6 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	cn.APIBackend = &CNAPIBackend{cn, nil}
 
 	gpoParams := config.GPO
-
-	// NOTE-Kaia Now we use latest unitPrice
-	//         So let's override gpoParams.Default with config.GasPrice
-	gpoParams.Default = config.GasPrice
 
 	cn.APIBackend.gpo = gasprice.NewOracle(cn.APIBackend, gpoParams, cn.txPool, mGov)
 	//@TODO Kaia add core component

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -58,7 +58,6 @@ func GetDefaultConfig() *Config {
 		LivePruningRetention:    blockchain.DefaultPruningRetention,
 		TxPruningRetention:      blockchain.DefaultPruningRetention,
 		ReceiptPruningRetention: blockchain.DefaultPruningRetention,
-		GasPrice:                big.NewInt(18 * params.Gkei),
 
 		TxPool: blockchain.DefaultTxPoolConfig,
 		GPO: gasprice.Config{
@@ -144,7 +143,6 @@ type Config struct {
 	// Mining-related options
 	ServiceChainSigner common.Address `toml:",omitempty"`
 	ExtraData          []byte         `toml:",omitempty"`
-	GasPrice           *big.Int
 
 	// Reward
 	Rewardbase common.Address `toml:",omitempty"`

--- a/node/cn/gasprice/gasprice.go
+++ b/node/cn/gasprice/gasprice.go
@@ -44,7 +44,6 @@ type Config struct {
 	Percentile       int
 	MaxHeaderHistory int
 	MaxBlockHistory  int
-	Default          *big.Int `toml:",omitempty"`
 	MaxPrice         *big.Int `toml:",omitempty"`
 }
 

--- a/node/cn/gasprice/gasprice_test.go
+++ b/node/cn/gasprice/gasprice_test.go
@@ -201,7 +201,7 @@ func TestGasPrice_NewOracle(t *testing.T) {
 	assert.Equal(t, 5, oracle.maxBlocks)
 	assert.Equal(t, 100, oracle.percentile)
 
-	params = Config{Percentile: 101, Default: big.NewInt(123)}
+	params = Config{Percentile: 101}
 	oracle = NewOracle(mockBackend, params, nil, nil)
 
 	assert.Equal(t, big.NewInt(0), oracle.lastPrice)
@@ -234,7 +234,7 @@ func TestGasPrice_SuggestPrice(t *testing.T) {
 	assert.Equal(t, common.Big0, price)
 	assert.Nil(t, err)
 
-	params = Config{Default: big.NewInt(123)}
+	params = Config{}
 	mockGov.EXPECT().EffectiveParamSet(gomock.Any()).Return(gov.ParamSet{UnitPrice: 25}).Times(1)
 	mockBackend.EXPECT().ChainConfig().Return(chainConfig).Times(2)
 	txPoolWith25 := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain, mockGov)
@@ -250,7 +250,6 @@ func TestSuggestTipCap(t *testing.T) {
 	config := Config{
 		Blocks:           3,
 		Percentile:       60,
-		Default:          big.NewInt(params.Gkei),
 		MaxHeaderHistory: 30,
 		MaxBlockHistory:  30,
 	}

--- a/tests/kaia_test_blockchain_test.go
+++ b/tests/kaia_test_blockchain_test.go
@@ -95,7 +95,6 @@ func NewBCData(maxAccounts, numValidators int) (*BCData, error) {
 	////////////////////////////////////////////////////////////////////////////////
 	// Create a governance
 	governance := generateGovernaceDataForTest()
-	governance.SetNodeAddress(nodeAddr)
 	////////////////////////////////////////////////////////////////////////////////
 	// Create a database
 	chainDb := NewDatabase(dir, database.LevelDB)
@@ -143,6 +142,7 @@ func NewBCData(maxAccounts, numValidators int) (*BCData, error) {
 			ChainConfig: genesis.Config,
 			Chain:       bc,
 			ChainKv:     chainDb.GetMiscDB(),
+			NodeAddress: nodeAddr,
 		}),
 		mReward.Init(&reward_impl.InitOpts{
 			ChainConfig:   genesis.Config,

--- a/work/work.go
+++ b/work/work.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax"
+	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -100,12 +101,12 @@ type Miner struct {
 	shouldStart int32 // should start indicates whether we should start after sync
 }
 
-func New(backend Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, nodetype common.ConnType, rewardbase common.Address, TxResendUseLegacy bool) *Miner {
+func New(backend Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, nodetype common.ConnType, rewardbase common.Address, TxResendUseLegacy bool, govModule gov.GovModule) *Miner {
 	miner := &Miner{
 		backend:  backend,
 		mux:      mux,
 		engine:   engine,
-		worker:   newWorker(config, engine, rewardbase, backend, mux, nodetype, TxResendUseLegacy),
+		worker:   newWorker(config, engine, rewardbase, backend, mux, nodetype, TxResendUseLegacy, govModule),
 		canStart: 1,
 	}
 	// TODO-Kaia drop or missing tx


### PR DESCRIPTION
## Proposed changes

This PR is a sequel of #162.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
<details>
<summary>MixedEngine method replaced by GovModule</summary>

It excludes `governance` directory, as they will be removed.

- [x] EffectiveParams
- [x] CurrentParams
- [x] AddVote
- [x] ValidateVote
- [x] ReadGovernance
- [x] WriteGovernance
- [x] GetEncodedVote
- [x] VerifyGovernance
- [x] GetVoteMapCopy
- [x] GetGovernanceTalliesCopy
- [x] CurrentSetCopy
- [x] PendingChanges
- [x] IdxCache
- [x] IdxCacheFromDb
- [x] NodeAddress
- [x] TotalVotingPower
- [x] MyVotingPower
- [x] SetNodeAddress
- [x] GetGovernanceItemsFromChainConfig
- [x] SetTxPool
- [x] GetTxPool
- [x] BlockChain
- [x] DB
</details>

<details>
<summary>MixedEngine methods that will be completely removed by ValSet module</summary>

These will be removed after introducing ValSet module.

- UpdateParams
- CanWriteGovernanceState
- WriteGovernanceState
- ClearVotes
- WriteGovernanceForNextEpoch
- UpdateCurrentSet
- HandleGovernanceVote
- Votes
- SetTotalVotingPower
- SetMyVotingPower
- SetBlockchain
</details>

<details>
<summary>ChainConfig replaced by GovModule</summary>

- [x] next basefee in worker
- [x] next basefee in txpool
- [x] `node/cn/backend.go:New`: UnitPrice. Removed because it's unused.
- [x] `blockchain/types/derivesha/mux.go:getType`: DeriveShaImpl.
</details>

<details>
<summary>ChainConfig left as-is</summary>

There are cases when the genesis chain config can be used. Either it's immutable, or not essential to use the latest value.

- `blockchain/genesis.go:SetGenesisGovernance`: initial 13 parameters. Not called by `ken init`.
- UnitPrice
    - `accounts/abi/bind/backends.go:SuggestGasPrice`: UnitPrice. The value does not matter. Also, importing GovModule results in import cycle.
    - `datasync/dbsyncer/dbsync.go:syncBlockHeader`: UnitPrice. The value does not matter.
    - `datasync/dbsyncer/dbsync_context.go:syncBlockHeaderContext`: UnitPrice. The value does not matter.
    - `datasync/dbsyncer/dbsync_multi.go:parallelSyncBlockHeader`: UnitPrice. The value does not matter.
- Governance
    - `blockchain/genesis.go:SetupGenesisBlock`: StakingUpdateInterval, ProposerUpdateInterval. The value is immutable.
    - `cmd/utils/nodecmd/chaincmd.go:initGenesis`: StakingUpdateInterval, ProposerUpdateInterval. The value is immutable.
    - `blockchain/genesis.go:ToBlock`: LowerBoundBaseFee. Genesis config must be used.
    - `kaiax/staking/impl/init.go:Init`: StakingUpdateInterval, UseGiniCoeff, MinimumStake. The value is immutable.
    - `node/cn/handler.go:{handleStakingInfoRequestMsg,handleStakingInfoMsg}`: UseGiniCoeff, MinimumStake. The value is immutable.
    - `blockchain/state_transition.go:TransitionDb`: DeferredTxFee. The value is immutable. Also, adding GovModule to the object is difficult.
    - `cmd/utils/nodecmd/chaincmd.go:ValidateGenesisConfig`: ProposerUpdateInterval, StakingUpdateInterval, GovernanceMode, GoverningNode. Genesis config must be used.
- Istanbul
    - `blockchain/blockchain.go:isCommitTrieRequired`: ProposerPolicy. The value is immutable.
    - `blockchain/blockchain.go:setHeadBeyondRoot`: Epoch. The value is immutable.
    - `consensus/istanbul/backend/engine.go:Finalize`: ProposerPolicy. The value is immutable.
    - `node/cn/handler.go:{handleStakingInfoRequestMsg,handleStakingInfoMsg}`: ProposerPolicy. The value is immutable.
</details>

<details>
<summary>ChainConfig replaced by GovModule</summary>

- [x] next basefee in worker
- [x] next basefee in txpool
- [x] `node/cn/backend.go:New`: UnitPrice. Removed because it's unused.
- [x] `blockchain/types/derivesha/mux.go:getType`: DeriveShaImpl.
</details>

<details>
<summary>ChainConfig that will be completely removed by ValSet module</summary>
These will be removed after introducing ValSet module.

- `consensus/istanbul/backend/backend.go:{ParentValidators,getValidators}`: ProposerPolicy, SubGroupSize.
- `consensus/istanbul/validator/weighted.go:RefreshValSet`: UseGiniCoeff.
</details>