### PR TITLE
build: RPM package installs initscripts and systemd services

### DIFF
--- a/build/rpm/etc/systemd/system/kbnd.service
+++ b/build/rpm/etc/systemd/system/kbnd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description= kbnd Service
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/kbnd start
+ExecStop=/etc/init.d/kbnd stop
+
+[Install]
+WantedBy=multi-user.target

--- a/build/rpm/etc/systemd/system/kcnd.service
+++ b/build/rpm/etc/systemd/system/kcnd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description= kcnd Service
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/kcnd start
+ExecStop=/etc/init.d/kcnd stop
+
+[Install]
+WantedBy=multi-user.target

--- a/build/rpm/etc/systemd/system/kend.service
+++ b/build/rpm/etc/systemd/system/kend.service
@@ -1,0 +1,10 @@
+[Unit]
+Description= kend Service
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/kend start
+ExecStop=/etc/init.d/kend stop
+
+[Install]
+WantedBy=multi-user.target

--- a/build/rpm/etc/systemd/system/kpnd.service
+++ b/build/rpm/etc/systemd/system/kpnd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description= kpnd Service
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/kpnd start
+ExecStop=/etc/init.d/kpnd stop
+
+[Install]
+WantedBy=multi-user.target

--- a/build/rpm/etc/systemd/system/kscnd.service
+++ b/build/rpm/etc/systemd/system/kscnd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description= kscnd Service
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/kscnd start
+ExecStop=/etc/init.d/kscnd stop
+
+[Install]
+WantedBy=multi-user.target

--- a/build/rpm/etc/systemd/system/ksend.service
+++ b/build/rpm/etc/systemd/system/ksend.service
@@ -1,0 +1,10 @@
+[Unit]
+Description= ksend Service
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/ksend start
+ExecStop=/etc/init.d/ksend stop
+
+[Install]
+WantedBy=multi-user.target

--- a/build/rpm/etc/systemd/system/kspnd.service
+++ b/build/rpm/etc/systemd/system/kspnd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description= kspnd Service
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/kspnd start
+ExecStop=/etc/init.d/kspnd stop
+
+[Install]
+WantedBy=multi-user.target

--- a/build/rpm/main.go
+++ b/build/rpm/main.go
@@ -205,6 +205,7 @@ License:            GNU
 URL:                https://kaia.io
 Source0:            %{name}-%{version}.tar.gz
 BuildRoot:          %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+Requires:           initscripts
 
 %global debug_package %{nil}
 
@@ -224,11 +225,13 @@ mkdir -p $RPM_BUILD_ROOT/usr/bin
 mkdir -p $RPM_BUILD_ROOT/etc/{{ .DaemonName }}/conf
 mkdir -p $RPM_BUILD_ROOT/etc/init.d
 mkdir -p $RPM_BUILD_ROOT/var/log/{{ .DaemonName }}
+mkdir -p $RPM_BUILD_ROOT/etc/systemd/system
 
 cp build/bin/{{ .ProgramName }} $RPM_BUILD_ROOT/usr/bin/{{ .ProgramName }}
 %if %is_daemon
 cp build/rpm/etc/init.d/{{ .DaemonName }} $RPM_BUILD_ROOT/etc/init.d/{{ .DaemonName }}
 cp build/rpm/etc/{{ .DaemonName }}/conf/{{ .DaemonName }}{{ .PostFix }}.conf $RPM_BUILD_ROOT/etc/{{ .DaemonName }}/conf/{{ .DaemonName }}.conf
+cp build/rpm/etc/systemd/system/{{ .DaemonName }}.service $RPM_BUILD_ROOT/etc/systemd/system/{{ .DaemonName }}.service
 %endif
 
 %files
@@ -236,16 +239,29 @@ cp build/rpm/etc/{{ .DaemonName }}/conf/{{ .DaemonName }}{{ .PostFix }}.conf $RP
 %if %is_daemon
 %config(noreplace) %attr(644, -, -) /etc/{{ .DaemonName }}/conf/{{ .DaemonName }}.conf
 %attr(754, -, -) /etc/init.d/{{ .DaemonName }}
+%attr(644, -, -) /etc/systemd/system/{{ .DaemonName }}.service
 %endif
 %exclude /usr/local/var/lib/rpm/*
 %exclude /usr/local/var/lib/rpm/.*
 %exclude /usr/local/var/tmp/*
 
 %pre
+# /etc/init.d/{{ .DaemonName }} requires /etc/init.d/functions file to work. That is why 'initscripts' is required.
+# Installing initscripts has two outcomes.
+# case 1. symlink /etc/init.d -> /etc/rc.d/init.d created. No action needed.
+# case 2. symlink /etc/init.d -> /etc/rc.d/init.d creation failed because /etc/init.d/ directory exists
+#         (e.g. kend.rpm v1.x was previously installed) If so, create symlink to 'functions'.
+if [ -d /etc/init.d ] && [ ! -e /etc/init.d/functions ]; then
+	ln -s /etc/rc.d/init.d/functions /etc/init.d/functions
+fi
 %if %is_daemon
 if [ $1 -eq 2 ]; then
 	# Package upgrade
-	systemctl stop {{ .DaemonName }}.service > /dev/null 2>&1
+	# rpm v1.x installs init.d only. rpm v2.0+ installs init.d and systemd.
+	# case 1. upgrading from v2.0 and systemctl works.
+	# case 2. upgrading from v1.x and init.d works.
+	# case 3. upgrading from v1.x and init.d fails (e.g. In Rocky Linux, init.d fails without systemd)
+	(systemctl stop {{ .DaemonName }}.service || /etc/init.d/{{ .DaemonName }} stop || true) > /dev/null 2>&1
 fi
 %endif
 


### PR DESCRIPTION
## Proposed changes

- kend rpm v1.0.3 had not been successfully installing on Rocky Linux 9. This PR makes rpm v2.0.0 work correctly.
- After installing the RPM package, following commands must work:
  - SysVInit commands (requires `/etc/init.d/functions` and `/etc/init.d/k*nd` files)
	```
	/etc/init.d/kend {start|stop|restart|status}
	```
  - Systemd commands (additionally requires `/etc/systemd/system/k*nd.service` file)
	```
	systemctl {start|stop|restart|status} kend
	```
  - Note that `/etc/init.d/kend` depends on `/etc/init.d/functions` file. The RPM script also handles it.
- RPM package must be correctly installed in both cases:
  - Clean install v2.0.0
  - Upgrade from v1.0.3
- RPM package must be correctly installed on following environments:
  - CentOS stream 9
  - Rocky Linux 9

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

Test results:

<details>
<summary>CentOS stream 9, clean install v2.0.0</summary>

- before install
	```
	+ ls -l /etc/init.d
	ls: cannot access '/etc/init.d': No such file or directory
	+ ls -l /etc/rc.d/init.d
	total 4
	-rw-r--r--. 1 root root 1161 Jan  8 07:56 README
	+ ls -l '/etc/systemd/system/kend*'
	ls: cannot access '/etc/systemd/system/kend*': No such file or directory
	```
- after install v2.0.0
	```
	sudo yum install kend-v2.0.0-0.el9.x86_64.rpm
	
	Installed:
	  chkconfig-1.24-1.el9.x86_64    initscripts-10.11.8-4.el9.x86_64    kend-v2.0.0-0.el9.x86_64
	```
	```
	+ ls -l /etc/init.d
	lrwxrwxrwx. 1 root root 11 May 23  2023 /etc/init.d -> rc.d/init.d
	+ ls -l /etc/rc.d/init.d
	total 36
	-rw-r--r--. 1 root root 18220 Aug 27 11:35 functions
	-rwxr-xr--. 1 root root 10161 Jan 23 13:25 kend
	-rw-r--r--. 1 root root  1161 Jan  8 07:56 README
	+ ls -l /etc/systemd/system/kend.service
	-rw-r--r--. 1 root root 158 Jan 23 13:25 /etc/systemd/system/kend.service
	```
</details>

<details>
<summary>CentOS stream 9, upgrade from v1.0.3 to v2.0.0</summary>

- before install
	```
	+ ls -l /etc/init.d
	ls: cannot access '/etc/init.d': No such file or directory
	+ ls -l /etc/rc.d/init.d
	total 4
	-rw-r--r--. 1 root root 1161 Jan  8 07:56 README
	+ ls -l '/etc/systemd/system/kend*'
	ls: cannot access '/etc/systemd/system/kend*': No such file or directory
	```
- after install v1.0.3
	```
	sudo yum install kend-v1.0.3-0.el7.x86_64.rpm
	
	Installed:
	  kend-v1.0.3-0.el7.x86_64
	```
	```
	+ ls -l /etc/init.d
	total 12
	-rwxr-xr--. 1 root root 10157 Sep 26 06:18 kend
	+ ls -l /etc/rc.d/init.d
	total 4
	-rw-r--r--. 1 root root 1161 Jan  8 07:56 README
	+ ls -l '/etc/systemd/system/kend*'
	ls: cannot access '/etc/systemd/system/kend*': No such file or directory
	```
- after install v2.0.0 - `chkconfig` install failed because `/etc/init.d` already exists; but `kend` was upgraded nevertheless.
	```
	sudo yum install kend-v2.0.0-0.el9.x86_64.rpm

	error: unpacking of archive failed on file /etc/init.d;679253fc: cpio: File from package already exists as a directory in system
	error: chkconfig-1.24-1.el9.x86_64: install failed

	Upgraded:
	  kend-v2.0.0-0.el9.x86_64
	Installed:
	  initscripts-10.11.8-4.el9.x86_64
	Failed:
	  chkconfig-1.24-1.el9.x86_64
	```
	```
	+ ls -l /etc/init.d
	total 12
	lrwxrwxrwx. 1 root root    26 Jan 23 14:36 functions -> /etc/rc.d/init.d/functions
	-rwxr-xr--. 1 root root 10161 Jan 23 13:25 kend
	+ ls -l /etc/rc.d/init.d
	total 24
	-rw-r--r--. 1 root root 18220 Aug 27 11:35 functions
	-rw-r--r--. 1 root root  1161 Jan  8 07:56 README
	+ ls -l /etc/systemd/system/kend.service
	-rw-r--r--. 1 root root 158 Jan 23 13:25 /etc/systemd/system/kend.service
	```
</details>


<details>
<summary>Rocky Linux 9, clean install v2.0.0</summary>

- before install
	```
	+ ls -l /etc/init.d
	ls: cannot access '/etc/init.d': No such file or directory
	+ ls -l /etc/rc.d/init.d
	total 4
	-rw-r--r--. 1 root root 1161 Nov 16 01:21 README
	+ ls -l '/etc/systemd/system/kend*'
	ls: cannot access '/etc/systemd/system/kend*': No such file or directory
	```
- after install v2.0.0
	```
	sudo yum install kend-v2.0.0-0.el9.x86_64.rpm

	Installed:
	  chkconfig-1.24-1.el9_5.1.x86_64    initscripts-10.11.7-1.el9.x86_64    kend-v2.0.0-0.el9.x86_64
	```
	```
	+ ls -l /etc/init.d
	lrwxrwxrwx. 1 root root 11 Nov 12 10:43 /etc/init.d -> rc.d/init.d
	+ ls -l /etc/rc.d/init.d
	total 36
	-rw-r--r--. 1 root root 18220 Mar  6  2024 functions
	-rwxr-xr--. 1 root root 10161 Jan 23 13:25 kend
	-rw-r--r--. 1 root root  1161 Nov 16 01:21 README
	+ ls -l /etc/systemd/system/kend.service
	-rw-r--r--. 1 root root 158 Jan 23 13:25 /etc/systemd/system/kend.service
	```
</details>

<details>
<summary>Rocky Linux 9, upgrade from v1.0.3 to v2.0.0</summary>

- before install
	```
	+ ls -l /etc/init.d
	ls: cannot access '/etc/init.d': No such file or directory
	+ ls -l /etc/rc.d/init.d
	total 4
	-rw-r--r--. 1 root root 1161 Nov 16 01:21 README
	+ ls -l '/etc/systemd/system/kend*'
	ls: cannot access '/etc/systemd/system/kend*': No such file or directory
	```
- after install v1.0.3
	```
	sudo yum install kend-v1.0.3-0.el7.x86_64.rpm
	Installed:
	  kend-v1.0.3-0.el7.x86_64
	```
	```
	+ ls -l /etc/init.d
	total 12
	-rwxr-xr--. 1 root root 10157 Sep 26 06:18 kend
	+ ls -l /etc/rc.d/init.d
	total 4
	-rw-r--r--. 1 root root 1161 Nov 16 01:21 README
	+ ls -l '/etc/systemd/system/kend*'
	ls: cannot access '/etc/systemd/system/kend*': No such file or directory
	```
- after install v2.0.0 - `chkconfig` install failed because `/etc/init.d` already exists; but `kend` was upgraded nevertheless.
	```
	sudo yum install kend-v2.0.0-0.el9.x86_64.rpm

	error: unpacking of archive failed on file /etc/init.d;6792568f: cpio: File from package already exists as a directory in system
	error: chkconfig-1.24-1.el9_5.1.x86_64: install failed

	Upgraded:
	  kend-v2.0.0-0.el9.x86_64
	Installed:
	  initscripts-10.11.7-1.el9.x86_64
	Failed:
	  chkconfig-1.24-1.el9_5.1.x86_64
	```
	```
	+ ls -l /etc/init.d
	total 12
	lrwxrwxrwx. 1 root root    26 Jan 23 14:47 functions -> /etc/rc.d/init.d/functions
	-rwxr-xr--. 1 root root 10161 Jan 23 13:25 kend
	+ ls -l /etc/rc.d/init.d
	total 24
	-rw-r--r--. 1 root root 18220 Mar  6  2024 functions
	-rw-r--r--. 1 root root  1161 Nov 16 01:21 README
	+ ls -l /etc/systemd/system/kend.service
	-rw-r--r--. 1 root root 158 Jan 23 13:25 /etc/systemd/system/kend.service
	```
</details>

