### PR TITLE
Set completion mark in correct timing

### DIFF
--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -831,10 +831,6 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 	dbm.setDBDir(StateTrieDB, dbDirToBeUsed)
 	dbm.dbs[StateTrieDB] = dbToBeUsed
 
-	// Set the completion mark.
-	// The old database will be completely removed (possibly not be removed if error occurs)
-	dbm.setStateTrieMigrationStatus(0)
-	dbm.dbs[StateTrieMigrationDB] = nil
 	dbm.setDBDir(StateTrieMigrationDB, "")
 
 	dbPathToBeRemoved := filepath.Join(dbm.config.Dir, dbDirToBeRemoved)
@@ -850,6 +846,10 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 // Remove old database. This is called once migration(copy) is done.
 func (dbm *databaseManager) removeOldDB(dbPath string, endCheck chan struct{}) {
 	defer func() {
+		// Set the completion mark.
+		// The old database will be completely removed (possibly not be removed if error occurs)
+		dbm.setStateTrieMigrationStatus(0)
+		dbm.dbs[StateTrieMigrationDB] = nil
 		if endCheck != nil {
 			close(endCheck)
 		}

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -831,6 +831,9 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 	dbm.setDBDir(StateTrieDB, dbDirToBeUsed)
 	dbm.dbs[StateTrieDB] = dbToBeUsed
 
+	// Set the completion mark.
+	// The old database will be completely removed (possibly not be removed if error occurs)
+	dbm.setStateTrieMigrationStatus(0)
 	dbm.dbs[StateTrieMigrationDB] = nil
 	dbm.setDBDir(StateTrieMigrationDB, "")
 
@@ -847,8 +850,6 @@ func (dbm *databaseManager) FinishStateMigration(succeed bool) chan struct{} {
 // Remove old database. This is called once migration(copy) is done.
 func (dbm *databaseManager) removeOldDB(dbPath string, endCheck chan struct{}) {
 	defer func() {
-		// Set the completion mark if old database is completely removed (possibly not be removed if error occurs)
-		dbm.setStateTrieMigrationStatus(0)
 		if endCheck != nil {
 			close(endCheck)
 		}


### PR DESCRIPTION
## Proposed changes

When state migration has been finished, it removes old DB and dbm for state migration. But setting the completion mark `inMigration = false` is done after `dbm.dbs[StateTrieMigrationDB] = nil` in separate go-routine (no lock held), which leads to potential nil dereference due to timing issue while opening a new trie (since it accesses to `dbm.dbs[StateTrieMigrationDB]` if `inMigration = true`).

I strongly suspect it's the root cause of the random test failure of `TestMigration_StartMigrationByMiscDBOnRestart` in CI.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

The CI failure always happens in #225.

## Further comments
