### PR TITLE
Fix simpleStorage regarding maximum number of nodes

### DIFF
--- a/networks/p2p/discover/discover_storage_simple.go
+++ b/networks/p2p/discover/discover_storage_simple.go
@@ -222,8 +222,11 @@ func (s *simpleStorage) closest(target common.Hash, nresults int) *nodesByDistan
 	// in the SimpleStorage. Change it
 	cNodes := &nodesByDistance{target: target}
 	nodes := s.shuffle(s.nodes)
-	if len(nodes) > s.max {
-		cNodes.entries = nodes[:s.max]
+	// TODO-Kaia We should cap the number of nodes with nresults, however we cannot estimate the side effect.
+	// As s.nodes can be longer than s.max, we cap the number of nodes returned with min(nresults, s.max).
+	cap := min(nresults, s.max)
+	if len(nodes) > cap {
+		cNodes.entries = nodes[:cap]
 	} else {
 		cNodes.entries = nodes
 	}
@@ -252,7 +255,10 @@ func (s *simpleStorage) bumpOrAdd(n *Node) bool {
 	}
 
 	s.localLogger.Trace("Add(New)", "StorageName", s.name(), "node", n)
-	s.nodes, _ = pushNode(s.nodes, n, math.MaxInt64) // TODO-Kaia-Node Change Max value for more reasonable one.
+	// TODO-Kaia-Node Change Max value for more reasonable one.
+	// As we cannot estimate the side effect, we leave s.nodes to be longer than s.max.
+	// s.max has been used to cap the number of nodes returned by `closest` function.
+	s.nodes, _ = pushNode(s.nodes, n, math.MaxInt64)
 	n.addedAt = time.Now()
 	if s.tab.nodeAddedHook != nil {
 		s.tab.nodeAddedHook(n)

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -775,6 +775,10 @@ func (req *neighbors) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byt
 func (req *neighbors) name() string { return "NEIGHBORS/v4" }
 
 func findnodeRetrieveSize(nType NodeType) int {
+	// Returning too small value will make CNs unable to find each other.
+	if nType == NodeTypeCN {
+		return 100
+	}
 	// Return at most 2 PNs.
 	// 1. Under current CN-PN-EN 3-tier operating practices, findnode(type=PN) packet originates only from EN.
 	//    CNs only connect to other CNs via CNBN. PNs are connected to PNs and CNs via static-nodes.json.


### PR DESCRIPTION
## Proposed changes

- `discover.simpleStorage.closest` does not respect its parameter `nresults` and returns `simpleStorage.max` number of nodes.
- `discover.simpleStorage.add` does not respect `simpleStorage.max` and allows up to `math.MaxInt64` number of nodes.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

None
