### PR TITLE
test: Enable prague's EIP7623

### DIFF
--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -102,14 +102,14 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 	b.receipts = append(b.receipts, receipt)
 }
 
-func (b *BlockGen) AddTxWithChainWithError(bc *BlockChain, tx *types.Transaction) error {
+func (b *BlockGen) AddTxWithChainEvenHasError(bc *BlockChain, tx *types.Transaction) error {
 	b.statedb.SetTxContext(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, err := bc.ApplyTransaction(b.config, &params.AuthorAddressForTesting, b.statedb, b.header, tx, &b.header.GasUsed, &vm.Config{})
-	if err != nil {
-		return err
-	}
+	receipt, _, _ := bc.ApplyTransaction(b.config, &params.AuthorAddressForTesting, b.statedb, b.header, tx, &b.header.GasUsed, &vm.Config{})
+
 	b.txs = append(b.txs, tx)
-	b.receipts = append(b.receipts, receipt)
+	if receipt != nil {
+		b.receipts = append(b.receipts, receipt)
+	}
 	return nil
 }
 

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -100,7 +100,6 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 
 	bt.skipLoad(`^prague\/eip2537_bls_12_381_precompiles`)             // gas error
 	bt.skipLoad(`^prague\/eip2935_historical_block_hashes_from_state`) // gas error
-	bt.skipLoad(`^prague\/eip7623_increase_calldata_cost`)             // unconfirmed
 	bt.skipLoad(`^prague\/eip7702_set_code_tx`)                        // state, gas (after update we should do it)
 
 	// tests to skip
@@ -113,6 +112,8 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	bt.skipLoad(`^prague\/eip7685_general_purpose_el_requests`)
 	bt.skipLoad(`^prague\/eip7002_el_triggerable_withdrawals`)
 	bt.skipLoad(`^prague\/eip6110_deposits`)
+	// type 3 tx (EIP-4844) is not supported
+	bt.skipLoad(`^prague\/eip7623_increase_calldata_cost\/.*type_3.*`)
 
 	bt.walk(t, executionSpecBlockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		skipForks := []string{

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -262,7 +262,7 @@ func (t *BlockTest) insertBlocksFromTx(bc *blockchain.BlockChain, preBlock *type
 		blocks, receiptsList := blockchain.GenerateChain(bc.Config(), preBlock, bc.Engine(), db, 1, func(i int, b *blockchain.BlockGen) {
 			b.SetRewardbase(common.Address(header.Coinbase))
 			for _, tx := range txs {
-				_ = b.AddTxWithChainWithError(nil, tx)
+				b.AddTxWithChainEvenHasError(nil, tx)
 			}
 		})
 


### PR DESCRIPTION
## Proposed changes

This PR enables prague's EIP7623 test in eets blockchain tests.
There was a problem with the test process that has now been fixed.
- It was not possible to create a block containing a transaction that returns an error using Generate chain. The test function makes this possible.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/kaiachain/kaia/issues/152#issuecomment-2597630897
  - Skiped prague except 7702 - EIP7623

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
