### PR TITLE
core/vm: Fix wrong enable Prague(7702) instruction

### DIFF
--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -102,6 +102,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	if cfg.JumpTable[STOP] == nil {
 		var jt JumpTable
 		switch {
+		case evm.chainRules.IsPrague:
+			jt = PragueInstructionSet
 		case evm.chainRules.IsCancun:
 			jt = CancunInstructionSet
 		case evm.chainRules.IsShanghai:

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -63,10 +63,17 @@ var (
 	KoreInstructionSet           = newKoreInstructionSet()
 	ShanghaiInstructionSet       = newShanghaiInstructionSet()
 	CancunInstructionSet         = newCancunInstructionSet()
+	PragueInstructionSet         = newPragueInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]*operation
+
+func newPragueInstructionSet() JumpTable {
+	instructionSet := newCancunInstructionSet()
+	enable7702(&instructionSet) // EIP-7702 Set EOA account
+	return instructionSet
+}
 
 func newCancunInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
@@ -77,7 +84,6 @@ func newCancunInstructionSet() JumpTable {
 	enable1153(&instructionSet) // EIP-1153 TLOAD, TSTORE opcode
 	enable1052(&instructionSet) // EIP-1052 EXTCODEHASH fix
 	enableCancunComputationCostModification(&instructionSet)
-	enable7702(&instructionSet)
 	return instructionSet
 }
 


### PR DESCRIPTION
## Proposed changes

In the fix for #119, we mistakenly added enable7702 to the cancun instruction set.
- Take the Prague instructions and set the correct instructions for the fork.

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
