### PR TITLE
feat: Use uint256 for chainId and return delegation designator for EXTCODE* in SET_CODE_TX_TYPE(EIP-7702)

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -162,7 +162,7 @@ func (b *BlockchainContractBackend) callContract(call kaia.CallMsg, block *types
 	}
 
 	msg := types.NewMessage(call.From, call.To, 0, call.Value, call.Gas, gasPrice, nil, nil, call.Data,
-		false, intrinsicGas, dataTokens, accessList, nil)
+		false, intrinsicGas, dataTokens, accessList, nil, nil)
 
 	txContext := blockchain.NewEVMTxContext(msg, block.Header(), b.bc.Config())
 	blockContext := blockchain.NewEVMBlockContext(block.Header(), b.bc, nil)

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -501,7 +501,7 @@ func (b *SimulatedBackend) callContract(_ context.Context, call kaia.CallMsg, bl
 		accessList = *call.AccessList
 	}
 	intrinsicGas, dataTokens, _ := types.IntrinsicGas(call.Data, accessList, nil, call.To == nil, b.config.Rules(block.Number()))
-	msg := types.NewMessage(call.From, call.To, nonce, call.Value, call.Gas, gasPrice, nil, nil, call.Data, true, intrinsicGas, dataTokens, accessList, nil)
+	msg := types.NewMessage(call.From, call.To, nonce, call.Value, call.Gas, gasPrice, nil, nil, call.Data, true, intrinsicGas, dataTokens, accessList, nil, nil)
 
 	txContext := blockchain.NewEVMTxContext(msg, block.Header(), b.config)
 	blockContext := blockchain.NewEVMBlockContext(block.Header(), b.blockchain, nil)

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -742,5 +742,5 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 	if args.AccessList != nil {
 		accessList = *args.AccessList
 	}
-	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, nil, nil, args.InputData(), false, intrinsicGas, dataTokens, accessList, nil), nil
+	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, nil, nil, args.InputData(), false, intrinsicGas, dataTokens, accessList, nil, nil), nil
 }

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -30,6 +30,7 @@ import (
 	"math/big"
 	"reflect"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/common"
@@ -812,7 +813,7 @@ func (args *EthTransactionArgs) toTransaction() (*types.Transaction, error) {
 			al = *args.AccessList
 		}
 		tx = types.NewTx(&types.TxInternalDataEthereumSetCode{
-			ChainID:           (*big.Int)(args.ChainID),
+			ChainID:           uint256.MustFromBig((*big.Int)(args.ChainID)),
 			AccountNonce:      uint64(*args.Nonce),
 			GasTipCap:         (*big.Int)(args.MaxPriorityFeePerGas),
 			GasFeeCap:         (*big.Int)(args.MaxFeePerGas),

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -799,7 +799,7 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 	if args.AuthorizationList != nil {
 		AuthorizationList = args.AuthorizationList
 	}
-	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, nil, nil, data, false, intrinsicGas, dataTokens, accessList, AuthorizationList), nil
+	return types.NewMessage(addr, args.To, 0, value, gas, gasPrice, nil, nil, data, false, intrinsicGas, dataTokens, accessList, nil, AuthorizationList), nil
 }
 
 // toTransaction converts the arguments to a transaction.

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -2330,13 +2331,13 @@ func TestEIP7702(t *testing.T) {
 	// 2. addr1:0xaaaa calls into addr2:0xbbbb
 	// 3. addr2:0xbbbb  writes to storage
 	auth1, _ := types.SignSetCode(key1, types.SetCodeAuthorization{
-		ChainID: gspec.Config.ChainID.Uint64(),
+		ChainID: *uint256.MustFromBig(gspec.Config.ChainID),
 		Address: aa,
 		Nonce:   1,
 	})
 
 	auth2, _ := types.SignSetCode(key2, types.SetCodeAuthorization{
-		ChainID: uint64(0),
+		ChainID: *uint256.NewInt(0),
 		Address: bb,
 		Nonce:   0,
 	})
@@ -2424,7 +2425,7 @@ func TestEIP7702(t *testing.T) {
 	// Set 0x0000000000000000000000000000000000000000000 test
 	{
 		authForEmpty, _ := types.SignSetCode(key1, types.SetCodeAuthorization{
-			ChainID: gspec.Config.ChainID.Uint64(),
+			ChainID: *uint256.MustFromBig(gspec.Config.ChainID),
 			Address: common.Address{},
 			Nonce:   state.GetNonce(addr1) + 1,
 		})

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1463,7 +1463,7 @@ func TestAccessListTx(t *testing.T) {
 
 			// One transaction to 0xAAAA
 			intrinsicGas, dataTokens, _ := types.IntrinsicGas([]byte{}, list, nil, false, gspec.Config.Rules(block.Number()))
-			tx, _ := types.SignTx(types.NewMessage(senderAddr, &contractAddr, senderNonce, big.NewInt(0), 30000, big.NewInt(1), nil, nil, []byte{}, false, intrinsicGas, dataTokens, list, nil), signer, senderKey)
+			tx, _ := types.SignTx(types.NewMessage(senderAddr, &contractAddr, senderNonce, big.NewInt(0), 30000, big.NewInt(1), nil, nil, []byte{}, false, intrinsicGas, dataTokens, list, nil, nil), signer, senderKey)
 			b.AddTx(tx)
 		})
 		if n, err := chain.InsertChain(blocks); err != nil {
@@ -2356,7 +2356,7 @@ func TestEIP7702(t *testing.T) {
 		}
 
 		tx, err := types.SignTx(types.NewMessage(addr1, &addr1, uint64(0), nil, 500000, nil, newGkei(50),
-			big.NewInt(20), nil, false, intrinsicGas, dataTokens, nil, authorizationList), signer, key1)
+			big.NewInt(20), nil, false, intrinsicGas, dataTokens, nil, nil, authorizationList), signer, key1)
 		if err != nil {
 			t.Fatalf("failed to sign tx: %v", err)
 		}
@@ -2437,7 +2437,7 @@ func TestEIP7702(t *testing.T) {
 		}
 
 		tx, err := types.SignTx(types.NewMessage(addr1, &addr1, state.GetNonce(addr1), nil, 500000, nil, newGkei(50),
-			big.NewInt(20), nil, false, intrinsicGas, dataTokens, nil, authorizationList), signer, key1)
+			big.NewInt(20), nil, false, intrinsicGas, dataTokens, nil, nil, authorizationList), signer, key1)
 		if err != nil {
 			t.Fatalf("failed to sign tx: %v", err)
 		}

--- a/blockchain/state_processor.go
+++ b/blockchain/state_processor.go
@@ -132,6 +132,7 @@ func ProcessParentBlockHash(header *types.Header, vmenv *vm.EVM, statedb vm.Stat
 		dataTokens,
 		nil,
 		nil,
+		nil,
 	)
 
 	vmenv.Reset(NewEVMTxContext(msg, header, vmenv.ChainConfig()), statedb)

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -530,7 +530,7 @@ var receiptstatus2errTxFailed = map[uint]error{
 
 func (st *StateTransition) validateAuthorization(auth *types.SetCodeAuthorization) (authority common.Address, err error) {
 	// Verify chain ID is 0 or equal to current chain ID.
-	if auth.ChainID != 0 && st.evm.ChainConfig().ChainID.Uint64() != auth.ChainID {
+	if !auth.ChainID.IsZero() && auth.ChainID.CmpBig(st.evm.ChainConfig().ChainID) != 0 {
 		return authority, ErrAuthorizationWrongChainID
 	}
 	// Limit nonce to 2^64-1 per EIP-2681.

--- a/blockchain/state_transition_test.go
+++ b/blockchain/state_transition_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/blockchain/vm"
@@ -110,7 +111,7 @@ func TestStateTransition_validateAuthorization(t *testing.T) {
 			name: "valid Authorization",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(1),
 				})
@@ -131,7 +132,7 @@ func TestStateTransition_validateAuthorization(t *testing.T) {
 			name: "wrong ChainID",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: uint64(10),
+					ChainID: *uint256.NewInt(10),
 					Address: aa,
 					Nonce:   1,
 				})
@@ -149,7 +150,7 @@ func TestStateTransition_validateAuthorization(t *testing.T) {
 			name: "nonce overflow by uint64 max value",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(18446744073709551615),
 				})
@@ -167,7 +168,7 @@ func TestStateTransition_validateAuthorization(t *testing.T) {
 			name: "invalid Signature in Authority",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(1),
 				})
@@ -187,7 +188,7 @@ func TestStateTransition_validateAuthorization(t *testing.T) {
 			name: "destination has code",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(1),
 				})
@@ -206,7 +207,7 @@ func TestStateTransition_validateAuthorization(t *testing.T) {
 			name: "nonce mismatch",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(10),
 				})
@@ -271,7 +272,7 @@ func TestStateTransition_applyAuthorization(t *testing.T) {
 			name: "success (minimum)",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(1),
 				})
@@ -292,7 +293,7 @@ func TestStateTransition_applyAuthorization(t *testing.T) {
 			name: "success (case of refund)",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   1,
 				})
@@ -315,7 +316,7 @@ func TestStateTransition_applyAuthorization(t *testing.T) {
 			name: "success (empty address 0x0000000000000000000000000000000000000000)",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: zeroAddress,
 					Nonce:   uint64(1),
 				})
@@ -336,7 +337,7 @@ func TestStateTransition_applyAuthorization(t *testing.T) {
 			name: "success (don't ecrecover authority)",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(1),
 				})
@@ -362,7 +363,7 @@ func TestStateTransition_applyAuthorization(t *testing.T) {
 			name: "invalid validateAuthorization",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: uint64(10),
+					ChainID: *uint256.NewInt(10),
 					Address: aa,
 					Nonce:   1,
 				})
@@ -379,7 +380,7 @@ func TestStateTransition_applyAuthorization(t *testing.T) {
 			name: "don't allow account key type: signer's key was updated",
 			makeAuthorization: func() types.SetCodeAuthorization {
 				auth, err := types.SignSetCode(authorityKey, types.SetCodeAuthorization{
-					ChainID: params.TestChainConfig.ChainID.Uint64(),
+					ChainID: *uint256.MustFromBig(params.TestChainConfig.ChainID),
 					Address: aa,
 					Nonce:   uint64(1),
 				})

--- a/blockchain/system/multicall.go
+++ b/blockchain/system/multicall.go
@@ -64,7 +64,7 @@ func (caller *ContractCallerForMultiCall) CallContract(ctx context.Context, call
 	}
 
 	msg := types.NewMessage(call.From, call.To, caller.state.GetNonce(call.From),
-		call.Value, gasLimit, gasPrice, nil, nil, call.Data, false, intrinsicGas, dataTokens, nil, nil)
+		call.Value, gasLimit, gasPrice, nil, nil, call.Data, false, intrinsicGas, dataTokens, nil, nil, nil)
 
 	blockContext := blockchain.NewEVMBlockContext(caller.header, caller.chain, nil)
 	txContext := blockchain.NewEVMTxContext(msg, caller.header, caller.chain.Config())

--- a/blockchain/system/rebalance.go
+++ b/blockchain/system/rebalance.go
@@ -123,7 +123,7 @@ func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call kaia.
 	//	return nil, err
 	//}
 	msg := types.NewMessage(call.From, call.To, caller.state.GetNonce(call.From),
-		call.Value, gasLimit, gasPrice, nil, nil, call.Data, false, intrinsicGas, dataTokens, nil, nil)
+		call.Value, gasLimit, gasPrice, nil, nil, call.Data, false, intrinsicGas, dataTokens, nil, nil, nil)
 
 	blockContext := blockchain.NewEVMBlockContext(caller.header, caller.chain, nil)
 	txContext := blockchain.NewEVMTxContext(msg, caller.header, caller.chain.Config())

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -1084,7 +1084,7 @@ func (t *TransactionsByPriceAndNonce) Clear() {
 }
 
 // NewMessage returns a `*Transaction` object with the given arguments.
-func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice, gasFeeCap, gasTipCap *big.Int, data []byte, checkNonce bool, intrinsicGas uint64, dataTokens uint64, list AccessList, auth []SetCodeAuthorization) *Transaction {
+func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice, gasFeeCap, gasTipCap *big.Int, data []byte, checkNonce bool, intrinsicGas uint64, dataTokens uint64, list AccessList, chainId *big.Int, auth []SetCodeAuthorization) *Transaction {
 	transaction := &Transaction{
 		validatedIntrinsicGas: &ValidatedIntrinsicGas{Gas: intrinsicGas, Tokens: dataTokens},
 		validatedFeePayer:     from,
@@ -1094,10 +1094,10 @@ func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *b
 
 	// Call supports EthereumAccessList, EthereumSetCode and Legacy txTypes only.
 	if auth != nil {
-		internalData := newTxInternalDataEthereumSetCodeWithValues(nonce, *to, amount, gasLimit, gasFeeCap, gasTipCap, data, list, auth, nil)
+		internalData := newTxInternalDataEthereumSetCodeWithValues(nonce, *to, amount, gasLimit, gasFeeCap, gasTipCap, data, list, chainId, auth)
 		transaction.setDecoded(internalData, 0)
 	} else if list != nil {
-		internalData := newTxInternalDataEthereumAccessListWithValues(nonce, to, amount, gasLimit, gasPrice, data, list, nil)
+		internalData := newTxInternalDataEthereumAccessListWithValues(nonce, to, amount, gasLimit, gasPrice, data, list, chainId)
 		transaction.setDecoded(internalData, 0)
 	} else {
 		internalData := newTxInternalDataLegacyWithValues(nonce, to, amount, gasLimit, gasPrice, data)

--- a/blockchain/types/transaction_signing.go
+++ b/blockchain/types/transaction_signing.go
@@ -329,7 +329,7 @@ func (s pragueSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 		panic(fmt.Sprintf("wrong size for signature: got %d, want %d", len(sig), crypto.SignatureLength))
 	}
 
-	// Check that chain ID of tx matches the signer. We also accept ID zero or nil here,
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
 	// because it indicates that the chain ID was not specified in the tx.
 	if tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
 		return nil, nil, nil, ErrInvalidChainId
@@ -439,7 +439,8 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 
 	// Check that chain ID of tx matches the signer. We also accept ID zero or nil here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
+	// NOTE: Kaia allow chain ID to be nil in this fork
+	if tx.data.ChainId() != nil && tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
 		return nil, nil, nil, ErrInvalidChainId
 	}
 
@@ -542,7 +543,8 @@ func (s eip2930Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *bi
 
 	// Check that chain ID of tx matches the signer. We also accept ID zero or nil here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
+	// NOTE: Kaia allow chain ID to be nil in this fork
+	if tx.data.ChainId() != nil && tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
 		return nil, nil, nil, ErrInvalidChainId
 	}
 

--- a/blockchain/types/transaction_signing.go
+++ b/blockchain/types/transaction_signing.go
@@ -331,7 +331,7 @@ func (s pragueSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 
 	// Check that chain ID of tx matches the signer. We also accept ID zero or nil here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if tx.data.ChainId() != nil && tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
+	if tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
 		return nil, nil, nil, ErrInvalidChainId
 	}
 
@@ -439,7 +439,7 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 
 	// Check that chain ID of tx matches the signer. We also accept ID zero or nil here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if tx.data.ChainId() != nil && tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
+	if tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
 		return nil, nil, nil, ErrInvalidChainId
 	}
 
@@ -542,7 +542,7 @@ func (s eip2930Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *bi
 
 	// Check that chain ID of tx matches the signer. We also accept ID zero or nil here,
 	// because it indicates that the chain ID was not specified in the tx.
-	if tx.data.ChainId() != nil && tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
+	if tx.data.ChainId().Sign() != 0 && tx.data.ChainId().Cmp(s.ChainID()) != 0 {
 		return nil, nil, nil, ErrInvalidChainId
 	}
 

--- a/blockchain/types/transaction_signing_test.go
+++ b/blockchain/types/transaction_signing_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
@@ -41,7 +42,7 @@ func TestPragueSigning(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 	accessList := AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
-	authorizationList := []SetCodeAuthorization{{ChainID: uint64(10), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizationList := []SetCodeAuthorization{{ChainID: *uint256.NewInt(10), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
 
 	testData := []struct {
 		name    string
@@ -66,7 +67,7 @@ func TestPragueSigning(t *testing.T) {
 			AccessList:        accessList,
 			AuthorizationList: authorizationList,
 			Recipient:         addr,
-			ChainID:           big.NewInt(10),
+			ChainID:           uint256.NewInt(10),
 		})},
 		{"WithNoBitChainID", NewTx(&TxInternalDataEthereumSetCode{
 			AccountNonce:      1,
@@ -77,7 +78,7 @@ func TestPragueSigning(t *testing.T) {
 			AccessList:        accessList,
 			AuthorizationList: authorizationList,
 			Recipient:         addr,
-			ChainID:           new(big.Int),
+			ChainID:           new(uint256.Int),
 		})},
 	}
 

--- a/blockchain/types/transaction_signing_test.go
+++ b/blockchain/types/transaction_signing_test.go
@@ -39,52 +39,69 @@ import (
 )
 
 func TestPragueSigning(t *testing.T) {
+	chainId := uint256.NewInt(10)
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
-	accessList := AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
-	authorizationList := []SetCodeAuthorization{{ChainID: *uint256.NewInt(10), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizationList := []SetCodeAuthorization{{ChainID: *chainId, Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+
+	signer := NewPragueSigner(chainId.ToBig())
 
 	testData := []struct {
 		name    string
+		isPanic bool
 		inputTx *Transaction
 	}{
-		{"WithoutChainID", NewTx(&TxInternalDataEthereumSetCode{
+		{"WithChainID", false, NewTx(&TxInternalDataEthereumSetCode{
 			AccountNonce:      1,
 			Amount:            big.NewInt(10),
 			GasFeeCap:         big.NewInt(10),
 			GasTipCap:         big.NewInt(10),
 			GasLimit:          100,
-			AccessList:        accessList,
 			AuthorizationList: authorizationList,
 			Recipient:         addr,
+			ChainID:           chainId,
 		})},
-		{"WithChainID", NewTx(&TxInternalDataEthereumSetCode{
+		{"WithChainID_Zero", false, NewTx(&TxInternalDataEthereumSetCode{
 			AccountNonce:      1,
 			Amount:            big.NewInt(10),
 			GasFeeCap:         big.NewInt(10),
 			GasTipCap:         big.NewInt(10),
 			GasLimit:          100,
-			AccessList:        accessList,
 			AuthorizationList: authorizationList,
 			Recipient:         addr,
-			ChainID:           uint256.NewInt(10),
+			ChainID:           uint256.NewInt(0),
 		})},
-		{"WithNoBitChainID", NewTx(&TxInternalDataEthereumSetCode{
+		{"WithNoBitChainID", false, NewTx(&TxInternalDataEthereumSetCode{
 			AccountNonce:      1,
 			Amount:            big.NewInt(10),
 			GasFeeCap:         big.NewInt(10),
 			GasTipCap:         big.NewInt(10),
 			GasLimit:          100,
-			AccessList:        accessList,
 			AuthorizationList: authorizationList,
 			Recipient:         addr,
-			ChainID:           new(uint256.Int),
+			ChainID:           new(uint256.Int), // = uint256.NewInt(0)
+		})},
+		{"WithoutChainID_expected_panic", true, NewTx(&TxInternalDataEthereumSetCode{
+			AccountNonce:      1,
+			Amount:            big.NewInt(10),
+			GasFeeCap:         big.NewInt(10),
+			GasTipCap:         big.NewInt(10),
+			GasLimit:          100,
+			AuthorizationList: authorizationList,
+			Recipient:         addr,
 		})},
 	}
 
-	signer := NewPragueSigner(big.NewInt(10))
 	for _, tc := range testData {
 		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tc.isPanic {
+						t.Errorf("unexpected panic:%x", r)
+					}
+				}
+			}()
+
 			tx, err := SignTx(tc.inputTx, signer, key)
 			if err != nil {
 				t.Fatal(err)

--- a/blockchain/types/transaction_signing_test.go
+++ b/blockchain/types/transaction_signing_test.go
@@ -42,7 +42,7 @@ func TestPragueSigning(t *testing.T) {
 	chainId := uint256.NewInt(10)
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
-	authorizationList := []SetCodeAuthorization{{ChainID: *chainId, Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizationList := []SetCodeAuthorization{{ChainID: *chainId, Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: *uint256.NewInt(0), S: *uint256.NewInt(0)}}
 
 	signer := NewPragueSigner(chainId.ToBig())
 

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
@@ -853,7 +854,7 @@ func TestTransactionCoding(t *testing.T) {
 			func(i uint64) TxInternalData {
 				// Tx with non-zero access list.
 				return &TxInternalDataEthereumSetCode{
-					ChainID:           big.NewInt(1),
+					ChainID:           uint256.NewInt(1),
 					AccountNonce:      i,
 					Recipient:         recipient,
 					GasLimit:          123457,
@@ -866,7 +867,7 @@ func TestTransactionCoding(t *testing.T) {
 			func(i uint64) TxInternalData {
 				// Tx with set code.
 				return &TxInternalDataEthereumSetCode{
-					ChainID:           big.NewInt(1),
+					ChainID:           uint256.NewInt(1),
 					AccountNonce:      i,
 					Recipient:         recipient,
 					GasLimit:          123457,

--- a/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
+++ b/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
@@ -47,9 +47,9 @@ type TxInternalDataEthereumDynamicFee struct {
 	AccessList   AccessList
 
 	// Signature values
-	V *big.Int `json:"v" gencodec:"required"`
-	R *big.Int `json:"r" gencodec:"required"`
-	S *big.Int `json:"s" gencodec:"required"`
+	V *big.Int
+	R *big.Int
+	S *big.Int
 
 	// This is only used when marshaling to JSON.
 	Hash *common.Hash `json:"hash" rlp:"-"`

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -112,7 +112,7 @@ func newTxInternalDataEthereumSetCode() *TxInternalDataEthereumSetCode {
 	}
 }
 
-func newTxInternalDataEthereumSetCodeWithValues(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasFeeCap, gasTipCap *big.Int, data []byte, accessList AccessList, authList []SetCodeAuthorization, chainID *big.Int) *TxInternalDataEthereumSetCode {
+func newTxInternalDataEthereumSetCodeWithValues(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasFeeCap, gasTipCap *big.Int, data []byte, accessList AccessList, chainID *big.Int, authList []SetCodeAuthorization) *TxInternalDataEthereumSetCode {
 	d := newTxInternalDataEthereumSetCode()
 
 	d.AccountNonce = nonce

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -23,6 +23,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
@@ -42,7 +43,7 @@ var (
 	gasTipCap      = big.NewInt(25)
 	gasFeeCap      = big.NewInt(25)
 	accesses       = AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
-	authorizations = []SetCodeAuthorization{{ChainID: uint64(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizations = []SetCodeAuthorization{{ChainID: *uint256.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
 )
 
 // TestTransactionSerialization tests RLP/JSON serialization for TxInternalData

--- a/blockchain/types/tx_internal_data_serializer_test.go
+++ b/blockchain/types/tx_internal_data_serializer_test.go
@@ -43,7 +43,7 @@ var (
 	gasTipCap      = big.NewInt(25)
 	gasFeeCap      = big.NewInt(25)
 	accesses       = AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
-	authorizations = []SetCodeAuthorization{{ChainID: *uint256.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizations = []SetCodeAuthorization{{ChainID: *uint256.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: *uint256.NewInt(0), S: *uint256.NewInt(0)}}
 )
 
 // TestTransactionSerialization tests RLP/JSON serialization for TxInternalData

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -387,12 +387,6 @@ func ChangeGasCostForTest(jt *JumpTable, opCode OpCode, constantGas uint64) {
 
 // enable7702 the EIP-7702 changes to support delegation designators.
 func enable7702(jt *JumpTable) {
-	jt[EXTCODECOPY].execute = opExtCodeCopyEIP7702
-
-	jt[EXTCODESIZE].execute = opExtCodeSizeEIP7702
-
-	jt[EXTCODEHASH].execute = opExtCodeHashEIP7702
-
 	jt[CALL].dynamicGas = gasCallEIP7702
 
 	jt[CALLCODE].dynamicGas = gasCallCodeEIP7702

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -151,7 +152,7 @@ func generateDefaultTx(sender *TestAccountType, recipient *TestAccountType, txTy
 	values := map[types.TxValueKeyType]interface{}{}
 
 	// Default authorization list
-	authorizationList := []types.SetCodeAuthorization{{ChainID: uint64(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizationList := []types.SetCodeAuthorization{{ChainID: *uint256.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
 
 	switch txType {
 	case types.TxTypeValueTransfer:

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -152,7 +152,7 @@ func generateDefaultTx(sender *TestAccountType, recipient *TestAccountType, txTy
 	values := map[types.TxValueKeyType]interface{}{}
 
 	// Default authorization list
-	authorizationList := []types.SetCodeAuthorization{{ChainID: *uint256.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizationList := []types.SetCodeAuthorization{{ChainID: *uint256.NewInt(2), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: nonce, V: uint8(0), R: *uint256.NewInt(0), S: *uint256.NewInt(0)}}
 
 	switch txType {
 	case types.TxTypeValueTransfer:

--- a/tests/gen_stauthorization.go
+++ b/tests/gen_stauthorization.go
@@ -16,7 +16,7 @@ var _ = (*stAuthorizationMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (s stAuthorization) MarshalJSON() ([]byte, error) {
 	type stAuthorization struct {
-		ChainID math.HexOrDecimal64
+		ChainID *math.HexOrDecimal256 `json:"chainId" gencodec:"required"`
 		Address common.Address        `gencodec:"required" json:"address"`
 		Nonce   math.HexOrDecimal64   `gencodec:"required" json:"nonce"`
 		V       math.HexOrDecimal64   `gencodec:"required" json:"v"`
@@ -24,7 +24,7 @@ func (s stAuthorization) MarshalJSON() ([]byte, error) {
 		S       *math.HexOrDecimal256 `gencodec:"required" json:"s"`
 	}
 	var enc stAuthorization
-	enc.ChainID = math.HexOrDecimal64(s.ChainID)
+	enc.ChainID = (*math.HexOrDecimal256)(s.ChainID)
 	enc.Address = s.Address
 	enc.Nonce = math.HexOrDecimal64(s.Nonce)
 	enc.V = math.HexOrDecimal64(s.V)
@@ -36,7 +36,7 @@ func (s stAuthorization) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (s *stAuthorization) UnmarshalJSON(input []byte) error {
 	type stAuthorization struct {
-		ChainID *math.HexOrDecimal64
+		ChainID *math.HexOrDecimal256 `json:"chainId" gencodec:"required"`
 		Address *common.Address       `gencodec:"required" json:"address"`
 		Nonce   *math.HexOrDecimal64  `gencodec:"required" json:"nonce"`
 		V       *math.HexOrDecimal64  `gencodec:"required" json:"v"`
@@ -47,9 +47,10 @@ func (s *stAuthorization) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-	if dec.ChainID != nil {
-		s.ChainID = uint64(*dec.ChainID)
+	if dec.ChainID == nil {
+		return errors.New("missing required field 'chainId' for stAuthorization")
 	}
+	s.ChainID = (*big.Int)(dec.ChainID)
 	if dec.Address == nil {
 		return errors.New("missing required field 'address' for stAuthorization")
 	}

--- a/tests/gen_stauthorization.go
+++ b/tests/gen_stauthorization.go
@@ -16,7 +16,7 @@ var _ = (*stAuthorizationMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (s stAuthorization) MarshalJSON() ([]byte, error) {
 	type stAuthorization struct {
-		ChainID *math.HexOrDecimal256 `json:"chainId" gencodec:"required"`
+		ChainID *math.HexOrDecimal256 `gencodec:"required" json:"chainId"`
 		Address common.Address        `gencodec:"required" json:"address"`
 		Nonce   math.HexOrDecimal64   `gencodec:"required" json:"nonce"`
 		V       math.HexOrDecimal64   `gencodec:"required" json:"v"`
@@ -36,7 +36,7 @@ func (s stAuthorization) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (s *stAuthorization) UnmarshalJSON(input []byte) error {
 	type stAuthorization struct {
-		ChainID *math.HexOrDecimal256 `json:"chainId" gencodec:"required"`
+		ChainID *math.HexOrDecimal256 `gencodec:"required" json:"chainId"`
 		Address *common.Address       `gencodec:"required" json:"address"`
 		Nonce   *math.HexOrDecimal64  `gencodec:"required" json:"nonce"`
 		V       *math.HexOrDecimal64  `gencodec:"required" json:"v"`

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -88,14 +88,9 @@ func (suite *ExecutionSpecStateTestSuite) TestExecutionSpecState() {
 	st := new(testMatcher)
 
 	// TODO-Kaia: should remove these skip
-	// json format error
-	st.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/invalid_tx_invalid_auth_signature.json`)
-	st.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/tx_validity_chain_id.json`)
-	st.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/tx_validity_nonce.json`)
 	// not yet supported EIPs for pectra-devnet-6
 	st.skipLoad(`^frontier\/opcodes\/all_opcodes\/all_opcodes.json`)
 	st.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json`)
-	st.skipLoad(`^prague\/eip7702_set_code_tx\/`)
 	st.skipLoad(`^prague\/eip7623_increase_calldata_cost\/`)
 
 	// tests to skip

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -433,8 +433,8 @@ func (tx *stTransaction) toMessage(ps stPostState, r params.Rules, isTestExecuti
 				Address: auth.Address,
 				Nonce:   auth.Nonce,
 				V:       auth.V,
-				R:       auth.R,
-				S:       auth.S,
+				R:       *uint256.MustFromBig(auth.R),
+				S:       *uint256.MustFromBig(auth.S),
 			})
 		}
 	}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -385,7 +385,13 @@ func (tx *stTransaction) toMessage(ps stPostState, r params.Rules, isTestExecuti
 	}
 	// Parse recipient if present.
 	var to *common.Address
-	if tx.To != "" {
+	if tx.To == "" {
+		if tx.AuthorizationList != nil {
+			// NOTE: Kaia's `newTxInternalDataEthereumSetCodeWithValues` in `MewMessage` ​​cannot be called with a "to" of "nil",
+			// so specify an emptyAddress to generate a test message and test it.
+			to = &common.Address{}
+		}
+	} else {
 		to = new(common.Address)
 		if err := to.UnmarshalText([]byte(tx.To)); err != nil {
 			return nil, fmt.Errorf("invalid to address: %v", err)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -132,7 +133,7 @@ type stTransactionMarshaling struct {
 // Authorization is an authorization from an account to deploy code at it's
 // address.
 type stAuthorization struct {
-	ChainID uint64
+	ChainID *big.Int       `gencodec:"required" json:"chainId"`
 	Address common.Address `gencodec:"required" json:"address"`
 	Nonce   uint64         `gencodec:"required" json:"nonce"`
 	V       uint8          `gencodec:"required" json:"v"`
@@ -142,7 +143,7 @@ type stAuthorization struct {
 
 // field type overrides for gencodec
 type stAuthorizationMarshaling struct {
-	ChainID math.HexOrDecimal64
+	ChainID *math.HexOrDecimal256
 	Nonce   math.HexOrDecimal64
 	V       math.HexOrDecimal64
 	R       *math.HexOrDecimal256
@@ -428,7 +429,7 @@ func (tx *stTransaction) toMessage(ps stPostState, r params.Rules, isTestExecuti
 		authorizationList = make([]types.SetCodeAuthorization, 0)
 		for _, auth := range tx.AuthorizationList {
 			authorizationList = append(authorizationList, types.SetCodeAuthorization{
-				ChainID: auth.ChainID,
+				ChainID: *uint256.MustFromBig(auth.ChainID),
 				Address: auth.Address,
 				Nonce:   auth.Nonce,
 				V:       auth.V,

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -451,7 +451,7 @@ func (tx *stTransaction) toMessage(ps stPostState, r params.Rules, isTestExecuti
 		return nil, err
 	}
 
-	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, tx.MaxFeePerGas, tx.MaxPriorityFeePerGas, data, true, intrinsicGas, dataTokens, accessList, authorizationList)
+	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, tx.MaxFeePerGas, tx.MaxPriorityFeePerGas, data, true, intrinsicGas, dataTokens, accessList, nil, authorizationList)
 	return msg, nil
 }
 

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -738,7 +738,7 @@ func genMapForSetCodeTransaction(from TestAccount, to TestAccount, gasPrice *big
 	data := []byte{0x11, 0x22}
 	gasPayload := uint64(len(data)) * params.TxDataGas
 	accessList := types.AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
-	authorizationList := []types.SetCodeAuthorization{{ChainID: *uint256.NewInt(1), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: 1, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizationList := []types.SetCodeAuthorization{{ChainID: *uint256.NewInt(1), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: 1, V: uint8(0), R: *uint256.NewInt(0), S: *uint256.NewInt(0)}}
 	toAddress := to.GetAddr()
 
 	gasPayload += uint64(len(accessList)) * params.TxAccessListAddressGas

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
@@ -737,7 +738,7 @@ func genMapForSetCodeTransaction(from TestAccount, to TestAccount, gasPrice *big
 	data := []byte{0x11, 0x22}
 	gasPayload := uint64(len(data)) * params.TxDataGas
 	accessList := types.AccessList{{Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), StorageKeys: []common.Hash{{0}}}}
-	authorizationList := []types.SetCodeAuthorization{{ChainID: uint64(1), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: 1, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
+	authorizationList := []types.SetCodeAuthorization{{ChainID: *uint256.NewInt(1), Address: common.HexToAddress("0x0000000000000000000000000000000000000001"), Nonce: 1, V: uint8(0), R: big.NewInt(0), S: big.NewInt(0)}}
 	toAddress := to.GetAddr()
 
 	gasPayload += uint64(len(accessList)) * params.TxAccessListAddressGas

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
@@ -443,7 +444,7 @@ func TestValidationPoolInsertPrague(t *testing.T) {
 	// set code for contract execution tx type
 	{
 		auth, err := types.SignSetCode(eoaWithCode.Keys[0], types.SetCodeAuthorization{
-			ChainID: bcdata.bc.Config().ChainID.Uint64(),
+			ChainID: *uint256.MustFromBig(bcdata.bc.Config().ChainID),
 			Address: contract.Addr,
 			Nonce:   uint64(0),
 		})

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -453,8 +453,7 @@ func TestValidationPoolInsertPrague(t *testing.T) {
 		authorizationList := []types.SetCodeAuthorization{auth}
 
 		tx := types.NewMessage(reservoir.Addr, &eoaWithCode.Addr, reservoir.GetNonce(), nil, gasLimit,
-			nil, big.NewInt(25*params.Gkei), big.NewInt(25*params.Gkei), nil, false, uint64(0), uint64(0), nil, authorizationList)
-		tx.ChainId().Set(bcdata.bc.Config().ChainID)
+			nil, big.NewInt(25*params.Gkei), big.NewInt(25*params.Gkei), nil, false, uint64(0), uint64(0), nil, bcdata.bc.Config().ChainID, authorizationList)
 		err = tx.SignWithKeys(signer, reservoir.Keys)
 		assert.Equal(t, nil, err)
 


### PR DESCRIPTION
## Proposed changes

Changes:
* Use `uint256` for `SET_CODE_TX_TYPE(EIP-7702)`
* `EXTCODE*` return delegation designator for `SET_CODE_TX_TYPE(EIP-7702)`
* Enable to EEST of EIP-7702
  * Thanks for these patches
    * https://github.com/kaiachain/kaia/pull/245
    * https://github.com/kaiachain/kaia/pull/247

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/kaiachain/kaia/issues/106
- https://github.com/kaiachain/kaia/pull/216
- https://github.com/kaiachain/kaia/pull/233

## Further comments
