### PR TITLE
api: Fixed RPC input type

### DIFF
--- a/kaiax/auction/impl/api.go
+++ b/kaiax/auction/impl/api.go
@@ -18,7 +18,6 @@ package impl
 
 import (
 	"context"
-	"math/big"
 	"strings"
 
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -67,7 +66,7 @@ type BidInput struct {
 	Sender        common.Address `json:"sender"`
 	To            common.Address `json:"to"`
 	Nonce         uint64         `json:"nonce"`
-	Bid           *big.Int       `json:"bid"`
+	Bid           hexutil.Big    `json:"bid"`
 	CallGasLimit  uint64         `json:"callGasLimit"`
 	Data          hexutil.Bytes  `json:"data"`
 	SearcherSig   hexutil.Bytes  `json:"searcherSig"`
@@ -81,7 +80,7 @@ func toBid(bidInput BidInput) *auction.Bid {
 		Sender:        bidInput.Sender,
 		To:            bidInput.To,
 		Nonce:         bidInput.Nonce,
-		Bid:           bidInput.Bid,
+		Bid:           bidInput.Bid.ToInt(),
 		CallGasLimit:  bidInput.CallGasLimit,
 		Data:          bidInput.Data,
 		SearcherSig:   bidInput.SearcherSig,
@@ -122,6 +121,7 @@ func (api *AuctionAPI) SubmitBid(ctx context.Context, bidInput BidInput) RPCOutp
 	bid := toBid(bidInput)
 	bidHash, errValidateBid := api.a.bidPool.AddBid(bid)
 	return makeRPCOutput(bidHash, errValidateBid)
+	return nil
 }
 
 func makeRPCOutput(bidHash common.Hash, err error) RPCOutput {

--- a/kaiax/auction/impl/api.go
+++ b/kaiax/auction/impl/api.go
@@ -121,7 +121,6 @@ func (api *AuctionAPI) SubmitBid(ctx context.Context, bidInput BidInput) RPCOutp
 	bid := toBid(bidInput)
 	bidHash, errValidateBid := api.a.bidPool.AddBid(bid)
 	return makeRPCOutput(bidHash, errValidateBid)
-	return nil
 }
 
 func makeRPCOutput(bidHash common.Hash, err error) RPCOutput {

--- a/kaiax/auction/impl/api_test.go
+++ b/kaiax/auction/impl/api_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/kaiax/auction"
 	"github.com/kaiachain/kaia/storage/database"
@@ -50,7 +51,7 @@ func TestSubmitBid(t *testing.T) {
 			Sender:        common.HexToAddress("0x14791697260E4c9A71f18484C9f997B308e59325"),
 			To:            common.HexToAddress("0x5FC8d32690cc91D4c39d9d3abcBD16989F875707"),
 			Nonce:         4,
-			Bid:           big.NewInt(3),
+			Bid:           hexutil.Big(*big.NewInt(3)),
 			CallGasLimit:  2,
 			Data:          common.Hex2Bytes("1234"),
 			SearcherSig:   common.Hex2Bytes("4f17bd3304ab18e8fd19938b6b3898c491134ecdd6a104244b458dc339ce2bf043f3b8d0a6a96d34cb27180146fe265e3213bb9ddcbafc0778cc39cde4d388d31b"),
@@ -77,7 +78,7 @@ func TestSubmitBid(t *testing.T) {
 
 	validBid.TargetTxRaw = nil
 
-	anotherBid.Bid = big.NewInt(10)
+	anotherBid.Bid = hexutil.Big(*big.NewInt(10))
 	anotherBid.SearcherSig = common.Hex2Bytes("6439652673f1544bcd95d25c1dad31944321bdc0e6720f6c59a582aa0c40cc403ef4b5d1865eb3fa0e26fc49d7ef88f77f42d1559131a83a2326445eab3649741b")
 	anotherBid.AuctioneerSig = common.Hex2Bytes("640a09994942d99bb751db3347ea3e909752b363a90dc3ed9c0b4d8ad512ae3d44ec820239f9875dcdbffc28fafafd3ca7d48a4ff6f4a2d8969a8f5d309460361b")
 


### PR DESCRIPTION
## Proposed changes

Changed to `hexutil.Big` for `Bid` type, Thank you @hyeonLewis.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
