### PR TITLE
blockchain: make a genesis block according to forks

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -322,13 +322,11 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 			stateDB.CreateSmartContractAccount(addr, params.CodeFormatEVM, rules)
 			stateDB.SetCode(addr, account.Code)
 		}
-		if len(account.Code) != 0 {
-			// If originalCode is not nil,
-			// just update the code and don't change the other states
-			if originalCode != nil {
-				logger.Warn("this address already has a not nil code, now the code of this address has been changed", "addr", addr.String())
-				continue
-			}
+		// If account.Code is nil and originalCode is not nil,
+		// just update the code and don't change the other states
+		if len(account.Code) != 0 && originalCode != nil {
+			logger.Warn("this address already has a not nil code, now the code of this address has been changed", "addr", addr.String())
+			continue
 		}
 		for key, value := range account.Storage {
 			stateDB.SetState(addr, key, value)

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -317,7 +317,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 		_, ok := types.ParseDelegation(account.Code)
 		isEOAWithCode := ok && rules.IsPrague
 		isEOAWithoutCode := len(account.Code) == 0 && len(account.Storage) != 0 && rules.IsPrague
-		isAccountWithCode := len(account.Code) != 0
+		isSCAWithCode := !isEOAWithCode && len(account.Code) != 0
 		switch {
 		case isEOAWithCode:
 			// EOA with code. Usually SetCodeTx creates it. Unit tests may create it here in the genesis.
@@ -325,7 +325,7 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 		case isEOAWithoutCode:
 			// Represents an EOA that had code then nullified with another SetCodeTx. Unit tests may create it here in the genesis.
 			stateDB.CreateEOA(addr, false, accountkey.NewAccountKeyLegacy())
-		case isAccountWithCode:
+		case isSCAWithCode:
 			// Regular genesis smart contract account.
 			stateDB.CreateSmartContractAccount(addr, params.CodeFormatEVM, rules)
 			stateDB.SetCode(addr, account.Code)

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -315,10 +315,13 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	for addr, account := range g.Alloc {
 		originalCode := stateDB.GetCode(addr)
 		if _, ok := types.ParseDelegation(account.Code); ok && rules.IsPrague {
+			// EOA with code. Usually SetCodeTx creates it. Unit tests may create it here in the genesis.
 			stateDB.SetCodeToEOA(addr, account.Code, rules)
 		} else if len(account.Code) == 0 && len(account.Storage) != 0 && rules.IsPrague {
+			// Represents an EOA that had code then nullified with another SetCodeTx. Unit tests may create it here in the genesis.
 			stateDB.CreateEOA(addr, false, accountkey.NewAccountKeyLegacy())
 		} else if len(account.Code) != 0 {
+			// Regular genesis smart contract account.
 			stateDB.CreateSmartContractAccount(addr, params.CodeFormatEVM, rules)
 			stateDB.SetCode(addr, account.Code)
 		}

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -314,13 +314,14 @@ func (g *Genesis) ToBlock(baseStateRoot common.Hash, db database.DBManager) *typ
 	}
 	for addr, account := range g.Alloc {
 		originalCode := stateDB.GetCode(addr)
-		if _, ok := types.ParseDelegation(account.Code); ok && rules.IsPrague {
+		switch _, ok := types.ParseDelegation(account.Code); {
+		case ok && rules.IsPrague:
 			// EOA with code. Usually SetCodeTx creates it. Unit tests may create it here in the genesis.
 			stateDB.SetCodeToEOA(addr, account.Code, rules)
-		} else if len(account.Code) == 0 && len(account.Storage) != 0 && rules.IsPrague {
+		case len(account.Code) == 0 && len(account.Storage) != 0 && rules.IsPrague:
 			// Represents an EOA that had code then nullified with another SetCodeTx. Unit tests may create it here in the genesis.
 			stateDB.CreateEOA(addr, false, accountkey.NewAccountKeyLegacy())
-		} else if len(account.Code) != 0 {
+		case len(account.Code) != 0:
 			// Regular genesis smart contract account.
 			stateDB.CreateSmartContractAccount(addr, params.CodeFormatEVM, rules)
 			stateDB.SetCode(addr, account.Code)

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -467,7 +467,8 @@ func TestGenesisAccount(t *testing.T) {
 			t.Run(fmt.Sprintf("%s fork %s", tcn, fork), func(t *testing.T) {
 				genesis := &Genesis{
 					Config: &params.ChainConfig{
-						ChainID: new(big.Int).SetUint64(uint64(1))},
+						ChainID: new(big.Int).SetUint64(1),
+					},
 					Alloc: GenesisAlloc{
 						addr: tc.account,
 					},


### PR DESCRIPTION
## Proposed changes

This PR enables to make genesis blocks according to forks. **This may have braking change in the case where the fork of genesis is Istanbul fork and after because this changes the state root of genesis by changing codeinfo of SCA (version 0 into version 1).** But there is no effect against mainnet and testnet because the genesis doesn't have any forks. You can see the state roof of genesis doesn't change in [this test](https://github.com/kaiachain/kaia/blob/dde4921a5dfac10f9f2c392cbfc20c0f1a7072bd/blockchain/genesis_test.go#L41-L51).

This stores genesis accounts like bellow:

- account with delegation code and fork is prague → CreateEOA and SetCodeToEOA
- account with empty code but non-empty storage and fork is prague → CreateEOA
- account with non-empty code except for delegation code → CreateSmartContractAccount and SetCode
- otherwise → as is

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #247

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
