### PR TITLE
test: EETS Set precompile correctly

### DIFF
--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -104,8 +104,11 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 
 func (b *BlockGen) AddTxWithChainEvenHasError(bc *BlockChain, tx *types.Transaction) error {
 	b.statedb.SetTxContext(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, _, _ := bc.ApplyTransaction(b.config, &params.AuthorAddressForTesting, b.statedb, b.header, tx, &b.header.GasUsed, &vm.Config{})
-
+	var vmConfig vm.Config
+	if bc != nil {
+		vmConfig = bc.vmConfig
+	}
+	receipt, _, _ := bc.ApplyTransaction(b.config, &params.AuthorAddressForTesting, b.statedb, b.header, tx, &b.header.GasUsed, &vmConfig)
 	b.txs = append(b.txs, tx)
 	if receipt != nil {
 		b.receipts = append(b.receipts, receipt)

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -299,6 +299,8 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 	}
 }
 
+var CreateContractWithCodeFormatInExecutionSpecTest bool
+
 // ToBlock creates the genesis block and writes state of a genesis specification
 // to the given database (or discards it if nil).
 func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *types.Block {
@@ -310,6 +312,9 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	for addr, account := range g.Alloc {
 		if len(account.Code) != 0 {
 			originalCode := stateDB.GetCode(addr)
+			if CreateContractWithCodeFormatInExecutionSpecTest {
+				stateDB.CreateSmartContractAccount(addr, params.CodeFormatEVM, g.Config.Rules(new(big.Int).SetUint64(g.Number)))
+			}
 			stateDB.SetCode(addr, account.Code)
 			// If originalCode is not nil,
 			// just update the code and don't change the other states

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -65,6 +65,7 @@ func (suite *ExecutionSpecBlockTestSuite) SetupSuite() {
 	suite.originalIsPrecompiledContractAddress = common.IsPrecompiledContractAddress
 	common.IsPrecompiledContractAddress = isPrecompiledContractAddressForEthTest
 	blockchain.UseKaiaCancunExtCodeHashFee = true
+	blockchain.CreateContractWithCodeFormatInExecutionSpecTest = true
 }
 
 func (suite *ExecutionSpecBlockTestSuite) TearDownSuite() {
@@ -72,6 +73,7 @@ func (suite *ExecutionSpecBlockTestSuite) TearDownSuite() {
 	common.IsPrecompiledContractAddress = suite.originalIsPrecompiledContractAddress
 	blockchain.UseKaiaCancunExtCodeHashFee = false
 	blockchain.GasLimitInExecutionSpecTest = 0
+	blockchain.CreateContractWithCodeFormatInExecutionSpecTest = false
 	types.IsPragueInExecutionSpecTest = false
 }
 

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -152,7 +152,7 @@ func (t *BlockTest) Run() error {
 			blockchain.ProcessParentBlockHash(header, vmenv, state, chain.Config().Rules(header.Number))
 		}
 	}
-	chain, err := blockchain.NewBlockChain(db, nil, config, gxhash.NewShared(), vm.Config{Debug: true, Tracer: tracer})
+	chain, err := blockchain.NewBlockChain(db, nil, config, gxhash.NewShared(), vm.Config{Debug: true, Tracer: tracer, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

- Give the genesis.Alloc account a code format when running the EETS blockchain test. This will set precompile correctly.
- When calling `AddTxWithChainEvenHasError`, if it was given a bc, call `ApplyTransaction` using that vmConfig.
- Add params.OpcodeComputationCostLimitInfinite to the blockchain’s vmConfig

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
