### PR TITLE
kaiax: fix duplicated init of gov module

### DIFF
--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -310,7 +310,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	cn.blockchain = bc
 
-	if cn.InitGovModule(mStaking, mGov, mValset) != nil {
+	if err := cn.InitGovModule(mStaking, mGov, mValset); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Proposed changes

- The gov module was init twice and it leads `deriveSha` package to use different `headerGovModule`. So the the other logics(such as insertChain) and deriveSha package references different `headergov.History` and it causes the unexpected stop at apply block of deriveSha vote (apply block is a block one epoch past from governance block).

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
