### PR TITLE
tests: organize skipping state tests for EEST

### DIFF
--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -88,16 +88,18 @@ func (suite *ExecutionSpecStateTestSuite) TestExecutionSpecState() {
 	st := new(testMatcher)
 
 	// TODO-Kaia: should remove these skip
-	// not yet supported EIPs for pectra-devnet-6
+	// executing precompiled contracts with value transferring is not permitted
 	st.skipLoad(`^frontier\/opcodes\/all_opcodes\/all_opcodes.json`)
-	st.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json`)
 
 	// tests to skip
 	// unsupported EIPs
 	st.skipLoad(`^cancun\/eip4788_beacon_root\/`)
 	st.skipLoad(`^cancun\/eip4844_blobs\/`)
-	// calculate the different consumed gas because 0x0a and 0x0b contract is set to access list by ActivePrecompiles in Cancun
-	st.skipLoad(`^prague\/eip2537_bls_12_381_precompiles\/bls12_precompiles_before_fork\/precompile_before_fork.json\/tests\/prague\/eip2537_bls_12_381_precompiles\/test_bls12_precompiles_before_fork.py::test_precompile_before_fork`)
+	// different amount of gas is consumed because 0x0b contract is added to access list by ActivePrecompiles although Cancun doesn't have it as a precompiled contract
+	st.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json\/tests\/frontier\/precompiles\/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-state_test-31_bytes\]`)
+	st.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json\/tests\/frontier\/precompiles\/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-state_test-32_bytes\]`)
+	st.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json\/tests\/frontier\/precompiles\/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-state_test-empty_calldata\]`)
+	st.skipLoad(`^prague\/eip2537_bls_12_381_precompiles\/bls12_precompiles_before_fork\/precompile_before_fork.json\/tests\/prague\/eip2537_bls_12_381_precompiles\/test_bls12_precompiles_before_fork.py::test_precompile_before_fork\[fork_CancunToPragueAtTime15k-state_test--G1ADD\]`)
 	// type 3 tx (EIP-4844) is not supported
 	st.skipLoad(`^prague\/eip7623_increase_calldata_cost\/.*type_3.*`)
 


### PR DESCRIPTION
## Proposed changes

This PR organizes skipping state tests for EEST.

- `frontier/opcodes/all_opcodes/all_opcodes.json`: Kaia doesn't permit to execute precompiled contracts with value transfering. I think this is needed because we previously missed to add Prague instruction sets (#179).
- `frontier/precompiles/precompile_absence/precompile_absence.json`: Thises tests succeeded for Prague. These skip for only Cancun. The reason of failure in Cancun is the same as `eip2537_bls_12_381_precompiles` test.

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
