### PR TITLE
kaiax/valset: Fix selectRandaoCommittee and migration

### DIFF
--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -158,12 +158,16 @@ func selectRandaoCommittee(qualified *valset.AddressSet, committeeSize uint64, p
 	// Because, the resulting committee will be one validator, and the only validator is also selected as the proposer.
 	// Therefore no special handling for committeeSize == 1 is needed.
 	mixHash := prevMixHash
-	if prevMixHash == nil || len(prevMixHash) == 0 {
+	if len(prevMixHash) == 0 { // At exactly Randao hardfork block, or genesis block, prevMixHash is empty.
 		mixHash = params.ZeroMixHash
 	}
 	seed := valset.HashToSeed(mixHash)
 	shuffled := qualified.ShuffledList(seed)
-	return shuffled[:committeeSize]
+	if len(shuffled) < int(committeeSize) {
+		return shuffled
+	} else {
+		return shuffled[:committeeSize]
+	}
 }
 
 func (v *ValsetModule) getProposer(c *blockContext, round uint64) (common.Address, error) {

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -165,7 +165,8 @@ func (v *ValsetModule) migrate() {
 		writeLowestScannedVoteNum(v.ChainKv, snapshotNum+1)
 		targetNum = snapshotNum
 	}
-
-	// Now the migration is complete.
-	writeLowestScannedVoteNum(v.ChainKv, 0)
+	if targetNum == 0 {
+		// Now the migration is complete.
+		writeLowestScannedVoteNum(v.ChainKv, 0)
+	}
 }


### PR DESCRIPTION
## Proposed changes

- Fix out-of-bounds error in `selectRandaoCommittee`. The bug is triggered during `getProposer()` when qualified.Len < committeeSize
- Fix migration logic where LowestScannedVoteNum is updated only when necessary.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
