### PR TITLE
kaiax/staking: revise reward,staking api response format

### DIFF
--- a/kaiax/reward/spec.go
+++ b/kaiax/reward/spec.go
@@ -18,6 +18,7 @@ package reward
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
@@ -117,8 +118,8 @@ type RewardResponse = RewardSpec
 // AccumulatedRewardsResponse is the response type for the governance_getRewardsAccumulated API.
 // TODO-kaiax: AccumulatedRewardsResponse to use hexutil.Big for time (as timestamp) and big.Int fields.
 type AccumulatedRewardsResponse struct {
-	FirstBlockTime string   `json:"firstBlockTime"`
-	LastBlockTime  string   `json:"lastBlockTime"`
+	FirstBlockTime int64    `json:"firstBlockTime"`
+	LastBlockTime  int64    `json:"lastBlockTime"`
 	FirstBlock     *big.Int `json:"firstBlock"`
 	LastBlock      *big.Int `json:"lastBlock"`
 
@@ -135,8 +136,8 @@ type AccumulatedRewardsResponse struct {
 
 func (spec RewardSpec) ToAccumulatedResponse(firstHeader, lastHeader *types.Header) *AccumulatedRewardsResponse {
 	return &AccumulatedRewardsResponse{
-		FirstBlockTime: firstHeader.Time.String(),
-		LastBlockTime:  lastHeader.Time.String(),
+		FirstBlockTime: time.Unix(firstHeader.Time.Int64(), 0).Unix(),
+		LastBlockTime:  time.Unix(lastHeader.Time.Int64(), 0).Unix(),
 		FirstBlock:     new(big.Int).SetUint64(firstHeader.Number.Uint64()),
 		LastBlock:      new(big.Int).SetUint64(lastHeader.Number.Uint64()),
 

--- a/kaiax/staking/staking_info.go
+++ b/kaiax/staking/staking_info.go
@@ -260,7 +260,7 @@ func (sl *StakingInfoLegacy) ToStakingInfo() *StakingInfo {
 
 // Convert to API response
 func (si *StakingInfo) ToResponse(useGini bool, minStake uint64) *StakingInfoResponse {
-	return &StakingInfoResponse{
+	res := &StakingInfoResponse{
 		StakingInfoLegacy: StakingInfoLegacy{
 			StakingInfo: *si,
 			KIRAddr:     si.KEFAddr,
@@ -271,4 +271,17 @@ func (si *StakingInfo) ToResponse(useGini bool, minStake uint64) *StakingInfoRes
 		UseGini: useGini,
 		Gini:    si.Gini(minStake),
 	}
+	if res.NodeIds == nil {
+		si.NodeIds = make([]common.Address, 0)
+	}
+	if res.RewardAddrs == nil {
+		si.RewardAddrs = make([]common.Address, 0)
+	}
+	if res.StakingContracts == nil {
+		si.StakingContracts = make([]common.Address, 0)
+	}
+	if res.StakingAmounts == nil {
+		si.StakingAmounts = make([]uint64, 0)
+	}
+	return res
 }


### PR DESCRIPTION
## Proposed changes

This PR revises some formats of reward and staking api responses.
1. In stakingInfo api, the empty NodeIds, RewardAddrs, StakingContracts, StakingAmounts returns `None`. But it should return []. So this PR supports [] format.
2. getRewardsAccumulated api's timestamp format is changed from UTC string to UNIX timestamp format.
- v1.0.3: 
```
> governance.getRewardsAccumulated(kaia.blockNumber-2, kaia.blockNumber)
{
  firstBlock: 1080,
  firstBlockTime: "2025-02-06 13:58:51 +0800 +08",
  lastBlock: 1082,
  lastBlockTime: "2025-02-06 13:58:53 +0800 +08",
  ...
}
```
- PR(will be included at v2.0.0):
```
> governance.getRewardsAccumulated(kaia.blockNumber-2, kaia.blockNumber)
{
  firstBlock: 1117,
  firstBlockTime: 1738821607,
  lastBlock: 1119,
  lastBlockTime: 1738821609,
  ...
}
```


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
