### PR TITLE
kaiax/builder: Add module skeleton

### DIFF
--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -1092,6 +1092,24 @@ func (t *TransactionsByPriceAndNonce) Clear() {
 	t.heads, t.txs = nil, nil
 }
 
+// Copy the current object.
+func (t *TransactionsByPriceAndNonce) Copy() *TransactionsByPriceAndNonce {
+	txsCopy := make(map[common.Address]Transactions)
+	for addr, txList := range t.txs {
+		txsCopy[addr] = txList
+	}
+
+	headsCopy := make(txByPriceAndTime, len(t.heads))
+	copy(headsCopy, t.heads)
+
+	return &TransactionsByPriceAndNonce{
+		txs:     txsCopy, // shift changes it.
+		heads:   t.heads, // pop, shift changes it.
+		signer:  t.signer,
+		baseFee: t.baseFee, // read-only
+	}
+}
+
 // NewMessage returns a `*Transaction` object with the given arguments.
 func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice, gasFeeCap, gasTipCap *big.Int, data []byte, checkNonce bool, intrinsicGas uint64, list AccessList, chainId *big.Int, auth []SetCodeAuthorization) *Transaction {
 	transaction := &Transaction{

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -1198,3 +1198,35 @@ func TestEmptyHeap(t *testing.T) {
 		heap.Clear()
 	})
 }
+
+func TestHeapCopy(t *testing.T) {
+	// Generate a batch of accounts to start with
+	keys := make([]*ecdsa.PrivateKey, 25)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+	}
+	baseFee := common.Big0
+
+	signer := LatestSignerForChainID(common.Big1)
+	// Generate a batch of transactions with overlapping values, but shifted nonces
+	groups := map[common.Address]Transactions{}
+	for start, key := range keys {
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		for i := 0; i < 25; i++ {
+			tx, _ := SignTx(NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
+			groups[addr] = append(groups[addr], tx)
+		}
+	}
+
+	// Sort the transactions and cross check the nonce ordering
+	txset := NewTransactionsByPriceAndNonce(signer, groups, baseFee)
+	txsetCopy := txset.Copy()
+
+	assert.False(t, txset.Empty())
+	assert.False(t, txsetCopy.Empty())
+	for i := 0; i < 25; i++ {
+		txset.Pop()
+	}
+	assert.True(t, txset.Empty())
+	assert.False(t, txsetCopy.Empty())
+}

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -32,13 +32,10 @@ type Bundle struct {
 // Has checks if the bundle contains a tx with the given hash.
 func (b *Bundle) Has(hash common.Hash) bool {
 	for _, txOrGen := range b.BundleTxs {
-		switch tx := txOrGen.(type) {
-		case *types.Transaction:
+		if tx, ok := txOrGen.(*types.Transaction); ok {
 			if tx.Hash() == hash {
 				return true
 			}
-		default:
-			continue
 		}
 	}
 

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -49,7 +49,12 @@ func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 		return true
 	}
 
-	// 2-1. Build a map of TxHash -> IndexInBundle
+	// 2-1. Empty bundleTxs does not conflict with other transactions
+	if len(b.BundleTxs) == 0 {
+		return false
+	}
+
+	// 2-2. Build a map of TxHash -> IndexInBundle
 	hashes := make(map[common.Hash]int)
 	for i, txOrGen := range b.BundleTxs {
 		tx, ok := txOrGen.(*types.Transaction)
@@ -59,14 +64,14 @@ func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 		hashes[tx.Hash()] = i
 	}
 
-	// 2-2. Check for TargetTxHash breaking current bundle.
+	// 2-3. Check for TargetTxHash breaking current bundle.
 	// If newBundle.TargetTxHash is equal to the last tx of current bundle, it is NOT a conflict.
 	// e.g.) b.txs = [0x1, 0x2] and newBundle's TargetTxHash is 0x2.
 	if idx, ok := hashes[newBundle.TargetTxHash]; ok && idx != len(b.BundleTxs)-1 {
 		return true
 	}
 
-	// 2-3. Check for overlapping txs
+	// 2-4. Check for overlapping txs
 	for _, txOrGen := range newBundle.BundleTxs {
 		if tx, ok := txOrGen.(*types.Transaction); ok {
 			if _, has := hashes[tx.Hash()]; has {

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -29,6 +29,22 @@ type Bundle struct {
 	TargetTxHash common.Hash
 }
 
+// Has checks if the bundle contains a tx with the given hash.
+func (b *Bundle) Has(hash common.Hash) bool {
+	for _, txOrGen := range b.BundleTxs {
+		switch tx := txOrGen.(type) {
+		case *types.Transaction:
+			if tx.Hash() == hash {
+				return true
+			}
+		default:
+			continue
+		}
+	}
+
+	return false
+}
+
 // IsConflict checks if newBundle conflicts with current bundle.
 func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 	// 1. Check for same target tx hash

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -1,0 +1,68 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+)
+
+type Bundle struct {
+	// each element can be either *types.Transaction, or TxGenerator
+	BundleTxs []interface{}
+
+	// BundleTxs is placed AFTER the target tx. If empty hash, it is placed at the very front.
+	TargetTxHash common.Hash
+}
+
+func (b *Bundle) IsConflict(newBundle *Bundle) bool {
+	// 1. Check for same target tx hash
+	if b.TargetTxHash == newBundle.TargetTxHash {
+		return true
+	}
+
+	// 2-1. Build a map of TxHash -> IndexInBundle
+	hashes := make(map[common.Hash]int)
+	for i, txOrGen := range b.BundleTxs {
+		tx, ok := txOrGen.(*types.Transaction)
+		if !ok {
+			continue
+		}
+		hashes[tx.Hash()] = i
+	}
+
+	// 2-2. Check for TargetTxHash breaking current bundle.
+	// If newBundle.TargetTxHash is equal to the last tx of current bundle, it is NOT a conflict.
+	// e.g.) b.txs = [0x1, 0x2] and newBundle's TargetTxHash is 0x2.
+	if idx, ok := hashes[newBundle.TargetTxHash]; ok && idx != len(b.BundleTxs)-1 {
+		return true
+	}
+
+	// 2-3. Check for overlapping txs
+	for _, txOrGen := range newBundle.BundleTxs {
+		tx, ok := txOrGen.(*types.Transaction)
+		if !ok {
+			continue
+		}
+
+		if _, ok := hashes[tx.Hash()]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -29,6 +29,7 @@ type Bundle struct {
 	TargetTxHash common.Hash
 }
 
+// IsConflict checks if newBundle conflicts with current bundle.
 func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 	// 1. Check for same target tx hash
 	if b.TargetTxHash == newBundle.TargetTxHash {

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -30,10 +30,16 @@ type Bundle struct {
 }
 
 // Has checks if the bundle contains a tx with the given hash.
-func (b *Bundle) Has(hash common.Hash) bool {
+// Nonce is optionally used for TxGenerator, where transaction is generated with the given nonce.
+func (b *Bundle) Has(hash common.Hash, nonce uint64) bool {
 	for _, txOrGen := range b.BundleTxs {
-		if tx, ok := txOrGen.(*types.Transaction); ok {
-			if tx.Hash() == hash {
+		switch v := txOrGen.(type) {
+		case *types.Transaction:
+			if v.Hash() == hash {
+				return true
+			}
+		case TxGenerator:
+			if tx, err := v(nonce); err != nil && tx.Hash() == hash {
 				return true
 			}
 		}

--- a/kaiax/builder/bundle.go
+++ b/kaiax/builder/bundle.go
@@ -68,13 +68,10 @@ func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 
 	// 2-3. Check for overlapping txs
 	for _, txOrGen := range newBundle.BundleTxs {
-		tx, ok := txOrGen.(*types.Transaction)
-		if !ok {
-			continue
-		}
-
-		if _, ok := hashes[tx.Hash()]; ok {
-			return true
+		if tx, ok := txOrGen.(*types.Transaction); ok {
+			if _, has := hashes[tx.Hash()]; has {
+				return true
+			}
 		}
 	}
 

--- a/kaiax/builder/bundle_test.go
+++ b/kaiax/builder/bundle_test.go
@@ -43,20 +43,11 @@ func TestBundle_IsConflict(t *testing.T) {
 		expected  bool
 	}{
 		{
-			name:   "Same TargetTxHash",
+			name:   "Same TargetTxHash (empty TargetHash)",
 			bundle: b0,
 			newBundle: &Bundle{
 				BundleTxs:    []interface{}{},
 				TargetTxHash: common.Hash{},
-			},
-			expected: true,
-		},
-		{
-			name:   "Empty TargetTxHash",
-			bundle: b0,
-			newBundle: &Bundle{
-				BundleTxs:    []interface{}{},
-				TargetTxHash: txs[0].Hash(),
 			},
 			expected: true,
 		},

--- a/kaiax/builder/bundle_test.go
+++ b/kaiax/builder/bundle_test.go
@@ -1,0 +1,107 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBundle_IsConflict(t *testing.T) {
+	txs := make([]*types.Transaction, 4)
+	for i := range txs {
+		txs[i] = types.NewTransaction(uint64(i), common.Address{}, common.Big0, 0, common.Big0, nil)
+	}
+
+	testcases := []struct {
+		name      string
+		bundle    *Bundle
+		newBundle *Bundle
+		expected  bool
+	}{
+		{
+			name: "Same target tx hash",
+			bundle: &Bundle{
+				BundleTxs:    []interface{}{},
+				TargetTxHash: txs[0].Hash(),
+			},
+			newBundle: &Bundle{
+				BundleTxs:    []interface{}{},
+				TargetTxHash: txs[0].Hash(),
+			},
+			expected: true,
+		},
+		{
+			name: "Target tx hash breaks bundle",
+			bundle: &Bundle{
+				BundleTxs:    []interface{}{txs[1], txs[2]},
+				TargetTxHash: txs[0].Hash(),
+			},
+			newBundle: &Bundle{
+				BundleTxs:    []interface{}{},
+				TargetTxHash: txs[1].Hash(),
+			},
+			expected: true,
+		},
+		{
+			name: "Target tx hash equals last tx (no conflict)",
+			bundle: &Bundle{
+				BundleTxs:    []interface{}{txs[1], txs[2]},
+				TargetTxHash: txs[0].Hash(),
+			},
+			newBundle: &Bundle{
+				BundleTxs:    []interface{}{},
+				TargetTxHash: txs[2].Hash(),
+			},
+			expected: false,
+		},
+		{
+			name: "Overlapping transactions",
+			bundle: &Bundle{
+				BundleTxs:    []interface{}{txs[0], txs[1]},
+				TargetTxHash: txs[0].Hash(),
+			},
+			newBundle: &Bundle{
+				BundleTxs:    []interface{}{txs[0]},
+				TargetTxHash: txs[1].Hash(),
+			},
+			expected: true,
+		},
+		{
+			name: "Non-overlapping transactions",
+			bundle: &Bundle{
+				BundleTxs:    []interface{}{txs[0], txs[1]},
+				TargetTxHash: txs[0].Hash(),
+			},
+			newBundle: &Bundle{
+				BundleTxs:    []interface{}{txs[2], txs[3]},
+				TargetTxHash: txs[1].Hash(),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.bundle.IsConflict(tc.newBundle)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/kaiax/builder/bundle_test.go
+++ b/kaiax/builder/bundle_test.go
@@ -52,6 +52,15 @@ func TestBundle_IsConflict(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:   "Empty TargetTxHash",
+			bundle: b0,
+			newBundle: &Bundle{
+				BundleTxs:    []interface{}{},
+				TargetTxHash: txs[0].Hash(),
+			},
+			expected: true,
+		},
+		{
 			name:   "TargetTxHash divides a bundle",
 			bundle: b0,
 			newBundle: &Bundle{

--- a/kaiax/builder/bundle_test.go
+++ b/kaiax/builder/bundle_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/kaiax/builder/bundle_test.go
+++ b/kaiax/builder/bundle_test.go
@@ -30,6 +30,12 @@ func TestBundle_IsConflict(t *testing.T) {
 		txs[i] = types.NewTransaction(uint64(i), common.Address{}, common.Big0, 0, common.Big0, nil)
 	}
 
+	b0 := &Bundle{
+		BundleTxs:    []interface{}{txs[0], txs[1]},
+		TargetTxHash: common.Hash{},
+	}
+	defaultTargetHash := txs[1].Hash()
+
 	testcases := []struct {
 		name      string
 		bundle    *Bundle
@@ -37,11 +43,17 @@ func TestBundle_IsConflict(t *testing.T) {
 		expected  bool
 	}{
 		{
-			name: "Same target tx hash",
-			bundle: &Bundle{
+			name:   "Same TargetTxHash",
+			bundle: b0,
+			newBundle: &Bundle{
 				BundleTxs:    []interface{}{},
-				TargetTxHash: txs[0].Hash(),
+				TargetTxHash: common.Hash{},
 			},
+			expected: true,
+		},
+		{
+			name:   "TargetTxHash divides a bundle",
+			bundle: b0,
 			newBundle: &Bundle{
 				BundleTxs:    []interface{}{},
 				TargetTxHash: txs[0].Hash(),
@@ -49,50 +61,20 @@ func TestBundle_IsConflict(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "Target tx hash breaks bundle",
-			bundle: &Bundle{
-				BundleTxs:    []interface{}{txs[1], txs[2]},
-				TargetTxHash: txs[0].Hash(),
-			},
-			newBundle: &Bundle{
-				BundleTxs:    []interface{}{},
-				TargetTxHash: txs[1].Hash(),
-			},
-			expected: true,
-		},
-		{
-			name: "Target tx hash equals last tx (no conflict)",
-			bundle: &Bundle{
-				BundleTxs:    []interface{}{txs[1], txs[2]},
-				TargetTxHash: txs[0].Hash(),
-			},
-			newBundle: &Bundle{
-				BundleTxs:    []interface{}{},
-				TargetTxHash: txs[2].Hash(),
-			},
-			expected: false,
-		},
-		{
-			name: "Overlapping transactions",
-			bundle: &Bundle{
-				BundleTxs:    []interface{}{txs[0], txs[1]},
-				TargetTxHash: txs[0].Hash(),
-			},
+			name:   "Overlapping BundleTxs",
+			bundle: b0,
 			newBundle: &Bundle{
 				BundleTxs:    []interface{}{txs[0]},
-				TargetTxHash: txs[1].Hash(),
+				TargetTxHash: defaultTargetHash,
 			},
 			expected: true,
 		},
 		{
-			name: "Non-overlapping transactions",
-			bundle: &Bundle{
-				BundleTxs:    []interface{}{txs[0], txs[1]},
-				TargetTxHash: txs[0].Hash(),
-			},
+			name:   "Non-overlapping BundleTxs",
+			bundle: b0,
 			newBundle: &Bundle{
 				BundleTxs:    []interface{}{txs[2], txs[3]},
-				TargetTxHash: txs[1].Hash(),
+				TargetTxHash: defaultTargetHash,
 			},
 			expected: false,
 		},

--- a/kaiax/builder/impl/api.go
+++ b/kaiax/builder/impl/api.go
@@ -1,0 +1,42 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"github.com/kaiachain/kaia/networks/rpc"
+)
+
+func (b *BuilderModule) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			Namespace: "kaia",
+			Version:   "1.0",
+			Service:   NewBuilderAPI(b),
+			Public:    true,
+		},
+	}
+}
+
+type BuilderAPI struct {
+	b *BuilderModule
+}
+
+func NewBuilderAPI(b *BuilderModule) *BuilderAPI {
+	return &BuilderAPI{b}
+}
+
+// TODO: implement SendRawTransactionBundle

--- a/kaiax/builder/impl/api.go
+++ b/kaiax/builder/impl/api.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/kaiax/builder/impl/api.go
+++ b/kaiax/builder/impl/api.go
@@ -39,4 +39,4 @@ func NewBuilderAPI(b *BuilderModule) *BuilderAPI {
 	return &BuilderAPI{b}
 }
 
-// TODO: implement SendRawTransactionBundle
+// TODO: implement SendRawTransactions

--- a/kaiax/builder/impl/errors.go
+++ b/kaiax/builder/impl/errors.go
@@ -1,0 +1,17 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl

--- a/kaiax/builder/impl/errors.go
+++ b/kaiax/builder/impl/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify
@@ -18,6 +18,4 @@ package impl
 
 import "errors"
 
-var (
-	ErrFailedToIncorporateBundle = errors.New("failed to incorporate bundle")
-)
+var ErrFailedToIncorporateBundle = errors.New("failed to incorporate bundle")

--- a/kaiax/builder/impl/errors.go
+++ b/kaiax/builder/impl/errors.go
@@ -15,3 +15,9 @@
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
 package impl
+
+import "errors"
+
+var (
+	ErrFailedToIncorporateBundle = errors.New("failed to incorporate bundle")
+)

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -18,7 +18,6 @@ package impl
 
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
-	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/builder"
 )
 
@@ -37,23 +36,10 @@ func (b *BuilderModule) Arrayify(heap []*types.TransactionsByPriceAndNonce) []*t
 
 // IsConflict checks if new bundles conflict with previous bundles
 func (b *BuilderModule) IsConflict(prevBundles []*builder.Bundle, newBundles []*builder.Bundle) bool {
-	// collect all tx hashes from previous bundles
-	prevTxHashes := make(map[common.Hash]struct{})
-	for _, bundle := range prevBundles {
-		for _, txOrGen := range bundle.BundleTxs {
-			if tx, ok := txOrGen.(*types.Transaction); ok {
-				prevTxHashes[tx.Hash()] = struct{}{}
-			}
-		}
-	}
-
-	// check if any new bundle tx exists in previous bundles
-	for _, bundle := range newBundles {
-		for _, txOrGen := range bundle.BundleTxs {
-			if tx, ok := txOrGen.(*types.Transaction); ok {
-				if _, exists := prevTxHashes[tx.Hash()]; exists {
-					return true
-				}
+	for _, newBundle := range newBundles {
+		for _, prevBundle := range prevBundles {
+			if prevBundle.IsConflict(newBundle) {
+				return true
 			}
 		}
 	}

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/kaiax/builder"
+)
+
+// IncorporateBundleTx incorporates bundle transactions into the transaction list
+func (b *BuilderModule) IncorporateBundleTx(txs []*types.Transaction, bundles []*builder.Bundle) []*types.Transaction {
+	// TODO: implement
+	return nil
+}
+
+// Arrayify flattens transaction heaps into a single array
+func (b *BuilderModule) Arrayify(heap []*types.TransactionsByPriceAndNonce) []*types.Transaction {
+	// TODO: implement
+	result := make([]*types.Transaction, 0)
+	return result
+}
+
+// IsConflict checks if new bundles conflict with previous bundles
+func (b *BuilderModule) IsConflict(prevBundles []*builder.Bundle, newBundles []*builder.Bundle) bool {
+	// TODO: implement
+	return false
+}

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -23,12 +23,19 @@ import (
 )
 
 // IncorporateBundleTx incorporates bundle transactions into the transaction list
-func (b *BuilderModule) IncorporateBundleTx(txs []*types.Transaction, bundles []*builder.Bundle) []*types.Transaction {
-	// TODO: implement
-	return nil
+func (b *BuilderModule) IncorporateBundleTx(txs []*types.Transaction, bundles []*builder.Bundle) []interface{} {
+	ret := make([]interface{}, len(txs))
+	for i := range txs {
+		ret[i] = txs[i]
+	}
+
+	for _, bundle := range bundles {
+		ret = incorporate(ret, bundle)
+	}
+	return ret
 }
 
-func (b *BuilderModule) incorporate(txs []interface{}, bundle *builder.Bundle) []interface{} {
+func incorporate(txs []interface{}, bundle *builder.Bundle) []interface{} {
 	ret := make([]interface{}, 0)
 
 	// 1. collect txs that are not in bundle
@@ -56,9 +63,11 @@ func (b *BuilderModule) incorporate(txs []interface{}, bundle *builder.Bundle) [
 			continue
 		}
 		if tx.Hash() == bundle.TargetTxHash {
-			tmp := ret[i+1:]
-			ret = append(ret[:i+1], bundle.BundleTxs...)
-			ret = append(ret, tmp...)
+			tmp := ret
+			ret = make([]interface{}, len(ret)+len(bundle.BundleTxs))
+			copy(ret[:i+1], tmp[:i+1])
+			copy(ret[i+1:], bundle.BundleTxs)
+			copy(ret[i+1+len(bundle.BundleTxs):], tmp[i+1:])
 			return ret
 		}
 	}

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -33,7 +33,7 @@ func (b *BuilderModule) Arrayify(heap *types.TransactionsByPriceAndNonce) []*typ
 	copied := heap.Copy()
 	for !copied.Empty() {
 		ret = append(ret, copied.Peek())
-		copied.Pop()
+		copied.Shift()
 	}
 	return ret
 }

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -28,10 +28,14 @@ func (b *BuilderModule) IncorporateBundleTx(txs []*types.Transaction, bundles []
 }
 
 // Arrayify flattens transaction heaps into a single array
-func (b *BuilderModule) Arrayify(heap []*types.TransactionsByPriceAndNonce) []*types.Transaction {
-	// TODO: implement
-	result := make([]*types.Transaction, 0)
-	return result
+func (b *BuilderModule) Arrayify(heap *types.TransactionsByPriceAndNonce) []*types.Transaction {
+	// TODO: deep copy heap
+	ret := make([]*types.Transaction, 0)
+	for !heap.Empty() {
+		ret = append(ret, heap.Peek())
+		heap.Pop()
+	}
+	return ret
 }
 
 // IsConflict checks if new bundles conflict with previous bundles

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -47,7 +47,7 @@ func incorporate(txs []interface{}, bundle *builder.Bundle) ([]interface{}, erro
 	for _, txOrGen := range txs {
 		switch tx := txOrGen.(type) {
 		case *types.Transaction:
-			if !bundle.Has(tx.Hash()) {
+			if !bundle.Has(tx.Hash(), 0) {
 				ret = append(ret, tx)
 			}
 		case builder.TxGenerator:

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -18,6 +18,7 @@ package impl
 
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/builder"
 )
 
@@ -36,6 +37,26 @@ func (b *BuilderModule) Arrayify(heap []*types.TransactionsByPriceAndNonce) []*t
 
 // IsConflict checks if new bundles conflict with previous bundles
 func (b *BuilderModule) IsConflict(prevBundles []*builder.Bundle, newBundles []*builder.Bundle) bool {
-	// TODO: implement
+	// collect all tx hashes from previous bundles
+	prevTxHashes := make(map[common.Hash]struct{})
+	for _, bundle := range prevBundles {
+		for _, txOrGen := range bundle.BundleTxs {
+			if tx, ok := txOrGen.(*types.Transaction); ok {
+				prevTxHashes[tx.Hash()] = struct{}{}
+			}
+		}
+	}
+
+	// check if any new bundle tx exists in previous bundles
+	for _, bundle := range newBundles {
+		for _, txOrGen := range bundle.BundleTxs {
+			if tx, ok := txOrGen.(*types.Transaction); ok {
+				if _, exists := prevTxHashes[tx.Hash()]; exists {
+					return true
+				}
+			}
+		}
+	}
+
 	return false
 }

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -29,11 +29,11 @@ func (b *BuilderModule) IncorporateBundleTx(txs []*types.Transaction, bundles []
 
 // Arrayify flattens transaction heaps into a single array
 func (b *BuilderModule) Arrayify(heap *types.TransactionsByPriceAndNonce) []*types.Transaction {
-	// TODO: deep copy heap
 	ret := make([]*types.Transaction, 0)
-	for !heap.Empty() {
-		ret = append(ret, heap.Peek())
-		heap.Pop()
+	copied := heap.Copy()
+	for !copied.Empty() {
+		ret = append(ret, copied.Peek())
+		copied.Pop()
 	}
 	return ret
 }

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -22,7 +22,8 @@ import (
 	"github.com/kaiachain/kaia/kaiax/builder"
 )
 
-// IncorporateBundleTx incorporates bundle transactions into the transaction list
+// IncorporateBundleTx incorporates bundle transactions into the transaction list.
+// Caller must ensure that there is no conflict between bundles.
 func (b *BuilderModule) IncorporateBundleTx(txs []*types.Transaction, bundles []*builder.Bundle) []interface{} {
 	ret := make([]interface{}, len(txs))
 	for i := range txs {
@@ -51,7 +52,7 @@ func incorporate(txs []interface{}, bundle *builder.Bundle) []interface{} {
 		}
 	}
 
-	// 2. place bundle before TargetTxHash
+	// 2. place bundle after TargetTxHash
 	if bundle.TargetTxHash == (common.Hash{}) {
 		ret = append(bundle.BundleTxs, ret...)
 		return ret

--- a/kaiax/builder/impl/getter_test.go
+++ b/kaiax/builder/impl/getter_test.go
@@ -1,0 +1,64 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/builder"
+	"github.com/stretchr/testify/require"
+)
+
+func makeBundle(nonces []uint64) *builder.Bundle {
+	bundleTxs := make([]interface{}, len(nonces))
+	to := common.Address{}
+	for i, nonce := range nonces {
+		bundleTxs[i] = types.NewTransaction(nonce, to, common.Big0, 0, common.Big0, nil)
+	}
+	return &builder.Bundle{
+		BundleTxs:    bundleTxs,
+		TargetTxHash: common.Hash{},
+	}
+}
+
+func TestIsConflict(t *testing.T) {
+	testcases := []struct {
+		name        string
+		prevBundles []*builder.Bundle
+		newBundles  []*builder.Bundle
+		expected    bool
+	}{
+		{
+			name:        "Non-overlapping txs",
+			prevBundles: []*builder.Bundle{makeBundle([]uint64{1, 2})},
+			newBundles:  []*builder.Bundle{makeBundle([]uint64{3, 4})},
+			expected:    false,
+		},
+		{
+			name:        "Overlapping tx 1",
+			prevBundles: []*builder.Bundle{makeBundle([]uint64{1, 2})},
+			newBundles:  []*builder.Bundle{makeBundle([]uint64{1, 3})},
+			expected:    true,
+		},
+		{
+			name:        "Overlapping tx 2",
+			prevBundles: []*builder.Bundle{makeBundle([]uint64{1, 2})},
+			newBundles:  []*builder.Bundle{makeBundle([]uint64{2, 3, 4})},
+			expected:    true,
+		},
+		{
+			name:        "Overlapping tx 3",
+			prevBundles: []*builder.Bundle{makeBundle([]uint64{1, 2}), makeBundle([]uint64{3, 4})},
+			newBundles:  []*builder.Bundle{makeBundle([]uint64{3})},
+			expected:    true,
+		},
+	}
+
+	b := NewBuilderModule()
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotConflict := b.IsConflict(tc.prevBundles, tc.newBundles)
+			require.Equal(t, tc.expected, gotConflict)
+		})
+	}
+}

--- a/kaiax/builder/impl/getter_test.go
+++ b/kaiax/builder/impl/getter_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax/builder"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestArrayify(t *testing.T) {
@@ -55,6 +55,7 @@ func TestArrayify(t *testing.T) {
 	for i := range txs {
 		assert.Equal(t, hashes[txs[i].Hash()], true)
 	}
+	assert.False(t, heap.Empty()) // don't modify the original heap
 }
 
 func TestIsConflict(t *testing.T) {

--- a/kaiax/builder/impl/getter_test.go
+++ b/kaiax/builder/impl/getter_test.go
@@ -30,7 +30,9 @@ import (
 
 func TestArrayify(t *testing.T) {
 	// Generate a batch of accounts to start with
-	keys := make([]*ecdsa.PrivateKey, 25)
+	keyLen := 10
+	txLen := 30
+	keys := make([]*ecdsa.PrivateKey, keyLen)
 	for i := 0; i < len(keys); i++ {
 		keys[i], _ = crypto.GenerateKey()
 	}
@@ -41,7 +43,7 @@ func TestArrayify(t *testing.T) {
 	hashes := map[common.Hash]bool{}
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
-		for i := 0; i < 25; i++ {
+		for i := 0; i < txLen; i++ {
 			tx, _ := types.SignTx(types.NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
 			groups[addr] = append(groups[addr], tx)
 			hashes[tx.Hash()] = true
@@ -51,7 +53,7 @@ func TestArrayify(t *testing.T) {
 	heap := types.NewTransactionsByPriceAndNonce(signer, groups, nil)
 	b := NewBuilderModule()
 	txs := b.Arrayify(heap)
-	assert.Equal(t, len(txs), 25)
+	assert.Equal(t, keyLen*txLen, len(txs))
 	for i := range txs {
 		assert.Equal(t, hashes[txs[i].Hash()], true)
 	}

--- a/kaiax/builder/impl/getter_test.go
+++ b/kaiax/builder/impl/getter_test.go
@@ -81,7 +81,8 @@ func TestIncorporateBundleTx(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ret := b.IncorporateBundleTx(txs, tc.bundles)
+			ret, err := b.IncorporateBundleTx(txs, tc.bundles)
+			require.Nil(t, err)
 			require.Equal(t, len(tc.expected), len(ret))
 			for i := range ret {
 				require.Equal(t, reflect.TypeOf(tc.expected[i]), reflect.TypeOf(ret[i]), "type at ret[%d] is different", i)
@@ -138,7 +139,8 @@ func TestIncorporate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ret := incorporate(txOrGenList, tc.bundle)
+			ret, err := incorporate(txOrGenList, tc.bundle)
+			require.Nil(t, err)
 			assert.Equal(t, tc.expected, ret)
 		})
 	}

--- a/kaiax/builder/impl/getter_test.go
+++ b/kaiax/builder/impl/getter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/kaiax/builder/impl/getter_test.go
+++ b/kaiax/builder/impl/getter_test.go
@@ -199,31 +199,31 @@ func TestIsConflict(t *testing.T) {
 		{
 			name:        "Same TargetTxHash",
 			prevBundles: []*builder.Bundle{b0},
-			newBundles:  []*builder.Bundle{{[]interface{}{}, common.Hash{}}},
+			newBundles:  []*builder.Bundle{{BundleTxs: []interface{}{}, TargetTxHash: common.Hash{}}},
 			expected:    true,
 		},
 		{
 			name:        "TargetTxHash divides a bundle",
 			prevBundles: []*builder.Bundle{b0},
-			newBundles:  []*builder.Bundle{{[]interface{}{}, txs[0].Hash()}},
+			newBundles:  []*builder.Bundle{{BundleTxs: []interface{}{}, TargetTxHash: txs[0].Hash()}},
 			expected:    true,
 		},
 		{
 			name:        "Overlapping BundleTxs 1",
 			prevBundles: []*builder.Bundle{b0},
-			newBundles:  []*builder.Bundle{{[]interface{}{txs[0], txs[2]}, defaultTargetHash}},
+			newBundles:  []*builder.Bundle{{BundleTxs: []interface{}{txs[0], txs[2]}, TargetTxHash: defaultTargetHash}},
 			expected:    true,
 		},
 		{
 			name:        "Overlapping BundleTxs 2",
 			prevBundles: []*builder.Bundle{b0},
-			newBundles:  []*builder.Bundle{{[]interface{}{txs[1], txs[2], txs[3]}, defaultTargetHash}},
+			newBundles:  []*builder.Bundle{{BundleTxs: []interface{}{txs[1], txs[2], txs[3]}, TargetTxHash: defaultTargetHash}},
 			expected:    true,
 		},
 		{
 			name:        "Non-overlapping BundleTxs",
 			prevBundles: []*builder.Bundle{b0},
-			newBundles:  []*builder.Bundle{{[]interface{}{txs[2], txs[3]}, defaultTargetHash}},
+			newBundles:  []*builder.Bundle{{BundleTxs: []interface{}{txs[2], txs[3]}, TargetTxHash: defaultTargetHash}},
 			expected:    false,
 		},
 	}

--- a/kaiax/builder/impl/init.go
+++ b/kaiax/builder/impl/init.go
@@ -27,15 +27,13 @@ var (
 )
 
 type BuilderModule struct {
-	txBundlingModules []builder.TxBundlingModule
 }
 
 func NewBuilderModule() *BuilderModule {
 	return &BuilderModule{}
 }
 
-func (b *BuilderModule) Init(txBundlingModules []builder.TxBundlingModule) error {
-	b.txBundlingModules = txBundlingModules
+func (b *BuilderModule) Init() error {
 	return nil
 }
 

--- a/kaiax/builder/impl/init.go
+++ b/kaiax/builder/impl/init.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify
@@ -26,8 +26,7 @@ var (
 	logger                       = log.NewModuleLogger(log.KaiaxBuilder)
 )
 
-type BuilderModule struct {
-}
+type BuilderModule struct{}
 
 func NewBuilderModule() *BuilderModule {
 	return &BuilderModule{}

--- a/kaiax/builder/impl/init.go
+++ b/kaiax/builder/impl/init.go
@@ -1,0 +1,47 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"github.com/kaiachain/kaia/kaiax/builder"
+	"github.com/kaiachain/kaia/log"
+)
+
+var (
+	_      builder.BuilderModule = (*BuilderModule)(nil)
+	logger                       = log.NewModuleLogger(log.KaiaxBuilder)
+)
+
+type BuilderModule struct {
+	txBundlingModules []builder.TxBundlingModule
+}
+
+func NewBuilderModule() *BuilderModule {
+	return &BuilderModule{}
+}
+
+func (b *BuilderModule) Init(txBundlingModules []builder.TxBundlingModule) error {
+	b.txBundlingModules = txBundlingModules
+	return nil
+}
+
+func (b *BuilderModule) Start() error {
+	return nil
+}
+
+func (b *BuilderModule) Stop() {
+}

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -29,7 +29,7 @@ type BuilderModule interface {
 	kaiax.JsonRpcModule
 
 	// IncorporateBundleTx does the followings:
-	IncorporateBundleTx(txs []*types.Transaction, bundles []*Bundle) []interface{}
+	IncorporateBundleTx(txs []*types.Transaction, bundles []*Bundle) ([]interface{}, error)
 
 	// Arrayify flattens txs in heap into an array
 	Arrayify(heap *types.TransactionsByPriceAndNonce) []*types.Transaction

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package builder
+
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax"
+)
+
+type TxGenerator func(nonce uint64) (*types.Transaction, error)
+
+type Bundle struct {
+	// each element can be either *types.Transaction, or TxGenerator
+	BundleTxs []interface{}
+
+	// BundleTxs is placed AFTER the target tx. If empty hash, it is placed at the very front.
+	TargetTxHash common.Hash
+}
+
+//go:generate mockgen -destination=./mock/module.go -package=mock github.com/kaiachain/kaia/kaiax/builder BuilderModule
+type BuilderModule interface {
+	kaiax.BaseModule
+	kaiax.JsonRpcModule
+
+	// IncorporateBundleTx does the followings:
+	IncorporateBundleTx(txs []*types.Transaction, bundles []*Bundle) []*types.Transaction
+
+	// Arrayify flattens txs in heap into an array
+	Arrayify(heap []*types.TransactionsByPriceAndNonce) []*types.Transaction
+
+	// IsConflict checks if the new bundles conflict with the previous bundles
+	IsConflict(prevBundles []*Bundle, newBundles []*Bundle) bool
+}
+
+type TxBundlingModule interface {
+	// The function finds transactions to be bundled.
+	// New transactions can be injected.
+	// returned bundles must not have conflict with `prevBundles`.
+	// `txs` and `prevBundles` is read-only; it is only to check if there's conflict between new bundles.
+	ExtractTxBundles(txs []*types.Transaction, prevBundles []*Bundle) []*Bundle
+}

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -29,7 +29,7 @@ type BuilderModule interface {
 	kaiax.JsonRpcModule
 
 	// IncorporateBundleTx does the followings:
-	IncorporateBundleTx(txs []*types.Transaction, bundles []*Bundle) []*types.Transaction
+	IncorporateBundleTx(txs []*types.Transaction, bundles []*Bundle) []interface{}
 
 	// Arrayify flattens txs in heap into an array
 	Arrayify(heap *types.TransactionsByPriceAndNonce) []*types.Transaction

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -32,7 +32,7 @@ type BuilderModule interface {
 	IncorporateBundleTx(txs []*types.Transaction, bundles []*Bundle) []*types.Transaction
 
 	// Arrayify flattens txs in heap into an array
-	Arrayify(heap []*types.TransactionsByPriceAndNonce) []*types.Transaction
+	Arrayify(heap *types.TransactionsByPriceAndNonce) []*types.Transaction
 
 	// IsConflict checks if the new bundles conflict with the previous bundles
 	IsConflict(prevBundles []*Bundle, newBundles []*Bundle) bool

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -18,19 +18,10 @@ package builder
 
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
-	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax"
 )
 
 type TxGenerator func(nonce uint64) (*types.Transaction, error)
-
-type Bundle struct {
-	// each element can be either *types.Transaction, or TxGenerator
-	BundleTxs []interface{}
-
-	// BundleTxs is placed AFTER the target tx. If empty hash, it is placed at the very front.
-	TargetTxHash common.Hash
-}
 
 //go:generate mockgen -destination=./mock/module.go -package=mock github.com/kaiachain/kaia/kaiax/builder BuilderModule
 type BuilderModule interface {

--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/kaiax/gasless"
+	"github.com/kaiachain/kaia/kaiax/builder"
 	"github.com/kaiachain/kaia/params"
 )
 
@@ -212,7 +212,7 @@ func (g *GaslessModule) IsExecutable(approveTxOrNil, swapTx *types.Transaction) 
 // L2. LendTx.from = proposer
 // L3. LendTx.to = SwapTx.from
 // L4. LendTx.value = LendAmount(approveTxOrNil, swapTx)
-func (g *GaslessModule) GetLendTxGenerator(approveTxOrNil, swapTx *types.Transaction) gasless.TxGenerator {
+func (g *GaslessModule) GetLendTxGenerator(approveTxOrNil, swapTx *types.Transaction) builder.TxGenerator {
 	return func(nonce uint64) (*types.Transaction, error) {
 		var (
 			to      = swapTx.ValidatedSender()
@@ -237,6 +237,11 @@ func (g *GaslessModule) GetLendTxGenerator(approveTxOrNil, swapTx *types.Transac
 		err = tx.Sign(signer, key)
 		return tx, err
 	}
+}
+
+func (g *GaslessModule) ExtractTxBundles(txs []*types.Transaction, prevBundles []*builder.Bundle) []*builder.Bundle {
+	// TODO: implement me
+	return nil
 }
 
 func lendAmount(approveTxOrNil, swapTx *types.Transaction) *big.Int {

--- a/kaiax/gasless/interface.go
+++ b/kaiax/gasless/interface.go
@@ -19,14 +19,13 @@ package gasless
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/kaiax"
+	"github.com/kaiachain/kaia/kaiax/builder"
 )
-
-// TODO-kaiax: move it to kaiax/builder.
-type TxGenerator func(nonce uint64) (*types.Transaction, error)
 
 //go:generate mockgen -destination=./mock/module.go -package=mock github.com/kaiachain/kaia/kaiax/gasless GaslessModule
 type GaslessModule interface {
 	kaiax.BaseModule
+	builder.TxBundlingModule
 
 	// IsApproveTx checks if the transaction is a GaslessApproveTx, i.e. a transaction that approves an whitelisted ERC20 token to the SwapRouter contract.
 	// An ApproveTx can be inserted to txpool.queue even if sender's balance is insufficient.
@@ -41,5 +40,5 @@ type GaslessModule interface {
 	IsExecutable(approveTxOrNil, swapTx *types.Transaction) bool
 
 	// GetLendTxGenerator returns a function that creates a signed lend transaction that can fund the given approve and swap transactions.
-	GetLendTxGenerator(approveTxOrNil, swapTx *types.Transaction) TxGenerator
+	GetLendTxGenerator(approveTxOrNil, swapTx *types.Transaction) builder.TxGenerator
 }

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -9,7 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/kaiachain/kaia/blockchain/types"
-	gasless "github.com/kaiachain/kaia/kaiax/gasless"
+	builder "github.com/kaiachain/kaia/kaiax/builder"
 )
 
 // MockGaslessModule is a mock of GaslessModule interface.
@@ -35,11 +35,25 @@ func (m *MockGaslessModule) EXPECT() *MockGaslessModuleMockRecorder {
 	return m.recorder
 }
 
+// ExtractTxBundles mocks base method.
+func (m *MockGaslessModule) ExtractTxBundles(arg0 []*types.Transaction, arg1 []*builder.Bundle) []*builder.Bundle {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractTxBundles", arg0, arg1)
+	ret0, _ := ret[0].([]*builder.Bundle)
+	return ret0
+}
+
+// ExtractTxBundles indicates an expected call of ExtractTxBundles.
+func (mr *MockGaslessModuleMockRecorder) ExtractTxBundles(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractTxBundles", reflect.TypeOf((*MockGaslessModule)(nil).ExtractTxBundles), arg0, arg1)
+}
+
 // GetLendTxGenerator mocks base method.
-func (m *MockGaslessModule) GetLendTxGenerator(arg0, arg1 *types.Transaction) gasless.TxGenerator {
+func (m *MockGaslessModule) GetLendTxGenerator(arg0, arg1 *types.Transaction) builder.TxGenerator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLendTxGenerator", arg0, arg1)
-	ret0, _ := ret[0].(gasless.TxGenerator)
+	ret0, _ := ret[0].(builder.TxGenerator)
 	return ret0
 }
 

--- a/log/log_modules.go
+++ b/log/log_modules.go
@@ -224,4 +224,5 @@ var moduleNames = [ModuleNameLen]string{
 	"kaiax/valset",
 	"kaiax/randao",
 	"kaiax/gasless",
+	"kaiax/builder",
 }

--- a/log/log_modules.go
+++ b/log/log_modules.go
@@ -137,6 +137,7 @@ const (
 	KaiaxValset
 	KaiaxRandao
 	KaiaxGasless
+	KaiaxBuilder
 
 	// ModuleNameLen should be placed at the end of the list.
 	ModuleNameLen


### PR DESCRIPTION
## Proposed changes

Implement skeleton of [KIP-245](https://kips.kaia.io/kips/kip-245).
Because the result can contain TxGenerator, the return type of `IncorporateBundleTx` is `[]interface{}`.


## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

