### PR TITLE
tests: set accounts with empty code but non-empty storage as EOA

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -350,7 +350,6 @@ func MakePreState(db database.DBManager, accounts blockchain.GenesisAlloc, isTes
 				statedb.SetCode(addr, a.Code)
 			}
 		}
-
 		for k, v := range a.Storage {
 			statedb.SetState(addr, k, v)
 		}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -339,7 +339,7 @@ func MakePreState(db database.DBManager, accounts blockchain.GenesisAlloc, isTes
 		if isTestExecutionSpecState {
 			if _, ok := types.ParseDelegation(a.Code); ok && rules.IsPrague {
 				statedb.SetCodeToEOA(addr, a.Code, rules)
-			} else if len(a.Code) == 0 && len(a.Storage) != 0 {
+			} else if len(a.Code) == 0 && len(a.Storage) != 0 && rules.IsPrague {
 				statedb.CreateEOA(addr, false, accountkey.NewAccountKeyLegacy())
 			} else if len(a.Code) != 0 {
 				statedb.CreateSmartContractAccount(addr, params.CodeFormatEVM, rules)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -337,7 +337,7 @@ func MakePreState(db database.DBManager, accounts blockchain.GenesisAlloc, isTes
 	statedb, _ := state.New(common.Hash{}, sdb, nil, nil)
 	for addr, a := range accounts {
 		if isTestExecutionSpecState {
-			if _, ok := types.ParseDelegation(a.Code); ok || (len(a.Code) == 0 && len(a.Storage) != 0) {
+			if _, ok := types.ParseDelegation(a.Code); (ok && rules.IsPrague) || (len(a.Code) == 0 && len(a.Storage) != 0) {
 				statedb.CreateEOA(addr, false, accountkey.NewAccountKeyLegacy())
 			} else if len(a.Code) != 0 {
 				statedb.CreateSmartContractAccount(addr, params.CodeFormatEVM, rules)


### PR DESCRIPTION
## Proposed changes

EEST has accounts which have empty code but non-empty storage as the pre state. Kaia should recognize the following:

- account with delegation code and fork is prague → EOA
- account with empty code but non-empty storage and fork is prague  → EOA
- account with non-empty code except for delegation code → SCA
- otherwise → as is

This PR enables to recognize accounts with empty code but non-empty storage as EOA.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
