### PR TITLE
Return custom error to avoid nil pointer panic

### DIFF
--- a/kerrors/kerrors.go
+++ b/kerrors/kerrors.go
@@ -56,7 +56,8 @@ var (
 	ErrNestedCompositeType                  = errors.New("nested composite type")
 	ErrLegacyTransactionMustBeWithLegacyKey = errors.New("a legacy transaction must be with a legacy account key")
 
-	ErrDeprecated   = errors.New("deprecated feature")
-	ErrNotSupported = errors.New("not supported")
+	ErrDeprecated            = errors.New("deprecated feature")
+	ErrNotSupported          = errors.New("not supported")
 	ErrRevertedBundleByVmErr = errors.New("bundle is reverted by vm err")
+	ErrTxGeneration          = errors.New("transaction generation failed")
 )

--- a/work/worker.go
+++ b/work/worker.go
@@ -787,7 +787,7 @@ CommitTransactionLoop:
 		if len(targetBundle.BundleTxs) != 0 {
 			atomic.StoreInt32(&isExecutingBundleTxs, 1)
 			err, tx, logs = env.commitBundleTransaction(targetBundle, bc, rewardbase, vmConfig)
-			if err != nil {
+			if err != nil && tx != nil {
 				// override sender to error tx
 				from, _ = types.Sender(env.signer, tx)
 			}
@@ -834,6 +834,11 @@ CommitTransactionLoop:
 			// Pop transaction in bundle reverted by vm err without shifting in the next from the account
 			// During bundle execution, vm err is reverted, including the increment of the nonce, so a pop is executed.
 			logger.Trace("Skipping transaction in bundle reverted by vm err", "sender", from, "hash", tx.Hash().String())
+			builder_impl.PopTxs(&incorporatedTxs, numShift, &bundles, env.signer)
+
+		case kerrors.ErrTxGeneration:
+			// Pop transaction in bundle due to tx generation error without shifting in the next from the account
+			logger.Trace("Skipping transaction in bundle due to tx generation error", "err", err)
 			builder_impl.PopTxs(&incorporatedTxs, numShift, &bundles, env.signer)
 
 		case nil:
@@ -913,7 +918,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 			logger.Error("TxGenerator error", "error", err)
 			markAllTxUnexecutable()
 			restoreEnv()
-			return err, &types.Transaction{}, nil
+			return kerrors.ErrTxGeneration, nil, nil
 		}
 
 		env.state.SetTxContext(tx.Hash(), common.Hash{}, env.tcount)
@@ -940,7 +945,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 	env.txs = append(env.txs, txs...)
 	env.receipts = append(env.receipts, receipts...)
 
-	return nil, &types.Transaction{}, logs
+	return nil, nil, logs
 }
 
 func NewTask(config *params.ChainConfig, signer types.Signer, statedb *state.StateDB, header *types.Header) *Task {


### PR DESCRIPTION
## Proposed changes

This PR fixes the nil pointer panic due to accessing an empty transaction. Now `commitBundleTransactions` also explicitly returns nil for clarity.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
