### PR TITLE
kaiax/gasless: fix some bugs in Task.ApplyTransactions

### DIFF
--- a/kerrors/kerrors.go
+++ b/kerrors/kerrors.go
@@ -58,4 +58,5 @@ var (
 
 	ErrDeprecated   = errors.New("deprecated feature")
 	ErrNotSupported = errors.New("not supported")
+	ErrRevertedBundleByVmErr = errors.New("bundle is reverted by vm err")
 )

--- a/work/worker.go
+++ b/work/worker.go
@@ -770,7 +770,8 @@ CommitTransactionLoop:
 				continue
 			}
 		}
-		numTxsChecked++
+		// If target is the tx in bundle, len(targetBundle.BundleTxs) is appended to numTxsChecked.
+		numTxsChecked += int64(numShift)
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance is the transaction pool.
 		//


### PR DESCRIPTION
## Proposed changes

This PR fix following bugs in Task.ApplyTransactions.
- `env.tcount` used in `SetTxContext` within `commitBundleTransaction` is not being incremented.
- `numTxsChecked` does not increment correctly for bundles.
- When the return value of `bc.ApplyTransaction` is `err == nil && receipt.Status != ReceiptStatusSuccessful`, `ShiftTxs` is executed instead of `PopTxs`.


## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
