### PR TITLE
evm: EXTCODEHASH to return emptyCodeHash before Cancun

### DIFF
--- a/blockchain/vm/instructions.go
+++ b/blockchain/vm/instructions.go
@@ -424,7 +424,7 @@ func opExtCodeHash1052(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCont
 	slot := scope.Stack.peek()
 	address := common.Address(slot.Bytes20())
 	if interpreter.evm.StateDB.Empty(address) {
-		slot.Clear()
+		slot.Clear() // Return 0x0 for empty account
 	} else {
 		slot.SetBytes(interpreter.evm.StateDB.ResolveCodeHash(address).Bytes())
 	}
@@ -436,7 +436,11 @@ func opExtCodeHash1052(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCont
 func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
 	address := common.Address(slot.Bytes20())
-	slot.SetBytes(interpreter.evm.StateDB.ResolveCodeHash(address).Bytes())
+	if interpreter.evm.StateDB.Empty(address) {
+		slot.SetBytes(emptyCodeHash[:]) // Return 0xc5d246... for empty account before Cancun
+	} else {
+		slot.SetBytes(interpreter.evm.StateDB.ResolveCodeHash(address).Bytes())
+	}
 	return nil, nil
 }
 

--- a/blockchain/vm/instructions.go
+++ b/blockchain/vm/instructions.go
@@ -424,7 +424,7 @@ func opExtCodeHash1052(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCont
 	slot := scope.Stack.peek()
 	address := common.Address(slot.Bytes20())
 	if interpreter.evm.StateDB.Empty(address) {
-		slot.Clear() // Return 0x0 for empty account
+		slot.Clear()
 	} else {
 		slot.SetBytes(interpreter.evm.StateDB.ResolveCodeHash(address).Bytes())
 	}
@@ -437,7 +437,7 @@ func opExtCodeHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	slot := scope.Stack.peek()
 	address := common.Address(slot.Bytes20())
 	if interpreter.evm.StateDB.Empty(address) {
-		slot.SetBytes(emptyCodeHash[:]) // Return 0xc5d246... for empty account before Cancun
+		slot.SetBytes(emptyCodeHash[:]) // for empty account before Cancun
 	} else {
 		slot.SetBytes(interpreter.evm.StateDB.ResolveCodeHash(address).Bytes())
 	}


### PR DESCRIPTION
## Proposed changes

- dev branch return bad block at baobab 14598509. (cypress also) and this PR fixes opExtCodeHash not to return bad block.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
