### PR TITLE
Add isGaslessTx API

### DIFF
--- a/kaiax/gasless/impl/api.go
+++ b/kaiax/gasless/impl/api.go
@@ -98,7 +98,11 @@ func (s *GaslessAPI) IsGaslessTx(ctx context.Context, rawTxs []hexutil.Bytes) *G
 			}
 		}
 
-		reason, isExecutable := s.b.VerifyExecutable(nil, swapTx)
+		err, isExecutable := s.b.VerifyExecutable(nil, swapTx)
+		reason := ""
+		if err != nil {
+			reason = err.Error()
+		}
 		return &GaslessTxResult{
 			IsGasless: isExecutable,
 			Reason:    reason,
@@ -124,7 +128,11 @@ func (s *GaslessAPI) IsGaslessTx(ctx context.Context, rawTxs []hexutil.Bytes) *G
 			}
 		}
 
-		reason, isExecutable := s.b.VerifyExecutable(approveTx, swapTx)
+		err, isExecutable := s.b.VerifyExecutable(approveTx, swapTx)
+		reason := ""
+		if err != nil {
+			reason = err.Error()
+		}
 		return &GaslessTxResult{
 			IsGasless: isExecutable,
 			Reason:    reason,

--- a/kaiax/gasless/impl/api.go
+++ b/kaiax/gasless/impl/api.go
@@ -1,0 +1,138 @@
+// Copyright 2025 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/kaiachain/kaia/networks/rpc"
+	"github.com/kaiachain/kaia/rlp"
+)
+
+func (b *GaslessModule) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			Namespace: "debug",
+			Version:   "1.0",
+			Service:   NewGaslessAPI(b),
+			Public:    true,
+		},
+	}
+}
+
+type GaslessAPI struct {
+	b *GaslessModule
+}
+
+func NewGaslessAPI(b *GaslessModule) *GaslessAPI {
+	return &GaslessAPI{b}
+}
+
+// GaslessTxResult represents the result of checking if a transaction is a gasless transaction
+type GaslessTxResult struct {
+	IsGasless bool   `json:"isGasless"` // Whether the transaction is a gasless transaction
+	Reason    string `json:"reason"`    // Reason why the transaction is not a gasless transaction, empty if it is
+}
+
+// IsGaslessTx checks if the given raw transactions form a valid gasless transaction
+// It returns a detailed result explaining why a transaction is not a valid gasless transaction if it's not
+func (s *GaslessAPI) IsGaslessTx(ctx context.Context, rawTxs []hexutil.Bytes) *GaslessTxResult {
+	if len(rawTxs) == 0 {
+		return &GaslessTxResult{
+			IsGasless: false,
+			Reason:    "no transactions provided",
+		}
+	}
+
+	// Decode the raw transactions
+	txs := make([]*types.Transaction, 0, len(rawTxs))
+	for i, rawTx := range rawTxs {
+		if len(rawTx) == 0 {
+			return &GaslessTxResult{
+				IsGasless: false,
+				Reason:    fmt.Sprintf("empty transaction at index %d", i),
+			}
+		}
+
+		// Handle Ethereum transaction envelope
+		if 0 < rawTx[0] && rawTx[0] < 0x7f {
+			rawTx = append([]byte{byte(types.EthereumTxTypeEnvelope)}, rawTx...)
+		}
+
+		tx := new(types.Transaction)
+		if err := rlp.DecodeBytes(rawTx, tx); err != nil {
+			return &GaslessTxResult{
+				IsGasless: false,
+				Reason:    fmt.Sprintf("failed to decode transaction at index %d: %v", i, err),
+			}
+		}
+
+		txs = append(txs, tx)
+	}
+
+	// Check if the transactions form a valid gasless transaction
+	// Case 1: A single swap transaction
+	if len(txs) == 1 {
+		swapTx := txs[0]
+		if !s.b.IsSwapTx(swapTx) {
+			return &GaslessTxResult{
+				IsGasless: false,
+				Reason:    "transaction is not a swap transaction",
+			}
+		}
+
+		reason, isExecutable := s.b.VerifyExecutable(nil, swapTx)
+		return &GaslessTxResult{
+			IsGasless: isExecutable,
+			Reason:    reason,
+		}
+	}
+
+	// Case 2: An approve transaction followed by a swap transaction
+	if len(txs) == 2 {
+		approveTx := txs[0]
+		swapTx := txs[1]
+
+		if !s.b.IsApproveTx(approveTx) {
+			return &GaslessTxResult{
+				IsGasless: false,
+				Reason:    "first transaction is not an approve transaction",
+			}
+		}
+
+		if !s.b.IsSwapTx(swapTx) {
+			return &GaslessTxResult{
+				IsGasless: false,
+				Reason:    "second transaction is not a swap transaction",
+			}
+		}
+
+		reason, isExecutable := s.b.VerifyExecutable(approveTx, swapTx)
+		return &GaslessTxResult{
+			IsGasless: isExecutable,
+			Reason:    reason,
+		}
+	}
+
+	return &GaslessTxResult{
+		IsGasless: false,
+		Reason:    fmt.Sprintf("expected 1 or 2 transactions, got %d", len(txs)),
+	}
+}

--- a/kaiax/gasless/impl/api_test.go
+++ b/kaiax/gasless/impl/api_test.go
@@ -1,0 +1,265 @@
+// Copyright 2025 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/rlp"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper function to create a regular transaction for testing (not approve or swap)
+func makeRegularTx(t *testing.T, privKey *ecdsa.PrivateKey, nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int) *types.Transaction {
+	// Add some regular method signature (e.g., "transfer")
+	data := append([]byte{}, common.Hex2Bytes("a9059cbb")...)
+	data = append(data, common.Hex2BytesFixed(hex.EncodeToString(common.HexToAddress("0x1234567890123456789012345678901234567890").Bytes()), 32)...)
+	data = append(data, common.Hex2BytesFixed(hex.EncodeToString(amount.Bytes()), 32)...)
+	return makeTx(t, privKey, nonce, to, big.NewInt(0), gasLimit, gasPrice, data)
+}
+
+// Helper function to create a contract deployment transaction for testing
+func makeDeployTx(t *testing.T, privKey *ecdsa.PrivateKey, nonce uint64, gasLimit uint64, gasPrice *big.Int, data []byte) *types.Transaction {
+	if privKey == nil {
+		var err error
+		privKey, err = crypto.GenerateKey()
+		require.NoError(t, err)
+	}
+
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	tx := types.NewContractCreation(nonce, big.NewInt(0), gasLimit, gasPrice, data)
+	tx, err := types.SignTx(tx, signer, privKey)
+	require.NoError(t, err)
+
+	return tx
+}
+
+// Simple mock implementation of TxPoolForCaller for testing
+type mockTxPool struct {
+	statedb *state.StateDB
+}
+
+func (m *mockTxPool) GetCurrentState() *state.StateDB {
+	return m.statedb
+}
+
+// TestGaslessAPIIsGaslessTx tests the GaslessAPI.IsGaslessTx method
+func TestGaslessAPI_isGaslessTx(t *testing.T) {
+	// Create a private key for testing
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	sender := crypto.PubkeyToAddress(privKey.PublicKey)
+
+	// Create a different private key for testing
+	otherPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	// Create addresses for testing
+	tokenAddr := common.HexToAddress("0xabcd")
+	routerAddr := common.HexToAddress("0x1234")
+	differentTokenAddr := common.HexToAddress("0xdead1234dead1234dead1234dead1234dead1234")
+
+	// Setup test stateDB with a proper database
+	stateDB, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	stateDB.SetNonce(sender, 0) // For approve tx
+
+	// Create mock txpool
+	txpool := &mockTxPool{
+		statedb: stateDB,
+	}
+
+	// Create and initialize GaslessModule
+	gaslessModule := NewGaslessModule()
+	nodeKey, _ := crypto.GenerateKey()
+	err = gaslessModule.Init(&InitOpts{
+		ChainConfig: params.TestChainConfig,
+		NodeKey:     nodeKey,
+		TxPool:      txpool,
+	})
+	require.NoError(t, err)
+
+	// Override token and router maps for testing
+	gaslessModule.allowedTokens = map[common.Address]bool{
+		tokenAddr: true,
+	}
+	gaslessModule.swapRouters = map[common.Address]bool{
+		routerAddr: true,
+	}
+
+	// Create GaslessAPI
+	api := NewGaslessAPI(gaslessModule)
+
+	// Create test transactions
+	validApproveTx := makeApproveTx(t, privKey, 0, ApproveArgs{
+		Token:   tokenAddr,
+		Spender: routerAddr,
+		Amount:  big.NewInt(1000000),
+	})
+	// Create a standalone swap transaction for testing
+	standaloneSwapTx := makeSwapTx(t, privKey, 0, SwapArgs{
+		Router:       routerAddr,
+		Token:        tokenAddr,
+		AmountIn:     big.NewInt(500000),
+		MinAmountOut: big.NewInt(100),
+		AmountRepay:  big.NewInt(1021000),
+	})
+
+	// Create a swap transaction for testing
+	validSwapTx := makeSwapTx(t, privKey, 1, SwapArgs{
+		Router:       routerAddr,
+		Token:        tokenAddr,
+		AmountIn:     big.NewInt(500000),
+		MinAmountOut: big.NewInt(100),
+		AmountRepay:  big.NewInt(2021000),
+	})
+	invalidTokenSwapTx := makeSwapTx(t, privKey, 1, SwapArgs{
+		Router:       routerAddr,
+		Token:        differentTokenAddr,
+		AmountIn:     big.NewInt(500000),
+		MinAmountOut: big.NewInt(100),
+		AmountRepay:  big.NewInt(1000000),
+	})
+	insufficientAmountSwapTx := makeSwapTx(t, privKey, 1, SwapArgs{
+		Router:       routerAddr,
+		Token:        tokenAddr,
+		AmountIn:     big.NewInt(2000000),
+		MinAmountOut: big.NewInt(100),
+		AmountRepay:  big.NewInt(1000000),
+	})
+	differentSenderSwapTx := makeSwapTx(t, otherPrivKey, 0, SwapArgs{
+		Router:       routerAddr,
+		Token:        tokenAddr,
+		AmountIn:     big.NewInt(500000),
+		MinAmountOut: big.NewInt(100),
+		AmountRepay:  big.NewInt(1000000),
+	})
+	// Define gas parameters
+	gasPrice := big.NewInt(1)
+	approveGasLimit := uint64(1000000)
+	swapGasLimit := uint64(1000000)
+
+	regularTx := makeRegularTx(t, privKey, 0, tokenAddr, big.NewInt(1000), approveGasLimit, gasPrice)
+	deployTx := makeDeployTx(t, privKey, 0, swapGasLimit, gasPrice, []byte{0x60, 0x80, 0x60, 0x40})
+
+	// Test cases
+	testCases := []struct {
+		name           string
+		txs            []*types.Transaction
+		expectedResult bool
+		reasonContains string
+	}{
+		{
+			name:           "Valid standalone swap transaction",
+			txs:            []*types.Transaction{standaloneSwapTx},
+			expectedResult: true,
+			reasonContains: "",
+		},
+		{
+			name:           "Valid approve + swap pair",
+			txs:            []*types.Transaction{validApproveTx, validSwapTx},
+			expectedResult: true,
+			reasonContains: "",
+		},
+		{
+			name:           "Invalid - contract deployment",
+			txs:            []*types.Transaction{deployTx},
+			expectedResult: false,
+			reasonContains: "transaction is not a swap transaction",
+		},
+		{
+			name:           "Invalid - regular transaction",
+			txs:            []*types.Transaction{regularTx},
+			expectedResult: false,
+			reasonContains: "transaction is not a swap transaction",
+		},
+		{
+			name:           "Invalid - different token addresses in approve+swap pair",
+			txs:            []*types.Transaction{validApproveTx, invalidTokenSwapTx},
+			expectedResult: false,
+			reasonContains: "second transaction is not a swap transaction",
+		},
+		{
+			name:           "Invalid - insufficient approved amount in approve+swap pair",
+			txs:            []*types.Transaction{validApproveTx, insufficientAmountSwapTx},
+			expectedResult: false,
+			reasonContains: "approve transaction approves amount",
+		},
+		{
+			name:           "Invalid - different senders in approve+swap pair",
+			txs:            []*types.Transaction{validApproveTx, differentSenderSwapTx},
+			expectedResult: false,
+			reasonContains: "approve and swap transactions have different senders",
+		},
+		{
+			name:           "Invalid - too many transactions",
+			txs:            []*types.Transaction{validApproveTx, validSwapTx, validSwapTx},
+			expectedResult: false,
+			reasonContains: "expected 1 or 2 transactions",
+		},
+		{
+			name:           "Invalid - first transaction not approve in pair",
+			txs:            []*types.Transaction{regularTx, validSwapTx},
+			expectedResult: false,
+			reasonContains: "first transaction is not an approve transaction",
+		},
+		{
+			name:           "Invalid - second transaction not swap in pair",
+			txs:            []*types.Transaction{validApproveTx, regularTx},
+			expectedResult: false,
+			reasonContains: "second transaction is not a swap transaction",
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Convert transactions to raw bytes
+			rawTxs := make([]hexutil.Bytes, len(tc.txs))
+			for i, tx := range tc.txs {
+				data, err := rlp.EncodeToBytes(tx)
+				require.NoError(t, err)
+				rawTxs[i] = data
+			}
+
+			// Call IsGaslessTx
+			result := api.IsGaslessTx(context.Background(), rawTxs)
+
+			// Print debug information
+			t.Logf("IsGasless: %v, Reason: %s", result.IsGasless, result.Reason)
+
+			// Check result
+			assert.Equal(t, tc.expectedResult, result.IsGasless, "IsGasless flag should match expected result")
+			if tc.reasonContains != "" {
+				assert.Contains(t, result.Reason, tc.reasonContains, "Reason should contain expected message")
+			} else if !tc.expectedResult {
+				assert.NotEmpty(t, result.Reason, "Reason should not be empty for invalid transactions")
+			}
+		})
+	}
+}

--- a/kaiax/gasless/impl/errors.go
+++ b/kaiax/gasless/impl/errors.go
@@ -22,8 +22,19 @@ import (
 )
 
 var (
-	ErrInitUnexpectedNil = errors.New("unexpected nil during module init")
-	ErrGSRNotInstalled   = errors.New("Gasless swap router contract not installed")
+	ErrInitUnexpectedNil         = errors.New("unexpected nil during module init")
+	ErrGSRNotInstalled           = errors.New("Gasless swap router contract not installed")
+	ErrDecodeSwapTx              = errors.New("failed to decode swap transaction")
+	ErrSwapTxInvalid             = errors.New("swap transaction is not valid")
+	ErrDecodeApproveTx           = errors.New("failed to decode approve transaction")
+	ErrApproveTxInvalid          = errors.New("approve transaction is not valid")
+	ErrDifferentSenders          = errors.New("approve and swap transactions have different senders")
+	ErrDifferentTokens           = errors.New("approve transaction is for different token than swap transaction")
+	ErrInsufficientApproveAmount = errors.New("approve transaction approves insufficient amount")
+	ErrNonSequentialNonce        = errors.New("approve and swap transactions have non-sequential nonces")
+	ErrApproveNonceNotCurrent    = errors.New("approve transaction nonce is not current")
+	ErrSwapNonceNotCurrent       = errors.New("swap transaction nonce is not current")
+	ErrIncorrectRepayAmount      = errors.New("swap transaction has incorrect amountRepay")
 )
 
 func printApproveTx(args *ApproveArgs) string {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -569,7 +569,7 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	// Register modules to respective components
 	// TODO-kaiax: Organize below lines.
 	s.RegisterBaseModules(s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao)
-	s.RegisterJsonRpcModules(s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder)
+	s.RegisterJsonRpcModules(s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder, mGasless)
 	s.miner.RegisterExecutionModule(mExecution...)
 	s.miner.RegisterTxBundlingModule(mTxBundling...)
 	s.blockchain.RegisterExecutionModule(mExecution...)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -569,7 +569,10 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	// Register modules to respective components
 	// TODO-kaiax: Organize below lines.
 	s.RegisterBaseModules(s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao)
-	s.RegisterJsonRpcModules(s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder, mGasless)
+	if !gaslessDisabled {
+		s.RegisterJsonRpcModules(s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder, mGasless)
+	}
+	s.RegisterJsonRpcModules(s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder)
 	s.miner.RegisterExecutionModule(mExecution...)
 	s.miner.RegisterTxBundlingModule(mTxBundling...)
 	s.blockchain.RegisterExecutionModule(mExecution...)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -558,21 +558,20 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	mExecution := []kaiax.ExecutionModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao}
 	mTxBundling := []builder.TxBundlingModule{}
 	mTxPool := []kaiax.TxPoolModule{}
+	mJsonRpc := []kaiax.JsonRpcModule{s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder}
 
 	gaslessDisabled := mGasless.IsDisabled()
 	if !gaslessDisabled {
 		mExecution = append(mExecution, mGasless)
 		mTxBundling = append(mTxBundling, mGasless)
 		mTxPool = append(mTxPool, mGasless)
+		mJsonRpc = append(mJsonRpc, mGasless)
 	}
 
 	// Register modules to respective components
 	// TODO-kaiax: Organize below lines.
 	s.RegisterBaseModules(s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao)
-	if !gaslessDisabled {
-		s.RegisterJsonRpcModules(s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder, mGasless)
-	}
-	s.RegisterJsonRpcModules(s.stakingModule, mReward, mSupply, s.govModule, mRandao, mBuilder)
+	s.RegisterJsonRpcModules(mJsonRpc...)
 	s.miner.RegisterExecutionModule(mExecution...)
 	s.miner.RegisterTxBundlingModule(mTxBundling...)
 	s.blockchain.RegisterExecutionModule(mExecution...)


### PR DESCRIPTION
## Proposed changes

With the current gasless transaction, if you send an invalid tx using kaia_sendRawTransactions, no error is returned (the transaction receipt remains nil). So, the sender cannot know what the problem is.
Therefore, I added IsGaslessTx as an API for debugging.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
