### PR TITLE
tests: Add a test for the success of a bundle containing a tx generator and for evm error revert.

### DIFF
--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -286,11 +286,10 @@ func PopTxs(txs *[]interface{}, num int, bundles *[]*builder.Bundle, signer type
 	*bundles = newBundles
 }
 
-func ExtractBundlesAndIncorporate(txs *types.TransactionsByPriceAndNonce, txBundlingModules []builder.TxBundlingModule) ([]interface{}, []*builder.Bundle) {
+func ExtractBundlesAndIncorporate(arrayTxs []*types.Transaction, txBundlingModules []builder.TxBundlingModule) ([]interface{}, []*builder.Bundle) {
 	// Detect bundles and add them to bundles
 	bundles := []*builder.Bundle{}
 	flattenedTxs := []interface{}{}
-	arrayTxs := Arrayify(txs)
 	if txBundlingModules == nil {
 		for _, tx := range arrayTxs {
 			var itx interface{} = tx

--- a/tests/kaia_test_account_map_test.go
+++ b/tests/kaia_test_account_map_test.go
@@ -113,6 +113,8 @@ func (a *AccountMap) Update(txs types.Transactions, txHashesExpectedFail []commo
 	incorporatedTxs, _ := builder_impl.ExtractBundlesAndIncorporate(txs, txBundlingModules)
 	for _, txOrGen := range incorporatedTxs {
 		if gen, ok := txOrGen.(builder.TxGenerator); ok {
+			// To simulate tx, the nonce given to generate is set to zero.
+			// This does not affect subsequent operations on the AccountMap state.
 			tx, err := gen.Generate(0)
 			if err != nil {
 				continue

--- a/tests/kaia_test_blockchain_test.go
+++ b/tests/kaia_test_blockchain_test.go
@@ -367,7 +367,7 @@ func (bcdata *BCData) GenABlockWithTxpool(accountMap *AccountMap, txpool *blockc
 
 	// Update accountMap
 	start = time.Now()
-	if err := accountMap.Update(newtxs, nil, signer, statedb, b.NumberU64()); err != nil {
+	if err := accountMap.Update(newtxs, nil, nil, signer, statedb, b.NumberU64()); err != nil {
 		return err
 	}
 	prof.Profile("main_update_accountMap", time.Now().Sub(start))
@@ -448,7 +448,7 @@ func (bcdata *BCData) genABlockWithTransactionsWithBundle(accountMap *AccountMap
 
 	// Update accountMap
 	start := time.Now()
-	if err := accountMap.Update(transactions, txHashesExpectedFail, signer, statedb, bcdata.bc.CurrentBlock().NumberU64()); err != nil {
+	if err := accountMap.Update(transactions, txHashesExpectedFail, txBundlingModules, signer, statedb, bcdata.bc.CurrentBlock().NumberU64()); err != nil {
 		return err
 	}
 	prof.Profile("main_update_accountMap", time.Now().Sub(start))

--- a/work/worker.go
+++ b/work/worker.go
@@ -679,7 +679,8 @@ func (env *Task) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 }
 
 func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc BlockChain, rewardbase common.Address, txBundlingModules []builder.TxBundlingModule) []*types.Log {
-	incorporatedTxs, bundles := builder_impl.ExtractBundlesAndIncorporate(txs, txBundlingModules)
+	arrayTxs := builder_impl.Arrayify(txs)
+	incorporatedTxs, bundles := builder_impl.ExtractBundlesAndIncorporate(arrayTxs, txBundlingModules)
 	var coalescedLogs []*types.Log
 
 	// Limit the execution time of all transactions in a block


### PR DESCRIPTION
## Proposed changes

- Add a test for the success of a bundle containing a tx generator and for evm error revert.
- Change the arg txs of ExtractBundlesAndIncorporate from TransactionsByPriceAndNonce to []*Transaction
  - []*Transaction is the more commonly used type and is more convenient
- AccountMap.Update should now follow state changes made by TxGenerator
  - To simulate tx, the nonce given to generate is set to zero.
  - This does not affect subsequent operations on the AccountMap state.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
