### PR TITLE
api: Update pending block treatment

### DIFF
--- a/accounts/abi/bind/backends/blockchain.go
+++ b/accounts/abi/bind/backends/blockchain.go
@@ -301,7 +301,7 @@ func (b *BlockchainContractBackend) FilterLogs(ctx context.Context, query kaia.F
 	if !ok {
 		return nil, errors.New("BlockChainForCaller is not blockchain.BlockChain")
 	}
-	filter := filters.NewRangeFilter(&filterBackend{state.Database().TrieDB().DiskDB(), bc}, from, to, query.Addresses, query.Topics)
+	filter := filters.NewRangeFilter(&filterBackend{state.Database().TrieDB().DiskDB(), bc, nil}, from, to, query.Addresses, query.Topics)
 
 	logs, err := filter.Logs(ctx)
 	if err != nil {

--- a/accounts/abi/bind/backends/blockchain_test.go
+++ b/accounts/abi/bind/backends/blockchain_test.go
@@ -383,7 +383,7 @@ func initBackendForFiltererTests(t *testing.T, bc *blockchain.BlockChain) *Block
 	mockBackend.EXPECT().SubscribeRemovedLogsEvent(any).DoAndReturn(subscribeRemovedLogsEvent).AnyTimes()
 	mockBackend.EXPECT().SubscribeChainEvent(any).DoAndReturn(subscribeChainEvent).AnyTimes()
 
-	f := filters.NewEventSystem(&event.TypeMux{}, mockBackend, false)
+	f := filters.NewEventSystem(&event.TypeMux{}, mockBackend)
 	c := NewBlockchainContractBackend(bc, nil, f)
 
 	return c

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -85,7 +85,7 @@ func NewSimulatedBackendWithDatabase(database database.DBManager, alloc blockcha
 		database:   database,
 		blockchain: blockchain,
 		config:     genesis.Config,
-		events:     filters.NewEventSystem(new(event.TypeMux), &filterBackend{database, blockchain}, false),
+		events:     filters.NewEventSystem(new(event.TypeMux), &filterBackend{database, blockchain}),
 	}
 	backend.rollback()
 	return backend

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -65,9 +65,10 @@ type SimulatedBackend struct {
 	database   database.DBManager     // In memory database to store our testing data
 	blockchain *blockchain.BlockChain // Kaia blockchain to handle the consensus
 
-	mu           sync.Mutex
-	pendingBlock *types.Block   // Currently pending block that will be imported on request
-	pendingState *state.StateDB // Currently pending state that will be the active on request
+	mu              sync.Mutex
+	pendingBlock    *types.Block   // Currently pending block that will be imported on request
+	pendingState    *state.StateDB // Currently pending state that will be the active on request
+	pendingReceipts types.Receipts // Currently receipts for the pending block
 
 	events *filters.EventSystem // Event system for filtering log events live
 
@@ -85,8 +86,8 @@ func NewSimulatedBackendWithDatabase(database database.DBManager, alloc blockcha
 		database:   database,
 		blockchain: blockchain,
 		config:     genesis.Config,
-		events:     filters.NewEventSystem(new(event.TypeMux), &filterBackend{database, blockchain}),
 	}
+	backend.events = filters.NewEventSystem(new(event.TypeMux), &filterBackend{database, blockchain, backend})
 	backend.rollback()
 	return backend
 }
@@ -132,11 +133,12 @@ func (b *SimulatedBackend) Rollback() {
 }
 
 func (b *SimulatedBackend) rollback() {
-	blocks, _ := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), gxhash.NewFaker(), b.database, 1, func(int, *blockchain.BlockGen) {})
+	blocks, receipts := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), gxhash.NewFaker(), b.database, 1, func(int, *blockchain.BlockGen) {})
 	stateDB, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
 	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil, nil)
+	b.pendingReceipts = receipts[0]
 }
 
 // stateByBlockNumber retrieves a state by a given blocknumber.
@@ -531,7 +533,7 @@ func (b *SimulatedBackend) SendTransaction(_ context.Context, tx *types.Transact
 	}
 
 	// Include tx in chain.
-	blocks, _ := blockchain.GenerateChain(b.config, block, gxhash.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
+	blocks, receipts := blockchain.GenerateChain(b.config, block, gxhash.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
 		for _, tx := range b.pendingBlock.Transactions() {
 			block.AddTxWithChain(b.blockchain, tx)
 		}
@@ -541,6 +543,7 @@ func (b *SimulatedBackend) SendTransaction(_ context.Context, tx *types.Transact
 
 	b.pendingBlock = blocks[0]
 	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil, nil)
+	b.pendingReceipts = receipts[0]
 	return nil
 }
 
@@ -559,7 +562,7 @@ func (b *SimulatedBackend) FilterLogs(ctx context.Context, query kaia.FilterQuer
 		to = query.ToBlock.Int64()
 	}
 	// Construct and execute the filter
-	filter := filters.NewRangeFilter(&filterBackend{b.database, b.blockchain}, from, to, query.Addresses, query.Topics)
+	filter := filters.NewRangeFilter(&filterBackend{b.database, b.blockchain, b}, from, to, query.Addresses, query.Topics)
 
 	// Run the filter and return all the logs
 	logs, err := filter.Logs(ctx)
@@ -654,13 +657,14 @@ func (b *SimulatedBackend) AdjustTime(adjustment time.Duration) error {
 		return errors.New("Could not adjust time on non-empty block")
 	}
 
-	blocks, _ := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), gxhash.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
+	blocks, receipts := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), gxhash.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
 		block.OffsetTime(int64(adjustment.Seconds()))
 	})
 	stateDB, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
 	b.pendingState, _ = state.New(b.pendingBlock.Root(), stateDB.Database(), nil, nil)
+	b.pendingReceipts = receipts[0]
 
 	return nil
 }
@@ -677,8 +681,9 @@ func (b *SimulatedBackend) PendingBlock() *types.Block {
 // filterBackend implements filters.Backend to support filtering for logs without
 // taking bloom-bits acceleration structures into account.
 type filterBackend struct {
-	db database.DBManager
-	bc *blockchain.BlockChain
+	db      database.DBManager
+	bc      *blockchain.BlockChain
+	backend *SimulatedBackend
 }
 
 func (fb *filterBackend) ChainDB() database.DBManager { return fb.db }
@@ -693,6 +698,10 @@ func (fb *filterBackend) HeaderByNumber(_ context.Context, block rpc.BlockNumber
 		return fb.bc.CurrentHeader(), nil
 	}
 	return fb.bc.GetHeaderByNumber(uint64(block.Int64())), nil
+}
+
+func (fb *filterBackend) Pending() (*types.Block, types.Receipts, *state.StateDB) {
+	return fb.backend.pendingBlock, fb.backend.pendingReceipts, fb.backend.pendingState.Copy()
 }
 
 func (fb *filterBackend) GetBlockReceipts(_ context.Context, hash common.Hash) types.Receipts {

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -947,12 +947,21 @@ func formatTxToEthTxJSON(tx *types.Transaction) *ethTxJSON {
 
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
 func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *EthRPCTransaction {
-	return api.publicTransactionPoolAPI.GetTransactionByBlockNumberAndIndex(ctx, blockNr, index)
+	block, err := api.publicTransactionPoolAPI.b.BlockByNumber(ctx, blockNr)
+	if err != nil {
+		return nil
+	}
+
+	return newEthRPCTransactionFromBlockIndex(block, uint64(index), api.publicBlockChainAPI.b.ChainConfig())
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
 func (api *EthereumAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
-	return api.publicTransactionPoolAPI.GetTransactionByBlockHashAndIndex(ctx, blockHash, index)
+	block, err := api.publicTransactionPoolAPI.b.BlockByHash(ctx, blockHash)
+	if err != nil || block == nil {
+		return nil
+	}
+	return newEthRPCTransactionFromBlockIndex(block, uint64(index), api.publicBlockChainAPI.b.ChainConfig())
 }
 
 // GetRawTransactionByBlockNumberAndIndex returns the bytes of the transaction for the given block number and index.

--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -707,14 +707,12 @@ func (api *EthereumAPI) EstimateGas(ctx context.Context, args EthTransactionArgs
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.
 func (api *EthereumAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) *hexutil.Uint {
-	transactionCount, _ := api.publicTransactionPoolAPI.GetBlockTransactionCountByNumber(ctx, blockNr)
-	return transactionCount
+	return api.publicTransactionPoolAPI.GetBlockTransactionCountByNumber(ctx, blockNr)
 }
 
 // GetBlockTransactionCountByHash returns the number of transactions in the block with the given hash.
 func (api *EthereumAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) *hexutil.Uint {
-	transactionCount, _ := api.publicTransactionPoolAPI.GetBlockTransactionCountByHash(ctx, blockHash)
-	return transactionCount
+	return api.publicTransactionPoolAPI.GetBlockTransactionCountByHash(ctx, blockHash)
 }
 
 // EthRPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
@@ -949,27 +947,18 @@ func formatTxToEthTxJSON(tx *types.Transaction) *ethTxJSON {
 
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
 func (api *EthereumAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *EthRPCTransaction {
-	block, err := api.publicTransactionPoolAPI.b.BlockByNumber(ctx, blockNr)
-	if err != nil {
-		return nil
-	}
-
-	return newEthRPCTransactionFromBlockIndex(block, uint64(index), api.publicBlockChainAPI.b.ChainConfig())
+	return api.publicTransactionPoolAPI.GetTransactionByBlockNumberAndIndex(ctx, blockNr, index)
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
 func (api *EthereumAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
-	block, err := api.publicTransactionPoolAPI.b.BlockByHash(ctx, blockHash)
-	if err != nil || block == nil {
-		return nil
-	}
-	return newEthRPCTransactionFromBlockIndex(block, uint64(index), api.publicBlockChainAPI.b.ChainConfig())
+	return api.publicTransactionPoolAPI.GetTransactionByBlockHashAndIndex(ctx, blockHash, index)
 }
 
 // GetRawTransactionByBlockNumberAndIndex returns the bytes of the transaction for the given block number and index.
 func (api *EthereumAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) hexutil.Bytes {
-	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByBlockNumberAndIndex(ctx, blockNr, index)
-	if rawTx == nil || err != nil {
+	rawTx := api.publicTransactionPoolAPI.GetRawTransactionByBlockNumberAndIndex(ctx, blockNr, index)
+	if rawTx == nil {
 		return nil
 	}
 	if rawTx[0] == byte(types.EthereumTxTypeEnvelope) {
@@ -980,8 +969,8 @@ func (api *EthereumAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Conte
 
 // GetRawTransactionByBlockHashAndIndex returns the bytes of the transaction for the given block hash and index.
 func (api *EthereumAPI) GetRawTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) hexutil.Bytes {
-	rawTx, err := api.publicTransactionPoolAPI.GetRawTransactionByBlockHashAndIndex(ctx, blockHash, index)
-	if rawTx == nil || err != nil {
+	rawTx := api.publicTransactionPoolAPI.GetRawTransactionByBlockHashAndIndex(ctx, blockHash, index)
+	if rawTx == nil {
 		return nil
 	}
 	if rawTx[0] == byte(types.EthereumTxTypeEnvelope) {

--- a/api/api_public_klay.go
+++ b/api/api_public_klay.go
@@ -78,7 +78,7 @@ type FeeHistoryResult struct {
 
 // FeeHistory returns data relevant for fee estimation based on the specified range of blocks.
 func (s *PublicKaiaAPI) FeeHistory(ctx context.Context, blockCount DecimalOrHex, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*FeeHistoryResult, error) {
-	oldest, reward, baseFee, gasUsed, err := s.b.FeeHistory(ctx, int(blockCount), lastBlock, rewardPercentiles)
+	oldest, reward, baseFee, gasUsed, err := s.b.FeeHistory(ctx, uint64(blockCount), lastBlock, rewardPercentiles)
 	if err != nil {
 		return nil, err
 	}

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -576,18 +576,12 @@ func (s *PublicTransactionPoolAPI) RecoverFromTransaction(ctx context.Context, e
 		return common.Address{}, err
 	}
 
-	var bn uint64
-	if blockNumber == rpc.LatestBlockNumber || blockNumber == rpc.PendingBlockNumber {
-		bn = s.b.CurrentBlock().NumberU64()
-	} else {
-		bn = blockNumber.Uint64()
-	}
-
-	signer := types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(bn))
-	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNumber)
+	state, header, err := s.b.StateAndHeaderByNumber(ctx, blockNumber)
 	if err != nil {
 		return common.Address{}, err
 	}
+	bn := header.Number.Uint64()
+	signer := types.MakeSigner(s.b.ChainConfig(), new(big.Int).SetUint64(bn))
 	_, err = tx.ValidateSender(signer, state, bn)
 	if err != nil {
 		return common.Address{}, err

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -71,18 +71,18 @@ func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByHash(ctx context.Co
 }
 
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
-func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *EthRPCTransaction {
+func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) map[string]interface{} {
 	block, _ := s.b.BlockByNumber(ctx, blockNr)
 	if block != nil {
-		return newEthRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
+		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
 	}
 	return nil
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
-func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
+func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) map[string]interface{} {
 	if block, _ := s.b.BlockByHash(ctx, blockHash); block != nil {
-		return newEthRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
+		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
 	}
 	return nil
 }

--- a/api/api_public_transaction_pool.go
+++ b/api/api_public_transaction_pool.go
@@ -51,59 +51,56 @@ func NewPublicTransactionPoolAPI(b Backend, nonceLock *AddrLocker) *PublicTransa
 }
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.
-func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error) {
-	block, err := s.b.BlockByNumber(ctx, blockNr)
-	if block != nil && err == nil {
+func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) *hexutil.Uint {
+	block, _ := s.b.BlockByNumber(ctx, blockNr)
+	if block != nil {
 		n := hexutil.Uint(len(block.Transactions()))
-		return &n, err
+		return &n
 	}
-	return nil, err
+	return nil
 }
 
 // GetBlockTransactionCountByHash returns the number of transactions in the block with the given hash.
-func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (*hexutil.Uint, error) {
-	block, err := s.b.BlockByHash(ctx, blockHash)
-	if block != nil && err == nil {
+func (s *PublicTransactionPoolAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) *hexutil.Uint {
+	block, _ := s.b.BlockByHash(ctx, blockHash)
+	if block != nil {
 		n := hexutil.Uint(len(block.Transactions()))
-		return &n, err
+		return &n
 	}
-	return nil, err
+	return nil
 }
 
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
-func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (map[string]interface{}, error) {
-	block, err := s.b.BlockByNumber(ctx, blockNr)
-	if block != nil && err == nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig()), nil
+func (s *PublicTransactionPoolAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *EthRPCTransaction {
+	block, _ := s.b.BlockByNumber(ctx, blockNr)
+	if block != nil {
+		return newEthRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
 	}
-	return nil, err
+	return nil
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
-func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) (map[string]interface{}, error) {
-	block, err := s.b.BlockByHash(ctx, blockHash)
-	if block != nil && err == nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig()), nil
+func (s *PublicTransactionPoolAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *EthRPCTransaction {
+	if block, _ := s.b.BlockByHash(ctx, blockHash); block != nil {
+		return newEthRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
 	}
-	return nil, err
+	return nil
 }
 
 // GetRawTransactionByBlockNumberAndIndex returns the bytes of the transaction for the given block number and index.
-func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) (hexutil.Bytes, error) {
-	block, err := s.b.BlockByNumber(ctx, blockNr)
-	if block != nil && err == nil {
-		return newRPCRawTransactionFromBlockIndex(block, uint64(index)), nil
+func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) hexutil.Bytes {
+	if block, _ := s.b.BlockByNumber(ctx, blockNr); block != nil {
+		return newRPCRawTransactionFromBlockIndex(block, uint64(index))
 	}
-	return nil, err
+	return nil
 }
 
 // GetRawTransactionByBlockHashAndIndex returns the bytes of the transaction for the given block hash and index.
-func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) (hexutil.Bytes, error) {
-	block, err := s.b.BlockByHash(ctx, blockHash)
-	if block != nil && err == nil {
-		return newRPCRawTransactionFromBlockIndex(block, uint64(index)), nil
+func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) hexutil.Bytes {
+	if block, _ := s.b.BlockByHash(ctx, blockHash); block != nil {
+		return newRPCRawTransactionFromBlockIndex(block, uint64(index))
 	}
-	return nil, err
+	return nil
 }
 
 // GetTransactionCount returns the number of transactions the given address has sent for the given block number or hash

--- a/api/backend.go
+++ b/api/backend.go
@@ -60,7 +60,7 @@ type Backend interface {
 	RPCGasCap() *big.Int          // global gas cap for eth/kaia_call/estimateGas/estimateComputationCost
 	RPCTxFeeCap() float64         // global tx fee cap in eth_signTransaction
 	Engine() consensus.Engine
-	FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error)
+	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error)
 
 	// BlockChain API
 	SetHead(number uint64) error
@@ -72,6 +72,7 @@ type Backend interface {
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error)
 	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
+	Pending() (*types.Block, types.Receipts, *state.StateDB)
 	GetBlockReceipts(ctx context.Context, blockHash common.Hash) types.Receipts
 	GetTxLookupInfoAndReceipt(ctx context.Context, hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, *types.Receipt)
 	GetTxAndLookupInfo(hash common.Hash) (*types.Transaction, common.Hash, uint64, uint64)

--- a/api/mocks/backend_mock.go
+++ b/api/mocks/backend_mock.go
@@ -178,7 +178,7 @@ func (mr *MockBackendMockRecorder) EventMux() *gomock.Call {
 }
 
 // FeeHistory mocks base method.
-func (m *MockBackend) FeeHistory(arg0 context.Context, arg1 int, arg2 rpc.BlockNumber, arg3 []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
+func (m *MockBackend) FeeHistory(arg0 context.Context, arg1 uint64, arg2 rpc.BlockNumber, arg3 []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FeeHistory", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*big.Int)
@@ -451,6 +451,22 @@ func (m *MockBackend) LowerBoundGasPrice(arg0 context.Context) *big.Int {
 func (mr *MockBackendMockRecorder) LowerBoundGasPrice(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LowerBoundGasPrice", reflect.TypeOf((*MockBackend)(nil).LowerBoundGasPrice), arg0)
+}
+
+// Pending mocks base method.
+func (m *MockBackend) Pending() (*types.Block, types.Receipts, *state.StateDB) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Pending")
+	ret0, _ := ret[0].(*types.Block)
+	ret1, _ := ret[1].(types.Receipts)
+	ret2, _ := ret[2].(*state.StateDB)
+	return ret0, ret1, ret2
+}
+
+// Pending indicates an expected call of Pending.
+func (mr *MockBackendMockRecorder) Pending() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pending", reflect.TypeOf((*MockBackend)(nil).Pending))
 }
 
 // Progress mocks base method.

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -245,20 +245,6 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	return blocks, receipts
 }
 
-// GenerateChainWithGenesis is a wrapper of GenerateChain which will initialize
-// genesis block to database first according to the provided genesis specification
-// then generate chain on top.
-func GenerateChainWithGenesis(genesis *Genesis, engine consensus.Engine, n int, gen func(int, *BlockGen)) (database.Database, []*types.Block, []types.Receipts) {
-	db := database.NewMemoryDBManager()
-	_, err := genesis.Commit(common.Hash{}, db)
-	if err != nil {
-		panic(err)
-	}
-	genesisBlock := genesis.MustCommit(db)
-	blocks, receipts := GenerateChain(genesis.Config, genesisBlock, engine, db, n, gen)
-	return db.GetMemDB(), blocks, receipts
-}
-
 func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.StateDB, engine consensus.Engine) *types.Header {
 	var time *big.Int
 	if parent.Time() == nil {

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -245,6 +245,20 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	return blocks, receipts
 }
 
+// GenerateChainWithGenesis is a wrapper of GenerateChain which will initialize
+// genesis block to database first according to the provided genesis specification
+// then generate chain on top.
+func GenerateChainWithGenesis(genesis *Genesis, engine consensus.Engine, n int, gen func(int, *BlockGen)) (database.Database, []*types.Block, []types.Receipts) {
+	db := database.NewMemoryDBManager()
+	_, err := genesis.Commit(common.Hash{}, db)
+	if err != nil {
+		panic(err)
+	}
+	genesisBlock := genesis.MustCommit(db)
+	blocks, receipts := GenerateChain(genesis.Config, genesisBlock, engine, db, n, gen)
+	return db.GetMemDB(), blocks, receipts
+}
+
 func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.StateDB, engine consensus.Engine) *types.Header {
 	var time *big.Int
 	if parent.Time() == nil {

--- a/node/cn/api.go
+++ b/node/cn/api.go
@@ -291,7 +291,7 @@ func (api *PublicDebugAPI) DumpBlock(ctx context.Context, blockNrOrHash rpc.Bloc
 		// If we're dumping the pending state, we need to request
 		// both the pending block as well as the pending state from
 		// the miner and operate on those
-		_, stateDb := api.cn.miner.Pending()
+		_, _, stateDb := api.cn.miner.Pending()
 		if stateDb == nil {
 			return state.Dump{}, fmt.Errorf("pending block is not prepared yet")
 		}

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -172,10 +172,14 @@ func (b *CNAPIBackend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rp
 	return nil, fmt.Errorf("invalid arguments; neither block nor hash specified")
 }
 
+func (b *CNAPIBackend) Pending() (*types.Block, types.Receipts, *state.StateDB) {
+	return b.cn.miner.Pending()
+}
+
 func (b *CNAPIBackend) StateAndHeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
 	// Pending state is only known by the miner
 	if blockNr == rpc.PendingBlockNumber {
-		block, state := b.cn.miner.Pending()
+		block, _, state := b.cn.miner.Pending()
 		if block == nil || state == nil {
 			return nil, nil, fmt.Errorf("pending block is not prepared yet")
 		}
@@ -393,6 +397,6 @@ func (b *CNAPIBackend) StateAtTransaction(ctx context.Context, block *types.Bloc
 	return b.cn.stateAtTransaction(block, txIndex, reexec, base, readOnly, preferDisk)
 }
 
-func (b *CNAPIBackend) FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
+func (b *CNAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
 	return b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 }

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -425,6 +425,7 @@ func TestCNAPIBackend_BlockByNumberOrHash(t *testing.T) {
 func TestCNAPIBackend_StateAndHeaderByNumber(t *testing.T) {
 	blockNum := uint64(123)
 	block := newBlock(int(blockNum))
+	var reciept types.Receipts
 
 	stateDB, err := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	if err != nil {
@@ -436,7 +437,7 @@ func TestCNAPIBackend_StateAndHeaderByNumber(t *testing.T) {
 	expectedHeader := block.Header()
 	{
 		mockCtrl, _, mockMiner, api := newCNAPIBackend(t)
-		mockMiner.EXPECT().Pending().Return(block, stateDB).Times(1)
+		mockMiner.EXPECT().Pending().Return(block, reciept, stateDB).Times(1)
 
 		returnedStateDB, header, err := api.StateAndHeaderByNumber(context.Background(), rpc.PendingBlockNumber)
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -670,7 +670,7 @@ func (s *CN) APIs() []rpc.API {
 	// Append any APIs exposed explicitly by the consensus engine
 	apis = append(apis, s.engine.APIs(s.BlockChain())...)
 
-	publicFilterAPI := filters.NewPublicFilterAPI(s.APIBackend, false)
+	publicFilterAPI := filters.NewPublicFilterAPI(s.APIBackend)
 	publicDownloaderAPI := downloader.NewPublicDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
 	privateDownloaderAPI := downloader.NewPrivateDownloaderAPI(s.protocolManager.Downloader())
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -85,7 +85,7 @@ type Miner interface {
 	Mining() bool
 	HashRate() (tot int64)
 	SetExtra(extra []byte) error
-	Pending() (*types.Block, *state.StateDB)
+	Pending() (*types.Block, types.Receipts, *state.StateDB)
 	PendingBlock() *types.Block
 	kaiax.ExecutionModuleHost // Because miner executes blocks, inject ExecutionModule.
 }

--- a/node/cn/filters/api.go
+++ b/node/cn/filters/api.go
@@ -49,6 +49,8 @@ var (
 	GetLogsMaxItems       = int(10000)       // maximum allowed number of return items for getLogs and getFilterLogs APIs
 )
 
+var errPendingLogsUnsupported = errors.New("pending logs are not supported")
+
 // filter is a helper struct that holds meta information over the filter type
 // and associated subscription in the event system.
 type filter struct {
@@ -76,12 +78,12 @@ type PublicFilterAPI struct {
 }
 
 // NewPublicFilterAPI returns a new PublicFilterAPI instance.
-func NewPublicFilterAPI(backend Backend, lightMode bool) *PublicFilterAPI {
+func NewPublicFilterAPI(backend Backend) *PublicFilterAPI {
 	api := &PublicFilterAPI{
 		backend: backend,
 		mux:     backend.EventMux(),
 		chainDB: backend.ChainDB(),
-		events:  NewEventSystem(backend.EventMux(), backend, lightMode),
+		events:  NewEventSystem(backend.EventMux(), backend),
 		filters: make(map[rpc.ID]*filter),
 		timeout: defaultFilterDeadline,
 	}

--- a/node/cn/filters/filter.go
+++ b/node/cn/filters/filter.go
@@ -139,18 +139,23 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		return f.blockLogs(ctx, header)
 	}
 
+	// Disallow pending logs.
+	if f.begin == rpc.PendingBlockNumber.Int64() || f.end == rpc.PendingBlockNumber.Int64() {
+		return nil, errPendingLogsUnsupported
+	}
+
 	// Figure out the limits of the filter range
 	header, _ := f.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
 	if header == nil {
-		return nil, nil
+		return nil, errors.New("latest header not found")
 	}
 	head := header.Number.Uint64()
 
-	if f.begin == -1 {
+	if f.begin == rpc.LatestBlockNumber.Int64() {
 		f.begin = int64(head)
 	}
 	end := uint64(f.end)
-	if f.end == -1 {
+	if f.end == rpc.LatestBlockNumber.Int64() {
 		end = head
 	}
 	// Gather all indexed logs, and finish with non indexed ones

--- a/node/cn/filters/filter.go
+++ b/node/cn/filters/filter.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/bloombits"
+	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/event"
@@ -45,6 +46,7 @@ type Backend interface {
 	EventMux() *event.TypeMux
 	HeaderByHash(ctx context.Context, blockHash common.Hash) (*types.Header, error)
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
+	Pending() (*types.Block, types.Receipts, *state.StateDB)
 	GetBlockReceipts(ctx context.Context, blockHash common.Hash) types.Receipts
 	GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error)
 

--- a/node/cn/filters/filter_system_test.go
+++ b/node/cn/filters/filter_system_test.go
@@ -180,7 +180,9 @@ func (b *testBackend) notifyPending(logs []*types.Log) {
 	genesis := &blockchain.Genesis{
 		Config: params.TestChainConfig,
 	}
-	_, blocks, _ := blockchain.GenerateChainWithGenesis(genesis, gxhash.NewFaker(), 2, func(i int, b *blockchain.BlockGen) {})
+	db := database.NewMemoryDBManager()
+	genesisBlock := genesis.MustCommit(db)
+	blocks, _ := blockchain.GenerateChain(genesis.Config, genesisBlock, gxhash.NewFaker(), db, 2, func(i int, b *blockchain.BlockGen) {})
 	b.setPending(blocks[1], []*types.Receipt{{Logs: logs}})
 	b.chainFeed.Send(blockchain.ChainEvent{Block: blocks[0]})
 }

--- a/node/cn/filters/filter_test.go
+++ b/node/cn/filters/filter_test.go
@@ -179,7 +179,7 @@ func BenchmarkFilters(b *testing.B) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig, nil, nil}
 		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr1      = crypto.PubkeyToAddress(key1.PublicKey)
 		addr2      = common.BytesToAddress([]byte("jeff"))
@@ -242,7 +242,7 @@ func TestFilters(t *testing.T) {
 		rmLogsFeed = new(event.Feed)
 		logsFeed   = new(event.Feed)
 		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig}
+		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig, nil, nil}
 		key1, _    = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr       = crypto.PubkeyToAddress(key1.PublicKey)
 

--- a/node/cn/filters/mock/backend_mock.go
+++ b/node/cn/filters/mock/backend_mock.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	blockchain "github.com/kaiachain/kaia/blockchain"
 	bloombits "github.com/kaiachain/kaia/blockchain/bloombits"
+	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
 	event "github.com/kaiachain/kaia/event"
@@ -156,6 +157,22 @@ func (m *MockBackend) HeaderByNumber(arg0 context.Context, arg1 rpc.BlockNumber)
 func (mr *MockBackendMockRecorder) HeaderByNumber(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByNumber", reflect.TypeOf((*MockBackend)(nil).HeaderByNumber), arg0, arg1)
+}
+
+// Pending mocks base method.
+func (m *MockBackend) Pending() (*types.Block, types.Receipts, *state.StateDB) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Pending")
+	ret0, _ := ret[0].(*types.Block)
+	ret1, _ := ret[1].(types.Receipts)
+	ret2, _ := ret[2].(*state.StateDB)
+	return ret0, ret1, ret2
+}
+
+// Pending indicates an expected call of Pending.
+func (mr *MockBackendMockRecorder) Pending() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pending", reflect.TypeOf((*MockBackend)(nil).Pending))
 }
 
 // ServiceFilter mocks base method.

--- a/node/cn/gasprice/feehistory.go
+++ b/node/cn/gasprice/feehistory.go
@@ -167,9 +167,8 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 }
 
 // resolveBlockRange resolves the specified block range to absolute block numbers while also
-// enforcing backend specific limitations.
-// Pending block does not exist in Kaia, so there is no logic to look up pending blocks.
-// This part has a different implementation with Ethereum.
+// enforcing backend specific limitations. The pending block and corresponding receipts are
+// also returned if requested and available.
 // Note: an error is only returned if retrieving the head header has failed. If there are no
 // retrievable blocks in the specified range then zero block count is returned with no error.
 func (oracle *Oracle) resolveBlockRange(ctx context.Context, reqEnd rpc.BlockNumber, blocks uint64) (*types.Block, []*types.Receipt, uint64, uint64, error) {

--- a/node/cn/mocks/fetcher_mock.go
+++ b/node/cn/mocks/fetcher_mock.go
@@ -14,30 +14,30 @@ import (
 	fetcher "github.com/kaiachain/kaia/datasync/fetcher"
 )
 
-// MockProtocolManagerFetcher is a mock of ProtocolManagerFetcher interface
+// MockProtocolManagerFetcher is a mock of ProtocolManagerFetcher interface.
 type MockProtocolManagerFetcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockProtocolManagerFetcherMockRecorder
 }
 
-// MockProtocolManagerFetcherMockRecorder is the mock recorder for MockProtocolManagerFetcher
+// MockProtocolManagerFetcherMockRecorder is the mock recorder for MockProtocolManagerFetcher.
 type MockProtocolManagerFetcherMockRecorder struct {
 	mock *MockProtocolManagerFetcher
 }
 
-// NewMockProtocolManagerFetcher creates a new mock instance
+// NewMockProtocolManagerFetcher creates a new mock instance.
 func NewMockProtocolManagerFetcher(ctrl *gomock.Controller) *MockProtocolManagerFetcher {
 	mock := &MockProtocolManagerFetcher{ctrl: ctrl}
 	mock.recorder = &MockProtocolManagerFetcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProtocolManagerFetcher) EXPECT() *MockProtocolManagerFetcherMockRecorder {
 	return m.recorder
 }
 
-// Enqueue mocks base method
+// Enqueue mocks base method.
 func (m *MockProtocolManagerFetcher) Enqueue(arg0 string, arg1 *types.Block) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Enqueue", arg0, arg1)
@@ -45,13 +45,13 @@ func (m *MockProtocolManagerFetcher) Enqueue(arg0 string, arg1 *types.Block) err
 	return ret0
 }
 
-// Enqueue indicates an expected call of Enqueue
+// Enqueue indicates an expected call of Enqueue.
 func (mr *MockProtocolManagerFetcherMockRecorder) Enqueue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enqueue", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).Enqueue), arg0, arg1)
 }
 
-// FilterBodies mocks base method
+// FilterBodies mocks base method.
 func (m *MockProtocolManagerFetcher) FilterBodies(arg0 string, arg1 [][]*types.Transaction, arg2 time.Time) [][]*types.Transaction {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterBodies", arg0, arg1, arg2)
@@ -59,13 +59,13 @@ func (m *MockProtocolManagerFetcher) FilterBodies(arg0 string, arg1 [][]*types.T
 	return ret0
 }
 
-// FilterBodies indicates an expected call of FilterBodies
+// FilterBodies indicates an expected call of FilterBodies.
 func (mr *MockProtocolManagerFetcherMockRecorder) FilterBodies(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterBodies", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).FilterBodies), arg0, arg1, arg2)
 }
 
-// FilterHeaders mocks base method
+// FilterHeaders mocks base method.
 func (m *MockProtocolManagerFetcher) FilterHeaders(arg0 string, arg1 []*types.Header, arg2 time.Time) []*types.Header {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterHeaders", arg0, arg1, arg2)
@@ -73,13 +73,13 @@ func (m *MockProtocolManagerFetcher) FilterHeaders(arg0 string, arg1 []*types.He
 	return ret0
 }
 
-// FilterHeaders indicates an expected call of FilterHeaders
+// FilterHeaders indicates an expected call of FilterHeaders.
 func (mr *MockProtocolManagerFetcherMockRecorder) FilterHeaders(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterHeaders", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).FilterHeaders), arg0, arg1, arg2)
 }
 
-// Notify mocks base method
+// Notify mocks base method.
 func (m *MockProtocolManagerFetcher) Notify(arg0 string, arg1 common.Hash, arg2 uint64, arg3 time.Time, arg4 fetcher.HeaderRequesterFn, arg5 fetcher.BodyRequesterFn) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Notify", arg0, arg1, arg2, arg3, arg4, arg5)
@@ -87,31 +87,31 @@ func (m *MockProtocolManagerFetcher) Notify(arg0 string, arg1 common.Hash, arg2 
 	return ret0
 }
 
-// Notify indicates an expected call of Notify
+// Notify indicates an expected call of Notify.
 func (mr *MockProtocolManagerFetcherMockRecorder) Notify(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).Notify), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-// Start mocks base method
+// Start mocks base method.
 func (m *MockProtocolManagerFetcher) Start() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Start")
 }
 
-// Start indicates an expected call of Start
+// Start indicates an expected call of Start.
 func (mr *MockProtocolManagerFetcherMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).Start))
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockProtocolManagerFetcher) Stop() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Stop")
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockProtocolManagerFetcherMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).Stop))

--- a/node/cn/mocks/miner_mock.go
+++ b/node/cn/mocks/miner_mock.go
@@ -66,12 +66,13 @@ func (mr *MockMinerMockRecorder) Mining() *gomock.Call {
 }
 
 // Pending mocks base method.
-func (m *MockMiner) Pending() (*types.Block, *state.StateDB) {
+func (m *MockMiner) Pending() (*types.Block, types.Receipts, *state.StateDB) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Pending")
 	ret0, _ := ret[0].(*types.Block)
-	ret1, _ := ret[1].(*state.StateDB)
-	return ret0, ret1
+	ret1, _ := ret[1].(types.Receipts)
+	ret2, _ := ret[2].(*state.StateDB)
+	return ret0, ret1, ret2
 }
 
 // Pending indicates an expected call of Pending.

--- a/node/cn/peer_mock_test.go
+++ b/node/cn/peer_mock_test.go
@@ -17,126 +17,126 @@ import (
 	rlp "github.com/kaiachain/kaia/rlp"
 )
 
-// MockPeer is a mock of Peer interface
+// MockPeer is a mock of Peer interface.
 type MockPeer struct {
 	ctrl     *gomock.Controller
 	recorder *MockPeerMockRecorder
 }
 
-// MockPeerMockRecorder is the mock recorder for MockPeer
+// MockPeerMockRecorder is the mock recorder for MockPeer.
 type MockPeerMockRecorder struct {
 	mock *MockPeer
 }
 
-// NewMockPeer creates a new mock instance
+// NewMockPeer creates a new mock instance.
 func NewMockPeer(ctrl *gomock.Controller) *MockPeer {
 	mock := &MockPeer{ctrl: ctrl}
 	mock.recorder = &MockPeerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPeer) EXPECT() *MockPeerMockRecorder {
 	return m.recorder
 }
 
-// AddSnapExtension mocks base method
+// AddSnapExtension mocks base method.
 func (m *MockPeer) AddSnapExtension(arg0 *snap.Peer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddSnapExtension", arg0)
 }
 
-// AddSnapExtension indicates an expected call of AddSnapExtension
+// AddSnapExtension indicates an expected call of AddSnapExtension.
 func (mr *MockPeerMockRecorder) AddSnapExtension(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSnapExtension", reflect.TypeOf((*MockPeer)(nil).AddSnapExtension), arg0)
 }
 
-// AddToKnownBlocks mocks base method
+// AddToKnownBlocks mocks base method.
 func (m *MockPeer) AddToKnownBlocks(arg0 common.Hash) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddToKnownBlocks", arg0)
 }
 
-// AddToKnownBlocks indicates an expected call of AddToKnownBlocks
+// AddToKnownBlocks indicates an expected call of AddToKnownBlocks.
 func (mr *MockPeerMockRecorder) AddToKnownBlocks(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToKnownBlocks", reflect.TypeOf((*MockPeer)(nil).AddToKnownBlocks), arg0)
 }
 
-// AddToKnownTxs mocks base method
+// AddToKnownTxs mocks base method.
 func (m *MockPeer) AddToKnownTxs(arg0 common.Hash) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddToKnownTxs", arg0)
 }
 
-// AddToKnownTxs indicates an expected call of AddToKnownTxs
+// AddToKnownTxs indicates an expected call of AddToKnownTxs.
 func (mr *MockPeerMockRecorder) AddToKnownTxs(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToKnownTxs", reflect.TypeOf((*MockPeer)(nil).AddToKnownTxs), arg0)
 }
 
-// AsyncSendNewBlock mocks base method
+// AsyncSendNewBlock mocks base method.
 func (m *MockPeer) AsyncSendNewBlock(arg0 *types.Block, arg1 *big.Int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AsyncSendNewBlock", arg0, arg1)
 }
 
-// AsyncSendNewBlock indicates an expected call of AsyncSendNewBlock
+// AsyncSendNewBlock indicates an expected call of AsyncSendNewBlock.
 func (mr *MockPeerMockRecorder) AsyncSendNewBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendNewBlock", reflect.TypeOf((*MockPeer)(nil).AsyncSendNewBlock), arg0, arg1)
 }
 
-// AsyncSendNewBlockHash mocks base method
+// AsyncSendNewBlockHash mocks base method.
 func (m *MockPeer) AsyncSendNewBlockHash(arg0 *types.Block) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AsyncSendNewBlockHash", arg0)
 }
 
-// AsyncSendNewBlockHash indicates an expected call of AsyncSendNewBlockHash
+// AsyncSendNewBlockHash indicates an expected call of AsyncSendNewBlockHash.
 func (mr *MockPeerMockRecorder) AsyncSendNewBlockHash(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendNewBlockHash", reflect.TypeOf((*MockPeer)(nil).AsyncSendNewBlockHash), arg0)
 }
 
-// AsyncSendTransactions mocks base method
+// AsyncSendTransactions mocks base method.
 func (m *MockPeer) AsyncSendTransactions(arg0 types.Transactions) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AsyncSendTransactions", arg0)
 }
 
-// AsyncSendTransactions indicates an expected call of AsyncSendTransactions
+// AsyncSendTransactions indicates an expected call of AsyncSendTransactions.
 func (mr *MockPeerMockRecorder) AsyncSendTransactions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendTransactions", reflect.TypeOf((*MockPeer)(nil).AsyncSendTransactions), arg0)
 }
 
-// Broadcast mocks base method
+// Broadcast mocks base method.
 func (m *MockPeer) Broadcast() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Broadcast")
 }
 
-// Broadcast indicates an expected call of Broadcast
+// Broadcast indicates an expected call of Broadcast.
 func (mr *MockPeerMockRecorder) Broadcast() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockPeer)(nil).Broadcast))
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockPeer) Close() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Close")
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockPeerMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPeer)(nil).Close))
 }
 
-// ConnType mocks base method
+// ConnType mocks base method.
 func (m *MockPeer) ConnType() common.ConnType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnType")
@@ -144,25 +144,25 @@ func (m *MockPeer) ConnType() common.ConnType {
 	return ret0
 }
 
-// ConnType indicates an expected call of ConnType
+// ConnType indicates an expected call of ConnType.
 func (mr *MockPeerMockRecorder) ConnType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnType", reflect.TypeOf((*MockPeer)(nil).ConnType))
 }
 
-// DisconnectP2PPeer mocks base method
+// DisconnectP2PPeer mocks base method.
 func (m *MockPeer) DisconnectP2PPeer(arg0 p2p.DiscReason) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DisconnectP2PPeer", arg0)
 }
 
-// DisconnectP2PPeer indicates an expected call of DisconnectP2PPeer
+// DisconnectP2PPeer indicates an expected call of DisconnectP2PPeer.
 func (mr *MockPeerMockRecorder) DisconnectP2PPeer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectP2PPeer", reflect.TypeOf((*MockPeer)(nil).DisconnectP2PPeer), arg0)
 }
 
-// ExistSnapExtension mocks base method
+// ExistSnapExtension mocks base method.
 func (m *MockPeer) ExistSnapExtension() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExistSnapExtension")
@@ -170,13 +170,13 @@ func (m *MockPeer) ExistSnapExtension() bool {
 	return ret0
 }
 
-// ExistSnapExtension indicates an expected call of ExistSnapExtension
+// ExistSnapExtension indicates an expected call of ExistSnapExtension.
 func (mr *MockPeerMockRecorder) ExistSnapExtension() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExistSnapExtension", reflect.TypeOf((*MockPeer)(nil).ExistSnapExtension))
 }
 
-// FetchBlockBodies mocks base method
+// FetchBlockBodies mocks base method.
 func (m *MockPeer) FetchBlockBodies(arg0 []common.Hash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchBlockBodies", arg0)
@@ -184,13 +184,13 @@ func (m *MockPeer) FetchBlockBodies(arg0 []common.Hash) error {
 	return ret0
 }
 
-// FetchBlockBodies indicates an expected call of FetchBlockBodies
+// FetchBlockBodies indicates an expected call of FetchBlockBodies.
 func (mr *MockPeerMockRecorder) FetchBlockBodies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchBlockBodies", reflect.TypeOf((*MockPeer)(nil).FetchBlockBodies), arg0)
 }
 
-// FetchBlockHeader mocks base method
+// FetchBlockHeader mocks base method.
 func (m *MockPeer) FetchBlockHeader(arg0 common.Hash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchBlockHeader", arg0)
@@ -198,13 +198,13 @@ func (m *MockPeer) FetchBlockHeader(arg0 common.Hash) error {
 	return ret0
 }
 
-// FetchBlockHeader indicates an expected call of FetchBlockHeader
+// FetchBlockHeader indicates an expected call of FetchBlockHeader.
 func (mr *MockPeerMockRecorder) FetchBlockHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchBlockHeader", reflect.TypeOf((*MockPeer)(nil).FetchBlockHeader), arg0)
 }
 
-// GetAddr mocks base method
+// GetAddr mocks base method.
 func (m *MockPeer) GetAddr() common.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAddr")
@@ -212,13 +212,13 @@ func (m *MockPeer) GetAddr() common.Address {
 	return ret0
 }
 
-// GetAddr indicates an expected call of GetAddr
+// GetAddr indicates an expected call of GetAddr.
 func (mr *MockPeerMockRecorder) GetAddr() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAddr", reflect.TypeOf((*MockPeer)(nil).GetAddr))
 }
 
-// GetChainID mocks base method
+// GetChainID mocks base method.
 func (m *MockPeer) GetChainID() *big.Int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChainID")
@@ -226,13 +226,13 @@ func (m *MockPeer) GetChainID() *big.Int {
 	return ret0
 }
 
-// GetChainID indicates an expected call of GetChainID
+// GetChainID indicates an expected call of GetChainID.
 func (mr *MockPeerMockRecorder) GetChainID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChainID", reflect.TypeOf((*MockPeer)(nil).GetChainID))
 }
 
-// GetID mocks base method
+// GetID mocks base method.
 func (m *MockPeer) GetID() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetID")
@@ -240,13 +240,13 @@ func (m *MockPeer) GetID() string {
 	return ret0
 }
 
-// GetID indicates an expected call of GetID
+// GetID indicates an expected call of GetID.
 func (mr *MockPeerMockRecorder) GetID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetID", reflect.TypeOf((*MockPeer)(nil).GetID))
 }
 
-// GetP2PPeer mocks base method
+// GetP2PPeer mocks base method.
 func (m *MockPeer) GetP2PPeer() *p2p.Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetP2PPeer")
@@ -254,13 +254,13 @@ func (m *MockPeer) GetP2PPeer() *p2p.Peer {
 	return ret0
 }
 
-// GetP2PPeer indicates an expected call of GetP2PPeer
+// GetP2PPeer indicates an expected call of GetP2PPeer.
 func (mr *MockPeerMockRecorder) GetP2PPeer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetP2PPeer", reflect.TypeOf((*MockPeer)(nil).GetP2PPeer))
 }
 
-// GetP2PPeerID mocks base method
+// GetP2PPeerID mocks base method.
 func (m *MockPeer) GetP2PPeerID() discover.NodeID {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetP2PPeerID")
@@ -268,13 +268,13 @@ func (m *MockPeer) GetP2PPeerID() discover.NodeID {
 	return ret0
 }
 
-// GetP2PPeerID indicates an expected call of GetP2PPeerID
+// GetP2PPeerID indicates an expected call of GetP2PPeerID.
 func (mr *MockPeerMockRecorder) GetP2PPeerID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetP2PPeerID", reflect.TypeOf((*MockPeer)(nil).GetP2PPeerID))
 }
 
-// GetRW mocks base method
+// GetRW mocks base method.
 func (m *MockPeer) GetRW() p2p.MsgReadWriter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRW")
@@ -282,13 +282,13 @@ func (m *MockPeer) GetRW() p2p.MsgReadWriter {
 	return ret0
 }
 
-// GetRW indicates an expected call of GetRW
+// GetRW indicates an expected call of GetRW.
 func (mr *MockPeerMockRecorder) GetRW() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRW", reflect.TypeOf((*MockPeer)(nil).GetRW))
 }
 
-// GetVersion mocks base method
+// GetVersion mocks base method.
 func (m *MockPeer) GetVersion() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersion")
@@ -296,13 +296,13 @@ func (m *MockPeer) GetVersion() int {
 	return ret0
 }
 
-// GetVersion indicates an expected call of GetVersion
+// GetVersion indicates an expected call of GetVersion.
 func (mr *MockPeerMockRecorder) GetVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockPeer)(nil).GetVersion))
 }
 
-// Handle mocks base method
+// Handle mocks base method.
 func (m *MockPeer) Handle(arg0 *ProtocolManager) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle", arg0)
@@ -310,13 +310,13 @@ func (m *MockPeer) Handle(arg0 *ProtocolManager) error {
 	return ret0
 }
 
-// Handle indicates an expected call of Handle
+// Handle indicates an expected call of Handle.
 func (mr *MockPeerMockRecorder) Handle(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockPeer)(nil).Handle), arg0)
 }
 
-// Handshake mocks base method
+// Handshake mocks base method.
 func (m *MockPeer) Handshake(arg0 uint64, arg1, arg2 *big.Int, arg3, arg4 common.Hash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handshake", arg0, arg1, arg2, arg3, arg4)
@@ -324,13 +324,13 @@ func (m *MockPeer) Handshake(arg0 uint64, arg1, arg2 *big.Int, arg3, arg4 common
 	return ret0
 }
 
-// Handshake indicates an expected call of Handshake
+// Handshake indicates an expected call of Handshake.
 func (mr *MockPeerMockRecorder) Handshake(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handshake", reflect.TypeOf((*MockPeer)(nil).Handshake), arg0, arg1, arg2, arg3, arg4)
 }
 
-// Head mocks base method
+// Head mocks base method.
 func (m *MockPeer) Head() (common.Hash, *big.Int) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Head")
@@ -339,13 +339,13 @@ func (m *MockPeer) Head() (common.Hash, *big.Int) {
 	return ret0, ret1
 }
 
-// Head indicates an expected call of Head
+// Head indicates an expected call of Head.
 func (mr *MockPeerMockRecorder) Head() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Head", reflect.TypeOf((*MockPeer)(nil).Head))
 }
 
-// Info mocks base method
+// Info mocks base method.
 func (m *MockPeer) Info() *PeerInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Info")
@@ -353,13 +353,13 @@ func (m *MockPeer) Info() *PeerInfo {
 	return ret0
 }
 
-// Info indicates an expected call of Info
+// Info indicates an expected call of Info.
 func (mr *MockPeerMockRecorder) Info() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockPeer)(nil).Info))
 }
 
-// KnowsBlock mocks base method
+// KnowsBlock mocks base method.
 func (m *MockPeer) KnowsBlock(arg0 common.Hash) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnowsBlock", arg0)
@@ -367,13 +367,13 @@ func (m *MockPeer) KnowsBlock(arg0 common.Hash) bool {
 	return ret0
 }
 
-// KnowsBlock indicates an expected call of KnowsBlock
+// KnowsBlock indicates an expected call of KnowsBlock.
 func (mr *MockPeerMockRecorder) KnowsBlock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnowsBlock", reflect.TypeOf((*MockPeer)(nil).KnowsBlock), arg0)
 }
 
-// KnowsTx mocks base method
+// KnowsTx mocks base method.
 func (m *MockPeer) KnowsTx(arg0 common.Hash) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KnowsTx", arg0)
@@ -381,13 +381,13 @@ func (m *MockPeer) KnowsTx(arg0 common.Hash) bool {
 	return ret0
 }
 
-// KnowsTx indicates an expected call of KnowsTx
+// KnowsTx indicates an expected call of KnowsTx.
 func (mr *MockPeerMockRecorder) KnowsTx(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KnowsTx", reflect.TypeOf((*MockPeer)(nil).KnowsTx), arg0)
 }
 
-// ReSendTransactions mocks base method
+// ReSendTransactions mocks base method.
 func (m *MockPeer) ReSendTransactions(arg0 types.Transactions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReSendTransactions", arg0)
@@ -395,13 +395,13 @@ func (m *MockPeer) ReSendTransactions(arg0 types.Transactions) error {
 	return ret0
 }
 
-// ReSendTransactions indicates an expected call of ReSendTransactions
+// ReSendTransactions indicates an expected call of ReSendTransactions.
 func (mr *MockPeerMockRecorder) ReSendTransactions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReSendTransactions", reflect.TypeOf((*MockPeer)(nil).ReSendTransactions), arg0)
 }
 
-// RegisterConsensusMsgCode mocks base method
+// RegisterConsensusMsgCode mocks base method.
 func (m *MockPeer) RegisterConsensusMsgCode(arg0 uint64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterConsensusMsgCode", arg0)
@@ -409,13 +409,13 @@ func (m *MockPeer) RegisterConsensusMsgCode(arg0 uint64) error {
 	return ret0
 }
 
-// RegisterConsensusMsgCode indicates an expected call of RegisterConsensusMsgCode
+// RegisterConsensusMsgCode indicates an expected call of RegisterConsensusMsgCode.
 func (mr *MockPeerMockRecorder) RegisterConsensusMsgCode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterConsensusMsgCode", reflect.TypeOf((*MockPeer)(nil).RegisterConsensusMsgCode), arg0)
 }
 
-// RequestBodies mocks base method
+// RequestBodies mocks base method.
 func (m *MockPeer) RequestBodies(arg0 []common.Hash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestBodies", arg0)
@@ -423,13 +423,13 @@ func (m *MockPeer) RequestBodies(arg0 []common.Hash) error {
 	return ret0
 }
 
-// RequestBodies indicates an expected call of RequestBodies
+// RequestBodies indicates an expected call of RequestBodies.
 func (mr *MockPeerMockRecorder) RequestBodies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestBodies", reflect.TypeOf((*MockPeer)(nil).RequestBodies), arg0)
 }
 
-// RequestHeadersByHash mocks base method
+// RequestHeadersByHash mocks base method.
 func (m *MockPeer) RequestHeadersByHash(arg0 common.Hash, arg1, arg2 int, arg3 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestHeadersByHash", arg0, arg1, arg2, arg3)
@@ -437,13 +437,13 @@ func (m *MockPeer) RequestHeadersByHash(arg0 common.Hash, arg1, arg2 int, arg3 b
 	return ret0
 }
 
-// RequestHeadersByHash indicates an expected call of RequestHeadersByHash
+// RequestHeadersByHash indicates an expected call of RequestHeadersByHash.
 func (mr *MockPeerMockRecorder) RequestHeadersByHash(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestHeadersByHash", reflect.TypeOf((*MockPeer)(nil).RequestHeadersByHash), arg0, arg1, arg2, arg3)
 }
 
-// RequestHeadersByNumber mocks base method
+// RequestHeadersByNumber mocks base method.
 func (m *MockPeer) RequestHeadersByNumber(arg0 uint64, arg1, arg2 int, arg3 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestHeadersByNumber", arg0, arg1, arg2, arg3)
@@ -451,13 +451,13 @@ func (m *MockPeer) RequestHeadersByNumber(arg0 uint64, arg1, arg2 int, arg3 bool
 	return ret0
 }
 
-// RequestHeadersByNumber indicates an expected call of RequestHeadersByNumber
+// RequestHeadersByNumber indicates an expected call of RequestHeadersByNumber.
 func (mr *MockPeerMockRecorder) RequestHeadersByNumber(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestHeadersByNumber", reflect.TypeOf((*MockPeer)(nil).RequestHeadersByNumber), arg0, arg1, arg2, arg3)
 }
 
-// RequestNodeData mocks base method
+// RequestNodeData mocks base method.
 func (m *MockPeer) RequestNodeData(arg0 []common.Hash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestNodeData", arg0)
@@ -465,13 +465,13 @@ func (m *MockPeer) RequestNodeData(arg0 []common.Hash) error {
 	return ret0
 }
 
-// RequestNodeData indicates an expected call of RequestNodeData
+// RequestNodeData indicates an expected call of RequestNodeData.
 func (mr *MockPeerMockRecorder) RequestNodeData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestNodeData", reflect.TypeOf((*MockPeer)(nil).RequestNodeData), arg0)
 }
 
-// RequestReceipts mocks base method
+// RequestReceipts mocks base method.
 func (m *MockPeer) RequestReceipts(arg0 []common.Hash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestReceipts", arg0)
@@ -479,13 +479,13 @@ func (m *MockPeer) RequestReceipts(arg0 []common.Hash) error {
 	return ret0
 }
 
-// RequestReceipts indicates an expected call of RequestReceipts
+// RequestReceipts indicates an expected call of RequestReceipts.
 func (mr *MockPeerMockRecorder) RequestReceipts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReceipts", reflect.TypeOf((*MockPeer)(nil).RequestReceipts), arg0)
 }
 
-// RequestStakingInfo mocks base method
+// RequestStakingInfo mocks base method.
 func (m *MockPeer) RequestStakingInfo(arg0 []common.Hash) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestStakingInfo", arg0)
@@ -493,13 +493,13 @@ func (m *MockPeer) RequestStakingInfo(arg0 []common.Hash) error {
 	return ret0
 }
 
-// RequestStakingInfo indicates an expected call of RequestStakingInfo
+// RequestStakingInfo indicates an expected call of RequestStakingInfo.
 func (mr *MockPeerMockRecorder) RequestStakingInfo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestStakingInfo", reflect.TypeOf((*MockPeer)(nil).RequestStakingInfo), arg0)
 }
 
-// RunningCap mocks base method
+// RunningCap mocks base method.
 func (m *MockPeer) RunningCap(arg0 string, arg1 []uint) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunningCap", arg0, arg1)
@@ -507,13 +507,13 @@ func (m *MockPeer) RunningCap(arg0 string, arg1 []uint) bool {
 	return ret0
 }
 
-// RunningCap indicates an expected call of RunningCap
+// RunningCap indicates an expected call of RunningCap.
 func (mr *MockPeerMockRecorder) RunningCap(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningCap", reflect.TypeOf((*MockPeer)(nil).RunningCap), arg0, arg1)
 }
 
-// Send mocks base method
+// Send mocks base method.
 func (m *MockPeer) Send(arg0 uint64, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", arg0, arg1)
@@ -521,13 +521,13 @@ func (m *MockPeer) Send(arg0 uint64, arg1 interface{}) error {
 	return ret0
 }
 
-// Send indicates an expected call of Send
+// Send indicates an expected call of Send.
 func (mr *MockPeerMockRecorder) Send(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockPeer)(nil).Send), arg0, arg1)
 }
 
-// SendBlockBodies mocks base method
+// SendBlockBodies mocks base method.
 func (m *MockPeer) SendBlockBodies(arg0 []*blockBody) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendBlockBodies", arg0)
@@ -535,13 +535,13 @@ func (m *MockPeer) SendBlockBodies(arg0 []*blockBody) error {
 	return ret0
 }
 
-// SendBlockBodies indicates an expected call of SendBlockBodies
+// SendBlockBodies indicates an expected call of SendBlockBodies.
 func (mr *MockPeerMockRecorder) SendBlockBodies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBlockBodies", reflect.TypeOf((*MockPeer)(nil).SendBlockBodies), arg0)
 }
 
-// SendBlockBodiesRLP mocks base method
+// SendBlockBodiesRLP mocks base method.
 func (m *MockPeer) SendBlockBodiesRLP(arg0 []rlp.RawValue) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendBlockBodiesRLP", arg0)
@@ -549,13 +549,13 @@ func (m *MockPeer) SendBlockBodiesRLP(arg0 []rlp.RawValue) error {
 	return ret0
 }
 
-// SendBlockBodiesRLP indicates an expected call of SendBlockBodiesRLP
+// SendBlockBodiesRLP indicates an expected call of SendBlockBodiesRLP.
 func (mr *MockPeerMockRecorder) SendBlockBodiesRLP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBlockBodiesRLP", reflect.TypeOf((*MockPeer)(nil).SendBlockBodiesRLP), arg0)
 }
 
-// SendBlockHeaders mocks base method
+// SendBlockHeaders mocks base method.
 func (m *MockPeer) SendBlockHeaders(arg0 []*types.Header) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendBlockHeaders", arg0)
@@ -563,13 +563,13 @@ func (m *MockPeer) SendBlockHeaders(arg0 []*types.Header) error {
 	return ret0
 }
 
-// SendBlockHeaders indicates an expected call of SendBlockHeaders
+// SendBlockHeaders indicates an expected call of SendBlockHeaders.
 func (mr *MockPeerMockRecorder) SendBlockHeaders(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBlockHeaders", reflect.TypeOf((*MockPeer)(nil).SendBlockHeaders), arg0)
 }
 
-// SendFetchedBlockBodiesRLP mocks base method
+// SendFetchedBlockBodiesRLP mocks base method.
 func (m *MockPeer) SendFetchedBlockBodiesRLP(arg0 []rlp.RawValue) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendFetchedBlockBodiesRLP", arg0)
@@ -577,13 +577,13 @@ func (m *MockPeer) SendFetchedBlockBodiesRLP(arg0 []rlp.RawValue) error {
 	return ret0
 }
 
-// SendFetchedBlockBodiesRLP indicates an expected call of SendFetchedBlockBodiesRLP
+// SendFetchedBlockBodiesRLP indicates an expected call of SendFetchedBlockBodiesRLP.
 func (mr *MockPeerMockRecorder) SendFetchedBlockBodiesRLP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendFetchedBlockBodiesRLP", reflect.TypeOf((*MockPeer)(nil).SendFetchedBlockBodiesRLP), arg0)
 }
 
-// SendFetchedBlockHeader mocks base method
+// SendFetchedBlockHeader mocks base method.
 func (m *MockPeer) SendFetchedBlockHeader(arg0 *types.Header) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendFetchedBlockHeader", arg0)
@@ -591,13 +591,13 @@ func (m *MockPeer) SendFetchedBlockHeader(arg0 *types.Header) error {
 	return ret0
 }
 
-// SendFetchedBlockHeader indicates an expected call of SendFetchedBlockHeader
+// SendFetchedBlockHeader indicates an expected call of SendFetchedBlockHeader.
 func (mr *MockPeerMockRecorder) SendFetchedBlockHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendFetchedBlockHeader", reflect.TypeOf((*MockPeer)(nil).SendFetchedBlockHeader), arg0)
 }
 
-// SendNewBlock mocks base method
+// SendNewBlock mocks base method.
 func (m *MockPeer) SendNewBlock(arg0 *types.Block, arg1 *big.Int) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendNewBlock", arg0, arg1)
@@ -605,13 +605,13 @@ func (m *MockPeer) SendNewBlock(arg0 *types.Block, arg1 *big.Int) error {
 	return ret0
 }
 
-// SendNewBlock indicates an expected call of SendNewBlock
+// SendNewBlock indicates an expected call of SendNewBlock.
 func (mr *MockPeerMockRecorder) SendNewBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendNewBlock", reflect.TypeOf((*MockPeer)(nil).SendNewBlock), arg0, arg1)
 }
 
-// SendNewBlockHashes mocks base method
+// SendNewBlockHashes mocks base method.
 func (m *MockPeer) SendNewBlockHashes(arg0 []common.Hash, arg1 []uint64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendNewBlockHashes", arg0, arg1)
@@ -619,13 +619,13 @@ func (m *MockPeer) SendNewBlockHashes(arg0 []common.Hash, arg1 []uint64) error {
 	return ret0
 }
 
-// SendNewBlockHashes indicates an expected call of SendNewBlockHashes
+// SendNewBlockHashes indicates an expected call of SendNewBlockHashes.
 func (mr *MockPeerMockRecorder) SendNewBlockHashes(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendNewBlockHashes", reflect.TypeOf((*MockPeer)(nil).SendNewBlockHashes), arg0, arg1)
 }
 
-// SendNodeData mocks base method
+// SendNodeData mocks base method.
 func (m *MockPeer) SendNodeData(arg0 [][]byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendNodeData", arg0)
@@ -633,13 +633,13 @@ func (m *MockPeer) SendNodeData(arg0 [][]byte) error {
 	return ret0
 }
 
-// SendNodeData indicates an expected call of SendNodeData
+// SendNodeData indicates an expected call of SendNodeData.
 func (mr *MockPeerMockRecorder) SendNodeData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendNodeData", reflect.TypeOf((*MockPeer)(nil).SendNodeData), arg0)
 }
 
-// SendReceiptsRLP mocks base method
+// SendReceiptsRLP mocks base method.
 func (m *MockPeer) SendReceiptsRLP(arg0 []rlp.RawValue) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendReceiptsRLP", arg0)
@@ -647,13 +647,13 @@ func (m *MockPeer) SendReceiptsRLP(arg0 []rlp.RawValue) error {
 	return ret0
 }
 
-// SendReceiptsRLP indicates an expected call of SendReceiptsRLP
+// SendReceiptsRLP indicates an expected call of SendReceiptsRLP.
 func (mr *MockPeerMockRecorder) SendReceiptsRLP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendReceiptsRLP", reflect.TypeOf((*MockPeer)(nil).SendReceiptsRLP), arg0)
 }
 
-// SendStakingInfoRLP mocks base method
+// SendStakingInfoRLP mocks base method.
 func (m *MockPeer) SendStakingInfoRLP(arg0 []rlp.RawValue) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendStakingInfoRLP", arg0)
@@ -661,13 +661,13 @@ func (m *MockPeer) SendStakingInfoRLP(arg0 []rlp.RawValue) error {
 	return ret0
 }
 
-// SendStakingInfoRLP indicates an expected call of SendStakingInfoRLP
+// SendStakingInfoRLP indicates an expected call of SendStakingInfoRLP.
 func (mr *MockPeerMockRecorder) SendStakingInfoRLP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendStakingInfoRLP", reflect.TypeOf((*MockPeer)(nil).SendStakingInfoRLP), arg0)
 }
 
-// SendTransactions mocks base method
+// SendTransactions mocks base method.
 func (m *MockPeer) SendTransactions(arg0 types.Transactions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendTransactions", arg0)
@@ -675,43 +675,43 @@ func (m *MockPeer) SendTransactions(arg0 types.Transactions) error {
 	return ret0
 }
 
-// SendTransactions indicates an expected call of SendTransactions
+// SendTransactions indicates an expected call of SendTransactions.
 func (mr *MockPeerMockRecorder) SendTransactions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransactions", reflect.TypeOf((*MockPeer)(nil).SendTransactions), arg0)
 }
 
-// SetAddr mocks base method
+// SetAddr mocks base method.
 func (m *MockPeer) SetAddr(arg0 common.Address) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetAddr", arg0)
 }
 
-// SetAddr indicates an expected call of SetAddr
+// SetAddr indicates an expected call of SetAddr.
 func (mr *MockPeerMockRecorder) SetAddr(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAddr", reflect.TypeOf((*MockPeer)(nil).SetAddr), arg0)
 }
 
-// SetHead mocks base method
+// SetHead mocks base method.
 func (m *MockPeer) SetHead(arg0 common.Hash, arg1 *big.Int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetHead", arg0, arg1)
 }
 
-// SetHead indicates an expected call of SetHead
+// SetHead indicates an expected call of SetHead.
 func (mr *MockPeerMockRecorder) SetHead(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHead", reflect.TypeOf((*MockPeer)(nil).SetHead), arg0, arg1)
 }
 
-// UpdateRWImplementationVersion mocks base method
+// UpdateRWImplementationVersion mocks base method.
 func (m *MockPeer) UpdateRWImplementationVersion() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateRWImplementationVersion")
 }
 
-// UpdateRWImplementationVersion indicates an expected call of UpdateRWImplementationVersion
+// UpdateRWImplementationVersion indicates an expected call of UpdateRWImplementationVersion.
 func (mr *MockPeerMockRecorder) UpdateRWImplementationVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRWImplementationVersion", reflect.TypeOf((*MockPeer)(nil).UpdateRWImplementationVersion))

--- a/node/cn/peer_set_mock_test.go
+++ b/node/cn/peer_set_mock_test.go
@@ -14,30 +14,30 @@ import (
 	snap "github.com/kaiachain/kaia/node/cn/snap"
 )
 
-// MockPeerSet is a mock of PeerSet interface
+// MockPeerSet is a mock of PeerSet interface.
 type MockPeerSet struct {
 	ctrl     *gomock.Controller
 	recorder *MockPeerSetMockRecorder
 }
 
-// MockPeerSetMockRecorder is the mock recorder for MockPeerSet
+// MockPeerSetMockRecorder is the mock recorder for MockPeerSet.
 type MockPeerSetMockRecorder struct {
 	mock *MockPeerSet
 }
 
-// NewMockPeerSet creates a new mock instance
+// NewMockPeerSet creates a new mock instance.
 func NewMockPeerSet(ctrl *gomock.Controller) *MockPeerSet {
 	mock := &MockPeerSet{ctrl: ctrl}
 	mock.recorder = &MockPeerSetMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPeerSet) EXPECT() *MockPeerSetMockRecorder {
 	return m.recorder
 }
 
-// BestPeer mocks base method
+// BestPeer mocks base method.
 func (m *MockPeerSet) BestPeer() Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BestPeer")
@@ -45,13 +45,13 @@ func (m *MockPeerSet) BestPeer() Peer {
 	return ret0
 }
 
-// BestPeer indicates an expected call of BestPeer
+// BestPeer indicates an expected call of BestPeer.
 func (mr *MockPeerSetMockRecorder) BestPeer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BestPeer", reflect.TypeOf((*MockPeerSet)(nil).BestPeer))
 }
 
-// CNPeers mocks base method
+// CNPeers mocks base method.
 func (m *MockPeerSet) CNPeers() map[common.Address]Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CNPeers")
@@ -59,13 +59,13 @@ func (m *MockPeerSet) CNPeers() map[common.Address]Peer {
 	return ret0
 }
 
-// CNPeers indicates an expected call of CNPeers
+// CNPeers indicates an expected call of CNPeers.
 func (mr *MockPeerSetMockRecorder) CNPeers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CNPeers", reflect.TypeOf((*MockPeerSet)(nil).CNPeers))
 }
 
-// CNWithoutTx mocks base method
+// CNWithoutTx mocks base method.
 func (m *MockPeerSet) CNWithoutTx(arg0 common.Hash) []Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CNWithoutTx", arg0)
@@ -73,25 +73,25 @@ func (m *MockPeerSet) CNWithoutTx(arg0 common.Hash) []Peer {
 	return ret0
 }
 
-// CNWithoutTx indicates an expected call of CNWithoutTx
+// CNWithoutTx indicates an expected call of CNWithoutTx.
 func (mr *MockPeerSetMockRecorder) CNWithoutTx(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CNWithoutTx", reflect.TypeOf((*MockPeerSet)(nil).CNWithoutTx), arg0)
 }
 
-// Close mocks base method
+// Close mocks base method.
 func (m *MockPeerSet) Close() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Close")
 }
 
-// Close indicates an expected call of Close
+// Close indicates an expected call of Close.
 func (mr *MockPeerSetMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPeerSet)(nil).Close))
 }
 
-// ENPeers mocks base method
+// ENPeers mocks base method.
 func (m *MockPeerSet) ENPeers() map[common.Address]Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ENPeers")
@@ -99,13 +99,13 @@ func (m *MockPeerSet) ENPeers() map[common.Address]Peer {
 	return ret0
 }
 
-// ENPeers indicates an expected call of ENPeers
+// ENPeers indicates an expected call of ENPeers.
 func (mr *MockPeerSetMockRecorder) ENPeers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ENPeers", reflect.TypeOf((*MockPeerSet)(nil).ENPeers))
 }
 
-// Len mocks base method
+// Len mocks base method.
 func (m *MockPeerSet) Len() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Len")
@@ -113,13 +113,13 @@ func (m *MockPeerSet) Len() int {
 	return ret0
 }
 
-// Len indicates an expected call of Len
+// Len indicates an expected call of Len.
 func (mr *MockPeerSetMockRecorder) Len() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockPeerSet)(nil).Len))
 }
 
-// PNPeers mocks base method
+// PNPeers mocks base method.
 func (m *MockPeerSet) PNPeers() map[common.Address]Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PNPeers")
@@ -127,13 +127,13 @@ func (m *MockPeerSet) PNPeers() map[common.Address]Peer {
 	return ret0
 }
 
-// PNPeers indicates an expected call of PNPeers
+// PNPeers indicates an expected call of PNPeers.
 func (mr *MockPeerSetMockRecorder) PNPeers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PNPeers", reflect.TypeOf((*MockPeerSet)(nil).PNPeers))
 }
 
-// Peer mocks base method
+// Peer mocks base method.
 func (m *MockPeerSet) Peer(arg0 string) Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Peer", arg0)
@@ -141,13 +141,13 @@ func (m *MockPeerSet) Peer(arg0 string) Peer {
 	return ret0
 }
 
-// Peer indicates an expected call of Peer
+// Peer indicates an expected call of Peer.
 func (mr *MockPeerSetMockRecorder) Peer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peer", reflect.TypeOf((*MockPeerSet)(nil).Peer), arg0)
 }
 
-// Peers mocks base method
+// Peers mocks base method.
 func (m *MockPeerSet) Peers() map[string]Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Peers")
@@ -155,13 +155,13 @@ func (m *MockPeerSet) Peers() map[string]Peer {
 	return ret0
 }
 
-// Peers indicates an expected call of Peers
+// Peers indicates an expected call of Peers.
 func (mr *MockPeerSetMockRecorder) Peers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peers", reflect.TypeOf((*MockPeerSet)(nil).Peers))
 }
 
-// PeersWithoutBlock mocks base method
+// PeersWithoutBlock mocks base method.
 func (m *MockPeerSet) PeersWithoutBlock(arg0 common.Hash) []Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PeersWithoutBlock", arg0)
@@ -169,13 +169,13 @@ func (m *MockPeerSet) PeersWithoutBlock(arg0 common.Hash) []Peer {
 	return ret0
 }
 
-// PeersWithoutBlock indicates an expected call of PeersWithoutBlock
+// PeersWithoutBlock indicates an expected call of PeersWithoutBlock.
 func (mr *MockPeerSetMockRecorder) PeersWithoutBlock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeersWithoutBlock", reflect.TypeOf((*MockPeerSet)(nil).PeersWithoutBlock), arg0)
 }
 
-// PeersWithoutTx mocks base method
+// PeersWithoutTx mocks base method.
 func (m *MockPeerSet) PeersWithoutTx(arg0 common.Hash) []Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PeersWithoutTx", arg0)
@@ -183,13 +183,13 @@ func (m *MockPeerSet) PeersWithoutTx(arg0 common.Hash) []Peer {
 	return ret0
 }
 
-// PeersWithoutTx indicates an expected call of PeersWithoutTx
+// PeersWithoutTx indicates an expected call of PeersWithoutTx.
 func (mr *MockPeerSetMockRecorder) PeersWithoutTx(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeersWithoutTx", reflect.TypeOf((*MockPeerSet)(nil).PeersWithoutTx), arg0)
 }
 
-// Register mocks base method
+// Register mocks base method.
 func (m *MockPeerSet) Register(arg0 Peer, arg1 *snap.Peer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Register", arg0, arg1)
@@ -197,13 +197,13 @@ func (m *MockPeerSet) Register(arg0 Peer, arg1 *snap.Peer) error {
 	return ret0
 }
 
-// Register indicates an expected call of Register
+// Register indicates an expected call of Register.
 func (mr *MockPeerSetMockRecorder) Register(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPeerSet)(nil).Register), arg0, arg1)
 }
 
-// RegisterSnapExtension mocks base method
+// RegisterSnapExtension mocks base method.
 func (m *MockPeerSet) RegisterSnapExtension(arg0 *snap.Peer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterSnapExtension", arg0)
@@ -211,25 +211,25 @@ func (m *MockPeerSet) RegisterSnapExtension(arg0 *snap.Peer) error {
 	return ret0
 }
 
-// RegisterSnapExtension indicates an expected call of RegisterSnapExtension
+// RegisterSnapExtension indicates an expected call of RegisterSnapExtension.
 func (mr *MockPeerSetMockRecorder) RegisterSnapExtension(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterSnapExtension", reflect.TypeOf((*MockPeerSet)(nil).RegisterSnapExtension), arg0)
 }
 
-// RegisterValidator mocks base method
+// RegisterValidator mocks base method.
 func (m *MockPeerSet) RegisterValidator(arg0 common.ConnType, arg1 p2p.PeerTypeValidator) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RegisterValidator", arg0, arg1)
 }
 
-// RegisterValidator indicates an expected call of RegisterValidator
+// RegisterValidator indicates an expected call of RegisterValidator.
 func (mr *MockPeerSetMockRecorder) RegisterValidator(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterValidator", reflect.TypeOf((*MockPeerSet)(nil).RegisterValidator), arg0, arg1)
 }
 
-// SamplePeersToSendBlock mocks base method
+// SamplePeersToSendBlock mocks base method.
 func (m *MockPeerSet) SamplePeersToSendBlock(arg0 *types.Block, arg1 common.ConnType) []Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SamplePeersToSendBlock", arg0, arg1)
@@ -237,13 +237,13 @@ func (m *MockPeerSet) SamplePeersToSendBlock(arg0 *types.Block, arg1 common.Conn
 	return ret0
 }
 
-// SamplePeersToSendBlock indicates an expected call of SamplePeersToSendBlock
+// SamplePeersToSendBlock indicates an expected call of SamplePeersToSendBlock.
 func (mr *MockPeerSetMockRecorder) SamplePeersToSendBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SamplePeersToSendBlock", reflect.TypeOf((*MockPeerSet)(nil).SamplePeersToSendBlock), arg0, arg1)
 }
 
-// SampleResendPeersByType mocks base method
+// SampleResendPeersByType mocks base method.
 func (m *MockPeerSet) SampleResendPeersByType(arg0 common.ConnType) []Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SampleResendPeersByType", arg0)
@@ -251,13 +251,13 @@ func (m *MockPeerSet) SampleResendPeersByType(arg0 common.ConnType) []Peer {
 	return ret0
 }
 
-// SampleResendPeersByType indicates an expected call of SampleResendPeersByType
+// SampleResendPeersByType indicates an expected call of SampleResendPeersByType.
 func (mr *MockPeerSetMockRecorder) SampleResendPeersByType(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SampleResendPeersByType", reflect.TypeOf((*MockPeerSet)(nil).SampleResendPeersByType), arg0)
 }
 
-// SnapLen mocks base method
+// SnapLen mocks base method.
 func (m *MockPeerSet) SnapLen() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SnapLen")
@@ -265,13 +265,13 @@ func (m *MockPeerSet) SnapLen() int {
 	return ret0
 }
 
-// SnapLen indicates an expected call of SnapLen
+// SnapLen indicates an expected call of SnapLen.
 func (mr *MockPeerSetMockRecorder) SnapLen() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnapLen", reflect.TypeOf((*MockPeerSet)(nil).SnapLen))
 }
 
-// TypePeersWithoutTx mocks base method
+// TypePeersWithoutTx mocks base method.
 func (m *MockPeerSet) TypePeersWithoutTx(arg0 common.Hash, arg1 common.ConnType) []Peer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TypePeersWithoutTx", arg0, arg1)
@@ -279,13 +279,13 @@ func (m *MockPeerSet) TypePeersWithoutTx(arg0 common.Hash, arg1 common.ConnType)
 	return ret0
 }
 
-// TypePeersWithoutTx indicates an expected call of TypePeersWithoutTx
+// TypePeersWithoutTx indicates an expected call of TypePeersWithoutTx.
 func (mr *MockPeerSetMockRecorder) TypePeersWithoutTx(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TypePeersWithoutTx", reflect.TypeOf((*MockPeerSet)(nil).TypePeersWithoutTx), arg0, arg1)
 }
 
-// Unregister mocks base method
+// Unregister mocks base method.
 func (m *MockPeerSet) Unregister(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unregister", arg0)
@@ -293,25 +293,25 @@ func (m *MockPeerSet) Unregister(arg0 string) error {
 	return ret0
 }
 
-// Unregister indicates an expected call of Unregister
+// Unregister indicates an expected call of Unregister.
 func (mr *MockPeerSetMockRecorder) Unregister(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unregister", reflect.TypeOf((*MockPeerSet)(nil).Unregister), arg0)
 }
 
-// UpdateTypePeersWithoutTxs mocks base method
+// UpdateTypePeersWithoutTxs mocks base method.
 func (m *MockPeerSet) UpdateTypePeersWithoutTxs(arg0 *types.Transaction, arg1 common.ConnType, arg2 map[Peer]types.Transactions) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateTypePeersWithoutTxs", arg0, arg1, arg2)
 }
 
-// UpdateTypePeersWithoutTxs indicates an expected call of UpdateTypePeersWithoutTxs
+// UpdateTypePeersWithoutTxs indicates an expected call of UpdateTypePeersWithoutTxs.
 func (mr *MockPeerSetMockRecorder) UpdateTypePeersWithoutTxs(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTypePeersWithoutTxs", reflect.TypeOf((*MockPeerSet)(nil).UpdateTypePeersWithoutTxs), arg0, arg1, arg2)
 }
 
-// WaitSnapExtension mocks base method
+// WaitSnapExtension mocks base method.
 func (m *MockPeerSet) WaitSnapExtension(arg0 Peer) (*snap.Peer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitSnapExtension", arg0)
@@ -320,7 +320,7 @@ func (m *MockPeerSet) WaitSnapExtension(arg0 Peer) (*snap.Peer, error) {
 	return ret0, ret1
 }
 
-// WaitSnapExtension indicates an expected call of WaitSnapExtension
+// WaitSnapExtension indicates an expected call of WaitSnapExtension.
 func (mr *MockPeerSetMockRecorder) WaitSnapExtension(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitSnapExtension", reflect.TypeOf((*MockPeerSet)(nil).WaitSnapExtension), arg0)

--- a/node/sc/local_backend.go
+++ b/node/sc/local_backend.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/bloombits"
+	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/event"
@@ -82,6 +83,11 @@ func (fb *filterLocalBackend) GetBlockReceipts(ctx context.Context, hash common.
 		return nil
 	}
 	return fb.subbridge.blockchain.GetReceiptsByBlockHash(hash)
+}
+
+func (fb *filterLocalBackend) Pending() (*types.Block, types.Receipts, *state.StateDB) {
+	// Not supported
+	return nil, nil, nil
 }
 
 func (fb *filterLocalBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {

--- a/node/sc/subbridge.go
+++ b/node/sc/subbridge.go
@@ -368,7 +368,7 @@ func (sb *SubBridge) SetComponents(components []interface{}) {
 		}
 	}
 
-	es := filters.NewEventSystem(sb.eventMux, &filterLocalBackend{sb}, false)
+	es := filters.NewEventSystem(sb.eventMux, &filterLocalBackend{sb})
 	sb.localBackend = backends.NewBlockchainContractBackend(sb.blockchain, sb.txPool, es)
 
 	sb.bridgeManager, err = NewBridgeManager(sb)

--- a/work/work.go
+++ b/work/work.go
@@ -210,8 +210,8 @@ func (self *Miner) SetExtra(extra []byte) error {
 	return nil
 }
 
-// Pending returns the currently pending block and associated state.
-func (self *Miner) Pending() (*types.Block, *state.StateDB) {
+// Pending returns the currently pending block, corresponding receipts and associated state.
+func (self *Miner) Pending() (*types.Block, types.Receipts, *state.StateDB) {
 	return self.worker.pending()
 }
 

--- a/work/worker_fake.go
+++ b/work/worker_fake.go
@@ -39,6 +39,6 @@ func (*FakeWorker) Register(Agent)                                           {}
 func (*FakeWorker) Mining() bool                                             { return false }
 func (*FakeWorker) HashRate() (tot int64)                                    { return 0 }
 func (*FakeWorker) SetExtra([]byte) error                                    { return nil }
-func (*FakeWorker) Pending() (*types.Block, *state.StateDB)                  { return nil, nil }
+func (*FakeWorker) Pending() (*types.Block, types.Receipts, *state.StateDB)  { return nil, nil, nil }
 func (*FakeWorker) PendingBlock() *types.Block                               { return nil }
 func (*FakeWorker) RegisterExecutionModule(modules ...kaiax.ExecutionModule) {}


### PR DESCRIPTION
## Proposed changes

Change the behavior of APIs when `"pending"` is given as an `rpc.BlockNumber` parameter.

#### 1. Remove support for pending logs
- Following single-shot APIs do not accept "pending" as a block number parameters `fromBlock` nor `toBlock`.
  - eth_getLogs, kaia_getLogs  ([src](https://github.com/kaiachain/kaia/blob/87ea0583223248874724f1f11a69118ad774300d/node/cn/filters/api.go#L379))
  - eth_newFilter, kaia_newFilter ([src](https://github.com/kaiachain/kaia/blob/87ea0583223248874724f1f11a69118ad774300d/node/cn/filters/api.go#L346))
 - Following subscription APIs do not scan pending blocks when requested with "logs" event type ([src](https://github.com/kaiachain/kaia/blob/87ea0583223248874724f1f11a69118ad774300d/node/cn/filters/api.go#L295)) ([docs](https://docs.alchemy.com/reference/eth-subscribe))
   - eth_subscribe, kaia_subscribe
- Users who have been using "pending" must now use "latest" for single-shot APIs for the same result.
- Note that for ENs and PNs the behavior won't change as they don't mine blocks, thus pending block equals latest block.

#### 2. Add support for pending blocks for feehistory and recover APIs
- Following APIs, in CN, will now utilize currently mining block when given "pending" as a block argument.
  - eth_feeHistory, kaia_feeHistory ([src](https://github.com/kaiachain/kaia/blob/87ea0583223248874724f1f11a69118ad774300d/api/api_public_klay.go#L80))
  - kaia_recoverFromTransaction ([src](https://github.com/kaiachain/kaia/blob/87ea0583223248874724f1f11a69118ad774300d/api/api_public_transaction_pool.go#L565))
- Users can keep using "pending" argument.
- In EN and PN these APIs will behave the same. Pending block equals latest block.

#### 3. Do not return error from simple query APIs
- Following APIs no longer return error upon missing data. Instead they return `null`.
  - eth_getBlockTransactionCountByNumber, kaia_getBlockTransactionCountByNumber
  - eth_getBlockTransactionCountByHash, kaia_getBlockTransactionCountByHash
  - eth_getTransactionByBlockNumberAndIndex, kaia_getTransactionByBlockNumberAndIndex
  - eth_getTransactionByBlockHashAndIndex, kaia_getTransactionByBlockHashAndIndex
  - eth_getRawTransactionByBlockNumberAndIndex, kaia_getRawTransactionByBlockNumberAndIndex
  - eth_getRawTransactionByBlockHashAndIndex, kaia_getRawTransactionByBlockHashAndIndex
- Users might need to handle the `null` result.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
