### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2011,14 +2011,10 @@ func TestGolangBindings(t *testing.T) {
 		t.Skip("go sdk not found for testing")
 	}
 	// Create a temporary workspace for the test suite
-	ws, err := os.MkdirTemp("", "binding-test")
-	if err != nil {
-		t.Fatalf("failed to create temporary workspace: %v", err)
-	}
-	defer os.RemoveAll(ws)
+	ws := t.TempDir()
 
 	pkg := filepath.Join(ws, "bindtest")
-	if err = os.MkdirAll(pkg, 0o700); err != nil {
+	if err := os.MkdirAll(pkg, 0o700); err != nil {
 		t.Fatalf("failed to create package: %v", err)
 	}
 	// Generate the test suite for all the contracts

--- a/api/api_public_transaction_pool_test.go
+++ b/api/api_public_transaction_pool_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"math/big"
-	"os"
 	"reflect"
 	"testing"
 
@@ -71,11 +70,7 @@ func TestTxTypeSupport(t *testing.T) {
 	chainConf := params.ChainConfig{ChainID: big.NewInt(1)}
 
 	// generate a keystore and active accounts
-	dir, err := os.MkdirTemp("", "kaia-test-tx-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	ks := keystore.NewKeyStore(dir, 2, 1)
 	password := ""
 	acc, err := ks.ImportECDSA(senderPrvKey, password)

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -2208,11 +2208,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	journal, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temporary journal: %v", err)
-	}
-	defer os.Remove(journal)
+	journal := t.TempDir()
 
 	// Clean up the temporary file, we only need the path for now
 	os.Remove(journal)
@@ -2923,11 +2919,7 @@ func TestTransactionJournalingSortedByTime(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary file for the journal
-	journal, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("failed to create temporary journal: %v", err)
-	}
-	defer os.Remove(journal)
+	journal := t.TempDir()
 
 	// Clean up the temporary file, we only need the path for now
 	os.Remove(journal)


### PR DESCRIPTION
## Proposed changes

`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
