### PR TITLE
consensus: Added error check to valset

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -329,6 +329,9 @@ func (sb *backend) verifySigner(chain consensus.ChainReader, header *types.Heade
 
 	// Retrieve the snapshot needed to verify this header and cache it
 	valSet, err := sb.GetValidatorSet(number)
+	if err != nil {
+		return err
+	}
 
 	// resolve the authorization key and check against signers
 	signer, err := ecrecover(header)


### PR DESCRIPTION
## Proposed changes

The variable `valset`  may be nil and error check has been absent. This valset is used at L343 and leads to nil dereference if it is a nil. This PR adds a error check and returns error if it is not a nil.

It was discovered during setHead operation and this issue disappeared after restarting.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1850a8b]

goroutine 8515 [running]:
github.com/kaiachain/kaia/consensus/istanbul.(*BlockValSet).Qualified(...)
        /home/ubuntu/QA/rc/consensus/istanbul/validator.go:148
github.com/kaiachain/kaia/consensus/istanbul/backend.(*backend).verifySigner(0x8de1bbfa50036df5?, {0xa4534502a3c86890?, 0x96e37b8244bcc2ea?}, 0xc020e48c88, {0xc0206b1b88?, 0x4a8fc40?, 0x2174b20?})
        /home/ubuntu/QA/rc/consensus/istanbul/backend/engine.go:341 +0x6b
github.com/kaiachain/kaia/consensus/istanbul/backend.(*backend).verifyCascadingFields(0xc0180ea000, {0x3a192a8, 0xc018272008}, 0xc020e48c88, {0xc01d6bc108, 0x1, 0x1})
        /home/ubuntu/QA/rc/consensus/istanbul/backend/engine.go:275 +0x217
github.com/kaiachain/kaia/consensus/istanbul/backend.(*backend).verifyHeader(0xc0180ea000, {0x3a192a8, 0xc018272008}, 0xc020e48c88, {0xc01d6bc108, 0x1, 0x1})
        /home/ubuntu/QA/rc/consensus/istanbul/backend/engine.go:239 +0x385
github.com/kaiachain/kaia/consensus/istanbul/backend.(*backend).VerifyHeader(0xc0180ea000, {0x3a192a8, 0xc018272008}, 0xc020e48c88, 0x60?)
        /home/ubuntu/QA/rc/consensus/istanbul/backend/engine.go:199 +0x17a
github.com/kaiachain/kaia/blockchain.(*BlockChain).insertChain(0xc018272008, {0xc01d6bc0b8, 0x1, 0x1})
        /home/ubuntu/QA/rc/blockchain/blockchain.go:1976 +0x1463
github.com/kaiachain/kaia/blockchain.(*BlockChain).InsertChain(0xc018272008, {0xc01d6bc0b8?, 0x692b2bdf09b11d5a?, 0xc020a90aa0?})
        /home/ubuntu/QA/rc/blockchain/blockchain.go:1840 +0x1d
github.com/kaiachain/kaia/datasync/downloader.(*Downloader).importBlockResults(0xc0006b8d88, {0xc0333a1bd0, 0x9, 0x0?})
        /home/ubuntu/QA/rc/datasync/downloader/downloader.go:1717 +0x51e
github.com/kaiachain/kaia/datasync/downloader.(*Downloader).processFullSyncContent(0xc0006b8d88)
        /home/ubuntu/QA/rc/datasync/downloader/downloader.go:1685 +0x125
github.com/kaiachain/kaia/datasync/downloader.(*Downloader).spawnSync.func1()
        /home/ubuntu/QA/rc/datasync/downloader/downloader.go:571 +0x66
created by github.com/kaiachain/kaia/datasync/downloader.(*Downloader).spawnSync in goroutine 8457
        /home/ubuntu/QA/rc/datasync/downloader/downloader.go:571 +0x11e
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
