### PR TITLE
tests: organize skipping blockchain tests for EEST

### DIFF
--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -755,6 +755,11 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 	// Set sender address or use zero address if none specified.
 	addr := args.from()
 
+	// EIP7702's SetCodeTx inherits the Blob transaction specifications and does not allow a nil to.
+	if args.AuthorizationList != nil && args.To == nil {
+		return nil, errors.New("SetCodeTx does not allow a nil to")
+	}
+
 	// Set default gas & gas price if none were set
 	gas := globalGasCap
 	if gas == 0 {

--- a/api/tx_args.go
+++ b/api/tx_args.go
@@ -757,7 +757,7 @@ func (args *EthTransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int,
 
 	// EIP7702's SetCodeTx inherits the Blob transaction specifications and does not allow a nil to.
 	if args.AuthorizationList != nil && args.To == nil {
-		return nil, errors.New("SetCodeTx does not allow a nil to")
+		return nil, errors.New("SetCodeTx must have a non-nil recipient address")
 	}
 
 	// Set default gas & gas price if none were set

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -1093,6 +1093,7 @@ func (t *TransactionsByPriceAndNonce) Clear() {
 }
 
 // NewMessage returns a `*Transaction` object with the given arguments.
+// We need to be careful that a panic occurs when we intend to create a SetCodeTx.
 func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice, gasFeeCap, gasTipCap *big.Int, data []byte, checkNonce bool, intrinsicGas uint64, list AccessList, chainId *big.Int, auth []SetCodeAuthorization) *Transaction {
 	transaction := &Transaction{
 		validatedGas:      &ValidatedGas{IntrinsicGas: intrinsicGas, SigValidateGas: 0},

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -1093,7 +1093,8 @@ func (t *TransactionsByPriceAndNonce) Clear() {
 }
 
 // NewMessage returns a `*Transaction` object with the given arguments.
-// We need to be careful that a panic occurs when we intend to create a SetCodeTx.
+// Care must be taken when creating SetCodeTx because if you assign nil to `to`,
+// a panic will occur because `newTxInternalDataEthereumSetCodeWithValues` reference the pointer of `to`.
 func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice, gasFeeCap, gasTipCap *big.Int, data []byte, checkNonce bool, intrinsicGas uint64, list AccessList, chainId *big.Int, auth []SetCodeAuthorization) *Transaction {
 	transaction := &Transaction{
 		validatedGas:      &ValidatedGas{IntrinsicGas: intrinsicGas, SigValidateGas: 0},

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -249,12 +249,7 @@ func (t *TxInternalDataEthereumSetCode) GetGasLimit() uint64 {
 }
 
 func (t *TxInternalDataEthereumSetCode) GetRecipient() *common.Address {
-	if t.Recipient == (common.Address{}) {
-		return nil
-	}
-
-	to := common.Address(t.Recipient)
-	return &to
+	return &t.Recipient
 }
 
 func (t *TxInternalDataEthereumSetCode) GetAmount() *big.Int {
@@ -405,12 +400,8 @@ func (t *TxInternalDataEthereumSetCode) SenderTxHash() common.Hash {
 }
 
 func (t *TxInternalDataEthereumSetCode) Validate(stateDB StateDB, currentBlockNumber uint64) error {
-	if t.Recipient == (common.Address{}) {
-		return kerrors.ErrEmptyRecipient
-	} else {
-		if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
-			return kerrors.ErrPrecompiledContractAddress
-		}
+	if common.IsPrecompiledContractAddress(t.Recipient, *fork.Rules(big.NewInt(int64(currentBlockNumber)))) {
+		return kerrors.ErrPrecompiledContractAddress
 	}
 	return t.ValidateMutableValue(stateDB, currentBlockNumber)
 }
@@ -443,16 +434,11 @@ func (t *TxInternalDataEthereumSetCode) String() string {
 		from = "[invalid sender: nil V field]"
 	}
 
-	if t.GetRecipient() == nil {
-		to = "[contract creation]"
-	} else {
-		to = hex.EncodeToString(t.GetRecipient().Bytes())
-	}
+	to = hex.EncodeToString(t.GetRecipient().Bytes())
 	enc, _ := rlp.EncodeToBytes(tx)
 	return fmt.Sprintf(`
 		TX(%x)
-		Contract: %v
-		Chaind:   %#x
+		ChainId:   %#x
 		From:     %s
 		To:       %s
 		Nonce:    %v
@@ -469,7 +455,6 @@ func (t *TxInternalDataEthereumSetCode) String() string {
 		Hex:      %x
 	`,
 		tx.Hash(),
-		t.GetRecipient() == nil,
 		t.ChainId(),
 		from,
 		to,

--- a/snapshot/conversion.go
+++ b/snapshot/conversion.go
@@ -267,17 +267,17 @@ func generateTrieRoot(it Iterator, accountHash common.Hash, generatorFn trieGene
 				}
 				acc := serializer.GetAccount()
 				go func(hash common.Hash) {
-					contract, ok := acc.(*account.SmartContractAccount)
-					if !ok {
+					programAcc := account.GetProgramAccount(acc)
+					if programAcc == nil {
 						results <- nil
 						return
 					}
-					subroot, err := leafCallback(hash, common.BytesToHash(contract.GetCodeHash()), stats)
+					subroot, err := leafCallback(hash, common.BytesToHash(programAcc.GetCodeHash()), stats)
 					if err != nil {
 						results <- err
 						return
 					}
-					rootHash := contract.GetStorageRoot().Unextend()
+					rootHash := programAcc.GetStorageRoot().Unextend()
 					if rootHash != subroot {
 						results <- fmt.Errorf("invalid subroot(path %x), want %x, have %x", hash, rootHash, subroot)
 						return

--- a/snapshot/generate.go
+++ b/snapshot/generate.go
@@ -648,15 +648,12 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 		if err := checkAndFlush(marker); err != nil {
 			return err
 		}
-		// If the iterated account is the contract, create a further loop to
-		// verify or regenerate the contract storage.
-		contractAcc, ok := acc.(*account.SmartContractAccount)
-		if !ok {
+		// If the iterated account is the ProgramAccount, create a further loop to
+		// verify or regenerate the ProgramAccount storage.
+		programAcc := account.GetProgramAccount(acc)
+		if programAcc == nil {
 			// If the root is empty, we still need to ensure that any previous snapshot
 			// storage values are cleared
-			// TODO: investigate if this can be avoided, this will be very costly since it
-			// affects every single EOA account
-			//  - Perhaps we can avoid if where codeHash is emptyCode
 			prefix := append(database.SnapshotStoragePrefix, accountHash.Bytes()...)
 			keyLen := len(database.SnapshotStoragePrefix) + 2*common.HashLength
 			if err := wipeKeyRange(dl.diskdb, "storage", prefix, nil, nil, keyLen, snapWipedStorageMeter, false); err != nil {
@@ -668,7 +665,7 @@ func (dl *diskLayer) generate(stats *generatorStats) {
 			return nil
 		}
 
-		rootHash := contractAcc.GetStorageRoot().Unextend()
+		rootHash := programAcc.GetStorageRoot().Unextend()
 		if rootHash == types.EmptyRootHash {
 			prefix := append(database.SnapshotStoragePrefix, accountHash.Bytes()...)
 			keyLen := len(database.SnapshotStoragePrefix) + 2*common.HashLength

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -54,16 +54,10 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	bt := new(testMatcher)
 
 	// TODO-Kaia: should remove these skip
-	// json format error
-	bt.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/invalid_tx_invalid_auth_signature.json`)
-	bt.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/tx_validity_chain_id.json`)
-	bt.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/tx_validity_nonce.json`)
-	// not yet supported EIPs
-	bt.skipLoad(`^prague\/eip2537_bls_12_381_precompiles`) // gas error
-	bt.skipLoad(`^prague\/eip7702_set_code_tx`)            // state, gas (after update we should do it)
-	// temporary skip failing frontier tests
+	// executing precompiled contracts with value transferring is not permitted
 	bt.skipLoad(`^frontier\/opcodes\/all_opcodes\/all_opcodes.json`)
-	bt.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json`)
+	// executing precompiled contracts with set code tx is not permitted
+	bt.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs_2\/gas_diff_pointer_vs_direct_call.json`)
 
 	// tests to skip
 	// unsupported EIPs
@@ -75,8 +69,11 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	bt.skipLoad(`^prague\/eip7685_general_purpose_el_requests`)
 	bt.skipLoad(`^prague\/eip7002_el_triggerable_withdrawals`)
 	bt.skipLoad(`^prague\/eip6110_deposits`)
+	// different amount of gas is consumed because 0x0b contract is added to access list by ActivePrecompiles although Cancun doesn't have it as a precompiled contract
+	bt.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json`)
 	// type 3 tx (EIP-4844) is not supported
 	bt.skipLoad(`^prague\/eip7623_increase_calldata_cost\/.*type_3.*`)
+	bt.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/eoa_tx_after_set_code.json\/tests\/prague\/eip7702_set_code_tx\/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Prague-tx_type_3-evm_code_type_LEGACY-blockchain_test\]`)
 
 	bt.walk(t, executionSpecBlockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		skipForks := []string{

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -70,7 +70,9 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	bt.skipLoad(`^prague\/eip7002_el_triggerable_withdrawals`)
 	bt.skipLoad(`^prague\/eip6110_deposits`)
 	// different amount of gas is consumed because 0x0b contract is added to access list by ActivePrecompiles although Cancun doesn't have it as a precompiled contract
-	bt.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json`)
+	bt.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json\/tests\/frontier\/precompiles\/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-blockchain_test-31_bytes\]`)
+	bt.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json\/tests\/frontier\/precompiles\/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-blockchain_test-32_bytes\]`)
+	bt.skipLoad(`^frontier\/precompiles\/precompile_absence\/precompile_absence.json\/tests\/frontier\/precompiles\/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-blockchain_test-empty_calldata\]`)
 	// type 3 tx (EIP-4844) is not supported
 	bt.skipLoad(`^prague\/eip7623_increase_calldata_cost\/.*type_3.*`)
 	bt.skipLoad(`^prague\/eip7702_set_code_tx\/set_code_txs\/eoa_tx_after_set_code.json\/tests\/prague\/eip7702_set_code_tx\/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Prague-tx_type_3-evm_code_type_LEGACY-blockchain_test\]`)

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -212,12 +212,12 @@ func (t *BlockTest) Run() error {
 	if err != nil {
 		return err
 	}
-	simulatedRoot, err := useEthStateRoot(st)
+	simulatedRoot, err := useEthGenesisState(st)
 	if err != nil {
 		return err
 	}
 	if simulatedRoot != t.json.Genesis.Root {
-		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", gblock.Root().Bytes()[:6], t.json.Genesis.Root[:6])
+		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", simulatedRoot.Bytes()[:6], t.json.Genesis.Root[:6])
 	}
 
 	tracer := vm.NewStructLogger(nil)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -321,7 +321,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, isTest
 	root = st.IntermediateRoot(true)
 
 	if err == nil && isTestExecutionSpecState {
-		root, err = useEthStateRoot(st)
+		root, err = useEthState(st)
 		if err != nil {
 			return st, common.Hash{}, err
 		}
@@ -543,7 +543,15 @@ func calculateEthMiningReward(gasPrice, maxFeePerGas, maxPriorityFeePerGas, envB
 	return fee.Mul(fee, effectiveTip)
 }
 
-func useEthStateRoot(statedb *state.StateDB) (common.Hash, error) {
+func useEthGenesisState(statedb *state.StateDB) (common.Hash, error) {
+	return useEthStateRootWithOption(statedb, false)
+}
+
+func useEthState(statedb *state.StateDB) (common.Hash, error) {
+	return useEthStateRootWithOption(statedb, true)
+}
+
+func useEthStateRootWithOption(statedb *state.StateDB, deleteEmptyObjects bool) (common.Hash, error) {
 	memDb := database.NewMemoryDBManager()
 	db := state.NewDatabase(memDb)
 	newState, _ := state.New(common.Hash{}, db, nil, nil)
@@ -562,5 +570,5 @@ func useEthStateRoot(statedb *state.StateDB) (common.Hash, error) {
 		)
 	}
 
-	return newState.IntermediateRoot(true), nil
+	return newState.IntermediateRoot(deleteEmptyObjects), nil
 }


### PR DESCRIPTION
## Proposed changes

As mentioned in #238, we will enable the EEST blockchain test that we skipped.

- Enable 7702 tests and 2537 tests (Except for calls to system contracts and type3)
- There were some issues with the 7702, so this will fix them.
  - Prepared a simulation function for genesis.
    - If there was an empty account in genesis, `useEthStateRoot` deleted it.
  - Changing cast from SCA to ProgramAccount in snapshot.
    - After the introduction of 7702, if genesis contained EOAwithStorage, this was not recorded in the snap.
  - Allow set code tx to send to the zero address.
    - The validation of set code tx prohibited calls to the zero address.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/kaiachain/kaia/pull/238#issuecomment-2652576276
- #152 

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
