### PR TITLE
Add EIP-7702 compatibility

### DIFF
--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -1183,7 +1183,7 @@ func (s *StateDB) GetTxHash() common.Hash {
 
 var (
 	errNotExistingAddress = fmt.Errorf("there is no account corresponding to the given address")
-	errNotContractAddress = fmt.Errorf("given address is not a contract address")
+	errNotProgramAccount  = fmt.Errorf("given address is not a program account")
 )
 
 func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.ExtHash, error) {
@@ -1191,14 +1191,11 @@ func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.Ex
 	if acc == nil {
 		return common.ExtHash{}, errNotExistingAddress
 	}
-	if acc.Type() != account.SmartContractAccountType {
-		return common.ExtHash{}, errNotContractAddress
+	pa := account.GetProgramAccount(acc)
+	if pa == nil {
+		return common.ExtHash{}, errNotProgramAccount
 	}
-	contract, true := acc.(*account.SmartContractAccount)
-	if !true {
-		return common.ExtHash{}, errNotContractAddress
-	}
-	return contract.GetStorageRoot(), nil
+	return pa.GetStorageRoot(), nil
 }
 
 // Prepare handles the preparatory steps for executing a state transition with.

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -24,6 +24,7 @@ package state
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -1182,8 +1183,8 @@ func (s *StateDB) GetTxHash() common.Hash {
 }
 
 var (
-	errNotExistingAddress = fmt.Errorf("there is no account corresponding to the given address")
-	errNotProgramAccount  = fmt.Errorf("given address is not a program account")
+	errNotExistingAddress = errors.New("there is no account corresponding to the given address")
+	errNotProgramAccount  = errors.New("given address is not a program account")
 )
 
 func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.ExtHash, error) {

--- a/blockchain/types/account/account_test.go
+++ b/blockchain/types/account/account_test.go
@@ -149,6 +149,9 @@ func TestAccountSerializer(t *testing.T) {
 			"Empty EOA",
 			&ExternallyOwnedAccount{
 				AccountCommon: commonFieldsEmpty,
+				storageRoot:   emptyRoot.ExtendZero(),
+				codeHash:      emptyCodeHash,
+				codeInfo:      codeinfoZero,
 			},
 			// 01 ["","","","01",[]]
 			"0x01c580808001c0",
@@ -171,6 +174,9 @@ func TestAccountSerializer(t *testing.T) {
 			"Nonempty EOA",
 			&ExternallyOwnedAccount{
 				AccountCommon: commonFields,
+				storageRoot:   emptyRoot.ExtendZero(),
+				codeHash:      emptyCodeHash,
+				codeInfo:      codeinfoZero,
 			},
 			// 01 ["0x2a","0x12345678","","0x01",[]]
 			"0x01c92a84123456788001c0",
@@ -193,6 +199,9 @@ func TestAccountSerializer(t *testing.T) {
 			"AccountUpdated EOA",
 			&ExternallyOwnedAccount{
 				AccountCommon: commonFieldsUpdated,
+				storageRoot:   emptyRoot.ExtendZero(),
+				codeHash:      emptyCodeHash,
+				codeInfo:      codeinfoZero,
 			},
 			// 01 ["0x2a","0x12345678","","0x02","0x038318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75"]
 			"0x01ea2a84123456788002a1038318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75",

--- a/blockchain/types/account/externally_owned_account.go
+++ b/blockchain/types/account/externally_owned_account.go
@@ -99,7 +99,14 @@ func (e *ExternallyOwnedAccount) Dump() {
 }
 
 func (e *ExternallyOwnedAccount) String() string {
-	return fmt.Sprintf("EOA: %s", e.AccountCommon.String())
+	return fmt.Sprintf(`EOA:%s
+	StorageRoot: %s
+	CodeHash: %s
+	CodeInfo: %s`,
+		e.AccountCommon.String(),
+		e.storageRoot.String(),
+		common.Bytes2Hex(e.codeHash),
+		e.codeInfo.String())
 }
 
 func (e *ExternallyOwnedAccount) DeepCopy() Account {
@@ -117,7 +124,10 @@ func (e *ExternallyOwnedAccount) Equal(a Account) bool {
 		return false
 	}
 
-	return e.AccountCommon.Equal(e2.AccountCommon)
+	return e.AccountCommon.Equal(e2.AccountCommon) &&
+		e.storageRoot == e2.storageRoot &&
+		bytes.Equal(e.codeHash, e2.codeHash) &&
+		e.codeInfo == e2.codeInfo
 }
 
 func (e *ExternallyOwnedAccount) GetStorageRoot() common.ExtHash {

--- a/blockchain/types/account/externally_owned_account.go
+++ b/blockchain/types/account/externally_owned_account.go
@@ -105,6 +105,9 @@ func (e *ExternallyOwnedAccount) String() string {
 func (e *ExternallyOwnedAccount) DeepCopy() Account {
 	return &ExternallyOwnedAccount{
 		AccountCommon: e.AccountCommon.DeepCopy(),
+		storageRoot:   e.storageRoot,
+		codeHash:      common.CopyBytes(e.codeHash),
+		codeInfo:      e.codeInfo,
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

This PR suggests:
1. Copy all fields including EIP-7702 specific in `DeepCopy()`. Without this, dirtied EOA objects will have `default` values for each type, not `empty` values.
2. Use `ProgramAccount` to get the storage root.
3. Fix EIP-7702 related methods for EOA. (Only for testing)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
