### PR TITLE
kaiax/gasless: unify multiple gasless module instances

### DIFF
--- a/accounts/abi/bind/backends/blockchain_test.go
+++ b/accounts/abi/bind/backends/blockchain_test.go
@@ -281,7 +281,7 @@ func TestBlockChainSendTransaction(t *testing.T) {
 	state, err := bc.State()
 	txPoolConfig := blockchain.DefaultTxPoolConfig
 	txPoolConfig.Journal = "/dev/null" // disable journaling to file
-	txPool := blockchain.NewTxPool(txPoolConfig, bc.Config(), bc, &dummyGovModule{chainConfig: bc.Config()}, nil)
+	txPool := blockchain.NewTxPool(txPoolConfig, bc.Config(), bc, &dummyGovModule{chainConfig: bc.Config()})
 	defer txPool.Stop()
 	assert.Nil(t, err)
 	c := NewBlockchainContractBackend(bc, txPool, nil)
@@ -365,7 +365,7 @@ func initBackendForFiltererTests(t *testing.T, bc *blockchain.BlockChain) *Block
 	any := gomock.Any()
 	txPoolConfig := blockchain.DefaultTxPoolConfig
 	txPoolConfig.Journal = "/dev/null" // disable journaling to file
-	txPool := blockchain.NewTxPool(txPoolConfig, bc.Config(), bc, &dummyGovModule{chainConfig: bc.Config()}, nil)
+	txPool := blockchain.NewTxPool(txPoolConfig, bc.Config(), bc, &dummyGovModule{chainConfig: bc.Config()})
 	subscribeNewTxsEvent := func(ch chan<- blockchain.NewTxsEvent) kaia.Subscription {
 		return txPool.SubscribeNewTxsEvent(ch)
 	}

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -207,7 +207,7 @@ func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateK
 	blockchain := &testBlockChain{statedb, 10000000, new(event.Feed)}
 
 	key, _ := crypto.GenerateKey()
-	pool := NewTxPool(testTxPoolConfig, config, blockchain, &dummyGovModule{chainConfig: config}, nil)
+	pool := NewTxPool(testTxPoolConfig, config, blockchain, &dummyGovModule{chainConfig: config})
 
 	return pool, key
 }
@@ -318,7 +318,7 @@ func TestStateChangeDuringTransactionPoolReset(t *testing.T) {
 	tx0 := transaction(0, 100000, key)
 	tx1 := transaction(1, 100000, key)
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	nonce := pool.GetPendingNonce(address)
@@ -804,7 +804,7 @@ func TestTransactionPostponing(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create two test accounts to produce different gap profiles with
@@ -1023,7 +1023,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 	config.NoLocals = nolocals
 	config.NonExecSlotsAll = config.NonExecSlotsAccount*3 - 1 // reduce the queue limits to shorten test time (-1 to make it non divisible)
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them (last one will be the local)
@@ -1125,7 +1125,7 @@ func testTransactionQueueTimeLimiting(t *testing.T, nolocals, keepLocals bool) {
 	config.NoLocals = nolocals
 	config.KeepLocals = keepLocals
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create two test accounts to ensure remotes expire but locals do not
@@ -1288,7 +1288,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 	config := testTxPoolConfig
 	config.ExecSlotsAll = config.ExecSlotsAccount * 10
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1400,7 +1400,7 @@ func TestTransactionCapClearsFromAll(t *testing.T) {
 	config.NonExecSlotsAccount = 2
 	config.ExecSlotsAll = 8
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1432,7 +1432,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 	config := testTxPoolConfig
 	config.ExecSlotsAll = 0
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create a number of test accounts and fund them
@@ -1950,7 +1950,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	config.Journal = journal
 	config.JournalInterval = time.Second
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 
 	// Create two test accounts to ensure remotes expire but locals do not
 	local, _ := crypto.GenerateKey()
@@ -1987,7 +1987,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 	statedb.SetNonce(crypto.PubkeyToAddress(local.PublicKey), 1)
 	blockchain = &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool = NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 
 	pending, queued = pool.Stats()
 	if queued != 0 {
@@ -2013,7 +2013,7 @@ func testTransactionJournaling(t *testing.T, nolocals bool) {
 
 	statedb.SetNonce(crypto.PubkeyToAddress(local.PublicKey), 1)
 	blockchain = &testBlockChain{statedb, 1000000, new(event.Feed)}
-	pool = NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool = NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 
 	pending, queued = pool.Stats()
 	if pending != 0 {
@@ -2043,7 +2043,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(testTxPoolConfig, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create the test accounts to check various transaction statuses with
@@ -2663,7 +2663,7 @@ func TestTransactionJournalingSortedByTime(t *testing.T) {
 	config := testTxPoolConfig
 	config.Journal = journal
 
-	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig}, nil)
+	pool := NewTxPool(config, params.TestChainConfig, blockchain, &dummyGovModule{chainConfig: params.TestChainConfig})
 	defer pool.Stop()
 
 	// Create the test accounts to check various transaction statuses with

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -30,7 +30,10 @@ func (g *GaslessModule) ExtractTxBundles(txs []*types.Transaction, prevBundles [
 	approveTxs := map[common.Address]*types.Transaction{}
 	targetTxHash := common.Hash{}
 	for _, tx := range txs {
-		addr := tx.ValidatedSender()
+		addr, err := types.Sender(g.signer, tx)
+		if err != nil {
+			panic(err)
+		}
 		if g.IsApproveTx(tx) {
 			approveTxs[addr] = tx
 		} else if g.IsSwapTx(tx) && g.IsExecutable(approveTxs[addr], tx) {

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -32,7 +32,7 @@ func (g *GaslessModule) ExtractTxBundles(txs []*types.Transaction, prevBundles [
 	for _, tx := range txs {
 		addr, err := types.Sender(g.signer, tx)
 		if err != nil {
-			return nil
+			continue
 		}
 		if g.IsApproveTx(tx) {
 			approveTxs[addr] = tx

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -32,7 +32,7 @@ func (g *GaslessModule) ExtractTxBundles(txs []*types.Transaction, prevBundles [
 	for _, tx := range txs {
 		addr, err := types.Sender(g.signer, tx)
 		if err != nil {
-			panic(err)
+			return nil
 		}
 		if g.IsApproveTx(tx) {
 			approveTxs[addr] = tx

--- a/kaiax/gasless/impl/builder_test.go
+++ b/kaiax/gasless/impl/builder_test.go
@@ -36,11 +36,12 @@ func TestExtractTxBundles(t *testing.T) {
 
 	g := NewGaslessModule()
 	nodeKey, _ := crypto.GenerateKey()
+	sdb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	g.Init(&InitOpts{
 		ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 		NodeKey:     nodeKey,
+		TxPool:      &testTxPool{sdb},
 	})
-	g.currentState, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 
 	key1, _ := crypto.GenerateKey()
 	key2, _ := crypto.GenerateKey()

--- a/kaiax/gasless/impl/builder_test.go
+++ b/kaiax/gasless/impl/builder_test.go
@@ -37,11 +37,12 @@ func TestExtractTxBundles(t *testing.T) {
 	g := NewGaslessModule()
 	nodeKey, _ := crypto.GenerateKey()
 	sdb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
-	g.Init(&InitOpts{
+	err := g.Init(&InitOpts{
 		ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 		NodeKey:     nodeKey,
 		TxPool:      &testTxPool{sdb},
 	})
+	require.NoError(t, err)
 
 	key1, _ := crypto.GenerateKey()
 	key2, _ := crypto.GenerateKey()

--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -117,7 +117,7 @@ func decodeApproveTx(tx *types.Transaction, signer types.Signer) (*ApproveArgs, 
 	}
 	from, err := types.Sender(signer, tx)
 	if err != nil {
-		panic(err)
+		return nil, false
 	}
 	return &ApproveArgs{
 		Sender:  from,
@@ -150,7 +150,7 @@ func decodeSwapTx(tx *types.Transaction, signer types.Signer) (args *SwapArgs, o
 	}
 	from, err := types.Sender(signer, tx)
 	if err != nil {
-		panic(err)
+		return nil, false
 	}
 	return &SwapArgs{
 		Sender:       from,

--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -66,7 +66,7 @@ type SwapArgs struct {
 // A3. spender is a whitelisted SwapRouter contract.
 // A4. amount is nonzero.
 func (g *GaslessModule) IsApproveTx(tx *types.Transaction) bool {
-	args, ok := decodeApproveTx(tx)
+	args, ok := decodeApproveTx(tx, g.signer)
 	return ok && g.isApproveTx(args)
 }
 
@@ -81,7 +81,7 @@ func (g *GaslessModule) isApproveTx(args *ApproveArgs) bool {
 // S2. tx.data is `swapForGas(token, amountIn, minAmountOut, amountRepay)`.
 // S3. token is a whitelisted ERC20 token.
 func (g *GaslessModule) IsSwapTx(tx *types.Transaction) bool {
-	args, ok := decodeSwapTx(tx)
+	args, ok := decodeSwapTx(tx, g.signer)
 	return ok && g.isSwapTx(args)
 }
 
@@ -102,7 +102,7 @@ func mustParseAbi(abiJson string, funcName string) abi.Method {
 	return method
 }
 
-func decodeApproveTx(tx *types.Transaction) (*ApproveArgs, bool) {
+func decodeApproveTx(tx *types.Transaction, signer types.Signer) (*ApproveArgs, bool) {
 	to, inputs, ok := decodeFunctionCall(tx, erc20ApproveFunc)
 	if !ok {
 		return nil, false
@@ -115,15 +115,19 @@ func decodeApproveTx(tx *types.Transaction) (*ApproveArgs, bool) {
 	if !ok {
 		return nil, false
 	}
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		panic(err)
+	}
 	return &ApproveArgs{
-		Sender:  tx.ValidatedSender(),
+		Sender:  from,
 		Token:   to,
 		Spender: spender,
 		Amount:  amount,
 	}, true
 }
 
-func decodeSwapTx(tx *types.Transaction) (args *SwapArgs, ok bool) {
+func decodeSwapTx(tx *types.Transaction, signer types.Signer) (args *SwapArgs, ok bool) {
 	to, inputs, ok := decodeFunctionCall(tx, routerSwapFunc)
 	if !ok {
 		return nil, false
@@ -144,8 +148,12 @@ func decodeSwapTx(tx *types.Transaction) (args *SwapArgs, ok bool) {
 	if !ok {
 		return nil, false
 	}
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		panic(err)
+	}
 	return &SwapArgs{
-		Sender:       tx.ValidatedSender(),
+		Sender:       from,
 		Router:       to,
 		Token:        token,
 		AmountIn:     amountIn,
@@ -177,7 +185,7 @@ func decodeFunctionCall(tx *types.Transaction, method abi.Method) (common.Addres
 // SP4. SwapTx.amountRepay = RepayAmount(ApproveTx, SwapTx)
 func (g *GaslessModule) IsExecutable(approveTxOrNil, swapTx *types.Transaction) bool {
 	// Sx.
-	swapArgs, ok := decodeSwapTx(swapTx)
+	swapArgs, ok := decodeSwapTx(swapTx, g.signer)
 	if !ok || !g.isSwapTx(swapArgs) {
 		return false
 	}
@@ -185,12 +193,12 @@ func (g *GaslessModule) IsExecutable(approveTxOrNil, swapTx *types.Transaction) 
 	// Conditions involving ApproveTx
 	if approveTxOrNil != nil {
 		// Ax.
-		approveArgs, ok := decodeApproveTx(approveTxOrNil)
+		approveArgs, ok := decodeApproveTx(approveTxOrNil, g.signer)
 		if !ok || !g.isApproveTx(approveArgs) {
 			return false
 		}
 		// AP1.
-		if approveArgs.Sender != swapTx.ValidatedSender() {
+		if approveArgs.Sender != swapArgs.Sender {
 			return false
 		}
 		// SP1.
@@ -210,7 +218,7 @@ func (g *GaslessModule) IsExecutable(approveTxOrNil, swapTx *types.Transaction) 
 		}
 	} else {
 		// SP3.
-		if nonce := g.TxPool.GetCurrentState().GetNonce(swapTx.ValidatedSender()); nonce != swapTx.Nonce() {
+		if nonce := g.TxPool.GetCurrentState().GetNonce(swapArgs.Sender); nonce != swapTx.Nonce() {
 			return false
 		}
 	}
@@ -232,11 +240,15 @@ func (g *GaslessModule) GetLendTxGenerator(approveTxOrNil, swapTx *types.Transac
 	return builder.TxGenerator{
 		Generate: func(nonce uint64) (*types.Transaction, error) {
 			var (
-				to      = swapTx.ValidatedSender()
 				chainId = g.InitOpts.ChainConfig.ChainID
 				signer  = types.LatestSignerForChainID(chainId)
 				key     = g.InitOpts.NodeKey
 			)
+
+			to, err := types.Sender(signer, swapTx)
+			if err != nil {
+				return nil, err
+			}
 
 			tx, err := types.NewTransactionWithMap(types.TxTypeEthereumDynamicFee, map[types.TxValueKeyType]interface{}{
 				types.TxValueKeyNonce:      nonce,

--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -205,12 +205,12 @@ func (g *GaslessModule) IsExecutable(approveTxOrNil, swapTx *types.Transaction) 
 		if approveTxOrNil.Nonce()+1 != swapTx.Nonce() {
 			return false
 		}
-		if nonce := g.currentState.GetNonce(approveArgs.Sender); nonce != approveTxOrNil.Nonce() {
+		if nonce := g.TxPool.GetCurrentState().GetNonce(approveArgs.Sender); nonce != approveTxOrNil.Nonce() {
 			return false
 		}
 	} else {
 		// SP3.
-		if nonce := g.currentState.GetNonce(swapTx.ValidatedSender()); nonce != swapTx.Nonce() {
+		if nonce := g.TxPool.GetCurrentState().GetNonce(swapTx.ValidatedSender()); nonce != swapTx.Nonce() {
 			return false
 		}
 	}

--- a/kaiax/gasless/impl/getter_test.go
+++ b/kaiax/gasless/impl/getter_test.go
@@ -165,11 +165,12 @@ func TestIsExecutable(t *testing.T) {
 
 	g := NewGaslessModule()
 	key, _ := crypto.GenerateKey()
+	sdb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	g.Init(&InitOpts{
 		ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 		NodeKey:     key,
+		TxPool:      &testTxPool{sdb},
 	})
-	g.currentState, _ = state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			ok := g.IsExecutable(tc.approve, tc.swap)

--- a/kaiax/gasless/impl/getter_test.go
+++ b/kaiax/gasless/impl/getter_test.go
@@ -59,10 +59,12 @@ func TestIsApproveTx(t *testing.T) {
 
 	g := NewGaslessModule()
 	key, _ := crypto.GenerateKey()
-	g.Init(&InitOpts{
+	err := g.Init(&InitOpts{
 		ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 		NodeKey:     key,
+		TxPool:      &testTxPool{},
 	})
+	require.NoError(t, err)
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			ok := g.IsApproveTx(tc.tx)
@@ -96,10 +98,13 @@ func TestIsSwapTx(t *testing.T) {
 
 	g := NewGaslessModule()
 	key, _ := crypto.GenerateKey()
-	g.Init(&InitOpts{
+	err := g.Init(&InitOpts{
 		ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 		NodeKey:     key,
+		TxPool:      &testTxPool{},
 	})
+	require.NoError(t, err)
+
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			ok := g.IsSwapTx(tc.tx)
@@ -166,11 +171,13 @@ func TestIsExecutable(t *testing.T) {
 	g := NewGaslessModule()
 	key, _ := crypto.GenerateKey()
 	sdb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
-	g.Init(&InitOpts{
+	err := g.Init(&InitOpts{
 		ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 		NodeKey:     key,
 		TxPool:      &testTxPool{sdb},
 	})
+	require.NoError(t, err)
+
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			ok := g.IsExecutable(tc.approve, tc.swap)

--- a/kaiax/gasless/impl/helper_test.go
+++ b/kaiax/gasless/impl/helper_test.go
@@ -173,3 +173,11 @@ func flattenBundleTxs(txs []interface{}) ([]common.Hash, error) {
 	}
 	return hashes, nil
 }
+
+type testTxPool struct {
+	statedb *state.StateDB
+}
+
+func (pool *testTxPool) GetCurrentState() *state.StateDB {
+	return pool.statedb
+}

--- a/kaiax/gasless/impl/init.go
+++ b/kaiax/gasless/impl/init.go
@@ -19,8 +19,8 @@ package impl
 import (
 	"crypto/ecdsa"
 
-	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 )
@@ -30,11 +30,11 @@ var logger = log.NewModuleLogger(log.KaiaxGasless)
 type InitOpts struct {
 	ChainConfig *params.ChainConfig
 	NodeKey     *ecdsa.PrivateKey
+	TxPool      kaiax.TxPoolForCaller
 }
 
 type GaslessModule struct {
 	InitOpts
-	currentState  *state.StateDB
 	swapRouters   map[common.Address]bool
 	allowedTokens map[common.Address]bool
 }

--- a/kaiax/gasless/impl/init.go
+++ b/kaiax/gasless/impl/init.go
@@ -19,6 +19,7 @@ package impl
 import (
 	"crypto/ecdsa"
 
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/log"
@@ -37,6 +38,7 @@ type GaslessModule struct {
 	InitOpts
 	swapRouters   map[common.Address]bool
 	allowedTokens map[common.Address]bool
+	signer        types.Signer
 }
 
 func NewGaslessModule() *GaslessModule {
@@ -55,6 +57,7 @@ func (g *GaslessModule) Init(opts *InitOpts) error {
 	g.allowedTokens = map[common.Address]bool{
 		common.HexToAddress("0xabcd"): true,
 	}
+	g.signer = types.LatestSignerForChainID(g.ChainConfig.ChainID)
 	return nil
 }
 

--- a/kaiax/gasless/impl/init.go
+++ b/kaiax/gasless/impl/init.go
@@ -46,7 +46,7 @@ func NewGaslessModule() *GaslessModule {
 }
 
 func (g *GaslessModule) Init(opts *InitOpts) error {
-	if opts == nil || opts.ChainConfig == nil || opts.NodeKey == nil {
+	if opts == nil || opts.ChainConfig == nil || opts.NodeKey == nil || opts.TxPool == nil {
 		return ErrInitUnexpectedNil
 	}
 	g.InitOpts = *opts

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -63,7 +63,7 @@ func (g *GaslessModule) IsReady(txs map[uint64]*types.Transaction, i uint64, rea
 func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) bool {
 	addr, err := types.Sender(g.signer, approveTx)
 	if err != nil {
-		panic(err)
+		return false
 	}
 	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
 

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -59,14 +59,10 @@ func (g *GaslessModule) IsReady(txs map[uint64]*types.Transaction, i uint64, rea
 	return false
 }
 
-func (g *GaslessModule) Reset(pool kaiax.TxPoolForCaller, oldHead, newHead *types.Header) {
-	g.currentState = pool.GetCurrentState()
-}
-
 // isApproveTxReady assumes that the caller checked `g.IsApproveTx(approveTx)`
 func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) bool {
 	addr := approveTx.ValidatedSender()
-	nonce := g.currentState.GetNonce(addr)
+	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
 
 	if approveTx.Nonce() != nonce {
 		return false
@@ -81,7 +77,7 @@ func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) b
 // isSwapTxReady assumes that the caller checked `g.IsSwapTx(swapTx)`
 func (g *GaslessModule) isSwapTxReady(swapTx, prevTx *types.Transaction) bool {
 	addr := swapTx.ValidatedSender()
-	nonce := g.currentState.GetNonce(addr)
+	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
 
 	var approveTx *types.Transaction
 	if swapTx.Nonce() == nonce {

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -81,7 +81,7 @@ func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) b
 func (g *GaslessModule) isSwapTxReady(swapTx, prevTx *types.Transaction) bool {
 	addr, err := types.Sender(g.signer, swapTx)
 	if err != nil {
-		panic(err)
+		return false
 	}
 	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
 

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -61,7 +61,10 @@ func (g *GaslessModule) IsReady(txs map[uint64]*types.Transaction, i uint64, rea
 
 // isApproveTxReady assumes that the caller checked `g.IsApproveTx(approveTx)`
 func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) bool {
-	addr := approveTx.ValidatedSender()
+	addr, err := types.Sender(g.signer, approveTx)
+	if err != nil {
+		panic(err)
+	}
 	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
 
 	if approveTx.Nonce() != nonce {
@@ -76,7 +79,10 @@ func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) b
 
 // isSwapTxReady assumes that the caller checked `g.IsSwapTx(swapTx)`
 func (g *GaslessModule) isSwapTxReady(swapTx, prevTx *types.Transaction) bool {
-	addr := swapTx.ValidatedSender()
+	addr, err := types.Sender(g.signer, swapTx)
+	if err != nil {
+		panic(err)
+	}
 	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
 
 	var approveTx *types.Transaction

--- a/kaiax/gasless/impl/tx_pool_test.go
+++ b/kaiax/gasless/impl/tx_pool_test.go
@@ -64,10 +64,13 @@ func TestIsModuleTx(t *testing.T) {
 
 	g := NewGaslessModule()
 	key, _ := crypto.GenerateKey()
-	g.Init(&InitOpts{
+	err := g.Init(&InitOpts{
 		ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 		NodeKey:     key,
+		TxPool:      &testTxPool{},
 	})
+	require.NoError(t, err)
+
 	for _, tc := range testcases {
 		ok := g.IsModuleTx(tc.tx)
 		require.Equal(t, tc.ok, ok)
@@ -177,11 +180,12 @@ func TestIsReady(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			sdb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 			sdb.SetNonce(addr, tc.nonce)
-			g.Init(&InitOpts{
+			err := g.Init(&InitOpts{
 				ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 				NodeKey:     nodeKey,
 				TxPool:      &testTxPool{sdb},
 			})
+			require.NoError(t, err)
 			ok := g.IsReady(tc.queue, tc.i, tc.ready)
 			require.Equal(t, tc.expected, ok)
 		})
@@ -309,11 +313,12 @@ func TestPromoteGaslessTransactions(t *testing.T) {
 		pool := blockchain.NewTxPool(testTxPoolConfig, chainConfig, bc, &dummyGovModule{chainConfig: chainConfig})
 		g := NewGaslessModule()
 		nodeKey, _ := crypto.GenerateKey()
-		g.Init(&InitOpts{
+		err := g.Init(&InitOpts{
 			ChainConfig: &params.ChainConfig{ChainID: big.NewInt(1)},
 			NodeKey:     nodeKey,
 			TxPool:      pool,
 		})
+		require.NoError(t, err)
 		pool.RegisterTxPoolModule(g)
 		txMap := map[txTypeTest]*types.Transaction{}
 

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -9,7 +9,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/kaiachain/kaia/blockchain/types"
-	kaiax "github.com/kaiachain/kaia/kaiax"
 	builder "github.com/kaiachain/kaia/kaiax/builder"
 )
 
@@ -118,18 +117,6 @@ func (m *MockGaslessModule) PreAddRemote(arg0 *types.Transaction) error {
 func (mr *MockGaslessModuleMockRecorder) PreAddRemote(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreAddRemote", reflect.TypeOf((*MockGaslessModule)(nil).PreAddRemote), arg0)
-}
-
-// Reset mocks base method.
-func (m *MockGaslessModule) Reset(arg0 kaiax.TxPoolForCaller, arg1, arg2 *types.Header) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Reset", arg0, arg1, arg2)
-}
-
-// Reset indicates an expected call of Reset.
-func (mr *MockGaslessModuleMockRecorder) Reset(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockGaslessModule)(nil).Reset), arg0, arg1, arg2)
 }
 
 // Start mocks base method.

--- a/kaiax/interface.go
+++ b/kaiax/interface.go
@@ -153,9 +153,6 @@ type TxPoolModule interface {
 
 	// Additional actions to check if a module transaction should be appended to pending
 	IsReady(txs map[uint64]*types.Transaction, next uint64, ready types.Transactions) bool
-
-	// Additional actions to perform after resetting tx pool.
-	Reset(pool TxPoolForCaller, oldHead, newHead *types.Header)
 }
 
 type TxPoolForCaller interface {

--- a/node/cn/gasprice/gasprice_test.go
+++ b/node/cn/gasprice/gasprice_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/kaiachain/kaia/common/math"
 	"github.com/kaiachain/kaia/consensus/gxhash"
 	"github.com/kaiachain/kaia/crypto"
-	"github.com/kaiachain/kaia/kaiax"
-	mock_gasless "github.com/kaiachain/kaia/kaiax/gasless/mock"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
 	mock_gov "github.com/kaiachain/kaia/kaiax/gov/mock"
@@ -224,9 +222,7 @@ func TestGasPrice_SuggestPrice(t *testing.T) {
 	chainConfig := testBackend.ChainConfig()
 	mockGov := mock_gov.NewMockGovModule(gomock.NewController(t))
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{UnitPrice: 0}).Times(1)
-	mockGasless := mock_gasless.NewMockGaslessModule(gomock.NewController(t))
-	mockGasless.EXPECT().Reset(gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
-	txPoolWith0 := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain, mockGov, []kaiax.TxPoolModule{mockGasless})
+	txPoolWith0 := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain, mockGov)
 
 	oracle := NewOracle(mockBackend, params, txPoolWith0, mockGov)
 
@@ -241,7 +237,7 @@ func TestGasPrice_SuggestPrice(t *testing.T) {
 	params = Config{}
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{UnitPrice: 25}).Times(1)
 	mockBackend.EXPECT().ChainConfig().Return(chainConfig).Times(2)
-	txPoolWith25 := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain, mockGov, []kaiax.TxPoolModule{mockGasless})
+	txPoolWith25 := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain, mockGov)
 	oracle = NewOracle(mockBackend, params, txPoolWith25, mockGov)
 
 	price, err = oracle.SuggestPrice(nil)
@@ -295,9 +291,7 @@ func TestSuggestTipCap(t *testing.T) {
 			mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{UnitPrice: testBackend.ChainConfig().UnitPrice, LowerBoundBaseFee: math.MaxUint64}).AnyTimes()
 			testGov = mockGov
 		}
-		mockGasless := mock_gasless.NewMockGaslessModule(gomock.NewController(t))
-		mockGasless.EXPECT().Reset(gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
-		txPool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain, testGov, []kaiax.TxPoolModule{mockGasless})
+		txPool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, chainConfig, testBackend.chain, testGov)
 		oracle := NewOracle(testBackend, config, txPool, testGov)
 
 		// The gas price sampled is: 32G, 31G, 30G, 29G, 28G, 27G

--- a/node/sc/mainbridge_test.go
+++ b/node/sc/mainbridge_test.go
@@ -36,8 +36,6 @@ import (
 	"github.com/kaiachain/kaia/consensus/istanbul/backend"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
-	"github.com/kaiachain/kaia/kaiax"
-	gasless_mock "github.com/kaiachain/kaia/kaiax/gasless/mock"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	gov_mock "github.com/kaiachain/kaia/kaiax/gov/mock"
 	"github.com/kaiachain/kaia/networks/p2p"
@@ -102,9 +100,7 @@ func testTxPool(t *testing.T, dataDir string, bc *blockchain.BlockChain) *blockc
 	blockchain.DefaultTxPoolConfig.Journal = path.Join(dataDir, blockchain.DefaultTxPoolConfig.Journal)
 	mockGov := gov_mock.NewMockGovModule(gomock.NewController(t))
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{UnitPrice: bc.Config().UnitPrice}).AnyTimes()
-	mockGasless := gasless_mock.NewMockGaslessModule(gomock.NewController(t))
-	mockGasless.EXPECT().Reset(gomock.Any(), gomock.Any(), gomock.Any()).Return().AnyTimes()
-	return blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bc.Config(), bc, mockGov, []kaiax.TxPoolModule{mockGasless})
+	return blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bc.Config(), bc, mockGov)
 }
 
 // TestCreateDB tests creation of chain database and proper working of database operation.

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -697,7 +697,7 @@ func TestAccountUpdateMultiSigKeyMaxKey(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// update key to a multiSig account with 11 different private keys (more than 10 -> failed)
 	{
@@ -811,7 +811,7 @@ func TestAccountUpdateMultiSigKeyBigThreshold(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// update key to a multisig key with a threshold (10) and the total weight (6). (failed case)
 	{
@@ -922,7 +922,7 @@ func TestAccountUpdateMultiSigKeyDupPrvKeys(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 2. Update to a multisig key which has two same private keys.
 	{
@@ -1038,7 +1038,7 @@ func TestAccountUpdateMultiSigKeyWeightOverflow(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 2. update toc a multisig key with a threshold, uint(MAX), and the total weight, uint(MAX/2)*3. (failed case)
 	{
@@ -1137,7 +1137,7 @@ func TestAccountUpdateRoleBasedKeyInvalidNumKey(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 2. update to a RoleBased key which contains 4 sub-keys.
 	{
@@ -1282,7 +1282,7 @@ func TestAccountUpdateRoleBasedKeyInvalidTypeKey(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 1. a RoleBased key contains an AccountKeyNil type sub-key as a first sub-key. (fail)
 	{
@@ -1577,7 +1577,7 @@ func TestAccountUpdateRoleBasedKey(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 1. try to update the account with a RoleTransaction key. (fail)
 	{
@@ -1764,7 +1764,7 @@ func TestAccountUpdateRoleBasedKeyNested(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 2. Update an accountKey with a nested RoleBasedKey.
 	{
@@ -1939,7 +1939,7 @@ func TestRoleBasedKeySendTx(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test fee delegation txs for each role of role-based key.
 	// only RoleFeePayer type can generate valid signature as a fee payer.
@@ -2144,7 +2144,7 @@ func TestRoleBasedKeyFeeDelegation(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test fee delegation txs for each role of role-based key.
 	// only RoleFeePayer type can generate valid signature as a fee payer.

--- a/tests/addtx_test.go
+++ b/tests/addtx_test.go
@@ -124,7 +124,7 @@ func benchAddTx(b *testing.B, maxAccounts, numValidators int, parallel string, n
 
 		Lifetime: 5 * time.Minute,
 	}
-	txpool := blockchain.NewTxPool(poolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(poolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	signer := types.MakeSigner(bcdata.bc.Config(), bcdata.bc.CurrentBlock().Number())
 

--- a/tests/kaia_test.go
+++ b/tests/kaia_test.go
@@ -757,5 +757,5 @@ func makeTxPool(bcdata *BCData, txPoolSize int) *blockchain.TxPool {
 	txpoolconfig.NonExecSlotsAccount = uint64(txPoolSize)
 	txpoolconfig.ExecSlotsAll = 2 * uint64(txPoolSize)
 	txpoolconfig.NonExecSlotsAll = 2 * uint64(txPoolSize)
-	return blockchain.NewTxPool(txpoolconfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	return blockchain.NewTxPool(txpoolconfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 }

--- a/tests/kaia_test_blockchain_test.go
+++ b/tests/kaia_test_blockchain_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/sha3"
 	"github.com/kaiachain/kaia/datasync/downloader"
-	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/kaiax/builder"
 	gasless_impl "github.com/kaiachain/kaia/kaiax/gasless/impl"
 	"github.com/kaiachain/kaia/kaiax/gov"
@@ -74,7 +73,6 @@ type BCData struct {
 	engine             consensus.Istanbul
 	genesis            *blockchain.Genesis
 	govModule          gov.GovModule
-	txPoolModules      []kaiax.TxPoolModule
 }
 
 var (
@@ -189,7 +187,6 @@ func NewBCDataWithForkConfig(maxAccounts, numValidators int, chainCfg *params.Ch
 		bc, addrs, privKeys, chainDb,
 		&genesisAddr, validatorAddresses,
 		validatorPrivKeys, engine, genesis, mGov,
-		[]kaiax.TxPoolModule{mGasless},
 	}, nil
 }
 

--- a/tests/kaia_test_blockchain_test.go
+++ b/tests/kaia_test_blockchain_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/kaiachain/kaia/crypto/sha3"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/kaiax/builder"
-	gasless_impl "github.com/kaiachain/kaia/kaiax/gasless/impl"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
 	randao_impl "github.com/kaiachain/kaia/kaiax/randao/impl"
@@ -142,7 +141,6 @@ func NewBCDataWithForkConfig(maxAccounts, numValidators int, chainCfg *params.Ch
 	mReward := reward_impl.NewRewardModule()
 	mValset := valset_impl.NewValsetModule()
 	mRandao := randao_impl.NewRandaoModule()
-	mGasless := gasless_impl.NewGaslessModule()
 	fakeDownloader := downloader.NewFakeDownloader()
 	err = errors.Join(
 		mGov.Init(&gov_impl.InitOpts{
@@ -168,10 +166,6 @@ func NewBCDataWithForkConfig(maxAccounts, numValidators int, chainCfg *params.Ch
 			ChainConfig: genesis.Config,
 			Chain:       bc,
 			Downloader:  fakeDownloader,
-		}),
-		mGasless.Init(&gasless_impl.InitOpts{
-			ChainConfig: genesis.Config,
-			NodeKey:     validatorPrivKeys[0],
 		}),
 	)
 	if err != nil {

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	istanbulBackend "github.com/kaiachain/kaia/consensus/istanbul/backend"
 	"github.com/kaiachain/kaia/crypto"
-	"github.com/kaiachain/kaia/kaiax"
 	gasless_impl "github.com/kaiachain/kaia/kaiax/gasless/impl"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
 	"github.com/kaiachain/kaia/log"
@@ -422,7 +421,6 @@ func NewBCDataForPreGeneratedTest(testDataDir string, tc *preGeneratedTC) (*BCDa
 		bc, addrs, privKeys, chainDB,
 		&genesisAddr, validatorAddresses,
 		validatorPrivKeys, engine, genesis, mGov,
-		[]kaiax.TxPoolModule{mGasless},
 	}, nil
 }
 

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	istanbulBackend "github.com/kaiachain/kaia/consensus/istanbul/backend"
 	"github.com/kaiachain/kaia/crypto"
-	gasless_impl "github.com/kaiachain/kaia/kaiax/gasless/impl"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
@@ -403,15 +402,6 @@ func NewBCDataForPreGeneratedTest(testDataDir string, tc *preGeneratedTC) (*BCDa
 		ChainConfig: genesis.Config,
 		Chain:       bc,
 		ChainKv:     chainDB.GetMiscDB(),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	mGasless := gasless_impl.NewGaslessModule()
-	err = mGasless.Init(&gasless_impl.InitOpts{
-		ChainConfig: genesis.Config,
-		NodeKey:     validatorPrivKeys[0],
 	})
 	if err != nil {
 		return nil, err

--- a/tests/transaction_test.go
+++ b/tests/transaction_test.go
@@ -84,7 +84,7 @@ func TestAccountCreationDisable(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	{
 		// generate an accountCreation tx
@@ -154,7 +154,7 @@ func TestContractDeployWithDisabledAddress(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	for _, txType := range testTxTypes {
 		// generate an invalid contract deploy tx with humanReadable flag as true

--- a/tests/transaction_validation_test.go
+++ b/tests/transaction_validation_test.go
@@ -149,7 +149,7 @@ func TestValidatingUnavailableContractExecution(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 1. contract execution transaction to the contract account.
 	{

--- a/tests/tx_cancel_test.go
+++ b/tests/tx_cancel_test.go
@@ -59,7 +59,7 @@ func TestTxCancel(t *testing.T) {
 	prof.Profile("main_init_accountMap", time.Now().Sub(start))
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	signer := types.MakeSigner(bcdata.bc.Config(), bcdata.bc.CurrentHeader().Number)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
@@ -210,7 +210,7 @@ func TestTxFeeDelegatedCancel(t *testing.T) {
 	prof.Profile("main_init_accountMap", time.Now().Sub(start))
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	signer := types.MakeSigner(bcdata.bc.Config(), bcdata.bc.CurrentHeader().Number)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
@@ -369,7 +369,7 @@ func TestTxFeeDelegatedCancelWithRatio(t *testing.T) {
 	prof.Profile("main_init_accountMap", time.Now().Sub(start))
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	signer := types.MakeSigner(bcdata.bc.Config(), bcdata.bc.CurrentHeader().Number)
 	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)

--- a/tests/tx_fee_ratio_range_test.go
+++ b/tests/tx_fee_ratio_range_test.go
@@ -141,7 +141,7 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// 1. TxTypeFeeDelegatedValueTransferWithRatio
 	{

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -194,7 +194,7 @@ func TestValidationPoolInsertEthTxType(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test for all tx types
 	for _, testTxType := range testTxTypes {
@@ -318,7 +318,7 @@ func TestValidationPoolInsertMagma(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test for all tx types
 	for _, testTxType := range testTxTypes {
@@ -469,7 +469,7 @@ func TestValidationPoolInsertPrague(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test for all tx types
 	for _, testTxType := range testTxTypes {
@@ -819,7 +819,7 @@ func TestValidationInvalidSig(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test for all tx types
 	for _, testTxType := range testTxTypes {
@@ -946,7 +946,7 @@ func TestLegacyTxFromNonLegacyAcc(t *testing.T) {
 	reservoir.AddNonce()
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	valueMap, _ = genMapForTxTypes(reservoir, reservoir, types.TxTypeLegacyTransaction)
 	tx, err = types.NewTransactionWithMap(types.TxTypeLegacyTransaction, valueMap)
@@ -1066,7 +1066,7 @@ func TestInvalidBalance(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test for all tx types
 	for _, testTxType := range testTxTypes {
@@ -1839,7 +1839,7 @@ func TestValidationTxSizeAfterRLP(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// test for all tx types
 	for _, txType := range testTxTypes {
@@ -1999,7 +1999,7 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// state changing tx which will invalidate other txs when it is contained in a block.
 	var txs types.Transactions
@@ -2175,7 +2175,7 @@ func TestValidationPoolResetAfterFeePayerKeyChange(t *testing.T) {
 	}
 
 	// make TxPool to test validation in 'TxPool add' process
-	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule, bcdata.txPoolModules)
+	txpool := blockchain.NewTxPool(blockchain.DefaultTxPoolConfig, bcdata.bc.Config(), bcdata.bc, bcdata.govModule)
 
 	// state changing tx which will invalidate other txs when it is contained in a block.
 	var txs types.Transactions

--- a/work/mocks/txpool_mock.go
+++ b/work/mocks/txpool_mock.go
@@ -10,9 +10,11 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	blockchain "github.com/kaiachain/kaia/blockchain"
+	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
 	event "github.com/kaiachain/kaia/event"
+	kaiax "github.com/kaiachain/kaia/kaiax"
 )
 
 // MockTxPool is a mock of TxPool interface.
@@ -109,6 +111,20 @@ func (mr *MockTxPoolMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTxPool)(nil).Get), arg0)
 }
 
+// GetCurrentState mocks base method.
+func (m *MockTxPool) GetCurrentState() *state.StateDB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentState")
+	ret0, _ := ret[0].(*state.StateDB)
+	return ret0
+}
+
+// GetCurrentState indicates an expected call of GetCurrentState.
+func (mr *MockTxPoolMockRecorder) GetCurrentState() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentState", reflect.TypeOf((*MockTxPool)(nil).GetCurrentState))
+}
+
 // GetPendingNonce mocks base method.
 func (m *MockTxPool) GetPendingNonce(arg0 common.Address) uint64 {
 	m.ctrl.T.Helper()
@@ -148,6 +164,22 @@ func (m *MockTxPool) Pending() (map[common.Address]types.Transactions, error) {
 func (mr *MockTxPoolMockRecorder) Pending() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pending", reflect.TypeOf((*MockTxPool)(nil).Pending))
+}
+
+// RegisterTxPoolModule mocks base method.
+func (m *MockTxPool) RegisterTxPoolModule(arg0 ...kaiax.TxPoolModule) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "RegisterTxPoolModule", varargs...)
+}
+
+// RegisterTxPoolModule indicates an expected call of RegisterTxPoolModule.
+func (mr *MockTxPoolMockRecorder) RegisterTxPoolModule(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTxPoolModule", reflect.TypeOf((*MockTxPool)(nil).RegisterTxPoolModule), arg0...)
 }
 
 // SetGasPrice mocks base method.

--- a/work/work.go
+++ b/work/work.go
@@ -76,6 +76,9 @@ type TxPool interface {
 	Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	StartSpamThrottler(conf *blockchain.ThrottlerConfig) error
 	StopSpamThrottler()
+	GetCurrentState() *state.StateDB
+
+	kaiax.TxPoolModuleHost
 }
 
 // Backend wraps all methods required for mining.


### PR DESCRIPTION
## Proposed changes

There are two instances of gasless module as TxPoolMoudule and TxBundlingModule. However, TxBundlingModule's one doesn't call tx pool's reset so state db has never been set. This PR fixes this.

- Make two gasless modules instances one
- Register transaction pool modules by `RegisterTxPoolModule` after initializing transaction pool

Moreover, updating statedb is a little complicated so this changes the way to pass statedb to setting pool field in moduels. This also change the way to get sender address from a transaction.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
