### PR TITLE
kaiax/gov: add crits and fix kaia_getParams

### DIFF
--- a/kaiax/gov/headergov/impl/getter.go
+++ b/kaiax/gov/headergov/impl/getter.go
@@ -30,7 +30,7 @@ func (h *headerGovModule) GetPartialParamSet(blockNum uint64) gov.PartialParamSe
 	for _, num := range h.GovBlockNums() {
 		if num <= prevEpochStart {
 			for name, value := range h.governances[num].Items() {
-				ret[name] = value
+				ret.Add(string(name), value)
 			}
 		}
 	}

--- a/kaiax/gov/impl/getter.go
+++ b/kaiax/gov/impl/getter.go
@@ -9,18 +9,27 @@ func (m *GovModule) GetParamSet(blockNum uint64) gov.ParamSet {
 
 	p0 := m.Fallback
 	for k, v := range p0 {
-		ret.Set(k, v)
+		err := ret.Set(k, v)
+		if err != nil {
+			logger.CritWithStack("Failed to add param from Fallback", "name", k, "value", v, "error", err)
+		}
 	}
 
 	p1 := m.Hgm.GetPartialParamSet(blockNum)
 	for k, v := range p1 {
-		ret.Set(k, v)
+		err := ret.Set(k, v)
+		if err != nil {
+			logger.CritWithStack("Failed to add param from HeaderGov", "name", k, "value", v, "error", err)
+		}
 	}
 
 	if m.isKoreHF(blockNum) {
 		p2 := m.Cgm.GetPartialParamSet(blockNum)
 		for k, v := range p2 {
-			ret.Set(k, v)
+			err := ret.Set(k, v)
+			if err != nil {
+				logger.CritWithStack("Failed to add param from ContractGov", "name", k, "value", v, "error", err)
+			}
 		}
 	}
 

--- a/kaiax/gov/impl/init.go
+++ b/kaiax/gov/impl/init.go
@@ -127,13 +127,14 @@ func ChainConfigFallback(chainConfig *params.ChainConfig) gov.PartialParamSet {
 		param := gov.Params[name]
 		value, err := param.ChainConfigValue(chainConfig)
 		if err != nil {
-			logger.CritWithStack("Failed to fetch value from ChainConfig", "name", name, "error", err)
+			logger.Error("Failed to fetch value from ChainConfig", "name", name, "error", err)
+			continue
 		}
 
 		if !reflect.DeepEqual(value, param.DefaultValue) {
 			err := fallback.Add(string(name), value)
 			if err != nil {
-				logger.CritWithStack("Failed to add param to fallback", "name", name, "value", value, "error", err)
+				logger.Error("Failed to add param to fallback", "name", name, "value", value, "error", err)
 			}
 		}
 	}

--- a/kaiax/gov/paramset.go
+++ b/kaiax/gov/paramset.go
@@ -155,9 +155,9 @@ func (p *ParamSet) ToMap() map[ParamName]any {
 		case RewardKip82Ratio:
 			ret[name] = p.Kip82Ratio
 		case RewardMintingAmount:
-			ret[name] = p.MintingAmount
+			ret[name] = p.MintingAmount.String()
 		case RewardMinimumStake:
-			ret[name] = p.MinimumStake
+			ret[name] = p.MinimumStake.String()
 		case RewardProposerUpdateInterval:
 			ret[name] = p.ProposerUpdateInterval
 		case RewardRatio:

--- a/tests/gov_test.go
+++ b/tests/gov_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"math/big"
 	"os"
 	"testing"
 
@@ -70,11 +69,6 @@ func TestMainnetGenesisGovernance(t *testing.T) {
 	for name, val := range genesisParamsMap {
 		govVal, exists := govParamsMap[gov.ParamName(name)]
 		assert.True(t, exists, "Key %s missing from GovModule params", name)
-		switch name {
-		case string(gov.RewardMintingAmount), string(gov.RewardMinimumStake):
-			assert.Equal(t, val, govVal.(*big.Int).String())
-		default:
-			assert.Equal(t, val, govVal, "Key %s mismatch", name)
-		}
+		assert.Equal(t, val, govVal, "Key %s mismatch", name)
 	}
 }


### PR DESCRIPTION
## Proposed changes

Add `Crit` on unexpected error; it may be better to panic than to continue with invalid value.

For backward compatibility, fix the return type of `kaia_getParams` from int to string for `reward.mintingamount` and `reward.minimumstake`.

See https://github.com/kaiachain/kaia/issues/189#issuecomment-2609106572

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
