### PR TITLE
p2p: Add discover-types flag

### DIFF
--- a/cmd/kbn/main.go
+++ b/cmd/kbn/main.go
@@ -148,6 +148,7 @@ func bootnode(ctx *cli.Context) error {
 		Id:              discover.PubkeyID(&bcfg.nodeKey.PublicKey),
 		NodeType:        p2p.ConvertNodeType(common.BOOTNODE),
 		AuthorizedNodes: bcfg.AuthorizedNodes,
+		DiscoverTypes:   discover.DiscoverTypesConfig{Auto: true},
 	}
 
 	tab, err := discover.ListenUDP(&cfg)

--- a/cmd/kbn/main.go
+++ b/cmd/kbn/main.go
@@ -148,7 +148,7 @@ func bootnode(ctx *cli.Context) error {
 		Id:              discover.PubkeyID(&bcfg.nodeKey.PublicKey),
 		NodeType:        p2p.ConvertNodeType(common.BOOTNODE),
 		AuthorizedNodes: bcfg.AuthorizedNodes,
-		DiscoverTypes:   discover.DiscoverTypesConfig{Auto: true},
+		DiscoverTypes:   discover.DiscoverTypesConfig{CN: true, PN: true, EN: true},
 	}
 
 	tab, err := discover.ListenUDP(&cfg)

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -193,6 +193,28 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 	cfg.NoDiscovery = ctx.Bool(NoDiscoverFlag.Name)
 
+	if ctx.IsSet(DiscoverTypesFlag.Name) {
+		nodetypes := strings.Split(ctx.String(DiscoverTypesFlag.Name), ",")
+		for _, nodetype := range nodetypes {
+			switch strings.ToLower(nodetype) {
+			case "auto":
+				cfg.DiscoverTypes.Auto = true
+			case "cn":
+				cfg.DiscoverTypes.CN = true
+			case "pn":
+				cfg.DiscoverTypes.PN = true
+			case "en":
+				cfg.DiscoverTypes.EN = true
+			default:
+				logger.Crit("Invalid node type in DiscoverTypesFlag", "nodetype", nodetype, "DiscoverTypesFlag", DiscoverTypesFlag.Name)
+			}
+		}
+	} else {
+		// Default to enable all node types for backward compatibility.
+		// To disable discovery, set NoDiscoverFlag instead of setting DiscoverTypesFlag to empty.
+		cfg.DiscoverTypes.Auto = true
+	}
+
 	cfg.RWTimerConfig = p2p.RWTimerConfig{}
 	cfg.RWTimerConfig.Interval = ctx.Uint64(RWTimerIntervalFlag.Name)
 	cfg.RWTimerConfig.WaitTime = ctx.Duration(RWTimerWaitTimeFlag.Name)

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -198,7 +198,7 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 		for _, nodetype := range nodetypes {
 			switch strings.ToLower(nodetype) {
 			case "auto":
-				cfg.DiscoverTypes.Auto = true
+				setDefaultDiscoverTypes(cfg)
 			case "cn":
 				cfg.DiscoverTypes.CN = true
 			case "pn":
@@ -206,13 +206,13 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 			case "en":
 				cfg.DiscoverTypes.EN = true
 			default:
-				logger.Crit("Invalid node type in DiscoverTypesFlag", "nodetype", nodetype, "DiscoverTypesFlag", DiscoverTypesFlag.Name)
+				logger.Crit("Invalid node type in DiscoverTypesFlag, should be one of auto, cn, pn, en", "nodetype", nodetype)
 			}
 		}
 	} else {
-		// Default to enable all node types for backward compatibility.
+		// Enable discovery for default node type
 		// To disable discovery, set NoDiscoverFlag instead of setting DiscoverTypesFlag to empty.
-		cfg.DiscoverTypes.Auto = true
+		setDefaultDiscoverTypes(cfg)
 	}
 
 	cfg.RWTimerConfig = p2p.RWTimerConfig{}
@@ -230,6 +230,17 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	common.MaxRequestContentLength = ctx.Int(MaxRequestContentLengthFlag.Name)
 
 	cfg.NetworkID, _ = getNetworkId(ctx)
+}
+
+// setDefaultDiscoverTypes sets the default discovery types for the node type
+// Note that cfg.ConnectionType should be properly set before calling this function
+func setDefaultDiscoverTypes(cfg *p2p.Config) {
+	if cfg.ConnectionType == common.CONSENSUSNODE {
+		cfg.DiscoverTypes.CN = true
+	} else { // PN or EN
+		cfg.DiscoverTypes.PN = true
+		cfg.DiscoverTypes.EN = true
+	}
 }
 
 // setNodeKey parses manually provided node key from command line flags,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1192,6 +1192,14 @@ var (
 		EnvVars:  []string{"KLAYTN_NODISCOVER", "KAIA_NODISCOVER"},
 		Category: "NETWORK",
 	}
+	DiscoverTypesFlag = &cli.StringFlag{
+		Name:     "discover-types",
+		Usage:    "Comma-separated node type to enable discovery (auto, cn, pn, en)",
+		Value:    "auto",
+		Aliases:  []string{"p2p.discover-types"},
+		EnvVars:  []string{"KLAYTN_DISCOVER_TYPES", "KAIA_DISCOVER_TYPES"},
+		Category: "NETWORK",
+	}
 	NetrestrictFlag = &cli.StringFlag{
 		Name:     "netrestrict",
 		Usage:    "Restricts network communication to the given IP network (CIDR masks)",

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -244,6 +244,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewUint64Flag(TargetGasLimitFlag),
 	altsrc.NewStringFlag(NATFlag),
 	altsrc.NewBoolFlag(NoDiscoverFlag),
+	altsrc.NewStringFlag(DiscoverTypesFlag),
 	altsrc.NewDurationFlag(RWTimerWaitTimeFlag),
 	altsrc.NewUint64Flag(RWTimerIntervalFlag),
 	altsrc.NewStringFlag(NetrestrictFlag),

--- a/networks/p2p/discover/table.go
+++ b/networks/p2p/discover/table.go
@@ -156,10 +156,10 @@ func newTable(cfg *Config) (Discovery, error) {
 	// - EN: PN, EN, BN
 	// - BN: CN, PN, EN, BN
 
-	// if NodeType == BN, add all types (CN, PN, EN, BN)
-	// if NodeType != BN, add:
-	// - BN: always add
-	// - not BN: add if (auto || specified) && supported
+	// if self.NodeType == BN, add all types (CN, PN, EN, BN)
+	// if self.NodeType != BN,
+	// - Always add BN
+	// - Add xN if (Auto || DiscoverTypes.xN) && xN is supported by self.NodeType
 	switch cfg.NodeType {
 	case NodeTypeCN:
 		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.CN {

--- a/networks/p2p/discover/table.go
+++ b/networks/p2p/discover/table.go
@@ -55,6 +55,23 @@ const (
 	seedMaxAge = 5 * 24 * time.Hour
 )
 
+const (
+	// Below configuration reflects the Mainnet's size and network structure.
+	// Note that PNEN and ENEN connections are discovered with the Kademlia algorithm which doesn't accept a max argument.
+
+	// CN connects to each other in a mesh structure. Assuming up to 100 validators.
+	MaxCNCNCount = 100
+	// PN connects to one neighboring PN. In production, PN connections are usually specified via static nodes to make up a certain network structure, in which case this number is ignored.
+	MaxPNPNCount = 1
+	// EN connects to up to 2 PNs for high availability.
+	MaxENPNCount = 2
+	// BN connects to every CN and PN
+	MaxBNCNCount = 100
+	MaxBNPNCount = 100
+	// All nodes try to discover up to 3 BNs
+	MaxBNConn = 3
+)
+
 type DiscoveryType uint8
 
 type Discovery interface {
@@ -163,7 +180,7 @@ func newTable(cfg *Config) (Discovery, error) {
 	switch cfg.NodeType {
 	case NodeTypeCN:
 		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.CN {
-			tab.addStorage(NodeTypeCN, &simpleStorage{targetType: NodeTypeCN, noDiscover: true, max: 100})
+			tab.addStorage(NodeTypeCN, &simpleStorage{targetType: NodeTypeCN, noDiscover: true, max: MaxCNCNCount})
 		}
 		if cfg.DiscoverTypes.PN {
 			logger.Crit("Cannot enable PN discovery for CN")
@@ -171,32 +188,32 @@ func newTable(cfg *Config) (Discovery, error) {
 		if cfg.DiscoverTypes.EN {
 			logger.Crit("Cannot enable EN discovery for CN")
 		}
-		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: 3})
+		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: MaxBNConn})
 	case NodeTypePN:
 		if cfg.DiscoverTypes.CN {
 			logger.Crit("Cannot enable CN discovery for PN")
 		}
 		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.PN {
-			tab.addStorage(NodeTypePN, &simpleStorage{targetType: NodeTypePN, noDiscover: true, max: 1})
+			tab.addStorage(NodeTypePN, &simpleStorage{targetType: NodeTypePN, noDiscover: true, max: MaxPNPNCount})
 		}
 		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.EN {
 			tab.addStorage(NodeTypeEN, &KademliaStorage{targetType: NodeTypeEN, noDiscover: true})
 		}
-		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: 3})
+		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: MaxBNConn})
 	case NodeTypeEN:
 		if cfg.DiscoverTypes.CN {
 			logger.Crit("Cannot enable CN discovery for EN")
 		}
 		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.PN {
-			tab.addStorage(NodeTypePN, &simpleStorage{targetType: NodeTypePN, noDiscover: true, max: 2})
+			tab.addStorage(NodeTypePN, &simpleStorage{targetType: NodeTypePN, noDiscover: true, max: MaxENPNCount})
 		}
 		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.EN {
 			tab.addStorage(NodeTypeEN, &KademliaStorage{targetType: NodeTypeEN})
 		}
-		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: 3})
+		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: MaxBNConn})
 	case NodeTypeBN:
-		tab.addStorage(NodeTypeCN, NewSimpleStorage(NodeTypeCN, true, 100, cfg.AuthorizedNodes))
-		tab.addStorage(NodeTypePN, NewSimpleStorage(NodeTypePN, true, 100, cfg.AuthorizedNodes))
+		tab.addStorage(NodeTypeCN, NewSimpleStorage(NodeTypeCN, true, MaxBNCNCount, cfg.AuthorizedNodes))
+		tab.addStorage(NodeTypePN, NewSimpleStorage(NodeTypePN, true, MaxBNPNCount, cfg.AuthorizedNodes))
 		tab.addStorage(NodeTypeEN, &KademliaStorage{targetType: NodeTypeEN, noDiscover: true})
 		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, max: 3})
 	}

--- a/networks/p2p/discover/table.go
+++ b/networks/p2p/discover/table.go
@@ -179,7 +179,7 @@ func newTable(cfg *Config) (Discovery, error) {
 	// - Add xN if (Auto || DiscoverTypes.xN) && xN is supported by self.NodeType
 	switch cfg.NodeType {
 	case NodeTypeCN:
-		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.CN {
+		if cfg.DiscoverTypes.CN {
 			tab.addStorage(NodeTypeCN, &simpleStorage{targetType: NodeTypeCN, noDiscover: true, max: MaxCNCNCount})
 		}
 		if cfg.DiscoverTypes.PN {
@@ -193,10 +193,10 @@ func newTable(cfg *Config) (Discovery, error) {
 		if cfg.DiscoverTypes.CN {
 			logger.Crit("Cannot enable CN discovery for PN")
 		}
-		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.PN {
+		if cfg.DiscoverTypes.PN {
 			tab.addStorage(NodeTypePN, &simpleStorage{targetType: NodeTypePN, noDiscover: true, max: MaxPNPNCount})
 		}
-		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.EN {
+		if cfg.DiscoverTypes.EN {
 			tab.addStorage(NodeTypeEN, &KademliaStorage{targetType: NodeTypeEN, noDiscover: true})
 		}
 		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: MaxBNConn})
@@ -204,10 +204,10 @@ func newTable(cfg *Config) (Discovery, error) {
 		if cfg.DiscoverTypes.CN {
 			logger.Crit("Cannot enable CN discovery for EN")
 		}
-		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.PN {
+		if cfg.DiscoverTypes.PN {
 			tab.addStorage(NodeTypePN, &simpleStorage{targetType: NodeTypePN, noDiscover: true, max: MaxENPNCount})
 		}
-		if cfg.DiscoverTypes.Auto || cfg.DiscoverTypes.EN {
+		if cfg.DiscoverTypes.EN {
 			tab.addStorage(NodeTypeEN, &KademliaStorage{targetType: NodeTypeEN})
 		}
 		tab.addStorage(NodeTypeBN, &simpleStorage{targetType: NodeTypeBN, noDiscover: true, max: MaxBNConn})

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -141,10 +141,9 @@ type (
 	NodeType uint8
 
 	DiscoverTypesConfig struct {
-		Auto bool
-		CN   bool
-		PN   bool
-		EN   bool
+		CN bool
+		PN bool
+		EN bool
 	}
 )
 

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -139,6 +139,13 @@ type (
 
 	// TODO-Kaia Change private type
 	NodeType uint8
+
+	DiscoverTypesConfig struct {
+		Auto bool
+		CN   bool
+		PN   bool
+		EN   bool
+	}
 )
 
 func makeEndpoint(addr *net.UDPAddr, tcpPort uint16, nType NodeType) rpcEndpoint {
@@ -281,6 +288,9 @@ type Config struct {
 	// These settings are required for discovery packet control
 	MaxNeighborsNode uint
 	AuthorizedNodes  []*Node
+
+	// DiscoverNodetype is list of node type to enable discovery.
+	DiscoverTypes DiscoverTypesConfig
 }
 
 // ListenUDP returns a new table that listens for UDP packets on laddr.

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -55,6 +55,9 @@ const (
 
 	// Maximum amount of time allowed for writing a complete message.
 	frameWriteTimeout = 20 * time.Second
+
+	// Maximum number of times to retry typed static node discovery.
+	typedStaticRetry = 3
 )
 
 var errServerStopped = errors.New("server stopped")
@@ -1580,19 +1583,19 @@ func (srv *BaseServer) getTypeStatics() map[dialType]typedStatic {
 	case common.CONSENSUSNODE:
 		tsMap := make(map[dialType]typedStatic)
 		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.CN {
-			tsMap[DT_CN] = typedStatic{100, 3} // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+			tsMap[DT_CN] = typedStatic{discover.MaxCNCNCount, typedStaticRetry}
 		}
 		return tsMap
 	case common.PROXYNODE:
 		tsMap := make(map[dialType]typedStatic)
 		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.PN {
-			tsMap[DT_PN] = typedStatic{1, 3} // // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+			tsMap[DT_PN] = typedStatic{discover.MaxPNPNCount, typedStaticRetry}
 		}
 		return tsMap
 	case common.ENDPOINTNODE:
 		tsMap := make(map[dialType]typedStatic)
 		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.PN {
-			tsMap[DT_PN] = typedStatic{2, 3} // // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+			tsMap[DT_PN] = typedStatic{discover.MaxENPNCount, typedStaticRetry}
 		}
 		return tsMap
 	case common.BOOTNODE:

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -88,6 +88,9 @@ type Config struct {
 	// Disabling is useful for protocol debugging (manual topology).
 	NoDiscovery bool
 
+	// DiscoverTypes is list of node type to enable discovery.
+	DiscoverTypes discover.DiscoverTypesConfig
+
 	// Name sets the node name of this server.
 	// Use common.MakeName to create a name that follows existing conventions.
 	Name string `toml:"-"`
@@ -356,17 +359,18 @@ func (srv *MultiChannelServer) Start() (err error) {
 	// node table
 	if !srv.NoDiscovery {
 		cfg := discover.Config{
-			PrivateKey:   srv.PrivateKey,
-			AnnounceAddr: realaddr,
-			NodeDBPath:   srv.NodeDatabase,
-			NetRestrict:  srv.NetRestrict,
-			Bootnodes:    srv.BootstrapNodes,
-			Unhandled:    unhandled,
-			Conn:         conn,
-			Addr:         realaddr,
-			Id:           discover.PubkeyID(&srv.PrivateKey.PublicKey),
-			NodeType:     ConvertNodeType(srv.ConnectionType),
-			NetworkID:    srv.NetworkID,
+			PrivateKey:    srv.PrivateKey,
+			AnnounceAddr:  realaddr,
+			NodeDBPath:    srv.NodeDatabase,
+			NetRestrict:   srv.NetRestrict,
+			Bootnodes:     srv.BootstrapNodes,
+			Unhandled:     unhandled,
+			Conn:          conn,
+			Addr:          realaddr,
+			Id:            discover.PubkeyID(&srv.PrivateKey.PublicKey),
+			NodeType:      ConvertNodeType(srv.ConnectionType),
+			NetworkID:     srv.NetworkID,
+			DiscoverTypes: srv.DiscoverTypes,
 		}
 
 		ntab, err := discover.ListenUDP(&cfg)
@@ -1261,17 +1265,18 @@ func (srv *BaseServer) Start() (err error) {
 	// node table
 	if !srv.NoDiscovery {
 		cfg := discover.Config{
-			PrivateKey:   srv.PrivateKey,
-			AnnounceAddr: realaddr,
-			NodeDBPath:   srv.NodeDatabase,
-			NetRestrict:  srv.NetRestrict,
-			Bootnodes:    srv.BootstrapNodes,
-			Unhandled:    unhandled,
-			Conn:         conn,
-			Addr:         realaddr,
-			Id:           discover.PubkeyID(&srv.PrivateKey.PublicKey),
-			NodeType:     ConvertNodeType(srv.ConnectionType),
-			NetworkID:    srv.NetworkID,
+			PrivateKey:    srv.PrivateKey,
+			AnnounceAddr:  realaddr,
+			NodeDBPath:    srv.NodeDatabase,
+			NetRestrict:   srv.NetRestrict,
+			Bootnodes:     srv.BootstrapNodes,
+			Unhandled:     unhandled,
+			Conn:          conn,
+			Addr:          realaddr,
+			Id:            discover.PubkeyID(&srv.PrivateKey.PublicKey),
+			NodeType:      ConvertNodeType(srv.ConnectionType),
+			NetworkID:     srv.NetworkID,
+			DiscoverTypes: srv.DiscoverTypes,
 		}
 
 		cfgForLog := cfg
@@ -1574,15 +1579,21 @@ func (srv *BaseServer) getTypeStatics() map[dialType]typedStatic {
 	switch srv.ConnectionType {
 	case common.CONSENSUSNODE:
 		tsMap := make(map[dialType]typedStatic)
-		tsMap[DT_CN] = typedStatic{100, 3} // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.CN {
+			tsMap[DT_CN] = typedStatic{100, 3} // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+		}
 		return tsMap
 	case common.PROXYNODE:
 		tsMap := make(map[dialType]typedStatic)
-		tsMap[DT_PN] = typedStatic{1, 3} // // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.PN {
+			tsMap[DT_PN] = typedStatic{1, 3} // // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+		}
 		return tsMap
 	case common.ENDPOINTNODE:
 		tsMap := make(map[dialType]typedStatic)
-		tsMap[DT_PN] = typedStatic{2, 3} // // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.PN {
+			tsMap[DT_PN] = typedStatic{2, 3} // // TODO-Kaia-Node Change to literal to constant (maxNodeCount, MaxTry)
+		}
 		return tsMap
 	case common.BOOTNODE:
 		return nil

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -1582,19 +1582,19 @@ func (srv *BaseServer) getTypeStatics() map[dialType]typedStatic {
 	switch srv.ConnectionType {
 	case common.CONSENSUSNODE:
 		tsMap := make(map[dialType]typedStatic)
-		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.CN {
+		if srv.DiscoverTypes.CN {
 			tsMap[DT_CN] = typedStatic{discover.MaxCNCNCount, typedStaticRetry}
 		}
 		return tsMap
 	case common.PROXYNODE:
 		tsMap := make(map[dialType]typedStatic)
-		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.PN {
+		if srv.DiscoverTypes.PN {
 			tsMap[DT_PN] = typedStatic{discover.MaxPNPNCount, typedStaticRetry}
 		}
 		return tsMap
 	case common.ENDPOINTNODE:
 		tsMap := make(map[dialType]typedStatic)
-		if srv.DiscoverTypes.Auto || srv.DiscoverTypes.PN {
+		if srv.DiscoverTypes.PN {
 			tsMap[DT_PN] = typedStatic{discover.MaxENPNCount, typedStaticRetry}
 		}
 		return tsMap


### PR DESCRIPTION
## Proposed changes

- This PR adds `--discover-types` flag to enable discovery for specified node types only.
- Supported discovery types for each NodeType:
    - CN: CN
    - PN: PN, EN
    - EN: PN, EN
    - Note that BN is automatically enabled for all node types, and BNs have all node types enabled too.
 - This PR is to fix PN-EN connection issue, so it should:
    - not break current PN's static-driven connection structure, even after PNs are restarted
    - make sure BNs bond with PNs (PNs report themselves to BNs)
    - make sure ENs bond with PNs (ENs can discover and bond PNs)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
