### PR TITLE
blockchain/vm: reject contract creation to non-empty storage root

### DIFF
--- a/blockchain/state/state_object.go
+++ b/blockchain/state/state_object.go
@@ -588,6 +588,13 @@ func (s *stateObject) Nonce() uint64 {
 	return s.account.GetNonce()
 }
 
+func (s *stateObject) Root() common.Hash {
+	if acc := account.GetProgramAccount(s.account); acc != nil {
+		return acc.GetStorageRoot().Unextend()
+	}
+	return common.Hash{}
+}
+
 // Never called, but must be present to allow stateObject to be used
 // as a vm.Account interface that also satisfies the vm.ContractRef
 // interface. Interfaces are awesome.

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -291,6 +291,14 @@ func (s *StateDB) GetCode(addr common.Address) []byte {
 	return nil
 }
 
+func (s *StateDB) GetStorageRoot(addr common.Address) common.Hash {
+	stateObject := s.getStateObject(addr)
+	if stateObject != nil {
+		return stateObject.Root()
+	}
+	return common.Hash{}
+}
+
 func (s *StateDB) GetAccount(addr common.Address) account.Account {
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {

--- a/blockchain/vm/interface.go
+++ b/blockchain/vm/interface.go
@@ -53,6 +53,7 @@ type StateDB interface {
 	SetCodeToEOA(common.Address, []byte, params.Rules) error
 	GetCodeSize(common.Address) int
 	GetVmVersion(common.Address) (params.VmVersion, bool)
+	GetStorageRoot(common.Address) common.Hash
 
 	ResolveCodeHash(common.Address) common.Hash
 	ResolveCode(common.Address) []byte

--- a/blockchain/vm/mocks/statedb_mock.go
+++ b/blockchain/vm/mocks/statedb_mock.go
@@ -365,6 +365,20 @@ func (mr *MockStateDBMockRecorder) GetState(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockStateDB)(nil).GetState), arg0, arg1)
 }
 
+// GetStorageRoot mocks base method.
+func (m *MockStateDB) GetStorageRoot(arg0 common.Address) common.Hash {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageRoot", arg0)
+	ret0, _ := ret[0].(common.Hash)
+	return ret0
+}
+
+// GetStorageRoot indicates an expected call of GetStorageRoot.
+func (mr *MockStateDBMockRecorder) GetStorageRoot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageRoot", reflect.TypeOf((*MockStateDB)(nil).GetStorageRoot), arg0)
+}
+
 // GetTransientState mocks base method.
 func (m *MockStateDB) GetTransientState(addr common.Address, key common.Hash) common.Hash {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Proposed changes

This PR bring EIP-7610 implementation. Please refer to original implementation [here](https://github.com/ethereum/go-ethereum/pull/28912).

Both EIP-684 and EIP-6710 apply retroactively for all blocks since genesis in Ethereum. In Kaia, since we already decided to introduce EIP-684 in Shanghai hardfork (not from genesis), I added EIP-6710 in Shanghai to align the activation. If you have other opinions, please let me know.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
