### PR TITLE
kaiax/gasless: fix gasless initialization, add gasless info api

### DIFF
--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -49,7 +49,7 @@ func GetGaslessConfig(ctx *cli.Context) *GaslessConfig {
 			allowedTokens = nil
 			break
 		}
-		if allowedTokens != nil {
+		if allowedTokens == nil {
 			allowedTokens = []common.Address{}
 		}
 		allowedTokens = append(allowedTokens, common.HexToAddress(addr))

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -24,7 +24,7 @@ import (
 var (
 	AllowedTokensFlag = &cli.StringSliceFlag{
 		Name:    "gasless.allowed-tokens",
-		Usage:   "allow token addresses for gasless module, default is all",
+		Usage:   "allow token addresses for gasless module, allow all tokens if all",
 		Value:   cli.NewStringSlice("all"),
 		Aliases: []string{"genesis.module.gasless.allowed-tokens"},
 	}
@@ -43,11 +43,14 @@ type GaslessConfig struct {
 }
 
 func GetGaslessConfig(ctx *cli.Context) *GaslessConfig {
-	allowedTokens := []common.Address{}
+	var allowedTokens []common.Address
 	for _, addr := range ctx.StringSlice(AllowedTokensFlag.Name) {
 		if addr == "all" {
 			allowedTokens = nil
 			break
+		}
+		if allowedTokens != nil {
+			allowedTokens = []common.Address{}
 		}
 		allowedTokens = append(allowedTokens, common.HexToAddress(addr))
 	}

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -43,7 +43,7 @@ type GaslessConfig struct {
 }
 
 func GetGaslessConfig(ctx *cli.Context) *GaslessConfig {
-	var allowedTokens []common.Address
+	allowedTokens := []common.Address(nil)
 	for _, addr := range ctx.StringSlice(AllowedTokensFlag.Name) {
 		if addr == "all" {
 			allowedTokens = nil

--- a/kaiax/gasless/impl/api.go
+++ b/kaiax/gasless/impl/api.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/rlp"
@@ -142,5 +143,23 @@ func (s *GaslessAPI) IsGaslessTx(ctx context.Context, rawTxs []hexutil.Bytes) *G
 	return &GaslessTxResult{
 		IsGasless: false,
 		Reason:    fmt.Sprintf("expected 1 or 2 transactions, got %d", len(txs)),
+	}
+}
+
+type GaslessInfoResult struct {
+	IsDisabled    bool             `json:"isDisabled"`
+	SwapRouter    common.Address   `json:"swapRouter"`
+	AllowedTokens []common.Address `json:"allowedTokens"`
+}
+
+func (s *GaslessAPI) GaslessInfo() *GaslessInfoResult {
+	at := []common.Address{}
+	for addr := range s.b.allowedTokens {
+		at = append(at, addr)
+	}
+	return &GaslessInfoResult{
+		IsDisabled:    s.b.IsDisabled(),
+		SwapRouter:    s.b.swapRouter,
+		AllowedTokens: at,
 	}
 }

--- a/kaiax/gasless/impl/api_test.go
+++ b/kaiax/gasless/impl/api_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
-	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
@@ -76,19 +75,19 @@ func TestGaslessAPI_isGaslessTx(t *testing.T) {
 	routerAddr := common.HexToAddress("0x1234")
 	differentTokenAddr := common.HexToAddress("0xdead1234dead1234dead1234dead1234dead1234")
 
+	// Create a simulated backend for testing
+	dbm := database.NewMemoryDBManager()
+	alloc := testAllocStorage()
+	backend := backends.NewSimulatedBackendWithDatabase(dbm, alloc, testChainConfig)
+
 	// Setup test stateDB with a proper database
-	stateDB, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	stateDB, _ := backend.BlockChain().State()
 	stateDB.SetNonce(sender, 0) // For approve tx
 
 	// Create mock txpool
 	txpool := &testTxPool{
 		statedb: stateDB,
 	}
-
-	// Create a simulated backend for testing
-	dbm := database.NewMemoryDBManager()
-	alloc := testAllocStorage()
-	backend := backends.NewSimulatedBackendWithDatabase(dbm, alloc, testChainConfig)
 
 	// Create and initialize GaslessModule
 	gaslessModule := NewGaslessModule()

--- a/kaiax/gasless/impl/builder_test.go
+++ b/kaiax/gasless/impl/builder_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
-	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
@@ -36,9 +35,9 @@ func TestExtractTxBundles(t *testing.T) {
 
 	g := NewGaslessModule()
 	dbm := database.NewMemoryDBManager()
-	sdb, _ := state.New(common.Hash{}, state.NewDatabase(dbm), nil, nil)
 	alloc := testAllocStorage()
 	backend := backends.NewSimulatedBackendWithDatabase(dbm, alloc, testChainConfig)
+	sdb, _ := backend.BlockChain().State()
 	nodeKey, _ := crypto.GenerateKey()
 	err := g.Init(&InitOpts{
 		ChainConfig:   testChainConfig,

--- a/kaiax/gasless/impl/execution.go
+++ b/kaiax/gasless/impl/execution.go
@@ -24,5 +24,5 @@ import (
 var _ kaiax.ExecutionModule = (*GaslessModule)(nil)
 
 func (g *GaslessModule) PostInsertBlock(block *types.Block) error {
-	return g.updateAddresses()
+	return g.updateAddresses(block.Header())
 }

--- a/kaiax/gasless/impl/execution.go
+++ b/kaiax/gasless/impl/execution.go
@@ -24,5 +24,5 @@ import (
 var _ kaiax.ExecutionModule = (*GaslessModule)(nil)
 
 func (g *GaslessModule) PostInsertBlock(block *types.Block) error {
-	return g.updateAddresses(block.Number())
+	return g.updateAddresses()
 }

--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -297,9 +297,9 @@ func (g *GaslessModule) GetLendTxGenerator(approveTxOrNil, swapTx *types.Transac
 	return builder.NewTxOrGenFromGen(gen, bundleHash)
 }
 
-func (g *GaslessModule) updateAddresses(blockNumber *big.Int) error {
+func (g *GaslessModule) updateAddresses() error {
 	statedb := g.TxPool.GetCurrentState()
-	swapRouter, tokens, err := getGaslessInfo(statedb, g.Chain, blockNumber)
+	swapRouter, tokens, err := getGaslessInfo(statedb, g.Chain)
 	// proceed even if there is something wrong with multicall contract
 	if err != nil {
 		g.swapRouter = common.Address{}
@@ -349,13 +349,13 @@ func repayAmount(approveTxOrNil, swapTx *types.Transaction) *big.Int {
 	return new(big.Int).Add(r1, lendAmount(approveTxOrNil, swapTx))
 }
 
-func getGaslessInfo(statedb *state.StateDB, bc backends.BlockChainForCaller, blockNumber *big.Int) (common.Address, []common.Address, error) {
+func getGaslessInfo(statedb *state.StateDB, bc backends.BlockChainForCaller) (common.Address, []common.Address, error) {
 	caller, err := system.NewMultiCallContractCaller(statedb, bc, bc.CurrentBlock().Header())
 	if err != nil {
 		return common.Address{}, nil, err
 	}
 
-	opts := &bind.CallOpts{BlockNumber: blockNumber}
+	opts := &bind.CallOpts{BlockNumber: bc.CurrentBlock().Number()}
 	info, err := caller.MultiCallGaslessInfo(opts)
 
 	return info.Gsr, info.Tokens, err

--- a/kaiax/gasless/impl/getter_test.go
+++ b/kaiax/gasless/impl/getter_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"
-	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
@@ -137,8 +136,8 @@ func TestIsExecutable(t *testing.T) {
 	db := database.NewMemoryDBManager()
 	alloc := testAllocStorage()
 	backend := backends.NewSimulatedBackendWithDatabase(db, alloc, testChainConfig)
+	sdb, _ := backend.BlockChain().State()
 	key, _ := crypto.GenerateKey()
-	sdb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	err := g.Init(&InitOpts{
 		ChainConfig:   testChainConfig,
 		GaslessConfig: testGaslessConfig,
@@ -216,7 +215,7 @@ func TestGetLendTxGenerator(t *testing.T) {
 	alloc := testAllocStorage()
 	backend := backends.NewSimulatedBackendWithDatabase(db, alloc, testChainConfig)
 	nodekey, _ := crypto.GenerateKey()
-	sdb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	sdb, _ := backend.BlockChain().State()
 	sdb.SetBalance(crypto.PubkeyToAddress(nodekey.PublicKey), new(big.Int).SetUint64(params.KAIA))
 
 	testTxPoolConfig := blockchain.DefaultTxPoolConfig

--- a/kaiax/gasless/impl/init.go
+++ b/kaiax/gasless/impl/init.go
@@ -57,7 +57,7 @@ func (g *GaslessModule) Init(opts *InitOpts) error {
 	g.InitOpts = *opts
 	g.signer = types.LatestSignerForChainID(g.ChainConfig.ChainID)
 
-	return g.updateAddresses()
+	return g.updateAddresses(g.Chain.CurrentBlock().Header())
 }
 
 func (g *GaslessModule) IsDisabled() bool {

--- a/kaiax/gasless/impl/init.go
+++ b/kaiax/gasless/impl/init.go
@@ -57,7 +57,7 @@ func (g *GaslessModule) Init(opts *InitOpts) error {
 	g.InitOpts = *opts
 	g.signer = types.LatestSignerForChainID(g.ChainConfig.ChainID)
 
-	return g.updateAddresses(g.Chain.CurrentBlock().Number())
+	return g.updateAddresses()
 }
 
 func (g *GaslessModule) IsDisabled() bool {

--- a/kaiax/gasless/impl/tx_pool_test.go
+++ b/kaiax/gasless/impl/tx_pool_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"
-	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
@@ -81,9 +80,9 @@ func TestIsReady(t *testing.T) {
 	log.EnableLogForTest(log.LvlTrace, log.LvlTrace)
 
 	dbm := database.NewMemoryDBManager()
-	sdb, _ := state.New(common.Hash{}, state.NewDatabase(dbm), nil, nil)
 	alloc := testAllocStorage()
 	backend := backends.NewSimulatedBackendWithDatabase(dbm, alloc, testChainConfig)
+	sdb, _ := backend.BlockChain().State()
 	nodeKey, _ := crypto.GenerateKey()
 
 	privkey, _ := crypto.GenerateKey()
@@ -217,7 +216,7 @@ func TestPromoteGaslessTxsWithSingleSender(t *testing.T) {
 	dbm := database.NewMemoryDBManager()
 	alloc := testAllocStorage()
 	backend := backends.NewSimulatedBackendWithDatabase(dbm, alloc, testChainConfig)
-	sdb, _ := state.New(common.Hash{}, state.NewDatabase(dbm), nil, nil)
+	sdb, _ := backend.BlockChain().State()
 	nodeKey, _ := crypto.GenerateKey()
 
 	userKey, err := crypto.GenerateKey()
@@ -396,7 +395,7 @@ func TestPromoteGaslessTxsWithMultiSenders(t *testing.T) {
 	dbm := database.NewMemoryDBManager()
 	alloc := testAllocStorage()
 	backend := backends.NewSimulatedBackendWithDatabase(dbm, alloc, testChainConfig)
-	sdb, _ := state.New(common.Hash{}, state.NewDatabase(dbm), nil, nil)
+	sdb, _ := backend.BlockChain().State()
 	nodeKey, _ := crypto.GenerateKey()
 
 	key1, _ := crypto.GenerateKey()


### PR DESCRIPTION
## Proposed changes

This PR handle the following items:

- fix cn config initialization to set nil to allowedTokens
- use correct MultiCallContractCaller
- add gasless info api `debug_gaslessInfo`
- use backend statedb in tests

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
