### PR TITLE
storage/database: cleanup old database after migration

### DIFF
--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -308,6 +308,10 @@ func (bc *BlockChain) restartStateMigration() {
 			bc.migrateState(root)
 			bc.wg.Done()
 		}()
+	} else if dbPath := bc.db.MigrationOldDBPath(); dbPath != "" {
+		// Remove the old database if it exists.
+		// This can happen when the node is stopped while removing the old database.
+		go bc.db.RemoveOldDB(dbPath, nil)
 	}
 }
 

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -130,6 +130,8 @@ var (
 	databaseDirPrefix  = []byte("databaseDirectory")
 	migrationStatusKey = []byte("migrationStatus")
 
+	migrationOldDBPathKey = []byte("migrationOldDBPath")
+
 	stakingInfoPrefix = []byte("stakingInfo")
 
 	supplyCheckpointPrefix        = []byte("supplyCheckpoint")


### PR DESCRIPTION
## Proposed changes

When the node stops while removing the old db, the state migration restarts from scratch. This PR sets the old db path before removal so the node can find a pending removal job when restarted. Inspired from https://github.com/kaiachain/kaia/pull/229#issuecomment-2611410684

Please note that PR #229 only fixes nil dereference issue.

The overall process will be:
1. Set the completion mark and old db path.
2. Start removing old db.
3. The node stops before completely removing the old db.
4. The node will find the old db path and remove it.
5. Set empty old db path.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
