### PR TITLE
ci: Increase executor size of test-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,14 @@ executors:
         auth:
           username: $DOCKER_LOGIN
           password: $DOCKER_PASSWORD
+  test-tests-executor: # this executor is for test-tests job
+    working_directory: ~/go/src/github.com/kaiachain/kaia
+    resource_class: medium+
+    docker:
+      - image: kaiachain/build_base:go1.23-solc0.8.13-ubuntu-22.04
+        auth:
+          username: $DOCKER_LOGIN
+          password: $DOCKER_PASSWORD
   test-others-executor: # this executor is for test-others job
     working_directory: /go/src/github.com/kaiachain/kaia
     resource_class: xlarge
@@ -396,7 +404,7 @@ jobs:
           no_output_timeout: 30m
           command: make test-node
   test-tests:
-    executor: test-executor
+    executor: test-tests-executor
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Proposed changes

- Increase the [`resource_class`](https://circleci.com/docs/configuration-reference/#resourceclass) of `test-tests` job from medium (2core 4GB) to medium+ (3core 6GB) in an attempt to eliminate the intermittent CI failure.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
