### PR TITLE
tests: add comments of why we can skip old forks in EEST

### DIFF
--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -80,6 +80,8 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 
 	bt.walk(t, executionSpecBlockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		skipForks := []string{
+			// Even if we skip fork levels, old EIPs are still retrospectively tested against Cancun or later forks.
+			// The EEST framework was added when Kaia was at Cancun hardfork.
 			"Frontier",
 			"Homestead",
 			"Byzantium",

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -107,6 +107,8 @@ func (suite *ExecutionSpecStateTestSuite) TestExecutionSpecState() {
 
 	st.walk(t, executionSpecStateTestDir, func(t *testing.T, name string, test *StateTest) {
 		execStateTest(t, st, test, name, []string{
+			// Even if we skip fork levels, old EIPs are still retrospectively tested against Cancun or later forks.
+			// The EEST framework was added when Kaia was at Cancun hardfork. Previous forks will be, and continue to be tested with kaia-core-tests.
 			"Frontier",
 			"Homestead",
 			"Byzantium",


### PR DESCRIPTION
## Proposed changes

This PR adds the comments of  why we can skip old forks in EEST

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
