### PR TITLE
kaiax/builder: Introduce TxOrGen

### DIFF
--- a/kaiax/builder/bundle_test.go
+++ b/kaiax/builder/bundle_test.go
@@ -31,7 +31,7 @@ func TestBundle_IsConflict(t *testing.T) {
 	}
 
 	b0 := &Bundle{
-		BundleTxs:    []interface{}{txs[0], txs[1]},
+		BundleTxs:    NewTxOrGenListFromTxs(txs[0], txs[1]),
 		TargetTxHash: common.Hash{},
 	}
 	defaultTargetHash := txs[1].Hash()
@@ -46,7 +46,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "Same TargetTxHash (empty TargetHash)",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    []interface{}{},
+				BundleTxs:    NewTxOrGenListFromTxs(),
 				TargetTxHash: common.Hash{},
 			},
 			expected: true,
@@ -55,7 +55,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "TargetTxHash divides a bundle",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    []interface{}{},
+				BundleTxs:    NewTxOrGenListFromTxs(),
 				TargetTxHash: txs[0].Hash(),
 			},
 			expected: true,
@@ -64,7 +64,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "Overlapping BundleTxs",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    []interface{}{txs[0]},
+				BundleTxs:    NewTxOrGenListFromTxs(txs[0]),
 				TargetTxHash: defaultTargetHash,
 			},
 			expected: true,
@@ -73,7 +73,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "Non-overlapping BundleTxs",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    []interface{}{txs[2], txs[3]},
+				BundleTxs:    NewTxOrGenListFromTxs(txs[2], txs[3]),
 				TargetTxHash: defaultTargetHash,
 			},
 			expected: false,

--- a/kaiax/builder/bundle_test.go
+++ b/kaiax/builder/bundle_test.go
@@ -31,7 +31,7 @@ func TestBundle_IsConflict(t *testing.T) {
 	}
 
 	b0 := &Bundle{
-		BundleTxs:    NewTxOrGenListFromTxs(txs[0], txs[1]),
+		BundleTxs:    NewTxOrGenList(txs[0], txs[1]),
 		TargetTxHash: common.Hash{},
 	}
 	defaultTargetHash := txs[1].Hash()
@@ -46,7 +46,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "Same TargetTxHash (empty TargetHash)",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    NewTxOrGenListFromTxs(),
+				BundleTxs:    NewTxOrGenList(),
 				TargetTxHash: common.Hash{},
 			},
 			expected: true,
@@ -55,7 +55,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "TargetTxHash divides a bundle",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    NewTxOrGenListFromTxs(),
+				BundleTxs:    NewTxOrGenList(),
 				TargetTxHash: txs[0].Hash(),
 			},
 			expected: true,
@@ -64,7 +64,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "Overlapping BundleTxs",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    NewTxOrGenListFromTxs(txs[0]),
+				BundleTxs:    NewTxOrGenList(txs[0]),
 				TargetTxHash: defaultTargetHash,
 			},
 			expected: true,
@@ -73,7 +73,7 @@ func TestBundle_IsConflict(t *testing.T) {
 			name:   "Non-overlapping BundleTxs",
 			bundle: b0,
 			newBundle: &Bundle{
-				BundleTxs:    NewTxOrGenListFromTxs(txs[2], txs[3]),
+				BundleTxs:    NewTxOrGenList(txs[2], txs[3]),
 				TargetTxHash: defaultTargetHash,
 			},
 			expected: false,

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -17,30 +17,27 @@
 package impl
 
 import (
-	"bytes"
-
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax/builder"
 )
 
 // buildDependencyIndices builds a dependency indices of txs.
 // Two txs with the same sender has an edge.
 // Two txs in the same bundle has an edge.
-func buildDependencyIndices(txs []interface{}, bundles []*builder.Bundle, signer types.Signer) (map[common.Address][]int, map[int][]int, error) {
+func buildDependencyIndices(txs []*builder.TxOrGen, bundles []*builder.Bundle, signer types.Signer) (map[common.Address][]int, map[int][]int, error) {
 	senderToIndices := make(map[common.Address][]int)
 	bundleToIndices := make(map[int][]int)
 
 	for i, txOrGen := range txs {
-		if tx, ok := txOrGen.(*types.Transaction); ok {
-			from, err := types.Sender(signer, tx)
+		if txOrGen.IsConcreteTx() {
+			from, err := types.Sender(signer, txOrGen.ConcreteTx)
 			if err != nil {
 				return nil, nil, err
 			}
 			senderToIndices[from] = append(senderToIndices[from], i)
 		}
-		if bundleIdx := FindBundleIdxAsTxOrGen(bundles, txOrGen); bundleIdx != -1 {
+		if bundleIdx := FindBundleIdx(bundles, txOrGen); bundleIdx != -1 {
 			bundleToIndices[bundleIdx] = append(bundleToIndices[bundleIdx], i)
 		}
 	}
@@ -50,10 +47,10 @@ func buildDependencyIndices(txs []interface{}, bundles []*builder.Bundle, signer
 
 // IncorporateBundleTx incorporates bundle transactions into the transaction list.
 // Caller must ensure that there is no conflict between bundles.
-func IncorporateBundleTx(txs []*types.Transaction, bundles []*builder.Bundle) ([]interface{}, error) {
-	ret := make([]interface{}, len(txs))
-	for i := range txs {
-		ret[i] = txs[i]
+func IncorporateBundleTx(txs []*types.Transaction, bundles []*builder.Bundle) ([]*builder.TxOrGen, error) {
+	ret := make([]*builder.TxOrGen, len(txs))
+	for i, tx := range txs {
+		ret[i] = builder.NewTxOrGenFromTx(tx)
 	}
 
 	for _, bundle := range bundles {
@@ -67,8 +64,8 @@ func IncorporateBundleTx(txs []*types.Transaction, bundles []*builder.Bundle) ([
 }
 
 // incorporate assumes that `txs` does not contain any bundle transactions.
-func incorporate(txs []interface{}, bundle *builder.Bundle) ([]interface{}, error) {
-	ret := make([]interface{}, 0, len(txs)+len(bundle.BundleTxs))
+func incorporate(txs []*builder.TxOrGen, bundle *builder.Bundle) ([]*builder.TxOrGen, error) {
+	ret := make([]*builder.TxOrGen, 0, len(txs)+len(bundle.BundleTxs))
 	targetFound := false
 
 	// 1. place bundle at the beginning
@@ -79,29 +76,14 @@ func incorporate(txs []interface{}, bundle *builder.Bundle) ([]interface{}, erro
 
 	// 2. place bundle after TargetTxHash
 	for _, txOrGen := range txs {
-		switch tx := txOrGen.(type) {
-		case *types.Transaction:
-			// if tx-in-bundle, the tx will be appended when target is found.
-			if bundle.Has(tx.Hash()) {
-				continue
-			}
-			// Because bundle.TargetTxHash cannot be in the bundle, we only check tx-not-in-bundle case.
-			ret = append(ret, tx)
-			if tx.Hash() == bundle.TargetTxHash {
-				targetFound = true
-				for i, txInBundleI := range bundle.BundleTxs {
-					switch txInBundle := txInBundleI.(type) {
-					case *types.Transaction:
-						ret = append(ret, txInBundleI)
-					case builder.TxGenerator:
-						txInBundle.Hash = crypto.Keccak256Hash(bundle.TargetTxHash[:], common.Int64ToByteLittleEndian(uint64(i)))
-						txInBundleI = txInBundle
-						ret = append(ret, txInBundleI)
-					}
-				}
-			}
-		default: // if tx is TxGenerator, unconditionally append
-			ret = append(ret, txOrGen)
+		// if tx-in-bundle, the tx will be appended when target is found.
+		if bundle.Has(txOrGen.Id) {
+			continue
+		}
+		ret = append(ret, txOrGen)
+		if txOrGen.Id == bundle.TargetTxHash {
+			targetFound = true
+			ret = append(ret, bundle.BundleTxs...)
 		}
 	}
 
@@ -147,50 +129,16 @@ func Filter[T any](slice *[]T, toRemove map[int]bool) []T {
 	return ret
 }
 
-func FindBundleIdx(bundles []*builder.Bundle, tx *types.Transaction) int {
+func FindBundleIdx(bundles []*builder.Bundle, txOrGen *builder.TxOrGen) int {
 	for i, bundle := range bundles {
-		if bundle.Has(tx.Hash()) {
+		if bundle.Has(txOrGen.Id) {
 			return i
 		}
 	}
 	return -1
 }
 
-func FindBundleIdxAsTxOrGen(bundles []*builder.Bundle, txOrGen interface{}) int {
-	for i, bundle := range bundles {
-		for _, txOrGenInBundle := range bundle.BundleTxs {
-			if EqualTxOrGen(txOrGenInBundle, txOrGen) {
-				return i
-			}
-		}
-	}
-	return -1
-}
-
-func EqualTxOrGen(txOrGenIX, txOrGenIY interface{}) bool {
-	var (
-		txOrGenXHash common.Hash
-		txOrGenYHash common.Hash
-	)
-
-	switch txOrGenX := txOrGenIX.(type) {
-	case *types.Transaction:
-		txOrGenXHash = txOrGenX.Hash()
-	case builder.TxGenerator:
-		txOrGenXHash = txOrGenX.Hash
-	}
-
-	switch txOrGenY := txOrGenIY.(type) {
-	case *types.Transaction:
-		txOrGenYHash = txOrGenY.Hash()
-	case builder.TxGenerator:
-		txOrGenYHash = txOrGenY.Hash
-	}
-
-	return bytes.Equal(txOrGenXHash.Bytes(), txOrGenYHash.Bytes())
-}
-
-func SetCorrectTargetTxHash(bundles []*builder.Bundle, txs []interface{}) []*builder.Bundle {
+func SetCorrectTargetTxHash(bundles []*builder.Bundle, txs []*builder.TxOrGen) []*builder.Bundle {
 	ret := make([]*builder.Bundle, 0)
 	for _, bundle := range bundles {
 		bundle.TargetTxHash = FindTargetTxHash(bundle, txs)
@@ -199,25 +147,20 @@ func SetCorrectTargetTxHash(bundles []*builder.Bundle, txs []interface{}) []*bui
 	return ret
 }
 
-func FindTargetTxHash(bundle *builder.Bundle, txs []interface{}) common.Hash {
-	// If this is never updated it is expected to return an empty hash.
-	targetTxHash := common.Hash{}
-	for i, tx := range txs {
-		// For index greater than 0, if it can be cast to *types.Transaction then record this as the TargetTxHash.
-		if i > 0 {
-			if txTarget, ok := txs[i-1].(*types.Transaction); ok {
-				targetTxHash = txTarget.Hash()
+func FindTargetTxHash(bundle *builder.Bundle, txOrGens []*builder.TxOrGen) common.Hash {
+	for i := range txOrGens {
+		if bundle.BundleTxs[0].Id == txOrGens[i].Id {
+			if i == 0 {
+				return common.Hash{}
+			} else {
+				return txOrGens[i-1].Id
 			}
 		}
-		// If tx is the first tx in the bundle then there is no need to look further.
-		if EqualTxOrGen(bundle.BundleTxs[0], tx) {
-			break
-		}
 	}
-	return targetTxHash
+	return common.Hash{}
 }
 
-func ShiftTxs(txs *[]interface{}, num int) {
+func ShiftTxs(txs *[]*builder.TxOrGen, num int) {
 	if len(*txs) <= num {
 		*txs = (*txs)[:0]
 		return
@@ -225,7 +168,7 @@ func ShiftTxs(txs *[]interface{}, num int) {
 	*txs = (*txs)[num:]
 }
 
-func PopTxs(txs *[]interface{}, num int, bundles *[]*builder.Bundle, signer types.Signer) {
+func PopTxs(txs *[]*builder.TxOrGen, num int, bundles *[]*builder.Bundle, signer types.Signer) {
 	if len(*txs) == 0 || num == 0 {
 		return
 	}
@@ -249,8 +192,8 @@ func PopTxs(txs *[]interface{}, num int, bundles *[]*builder.Bundle, signer type
 		curIdx := queue[0]
 		queue = queue[1:]
 
-		if tx, ok := (*txs)[curIdx].(*types.Transaction); ok {
-			from, _ := types.Sender(signer, tx)
+		if (*txs)[curIdx].IsConcreteTx() {
+			from, _ := types.Sender(signer, (*txs)[curIdx].ConcreteTx)
 			for _, idx := range senderToIndices[from] {
 				if idx > curIdx && !toRemove[idx] {
 					toRemove[idx] = true
@@ -258,7 +201,7 @@ func PopTxs(txs *[]interface{}, num int, bundles *[]*builder.Bundle, signer type
 				}
 			}
 		}
-		if bundleIdx := FindBundleIdxAsTxOrGen(*bundles, (*txs)[curIdx]); bundleIdx != -1 {
+		if bundleIdx := FindBundleIdx(*bundles, (*txs)[curIdx]); bundleIdx != -1 {
 			for _, idx := range bundleToIndices[bundleIdx] {
 				if !toRemove[idx] {
 					toRemove[idx] = true
@@ -286,14 +229,13 @@ func PopTxs(txs *[]interface{}, num int, bundles *[]*builder.Bundle, signer type
 	*bundles = newBundles
 }
 
-func ExtractBundlesAndIncorporate(arrayTxs []*types.Transaction, txBundlingModules []builder.TxBundlingModule) ([]interface{}, []*builder.Bundle) {
+func ExtractBundlesAndIncorporate(arrayTxs []*types.Transaction, txBundlingModules []builder.TxBundlingModule) ([]*builder.TxOrGen, []*builder.Bundle) {
 	// Detect bundles and add them to bundles
 	bundles := []*builder.Bundle{}
-	flattenedTxs := []interface{}{}
+	flattenedTxs := []*builder.TxOrGen{}
 	if txBundlingModules == nil {
 		for _, tx := range arrayTxs {
-			var itx interface{} = tx
-			flattenedTxs = append(flattenedTxs, itx)
+			flattenedTxs = append(flattenedTxs, builder.NewTxOrGenFromTx(tx))
 		}
 		return flattenedTxs, nil
 	}

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -204,7 +204,7 @@ func PopTxs(txOrGens *[]*builder.TxOrGen, num int, bundles *[]*builder.Bundle, s
 				}
 			}
 		}
-		if bundleIdx := FindBundleIdx(*bundles, (*txOrGens)[curIdx]); bundleIdx != -1 {
+		if bundleIdx := FindBundleIdx(*bundles, txOrGen); bundleIdx != -1 {
 			for _, idx := range bundleToIndices[bundleIdx] {
 				if !toRemove[idx] {
 					toRemove[idx] = true

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -18,14 +18,10 @@ package builder
 
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
-	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax"
 )
 
-type TxGenerator struct {
-	Generate func(nonce uint64) (*types.Transaction, error)
-	Hash     common.Hash // initialized at incorporate, write-once
-}
+type TxGenerator func(nonce uint64) (*types.Transaction, error)
 
 //go:generate mockgen -destination=./mock/module.go -package=mock github.com/kaiachain/kaia/kaiax/builder BuilderModule
 type BuilderModule interface {

--- a/kaiax/builder/tx_or_gen.go
+++ b/kaiax/builder/tx_or_gen.go
@@ -8,37 +8,37 @@ import (
 )
 
 type TxOrGen struct {
-	ConcreteTx  *types.Transaction
-	TxGenerator TxGenerator
+	concreteTx  *types.Transaction
+	txGenerator TxGenerator
 	Id          common.Hash
 }
 
 func (t *TxOrGen) IsConcreteTx() bool {
-	return t.ConcreteTx != nil
+	return t.concreteTx != nil
 }
 
 func (t *TxOrGen) IsTxGenerator() bool {
-	return t.TxGenerator != nil
+	return t.txGenerator != nil
 }
 
 func NewTxOrGenFromTx(tx *types.Transaction) *TxOrGen {
+	if tx == nil {
+		return nil
+	}
+
 	return &TxOrGen{
-		ConcreteTx: tx,
+		concreteTx: tx,
 		Id:         tx.Hash(),
 	}
 }
 
-func NewTxOrGenListFromTxs(txs ...*types.Transaction) []*TxOrGen {
-	txOrGens := make([]*TxOrGen, len(txs))
-	for i, tx := range txs {
-		txOrGens[i] = NewTxOrGenFromTx(tx)
-	}
-	return txOrGens
-}
-
 func NewTxOrGenFromGen(generator TxGenerator, id common.Hash) *TxOrGen {
+	if generator == nil {
+		return nil
+	}
+
 	return &TxOrGen{
-		TxGenerator: generator,
+		txGenerator: generator,
 		Id:          id,
 	}
 }
@@ -51,6 +51,8 @@ func NewTxOrGenList(interfaces ...interface{}) []*TxOrGen {
 		switch v := tx.(type) {
 		case *types.Transaction:
 			txOrGens[i] = NewTxOrGenFromTx(v)
+		case TxGenerator:
+			txOrGens[i] = NewTxOrGenFromGen(v, common.Hash{byte(i + 1)})
 		case *TxOrGen:
 			txOrGens[i] = v
 		default:
@@ -66,7 +68,7 @@ func (t *TxOrGen) Equals(other *TxOrGen) bool {
 
 func (t *TxOrGen) GetTx(nonce uint64) (*types.Transaction, error) {
 	if t.IsConcreteTx() {
-		return t.ConcreteTx, nil
+		return t.concreteTx, nil
 	}
-	return t.TxGenerator(nonce)
+	return t.txGenerator(nonce)
 }

--- a/kaiax/builder/tx_or_gen.go
+++ b/kaiax/builder/tx_or_gen.go
@@ -10,7 +10,7 @@ import (
 type TxOrGen struct {
 	concreteTx  *types.Transaction
 	txGenerator TxGenerator
-	Id          common.Hash
+	Id          common.Hash // For concreteTx, txHash. For txGenerator, use a unique and deterministic identifier.
 }
 
 func NewTxOrGenFromTx(tx *types.Transaction) *TxOrGen {

--- a/kaiax/builder/tx_or_gen.go
+++ b/kaiax/builder/tx_or_gen.go
@@ -1,0 +1,66 @@
+package builder
+
+import (
+	"fmt"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+)
+
+type TxOrGen struct {
+	ConcreteTx  *types.Transaction
+	TxGenerator TxGenerator
+	Id          common.Hash
+}
+
+func (t *TxOrGen) IsConcreteTx() bool {
+	return t.ConcreteTx != nil
+}
+
+func NewTxOrGenFromTx(tx *types.Transaction) *TxOrGen {
+	return &TxOrGen{
+		ConcreteTx: tx,
+		Id:         tx.Hash(),
+	}
+}
+
+func NewTxOrGenListFromTxs(txs ...*types.Transaction) []*TxOrGen {
+	txOrGens := make([]*TxOrGen, len(txs))
+	for i, tx := range txs {
+		txOrGens[i] = NewTxOrGenFromTx(tx)
+	}
+	return txOrGens
+}
+
+func NewTxOrGenFromGen(generator TxGenerator, id common.Hash) *TxOrGen {
+	return &TxOrGen{
+		TxGenerator: generator,
+		Id:          id,
+	}
+}
+
+func NewTxOrGenList(interfaces ...interface{}) []*TxOrGen {
+	txOrGens := make([]*TxOrGen, len(interfaces))
+	for i, tx := range interfaces {
+		switch v := tx.(type) {
+		case *types.Transaction:
+			txOrGens[i] = NewTxOrGenFromTx(v)
+		case *TxOrGen:
+			txOrGens[i] = v
+		default:
+			panic(fmt.Sprintf("unknown type: %T", v))
+		}
+	}
+	return txOrGens
+}
+
+func (t *TxOrGen) Equals(other *TxOrGen) bool {
+	return t.Id == other.Id
+}
+
+func (t *TxOrGen) GetTx(nonce uint64) (*types.Transaction, error) {
+	if t.IsConcreteTx() {
+		return t.ConcreteTx, nil
+	}
+	return t.TxGenerator(nonce)
+}

--- a/kaiax/builder/tx_or_gen.go
+++ b/kaiax/builder/tx_or_gen.go
@@ -13,14 +13,6 @@ type TxOrGen struct {
 	Id          common.Hash
 }
 
-func (t *TxOrGen) IsConcreteTx() bool {
-	return t.concreteTx != nil
-}
-
-func (t *TxOrGen) IsTxGenerator() bool {
-	return t.txGenerator != nil
-}
-
 func NewTxOrGenFromTx(tx *types.Transaction) *TxOrGen {
 	if tx == nil {
 		return nil
@@ -62,13 +54,21 @@ func NewTxOrGenList(interfaces ...interface{}) []*TxOrGen {
 	return txOrGens
 }
 
-func (t *TxOrGen) Equals(other *TxOrGen) bool {
-	return t.Id == other.Id
-}
-
 func (t *TxOrGen) GetTx(nonce uint64) (*types.Transaction, error) {
 	if t.IsConcreteTx() {
 		return t.concreteTx, nil
 	}
 	return t.txGenerator(nonce)
+}
+
+func (t *TxOrGen) IsConcreteTx() bool {
+	return t.concreteTx != nil
+}
+
+func (t *TxOrGen) IsTxGenerator() bool {
+	return t.txGenerator != nil
+}
+
+func (t *TxOrGen) Equals(other *TxOrGen) bool {
+	return t.Id == other.Id
 }

--- a/kaiax/builder/tx_or_gen.go
+++ b/kaiax/builder/tx_or_gen.go
@@ -17,6 +17,10 @@ func (t *TxOrGen) IsConcreteTx() bool {
 	return t.ConcreteTx != nil
 }
 
+func (t *TxOrGen) IsTxGenerator() bool {
+	return t.TxGenerator != nil
+}
+
 func NewTxOrGenFromTx(tx *types.Transaction) *TxOrGen {
 	return &TxOrGen{
 		ConcreteTx: tx,
@@ -39,6 +43,8 @@ func NewTxOrGenFromGen(generator TxGenerator, id common.Hash) *TxOrGen {
 	}
 }
 
+// NewTxOrGenList creates a list of TxOrGen from a list of interfaces.
+// Used for testing.
 func NewTxOrGenList(interfaces ...interface{}) []*TxOrGen {
 	txOrGens := make([]*TxOrGen, len(interfaces))
 	for i, tx := range interfaces {

--- a/kaiax/builder/tx_or_gen_test.go
+++ b/kaiax/builder/tx_or_gen_test.go
@@ -1,1 +1,0 @@
-package builder

--- a/kaiax/builder/tx_or_gen_test.go
+++ b/kaiax/builder/tx_or_gen_test.go
@@ -1,0 +1,1 @@
+package builder

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -38,12 +38,12 @@ func (g *GaslessModule) ExtractTxBundles(txs []*types.Transaction, prevBundles [
 			approveTxs[addr] = tx
 		} else if g.IsSwapTx(tx) && g.IsExecutable(approveTxs[addr], tx) {
 			b := &builder.Bundle{
-				BundleTxs: []interface{}{g.GetLendTxGenerator(approveTxs[addr], tx)},
+				BundleTxs: builder.NewTxOrGenList(g.GetLendTxGenerator(approveTxs[addr], tx)),
 			}
 			if approveTxs[addr] != nil {
-				b.BundleTxs = append(b.BundleTxs, approveTxs[addr])
+				b.BundleTxs = append(b.BundleTxs, builder.NewTxOrGenFromTx(approveTxs[addr]))
 			}
-			b.BundleTxs = append(b.BundleTxs, tx)
+			b.BundleTxs = append(b.BundleTxs, builder.NewTxOrGenFromTx(tx))
 
 			b.TargetTxHash = targetTxHash
 			targetTxHash = tx.Hash()

--- a/kaiax/gasless/impl/builder_test.go
+++ b/kaiax/gasless/impl/builder_test.go
@@ -68,7 +68,7 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: common.Hash{},
 				},
 			},
@@ -78,7 +78,7 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: T4.Hash(),
 				},
 			},
@@ -88,7 +88,7 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: T4.Hash(),
 				},
 			},
@@ -98,11 +98,11 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: common.Hash{},
 				},
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A2, S2), A2, S2},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A2, S2), A2, S2),
 					TargetTxHash: T4.Hash(),
 				},
 			},
@@ -112,11 +112,11 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: common.Hash{},
 				},
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A2, S2), A2, S2},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A2, S2), A2, S2),
 					TargetTxHash: S1.Hash(),
 				},
 			},
@@ -126,11 +126,11 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: common.Hash{},
 				},
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A2, S2), A2, S2},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A2, S2), A2, S2),
 					TargetTxHash: S1.Hash(),
 				},
 			},
@@ -140,11 +140,11 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A2, S2), A2, S2},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A2, S2), A2, S2),
 					TargetTxHash: common.Hash{},
 				},
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: S2.Hash(),
 				},
 			},
@@ -154,11 +154,11 @@ func TestExtractTxBundles(t *testing.T) {
 			nil,
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(A1, S1), A1, S1},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(A1, S1), A1, S1),
 					TargetTxHash: common.Hash{},
 				},
 				{
-					BundleTxs:    []interface{}{g.GetLendTxGenerator(nil, S3), S3},
+					BundleTxs:    builder.NewTxOrGenList(g.GetLendTxGenerator(nil, S3), S3),
 					TargetTxHash: S1.Hash(),
 				},
 			},
@@ -167,7 +167,7 @@ func TestExtractTxBundles(t *testing.T) {
 			[]*types.Transaction{A1, S1, T4, T5},
 			[]*builder.Bundle{
 				{
-					BundleTxs:    []interface{}{},
+					BundleTxs:    builder.NewTxOrGenList(),
 					TargetTxHash: common.Hash{},
 				},
 			},

--- a/kaiax/gasless/impl/getter_test.go
+++ b/kaiax/gasless/impl/getter_test.go
@@ -229,7 +229,7 @@ func TestGetLendTxGenerator(t *testing.T) {
 			require.True(t, ok)
 
 			generator := g.GetLendTxGenerator(tc.approve, tc.swap)
-			tx, err := generator.Generate(0)
+			tx, err := generator.GetTx(0)
 			require.NoError(t, err)
 
 			// tx contents test
@@ -255,8 +255,8 @@ func TestTxGeneratorHashUniqueness(t *testing.T) {
 	g := NewGaslessModule()
 	for range 100 {
 		generator := g.GetLendTxGenerator(nil, makeSwapTx(t, nil, 0, SwapArgs{Token: common.HexToAddress("0xabcd"), AmountIn: big.NewInt(10), MinAmountOut: big.NewInt(1), AmountRepay: big.NewInt(1021000)}))
-		_, ok := hashSet[generator.Hash]
+		_, ok := hashSet[generator.Id]
 		assert.False(t, ok)
-		hashSet[generator.Hash] = struct{}{}
+		hashSet[generator.Id] = struct{}{}
 	}
 }

--- a/kaiax/gasless/impl/getter_test.go
+++ b/kaiax/gasless/impl/getter_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -246,5 +247,16 @@ func TestGetLendTxGenerator(t *testing.T) {
 			flatten := flattenPoolTxs(pending)
 			require.True(t, flatten[tx.Hash()])
 		})
+	}
+}
+
+func TestTxGeneratorHashUniqueness(t *testing.T) {
+	hashSet := make(map[common.Hash]struct{})
+	g := NewGaslessModule()
+	for range 100 {
+		generator := g.GetLendTxGenerator(nil, makeSwapTx(t, nil, 0, SwapArgs{Token: common.HexToAddress("0xabcd"), AmountIn: big.NewInt(10), MinAmountOut: big.NewInt(1), AmountRepay: big.NewInt(1021000)}))
+		_, ok := hashSet[generator.Hash]
+		assert.False(t, ok)
+		hashSet[generator.Hash] = struct{}{}
 	}
 }

--- a/tests/kaia_test_account_map_test.go
+++ b/tests/kaia_test_account_map_test.go
@@ -112,6 +112,8 @@ func (a *AccountMap) Initialize(bcdata *BCData) error {
 func (a *AccountMap) Update(txs types.Transactions, txHashesExpectedFail []common.Hash, txBundlingModules []builder.TxBundlingModule, signer types.Signer, picker types.AccountKeyPicker, currentBlockNumber uint64) error {
 	incorporatedTxs, _ := builder_impl.ExtractBundlesAndIncorporate(txs, txBundlingModules)
 	for _, txOrGen := range incorporatedTxs {
+		// To simulate tx, the nonce given to generate is set to zero.
+		// This does not affect subsequent operations on the AccountMap state.
 		tx, err := txOrGen.GetTx(0)
 		if err != nil {
 			return err

--- a/tests/kaia_test_account_map_test.go
+++ b/tests/kaia_test_account_map_test.go
@@ -112,17 +112,10 @@ func (a *AccountMap) Initialize(bcdata *BCData) error {
 func (a *AccountMap) Update(txs types.Transactions, txHashesExpectedFail []common.Hash, txBundlingModules []builder.TxBundlingModule, signer types.Signer, picker types.AccountKeyPicker, currentBlockNumber uint64) error {
 	incorporatedTxs, _ := builder_impl.ExtractBundlesAndIncorporate(txs, txBundlingModules)
 	for _, txOrGen := range incorporatedTxs {
-		if gen, ok := txOrGen.(builder.TxGenerator); ok {
-			// To simulate tx, the nonce given to generate is set to zero.
-			// This does not affect subsequent operations on the AccountMap state.
-			tx, err := gen.Generate(0)
-			if err != nil {
-				continue
-			}
-			txs = append(txs, tx)
+		tx, err := txOrGen.GetTx(0)
+		if err != nil {
+			return err
 		}
-	}
-	for _, tx := range txs {
 		if slices.Contains(txHashesExpectedFail, tx.Hash()) {
 			continue
 		}

--- a/work/worker.go
+++ b/work/worker.go
@@ -746,8 +746,6 @@ CommitTransactionLoop:
 		}
 
 		var (
-			tx      *types.Transaction
-			err     error
 			logs    []*types.Log
 			txOrGen = incorporatedTxs[0]
 			from    common.Address
@@ -756,22 +754,16 @@ CommitTransactionLoop:
 		// Verify that tx is included in the bundle
 		targetBundle := &builder.Bundle{}
 		numShift := 1
-		if bundleIdx := builder_impl.FindBundleIdxAsTxOrGen(bundles, txOrGen); bundleIdx != -1 {
+		if bundleIdx := builder_impl.FindBundleIdx(bundles, txOrGen); bundleIdx != -1 {
 			targetBundle = bundles[bundleIdx]
 			numShift = len(targetBundle.BundleTxs)
 		}
 
-		switch txOrGen.(type) {
-		case *types.Transaction:
-			tx = txOrGen.(*types.Transaction)
-		case builder.TxGenerator:
-			txGen := txOrGen.(builder.TxGenerator)
-			tx, err = txGen.Generate(env.state.GetNonce(rewardbase))
-			if tx == nil {
-				logger.Warn("TxGenerator returned a nil tx", "error", err)
-				builder_impl.PopTxs(&incorporatedTxs, numShift, &bundles, env.signer)
-				continue
-			}
+		tx, err := txOrGen.GetTx(env.state.GetNonce(rewardbase))
+		if err != nil {
+			logger.Warn("TxGenerator returned a nil tx", "error", err)
+			builder_impl.PopTxs(&incorporatedTxs, numShift, &bundles, env.signer)
+			continue
 		}
 		// If target is the tx in bundle, len(targetBundle.BundleTxs) is appended to numTxsChecked.
 		numTxsChecked += int64(numShift)
@@ -900,26 +892,27 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 	receipts := []*types.Receipt{}
 	logs := []*types.Log{}
 
-	for _, txOrGen := range bundle.BundleTxs {
-		var tx *types.Transaction
-		if gen, ok := txOrGen.(builder.TxGenerator); ok {
-			var err error
-			tx, err = gen.Generate(env.state.GetNonce(rewardbase))
-			if err != nil {
-				for _, txInBundle := range bundle.BundleTxs {
-					switch v := txInBundle.(type) {
-					case *types.Transaction:
-						v.MarkUnexecutable(true)
-					}
-				}
-				logger.Error("TxGenerator error", "error", err)
-				*env.state = *lastSnapshot
-				env.header.GasUsed = gasUsedSnapshot
-				env.tcount = tcountSnapshot
-				return err, &types.Transaction{}, nil
+	markAllTxUnexecutable := func() {
+		for _, txOrGen := range bundle.BundleTxs {
+			if txOrGen.IsConcreteTx() {
+				txOrGen.ConcreteTx.MarkUnexecutable(true)
 			}
-		} else {
-			tx = txOrGen.(*types.Transaction)
+		}
+	}
+
+	restoreEnv := func() {
+		*env.state = *lastSnapshot
+		env.header.GasUsed = gasUsedSnapshot
+		env.tcount = tcountSnapshot
+	}
+
+	for _, txOrGen := range bundle.BundleTxs {
+		tx, err := txOrGen.GetTx(env.state.GetNonce(rewardbase))
+		if err != nil {
+			logger.Error("TxGenerator error", "error", err)
+			markAllTxUnexecutable()
+			restoreEnv()
+			return err, &types.Transaction{}, nil
 		}
 
 		env.state.SetTxContext(tx.Hash(), common.Hash{}, env.tcount)
@@ -928,16 +921,9 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 		// There may be cases where a revert occurs within the EVM, which could result in an attack on a tx sender in an already executed bundle.
 		if err != nil || receipt.Status != types.ReceiptStatusSuccessful {
 			if err != vm.ErrInsufficientBalance && err != vm.ErrTotalTimeLimitReached {
-				for _, txInBundle := range bundle.BundleTxs {
-					switch v := txInBundle.(type) {
-					case *types.Transaction:
-						v.MarkUnexecutable(true)
-					}
-				}
+				markAllTxUnexecutable()
 			}
-			*env.state = *lastSnapshot
-			env.header.GasUsed = gasUsedSnapshot
-			env.tcount = tcountSnapshot
+			restoreEnv()
 			if err == nil {
 				err = kerrors.ErrRevertedBundleByVmErr
 			}

--- a/work/worker.go
+++ b/work/worker.go
@@ -895,7 +895,8 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 	markAllTxUnexecutable := func() {
 		for _, txOrGen := range bundle.BundleTxs {
 			if txOrGen.IsConcreteTx() {
-				txOrGen.ConcreteTx.MarkUnexecutable(true)
+				tx, _ := txOrGen.GetTx(0)
+				tx.MarkUnexecutable(true)
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed changes

- Now gasless module initializes TxGenerator hash with `ApproveTx.Hash || SwapTx.Hash`. Previously, hash was initialized at `incorporate` lazily, which resulted in TxGenerators having incorrect hashes. TxGenerator's type is reverted back to function.
- Introduce `TxOrGen`; it replaces `[]interfaces{}` array from builder. `txOrGen` can be evaluated to tx by `GetTx(nonce)`.
- Change `Has(hash common.Hash)` -> `Has(txOrGen *TxOrGen)`. To find by hash, `FindIdx(id common.Hash)` can be used.
- Lambda functions are introduced in worker, such as `markAllTxUnexecutable`.
- Fix `tests/kaia_test_account_map_test.go` so txOrGen is evaluated to tx in the correct order.

## Types of changes

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

