### PR TITLE
kaiax/staking,reward: Use CL info since Prague block

### DIFF
--- a/kaiax/reward/impl/getter.go
+++ b/kaiax/reward/impl/getter.go
@@ -428,7 +428,7 @@ func specWithProposerAndFunds(spec *reward.RewardSpec, config *reward.RewardConf
 	}
 
 	newSpec.Proposer = proposer
-	if !config.Rules.IsPrague {
+	if !config.Rules.IsPrague || si.CLStakingInfos == nil {
 		newSpec.IncRecipient(config.Rewardbase, proposer)
 		return newSpec
 	}

--- a/kaiax/reward/impl/getter_test.go
+++ b/kaiax/reward/impl/getter_test.go
@@ -886,6 +886,7 @@ func TestAssignStakingRewards(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		si := makeTestStakingInfo(tc.stakingAmounts, tc.prague)
+		config.Rules.IsPrague = tc.prague
 		alloc, remainder := assignStakingRewards(config, reward, si)
 
 		assert.Equal(t, tc.expectedAlloc, alloc, tc.desc)
@@ -965,7 +966,7 @@ func TestSpecWithProposerAndFundsPrague(t *testing.T) {
 		sumProposerKif = big.NewInt(proposer + kif)
 		sumProposerKef = big.NewInt(proposer + kef)
 
-		config = &reward.RewardConfig{Rewardbase: rewardbase}
+		config = &reward.RewardConfig{Rewardbase: rewardbase, Rules: params.Rules{IsPrague: true}}
 	)
 
 	testcases := []struct {

--- a/kaiax/staking/impl/getter.go
+++ b/kaiax/staking/impl/getter.go
@@ -127,8 +127,10 @@ func (s *StakingModule) getFromState(header *types.Header, statedb *state.StateD
 	var clRes clRegistryResult
 	if isForPrague {
 		// If Registry is not installed, do not handle CL staking info.
-		// It can happen in private network where Randao and Prague hardfork are activated at the same block.
-		if statedb.GetCode(system.RegistryAddr) == nil {
+		// In private network, Randao and Prague hardfork can be activated at the same block.
+		// It leads to staking info inconsistency between block processing and rpc query since the Registry hasn't been installed when finalizing the header.
+		// Note that Randao can't be activated after Prague according to fork ordering (Randao <= Kaia <= Prague).
+		if statedb.GetCode(system.RegistryAddr) == nil || s.ChainConfig.IsRandaoForkBlockParent(header.Number) {
 			logger.Trace("Registry not installed", "sourceNum", num)
 		} else {
 			// Note that if CLRegistry is not registered in Registry,


### PR DESCRIPTION
## Proposed changes

In previous PR #176, the CL info was filled since the `Prague + 1` block. But the CL staking info must be used for the Prague block. This PR makes staking modules to read CL for the Prague block.

Please note that it's safe to assume that `sourceBlockNum == number - 1` for the Prague block since Kaia hardfork must be the same or earlier than Prague fork.

<details><summary> kaia_getStakingInfo </summary>

`pragueCompatibleBlock == 50`

```
// Before this PR
> kaia.getStakingInfo(50)
{
  KIRAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  PoCAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  blockNum: 49,
  clStakingInfos: null,
  councilNodeAddrs: ["0xad77f7306d42a03d35ab3ae3302a970de795157f", "0x2b9d1f31a860a5c6649b8a77b2a6b7530fdebe3c", "0xf7d662c06e09a19770eacf38199699a6c1a60bcf", "0x00657d43847cc7ab4ae4058467ac8024518213ba"],
  councilRewardAddrs: ["0x1ffdee22fa4df55d66dea1d9435343be2c0d3b12", "0xf411483d602620203bbfc9ba87e38bcfb6430b90", "0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6", "0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44"],
  councilStakingAddrs: ["0x856d63e1465896109bb957ef8e2713ae54912314", "0xb0a2bdb787c341b0566049beb72bb8e86bbde261", "0xec1623f9b24fe8259173830b9e4fa45553f87d0e", "0xaf440c4df5a4c59eec5e22bc91e91911acf18d2a"],
  councilStakingAmounts: [5000000, 10000000, 15000000, 20000000],
  gini: 0.25,
  kcfAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kefAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kffAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  kifAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  useGini: false
}
> kaia.getStakingInfo(51)
{
  KIRAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  PoCAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  blockNum: 50,
  clStakingInfos: [{
      clNodeId: "0xad77f7306d42a03d35ab3ae3302a970de795157f",
      clPoolAddr: "0x5dcf87ef80a09f84c9cf418e885e1cfc079e6655",
      clRewardAddr: "0x10fd8bf375208e62077016d58329d2986eed45ce",
      clStakingAmount: 5000000
  }, {
      clNodeId: "0x2b9d1f31a860a5c6649b8a77b2a6b7530fdebe3c",
      clPoolAddr: "0x883aac21dfb2c511e142a6f97fd62af89e6aec2e",
      clRewardAddr: "0x7b056bafbddb86de6090afb572880d34451a46d0",
      clStakingAmount: 10000000
  }, {
      clNodeId: "0x9c6383f23079b8313d4a5aaa3137435bbed178b3",
      clPoolAddr: "0xb88481b32c35e6f5a5f2167093c90b04e03667cb",
      clRewardAddr: "0x3f7dabace014a602c25f610b411ec8875ae08002",
      clStakingAmount: 15000000
  }],
  councilNodeAddrs: ["0xad77f7306d42a03d35ab3ae3302a970de795157f", "0x2b9d1f31a860a5c6649b8a77b2a6b7530fdebe3c", "0xf7d662c06e09a19770eacf38199699a6c1a60bcf", "0x00657d43847cc7ab4ae4058467ac8024518213ba"],
  councilRewardAddrs: ["0x1ffdee22fa4df55d66dea1d9435343be2c0d3b12", "0xf411483d602620203bbfc9ba87e38bcfb6430b90", "0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6", "0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44"],
  councilStakingAddrs: ["0x856d63e1465896109bb957ef8e2713ae54912314", "0xb0a2bdb787c341b0566049beb72bb8e86bbde261", "0xec1623f9b24fe8259173830b9e4fa45553f87d0e", "0xaf440c4df5a4c59eec5e22bc91e91911acf18d2a"],
  councilStakingAmounts: [5000000, 10000000, 15000000, 20000000],
  gini: 0.13,
  kcfAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kefAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kffAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  kifAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  useGini: false
}
```

```
// After this PR
> kaia.getStakingInfo(50)
{
  KIRAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  PoCAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  blockNum: 49,
  clStakingInfos: [{
      clNodeId: "0xad77f7306d42a03d35ab3ae3302a970de795157f",
      clPoolAddr: "0x5dcf87ef80a09f84c9cf418e885e1cfc079e6655",
      clRewardAddr: "0x10fd8bf375208e62077016d58329d2986eed45ce",
      clStakingAmount: 5000000
  }, {
      clNodeId: "0x2b9d1f31a860a5c6649b8a77b2a6b7530fdebe3c",
      clPoolAddr: "0x883aac21dfb2c511e142a6f97fd62af89e6aec2e",
      clRewardAddr: "0x7b056bafbddb86de6090afb572880d34451a46d0",
      clStakingAmount: 10000000
  }, {
      clNodeId: "0x9c6383f23079b8313d4a5aaa3137435bbed178b3",
      clPoolAddr: "0xb88481b32c35e6f5a5f2167093c90b04e03667cb",
      clRewardAddr: "0x3f7dabace014a602c25f610b411ec8875ae08002",
      clStakingAmount: 15000000
  }],
  councilNodeAddrs: ["0xad77f7306d42a03d35ab3ae3302a970de795157f", "0x2b9d1f31a860a5c6649b8a77b2a6b7530fdebe3c", "0xf7d662c06e09a19770eacf38199699a6c1a60bcf", "0x00657d43847cc7ab4ae4058467ac8024518213ba"],
  councilRewardAddrs: ["0x1ffdee22fa4df55d66dea1d9435343be2c0d3b12", "0xf411483d602620203bbfc9ba87e38bcfb6430b90", "0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6", "0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44"],
  councilStakingAddrs: ["0x856d63e1465896109bb957ef8e2713ae54912314", "0xb0a2bdb787c341b0566049beb72bb8e86bbde261", "0xec1623f9b24fe8259173830b9e4fa45553f87d0e", "0xaf440c4df5a4c59eec5e22bc91e91911acf18d2a"],
  councilStakingAmounts: [5000000, 10000000, 15000000, 20000000],
  gini: 0.13,
  kcfAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kefAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kffAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  kifAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  useGini: false
}
> kaia.getStakingInfo(49)
{
  KIRAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  PoCAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  blockNum: 48,
  clStakingInfos: null,
  councilNodeAddrs: ["0xad77f7306d42a03d35ab3ae3302a970de795157f", "0x2b9d1f31a860a5c6649b8a77b2a6b7530fdebe3c", "0xf7d662c06e09a19770eacf38199699a6c1a60bcf", "0x00657d43847cc7ab4ae4058467ac8024518213ba"],
  councilRewardAddrs: ["0x1ffdee22fa4df55d66dea1d9435343be2c0d3b12", "0xf411483d602620203bbfc9ba87e38bcfb6430b90", "0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6", "0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44"],
  councilStakingAddrs: ["0x856d63e1465896109bb957ef8e2713ae54912314", "0xb0a2bdb787c341b0566049beb72bb8e86bbde261", "0xec1623f9b24fe8259173830b9e4fa45553f87d0e", "0xaf440c4df5a4c59eec5e22bc91e91911acf18d2a"],
  councilStakingAmounts: [5000000, 10000000, 15000000, 20000000],
  gini: 0.25,
  kcfAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kefAddr: "0x6c38302e00dbac91712d93ab94b4a827698be6f1",
  kffAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  kifAddr: "0xc8757a6b5b427ddcd5781c9faa5e41318d32336a",
  useGini: false
}
```
</details>

<details><summary> kaia_getRewards </summary>

`pragueCompatibleBlock == 50`

```
// Before this PR
> kaia.getRewards(50)
{
  burntFee: 0,
  kef: 1152000000000000000,
  kif: 5184000000000000000,
  minted: 9600000000000000000,
  proposer: 652800000000000000,
  rewards: {
    // Val1 doesn't appear here since it has exact 5M Kaia and not a proposer. (no CL applied)
    0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6: 870400000000000000,
    0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44: 1305600000000000000,
    0x6c38302e00dbac91712d93ab94b4a827698be6f1: 1152000000000000000,
    0xc8757a6b5b427ddcd5781c9faa5e41318d32336a: 5184000000000000000,
    0xf411483d602620203bbfc9ba87e38bcfb6430b90: 1088000000000000000
  },
  stakers: 2611200000000000000,
  totalFee: 0
}
> kaia.getRewards(51)
{
  burntFee: 0,
  kef: 1152000000000000000,
  kif: 5184000000000000000,
  minted: 9600000000000000000,
  proposer: 652800000000000000,
  rewards: {
    0x10fd8bf375208e62077016d58329d2986eed45ce: 145066666666666660,
    0x1ffdee22fa4df55d66dea1d9435343be2c0d3b12: 145066666666666660,
    0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6: 580266666666666600,
    0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44: 870400000000000000,
    0x6c38302e00dbac91712d93ab94b4a827698be6f1: 1152000000000000000,
    0x7b056bafbddb86de6090afb572880d34451a46d0: 761600000000000000,
    0xc8757a6b5b427ddcd5781c9faa5e41318d32336a: 5184000000000000000,
    0xf411483d602620203bbfc9ba87e38bcfb6430b90: 761600000000000000
  },
  stakers: 2611200000000000000,
  totalFee: 0
}
```

```
// After this PR
> kaia.getRewards(50)
{
  burntFee: 0,
  kef: 1152000000000000000,
  kif: 5184000000000000000,
  minted: 9600000000000000000,
  proposer: 652800000000000000,
  rewards: {
    // Val1 appears here even if not a proposer since it has 10M Kaia thanks to CL since the Prague block.
    0x10fd8bf375208e62077016d58329d2986eed45ce: 145066666666666660,
    0x1ffdee22fa4df55d66dea1d9435343be2c0d3b12: 145066666666666660,
    0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6: 580266666666666600,
    0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44: 870400000000000000,
    0x6c38302e00dbac91712d93ab94b4a827698be6f1: 1152000000000000000,
    0x7b056bafbddb86de6090afb572880d34451a46d0: 761600000000000000,
    0xc8757a6b5b427ddcd5781c9faa5e41318d32336a: 5184000000000000000,
    0xf411483d602620203bbfc9ba87e38bcfb6430b90: 761600000000000000
  },
  stakers: 2611200000000000000,
  totalFee: 0
}
> kaia.getRewards(49)
{
  burntFee: 0,
  kef: 1152000000000000000,
  kif: 5184000000000000000,
  minted: 9600000000000000000,
  proposer: 652800000000000000,
  rewards: {
    0x1ffdee22fa4df55d66dea1d9435343be2c0d3b12: 652800000000000000,
    0x2836a57c4fc95537ba2c3b1587d2a7d195a278e6: 870400000000000000,
    0x6b4679e1a0aa81ffcab3e0b70044b3c0928b7f44: 1305600000000000000,
    0x6c38302e00dbac91712d93ab94b4a827698be6f1: 1152000000000000000,
    0xc8757a6b5b427ddcd5781c9faa5e41318d32336a: 5184000000000000000,
    0xf411483d602620203bbfc9ba87e38bcfb6430b90: 435200000000000000
  },
  stakers: 2611200000000000000,
  totalFee: 0
}
```
</details>

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
