### PR TITLE
chore: "accomodate" → "accommodate"

### DIFF
--- a/kaiax/interface.go
+++ b/kaiax/interface.go
@@ -66,7 +66,7 @@ type ConsensusModule interface {
 	FinalizeHeader(header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) error
 }
 
-// Any component or module that accomodate consensus modules.
+// Any component or module that accommodate consensus modules.
 type ConsensusModuleHost interface {
 	RegisterConsensusModule(modules ...ConsensusModule)
 
@@ -83,7 +83,7 @@ type ExecutionModule interface {
 	PostInsertBlock(block *types.Block) error
 }
 
-// Any component or module that accomodate execution modules.
+// Any component or module that accommodate execution modules.
 type ExecutionModuleHost interface {
 	RegisterExecutionModule(modules ...ExecutionModule)
 }
@@ -112,7 +112,7 @@ type RewindableModule interface {
 	RewindDelete(hash common.Hash, num uint64)
 }
 
-// Any component or module that accomodate rewindable modules.
+// Any component or module that accommodate rewindable modules.
 type RewindableModuleHost interface {
 	RegisterRewindableModule(modules ...RewindableModule)
 }
@@ -131,7 +131,7 @@ type TxProcessModule interface {
 	PostRunTx(evm *vm.EVM, tx *types.Transaction) error
 }
 
-// Any component or module that accomodate tx process modules.
+// Any component or module that accommodate tx process modules.
 type TxProcessModuleHost interface {
 	RegisterTxProcessModule(modules ...TxProcessModule)
 }
@@ -159,7 +159,7 @@ type TxPoolForCaller interface {
 	GetCurrentState() *state.StateDB
 }
 
-// Any component or module that accomodate txpool modules.
+// Any component or module that accommodate txpool modules.
 type TxPoolModuleHost interface {
 	RegisterTxPoolModule(modules ...TxPoolModule)
 }


### PR DESCRIPTION
## Proposed changes

in several places where "accomodate" was used instead of the correct spelling, "accommodate."
this has been fixed to improve clarity and consistency.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
