### PR TITLE
kaiax/gasless: execute SetTxContext for each tx

### DIFF
--- a/work/worker.go
+++ b/work/worker.go
@@ -788,8 +788,6 @@ CommitTransactionLoop:
 		//	continue
 		//}
 		// Start executing the transaction
-		env.state.SetTxContext(tx.Hash(), common.Hash{}, env.tcount)
-
 		if len(targetBundle.BundleTxs) != 0 {
 			atomic.StoreInt32(&isExecutingBundleTxs, 1)
 			err, tx, logs = env.commitBundleTransaction(targetBundle, bc, rewardbase, vmConfig)
@@ -798,6 +796,7 @@ CommitTransactionLoop:
 				from, _ = types.Sender(env.signer, tx)
 			}
 		} else {
+			env.state.SetTxContext(tx.Hash(), common.Hash{}, env.tcount)
 			err, logs = env.commitTransaction(tx, bc, rewardbase, vmConfig)
 		}
 
@@ -918,6 +917,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 			tx = txOrGen.(*types.Transaction)
 		}
 
+		env.state.SetTxContext(tx.Hash(), common.Hash{}, env.tcount)
 		receipt, _, err := bc.ApplyTransaction(env.config, &rewardbase, env.state, env.header, tx, &env.header.GasUsed, vmConfig)
 		// Bundled tx will be rejected with any receipt.Status other than success.
 		// There may be cases where a revert occurs within the EVM, which could result in an attack on a tx sender in an already executed bundle.


### PR DESCRIPTION
## Proposed changes

Currently, there is a possibility that the bloom calculation may be incorrect and a bad block may be generated.
This is because `SetTxContext` is not executed for every tx that is executed.
This PR solves the problem by executing `SetTxContext` for each tx even when the execution target is a bundle.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
