### PR TITLE
kaiax/builder: limit the number of bundle transactions in pending

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -530,6 +530,10 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 		pset := pool.govModule.GetParamSet(newHead.Number.Uint64() + 1)
 		pool.gasPrice = misc.NextMagmaBlockBaseFee(newHead, pset.ToKip71Config())
 	}
+
+	for _, module := range pool.modules {
+		module.PostReset(oldHead, newHead)
+	}
 }
 
 // Stop terminates the transaction pool.

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -411,9 +411,11 @@ func (pool *TxPool) lockedReset(oldHead, newHead *types.Header) {
 // reset retrieves the current state of the blockchain and ensures the content
 // of the transaction pool is valid with regard to the chain state.
 func (pool *TxPool) reset(oldHead, newHead *types.Header) {
+	pool.txMu.Lock()
 	for _, module := range pool.modules {
 		module.PreReset(oldHead, newHead)
 	}
+	pool.txMu.Unlock()
 
 	// If we're reorging an old state, reinject all dropped transactions
 	var reinject types.Transactions
@@ -531,9 +533,11 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 		pool.gasPrice = misc.NextMagmaBlockBaseFee(newHead, pset.ToKip71Config())
 	}
 
+	pool.txMu.Lock()
 	for _, module := range pool.modules {
 		module.PostReset(oldHead, newHead)
 	}
+	pool.txMu.Unlock()
 }
 
 // Stop terminates the transaction pool.
@@ -642,6 +646,17 @@ func (pool *TxPool) Pending() (map[common.Address]types.Transactions, error) {
 	pool.txMu.Lock()
 	defer pool.txMu.Unlock()
 
+	pending := make(map[common.Address]types.Transactions)
+	for addr, list := range pool.pending {
+		pending[addr] = list.Flatten()
+	}
+	return pending, nil
+}
+
+// PendingUnlocked retrieves all currently processable transactions, groupped by origin
+// account and sorted by nonce. The returned transaction set is a copy and can be
+// freely modified by calling code. This function is not thread safe.
+func (pool *TxPool) PendingUnlocked() (map[common.Address]types.Transactions, error) {
 	pending := make(map[common.Address]types.Transactions)
 	for addr, list := range pool.pending {
 		pending[addr] = list.Flatten()

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -145,7 +145,7 @@ var HomiFlags = []cli.Flag{
 	// kaiax/gasless
 	altsrc.NewStringSliceFlag(gasless.AllowedTokensFlag),
 	altsrc.NewBoolFlag(gasless.DisableFlag),
-	altsrc.NewIntFlag(gasless.MaxGaslessBundleSizeFlag),
+	altsrc.NewIntFlag(gasless.MaxGaslessBundleNumFlag),
 }
 
 var SetupCommand = &cli.Command{

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -145,7 +145,7 @@ var HomiFlags = []cli.Flag{
 	// kaiax/gasless
 	altsrc.NewStringSliceFlag(gasless.AllowedTokensFlag),
 	altsrc.NewBoolFlag(gasless.DisableFlag),
-	altsrc.NewIntFlag(gasless.MaxGaslessBundleNumFlag),
+	altsrc.NewIntFlag(gasless.MaxBundleTxsInPendingFlag),
 }
 
 var SetupCommand = &cli.Command{

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -142,8 +142,10 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewStringFlag(kip113LogicAddressFlag),
 	altsrc.NewBoolFlag(kip113MockFlag),
 	altsrc.NewBoolFlag(registryMockFlag),
+	// kaiax/gasless
 	altsrc.NewStringSliceFlag(gasless.AllowedTokensFlag),
 	altsrc.NewBoolFlag(gasless.DisableFlag),
+	altsrc.NewIntFlag(gasless.MaxGaslessBundleSizeFlag),
 }
 
 var SetupCommand = &cli.Command{

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -760,7 +760,7 @@ func (kCfg *KaiaConfig) SetKaiaConfig(ctx *cli.Context, stack *node.Node) {
 	cfg.GPO.MaxPrice = big.NewInt(ctx.Int64(GpoMaxGasPriceFlag.Name))
 
 	// Set kaiax module config
-	cfg.Gasless = gasless.GetGaslessConfig(ctx)
+	gasless.SetGaslessConfig(ctx, cfg.Gasless)
 }
 
 // raiseFDLimit increases the file descriptor limit to process's maximum value

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -280,7 +280,7 @@ var CommonNodeFlags = []cli.Flag{
 	// kaiax/gasless
 	altsrc.NewStringSliceFlag(gasless.AllowedTokensFlag),
 	altsrc.NewBoolFlag(gasless.DisableFlag),
-	altsrc.NewIntFlag(gasless.MaxGaslessBundleNumFlag),
+	altsrc.NewIntFlag(gasless.MaxBundleTxsInPendingFlag),
 }
 
 // Common RPC flags

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -277,9 +277,10 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewIntFlag(GpoBlocksFlag),
 	altsrc.NewIntFlag(GpoPercentileFlag),
 	altsrc.NewInt64Flag(GpoMaxGasPriceFlag),
-	// kaiax
+	// kaiax/gasless
 	altsrc.NewStringSliceFlag(gasless.AllowedTokensFlag),
 	altsrc.NewBoolFlag(gasless.DisableFlag),
+	altsrc.NewIntFlag(gasless.MaxGaslessBundleSizeFlag),
 }
 
 // Common RPC flags

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -280,7 +280,7 @@ var CommonNodeFlags = []cli.Flag{
 	// kaiax/gasless
 	altsrc.NewStringSliceFlag(gasless.AllowedTokensFlag),
 	altsrc.NewBoolFlag(gasless.DisableFlag),
-	altsrc.NewIntFlag(gasless.MaxGaslessBundleSizeFlag),
+	altsrc.NewIntFlag(gasless.MaxGaslessBundleNumFlag),
 }
 
 // Common RPC flags

--- a/kaiax/builder/impl/errors.go
+++ b/kaiax/builder/impl/errors.go
@@ -21,4 +21,5 @@ import "errors"
 var (
 	ErrInitUnexpectedNil         = errors.New("unexpected nil during module init")
 	ErrFailedToIncorporateBundle = errors.New("failed to incorporate bundle")
+	ErrUnableToAddKnownBundleTx  = errors.New("unable to add known bundle tx into tx pool during lock period")
 )

--- a/kaiax/builder/impl/getter.go
+++ b/kaiax/builder/impl/getter.go
@@ -274,12 +274,12 @@ func ExtractBundlesAndIncorporate(arrayTxs []*types.Transaction, txBundlingModul
 // WrapAndConcatenateBundlingModules wraps bundling modules and concatenates them.
 // given: mTxPool = [ A, B, C ], mTxBundling = [ B, D ]
 // want : mTxPool = [ A, WB, C, WD ] (W: wrapped)
-func WrapAndConcatenateBundlingModules(mTxBundling []builder.TxBundlingModule, mTxPool []kaiax.TxPoolModule) []kaiax.TxPoolModule {
+func WrapAndConcatenateBundlingModules(mTxBundling []builder.TxBundlingModule, mTxPool []kaiax.TxPoolModule, txPool kaiax.TxPoolForCaller) []kaiax.TxPoolModule {
 	ret := make([]kaiax.TxPoolModule, 0, len(mTxBundling)+len(mTxPool))
 
 	for _, module := range mTxPool {
 		if txb, ok := module.(builder.TxBundlingModule); ok {
-			ret = append(ret, NewBuilderWrappingModule(txb))
+			ret = append(ret, NewBuilderWrappingModule(txb, txPool))
 		} else {
 			ret = append(ret, module)
 		}
@@ -287,7 +287,7 @@ func WrapAndConcatenateBundlingModules(mTxBundling []builder.TxBundlingModule, m
 
 	for _, module := range mTxBundling {
 		if txp, ok := module.(kaiax.TxPoolModule); !(ok && slices.Contains(mTxPool, txp)) {
-			ret = append(ret, NewBuilderWrappingModule(module))
+			ret = append(ret, NewBuilderWrappingModule(module, txPool))
 		}
 	}
 

--- a/kaiax/builder/impl/getter_test.go
+++ b/kaiax/builder/impl/getter_test.go
@@ -415,7 +415,7 @@ func TestWrapAndConcatenateBundlingModules(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := WrapAndConcatenateBundlingModules(tc.mTxBundling, tc.mTxPool)
+			result := WrapAndConcatenateBundlingModules(tc.mTxBundling, tc.mTxPool, nil)
 
 			// Check the length of the result
 			assert.Equal(t, len(tc.expected), len(result))

--- a/kaiax/builder/impl/init.go
+++ b/kaiax/builder/impl/init.go
@@ -35,8 +35,9 @@ type InitOpts struct {
 }
 
 type txAndTime struct {
-	tx   *types.Transaction
-	time time.Time
+	tx        *types.Transaction
+	time      time.Time
+	isDemoted bool
 }
 
 type BuilderModule struct {

--- a/kaiax/builder/impl/init.go
+++ b/kaiax/builder/impl/init.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kaiachain/kaia/api"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/builder"
 	"github.com/kaiachain/kaia/log"
 )
@@ -34,10 +35,64 @@ type InitOpts struct {
 	Backend api.Backend
 }
 
-type txAndTime struct {
+type knownTxs map[common.Hash]knownTx
+
+func (k knownTxs) add(tx *types.Transaction) {
+	k[tx.Hash()] = knownTx{
+		tx:        tx,
+		time:      time.Now(),
+		isDemoted: false,
+	}
+}
+
+func (k knownTxs) get(hash common.Hash) (knownTx, bool) {
+	tx, ok := k[hash]
+	return tx, ok
+}
+
+func (k knownTxs) has(hash common.Hash) bool {
+	_, ok := k[hash]
+	return ok
+}
+
+func (k knownTxs) delete(hash common.Hash) {
+	delete(k, hash)
+}
+
+func (k knownTxs) numExecutable() int {
+	num := 0
+	for _, knownTx := range k {
+		if !knownTx.tx.IsMarkedUnexecutable() && !knownTx.isDemoted {
+			num++
+		}
+	}
+	return num
+}
+
+func (k knownTxs) markUnexecutable(hash common.Hash) {
+	if tx, ok := k[hash]; ok {
+		tx.tx.MarkUnexecutable(true)
+	}
+}
+
+func (k knownTxs) markDemoted(hash common.Hash) {
+	if tx, ok := k[hash]; ok {
+		k[hash] = knownTx{
+			tx:        tx.tx,
+			time:      tx.time,
+			isDemoted: true,
+		}
+	}
+}
+
+type knownTx struct {
 	tx        *types.Transaction
 	time      time.Time
 	isDemoted bool
+}
+
+func (t *knownTx) elapsedTime() time.Duration {
+	return time.Since(t.time)
 }
 
 type BuilderModule struct {

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -94,8 +94,11 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 						flattened = append(flattened, tx.tx)
 					}
 				}
-				if len(b.txBundlingModule.ExtractTxBundles(flattened, nil)) >= maxBundleSize {
-					logger.Info("Max bundle size reached", "maxBundleSize", maxBundleSize)
+				// it's too much cost to check the size of the bundle here, so we just check the number of txs
+				// if the number of txs is greater than the max bundle size, we reject the tx
+				// but if there are ready txs, we should add the tx to the pool to complete the bundle
+				if len(flattened) >= maxBundleSize && len(ready) == 0 {
+					logger.Info("Pending tx pool is full of bundle txs, rejecting tx", "maxBundleSize", maxBundleSize)
 					return false
 				}
 			}

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -88,15 +88,16 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 	}
 	if isReady && b.txBundlingModule.IsBundleTx(tx) {
 		if _, ok := b.knownTxs[tx.Hash()]; !ok {
-			flattened := make([]*types.Transaction, 0, len(b.knownTxs))
-			for _, tx := range b.knownTxs {
-				if !tx.tx.IsMarkedUnexecutable() {
-					flattened = append(flattened, tx.tx)
+			if maxBundleSize := b.txBundlingModule.GetMaxBundleSize(); maxBundleSize > 0 {
+				flattened := make([]*types.Transaction, 0, len(b.knownTxs))
+				for _, tx := range b.knownTxs {
+					if !tx.tx.IsMarkedUnexecutable() {
+						flattened = append(flattened, tx.tx)
+					}
 				}
-			}
-			maxBundleSize := b.txBundlingModule.GetMaxBundleSize()
-			if maxBundleSize > 0 && len(b.txBundlingModule.ExtractTxBundles(flattened, nil)) >= maxBundleSize {
-				return false
+				if len(b.txBundlingModule.ExtractTxBundles(flattened, nil)) >= maxBundleSize {
+					return false
+				}
 			}
 			b.knownTxs[tx.Hash()] = txAndTime{
 				tx:   tx,

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -132,3 +132,6 @@ func (b *BuilderWrappingModule) PreReset(oldHead, newHead *types.Header) {
 		b.txPoolModule.PreReset(oldHead, newHead)
 	}
 }
+
+// PostReset is a wrapper function that calls the PostReset method of the underlying module.
+func (b *BuilderWrappingModule) PostReset(oldHead, newHead *types.Header) {}

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -108,13 +108,11 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 
 			numSeqTxs := uint(1)
 			for i := next + 1; i < next+uint64(len(txs)); i++ {
-				if _, ok := txs[i]; !ok {
+				if tx, ok := txs[i]; ok && b.txBundlingModule.IsBundleTx(tx) {
+					numSeqTxs++
+				} else {
 					break
 				}
-				if !b.txBundlingModule.IsBundleTx(txs[i]) {
-					break
-				}
-				numSeqTxs++
 			}
 
 			// false if there is possibility of exceeding max bundle tx num

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -169,4 +169,8 @@ func (b *BuilderWrappingModule) PostReset(oldHead, newHead *types.Header) {
 			b.knownTxs.markDemoted(hash)
 		}
 	}
+
+	if b.txPoolModule != nil {
+		b.txPoolModule.PostReset(oldHead, newHead)
+	}
 }

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -89,7 +89,7 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 	if isReady && b.txBundlingModule.IsBundleTx(tx) {
 		if _, ok := b.knownTxs[tx.Hash()]; !ok {
 			// if maxBundleSize is max uint64, it means no limit
-			if maxBundleSize := b.txBundlingModule.GetMaxBundleSize(); maxBundleSize != math.MaxUint64 {
+			if maxBundleNum := b.txBundlingModule.GetMaxBundleNum(); maxBundleNum != math.MaxUint64 {
 				numExecutable := uint(0)
 				for _, tx := range b.knownTxs {
 					if !tx.tx.IsMarkedUnexecutable() {
@@ -99,8 +99,8 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 				// it's too much cost to check the size of the bundle here, so we just check the number of txs
 				// if the number of txs is greater than the max bundle size, we reject the tx
 				// but if there are ready txs, we should add the tx to the pool to complete the bundle
-				if numExecutable >= maxBundleSize && len(ready) == 0 {
-					logger.Info("Pending tx pool is full of bundle txs, rejecting tx", "maxBundleSize", maxBundleSize)
+				if numExecutable >= maxBundleNum && len(ready) == 0 {
+					logger.Info("Pending tx pool is full of bundle txs, rejecting tx", "maxBundleNum", maxBundleNum)
 					return false
 				}
 			}

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -42,6 +42,7 @@ func NewBuilderWrappingModule(txBundlingModule builder.TxBundlingModule) *Builde
 		txBundlingModule: txBundlingModule,
 		txPoolModule:     txPoolModule,
 		knownTxs:         make(map[common.Hash]txAndTime),
+		mu:               sync.RWMutex{},
 	}
 }
 
@@ -87,6 +88,16 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 	}
 	if isReady && b.txBundlingModule.IsBundleTx(tx) {
 		if _, ok := b.knownTxs[tx.Hash()]; !ok {
+			flattened := make([]*types.Transaction, 0, len(b.knownTxs))
+			for _, tx := range b.knownTxs {
+				if !tx.tx.IsMarkedUnexecutable() {
+					flattened = append(flattened, tx.tx)
+				}
+			}
+			maxBundleSize := b.txBundlingModule.GetMaxBundleSize()
+			if maxBundleSize > 0 && len(b.txBundlingModule.ExtractTxBundles(flattened, nil)) >= maxBundleSize {
+				return false
+			}
 			b.knownTxs[tx.Hash()] = txAndTime{
 				tx:   tx,
 				time: time.Now(),

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -17,6 +17,7 @@
 package impl
 
 import (
+	"math"
 	"sync"
 	"time"
 
@@ -87,8 +88,9 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 	}
 	if isReady && b.txBundlingModule.IsBundleTx(tx) {
 		if _, ok := b.knownTxs[tx.Hash()]; !ok {
-			if maxBundleSize := b.txBundlingModule.GetMaxBundleSize(); maxBundleSize > 0 {
-				numExecutable := 0
+			// if maxBundleSize is max uint64, it means no limit
+			if maxBundleSize := b.txBundlingModule.GetMaxBundleSize(); maxBundleSize != math.MaxUint64 {
+				numExecutable := uint(0)
 				for _, tx := range b.knownTxs {
 					if !tx.tx.IsMarkedUnexecutable() {
 						numExecutable++

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -17,7 +17,6 @@
 package impl
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -53,7 +52,7 @@ func (b *BuilderWrappingModule) PreAddTx(tx *types.Transaction, local bool) erro
 
 	txTime, ok := b.knownTxs[tx.Hash()]
 	if ok && time.Since(txTime.time) < KnownTxTimeout {
-		return errors.New("Unable to add known bundle tx into tx pool during lock period")
+		return ErrUnableToAddKnownBundleTx
 	}
 	if b.txPoolModule != nil {
 		return b.txPoolModule.PreAddTx(tx, local)

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -96,6 +96,7 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 					}
 				}
 				if len(b.txBundlingModule.ExtractTxBundles(flattened, nil)) >= maxBundleSize {
+					logger.Info("Max bundle size reached", "maxBundleSize", maxBundleSize)
 					return false
 				}
 			}

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -152,6 +152,9 @@ func (b *BuilderWrappingModule) PreReset(oldHead, newHead *types.Header) {
 
 // PostReset is a wrapper function that calls the PostReset method of the underlying module.
 func (b *BuilderWrappingModule) PostReset(oldHead, newHead *types.Header) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	pending, err := b.txPool.PendingUnlocked()
 	if err != nil {
 		logger.Error("Failed to get pending txs", "error", err)

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -99,7 +99,7 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 		if next > 0 {
 			preReadyTx = txs[next-1]
 		}
-		if b.txBundlingModule.GetMaxBundleNum() != math.MaxUint64 && !b.txBundlingModule.IsBundleTx(preReadyTx) {
+		if b.txBundlingModule.GetMaxBundleTxsInPending() != math.MaxUint64 && !b.txBundlingModule.IsBundleTx(preReadyTx) {
 			numExecutable := uint(b.knownTxs.numExecutable())
 
 			numSeqTxs := uint(1)
@@ -114,7 +114,7 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 			}
 
 			// false if there is possibility of exceeding max bundle tx num
-			if numExecutable+numSeqTxs > b.txBundlingModule.GetMaxBundleNum() {
+			if numExecutable+numSeqTxs > b.txBundlingModule.GetMaxBundleTxsInPending() {
 				return false
 			}
 		}

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -107,7 +107,7 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 			numExecutable := uint(b.knownTxs.numExecutable())
 
 			numSeqTxs := uint(1)
-			for i := next + 1; true; i++ {
+			for i := next + 1; i < next+uint64(len(txs)); i++ {
 				if _, ok := txs[i]; !ok {
 					break
 				}

--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -88,16 +88,16 @@ func (b *BuilderWrappingModule) IsReady(txs map[uint64]*types.Transaction, next 
 	if isReady && b.txBundlingModule.IsBundleTx(tx) {
 		if _, ok := b.knownTxs[tx.Hash()]; !ok {
 			if maxBundleSize := b.txBundlingModule.GetMaxBundleSize(); maxBundleSize > 0 {
-				flattened := make([]*types.Transaction, 0, len(b.knownTxs))
+				numExecutable := 0
 				for _, tx := range b.knownTxs {
 					if !tx.tx.IsMarkedUnexecutable() {
-						flattened = append(flattened, tx.tx)
+						numExecutable++
 					}
 				}
 				// it's too much cost to check the size of the bundle here, so we just check the number of txs
 				// if the number of txs is greater than the max bundle size, we reject the tx
 				// but if there are ready txs, we should add the tx to the pool to complete the bundle
-				if len(flattened) >= maxBundleSize && len(ready) == 0 {
+				if numExecutable >= maxBundleSize && len(ready) == 0 {
 					logger.Info("Pending tx pool is full of bundle txs, rejecting tx", "maxBundleSize", maxBundleSize)
 					return false
 				}

--- a/kaiax/builder/impl/tx_pool_wrapping_test.go
+++ b/kaiax/builder/impl/tx_pool_wrapping_test.go
@@ -389,7 +389,7 @@ func TestIsReady_KnownTxs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockTxBundlingModule := mock_builder.NewMockTxBundlingModule(ctrl)
 			mockTxBundlingModule.EXPECT().IsBundleTx(gomock.Any()).Return(tt.isBundleTxResult).AnyTimes()
-			mockTxBundlingModule.EXPECT().GetMaxBundleSize().Return(uint(math.MaxUint64)).AnyTimes()
+			mockTxBundlingModule.EXPECT().GetMaxBundleNum().Return(uint(math.MaxUint64)).AnyTimes()
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
@@ -742,7 +742,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockTxBundlingModule := mock_builder.NewMockTxBundlingModule(ctrl)
 			mockTxBundlingModule.EXPECT().IsBundleTx(gomock.Any()).Return(true).AnyTimes()
-			mockTxBundlingModule.EXPECT().GetMaxBundleSize().Return(tt.maxBundleSize).AnyTimes()
+			mockTxBundlingModule.EXPECT().GetMaxBundleNum().Return(tt.maxBundleSize).AnyTimes()
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,

--- a/kaiax/builder/impl/tx_pool_wrapping_test.go
+++ b/kaiax/builder/impl/tx_pool_wrapping_test.go
@@ -43,19 +43,19 @@ func TestPreAddTx_KnownTxTimeout(t *testing.T) {
 	tests := []struct {
 		name          string
 		tx            *types.Transaction
-		knownTxs      map[common.Hash]txAndTime
+		knownTxs      map[common.Hash]knownTx
 		expectedError error
 	}{
 		{
 			name:          "Transaction not in knownTxs",
 			tx:            createTestTransaction(0),
-			knownTxs:      make(map[common.Hash]txAndTime),
+			knownTxs:      make(map[common.Hash]knownTx),
 			expectedError: nil,
 		},
 		{
 			name: "Transaction during KnownTxTimeout period",
 			tx:   createTestTransaction(0),
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: time.Now(),
@@ -66,7 +66,7 @@ func TestPreAddTx_KnownTxTimeout(t *testing.T) {
 		{
 			name: "Transaction after KnownTxTimeout period",
 			tx:   createTestTransaction(0),
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: time.Now().Add(-KnownTxTimeout),
@@ -141,7 +141,7 @@ func TestPreAddTx_TxPoolModule(t *testing.T) {
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         make(map[common.Hash]txAndTime),
+				knownTxs:         make(map[common.Hash]knownTx),
 			}
 
 			mockTxPoolModule := mock_kaiax.NewMockTxPoolModule(ctrl)
@@ -206,7 +206,7 @@ func TestIsModuleTx(t *testing.T) {
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         make(map[common.Hash]txAndTime),
+				knownTxs:         make(map[common.Hash]knownTx),
 			}
 
 			if tt.hasTxPoolModule {
@@ -279,7 +279,7 @@ func TestGetCheckBalance(t *testing.T) {
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         make(map[common.Hash]txAndTime),
+				knownTxs:         make(map[common.Hash]knownTx),
 			}
 
 			if tt.hasTxPoolModule {
@@ -318,29 +318,29 @@ func TestIsReady_KnownTxs(t *testing.T) {
 		name             string
 		txs              map[uint64]*types.Transaction
 		isBundleTxResult bool
-		knownTxs         map[common.Hash]txAndTime
-		expectedTxs      map[common.Hash]txAndTime
+		knownTxs         map[common.Hash]knownTx
+		expectedTxs      map[common.Hash]knownTx
 	}{
 		{
 			name:             "No txs transactions",
 			txs:              make(map[uint64]*types.Transaction),
 			isBundleTxResult: false,
-			knownTxs:         make(map[common.Hash]txAndTime),
-			expectedTxs:      make(map[common.Hash]txAndTime),
+			knownTxs:         make(map[common.Hash]knownTx),
+			expectedTxs:      make(map[common.Hash]knownTx),
 		},
 		{
 			name:             "Non-bundle transaction",
 			txs:              map[uint64]*types.Transaction{0: createTestTransaction(0)},
 			isBundleTxResult: false,
-			knownTxs:         map[common.Hash]txAndTime{},
-			expectedTxs:      map[common.Hash]txAndTime{},
+			knownTxs:         map[common.Hash]knownTx{},
+			expectedTxs:      map[common.Hash]knownTx{},
 		},
 		{
 			name:             "New bundle transaction",
 			txs:              map[uint64]*types.Transaction{0: createTestTransaction(0)},
 			isBundleTxResult: true,
-			knownTxs:         map[common.Hash]txAndTime{},
-			expectedTxs: map[common.Hash]txAndTime{
+			knownTxs:         map[common.Hash]knownTx{},
+			expectedTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx: createTestTransaction(0),
 				},
@@ -350,13 +350,13 @@ func TestIsReady_KnownTxs(t *testing.T) {
 			name:             "Existing bundle transaction",
 			txs:              map[uint64]*types.Transaction{0: createTestTransaction(0)},
 			isBundleTxResult: true,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: oldTime,
 				},
 			},
-			expectedTxs: map[common.Hash]txAndTime{
+			expectedTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: oldTime,
@@ -367,13 +367,13 @@ func TestIsReady_KnownTxs(t *testing.T) {
 			name:             "KnownTx has txs",
 			txs:              map[uint64]*types.Transaction{0: createTestTransaction(4)},
 			isBundleTxResult: true,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(3).Hash(): {
 					tx:   createTestTransaction(3),
 					time: oldTime,
 				},
 			},
-			expectedTxs: map[common.Hash]txAndTime{
+			expectedTxs: map[common.Hash]knownTx{
 				createTestTransaction(3).Hash(): {
 					tx:   createTestTransaction(3),
 					time: oldTime,
@@ -393,7 +393,7 @@ func TestIsReady_KnownTxs(t *testing.T) {
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         copyTxAndTimeMap(tt.knownTxs),
+				knownTxs:         copyknownTxMap(tt.knownTxs),
 			}
 
 			builderModule.IsReady(tt.txs, 0, nil)
@@ -452,7 +452,7 @@ func TestIsReady_TxPoolModule(t *testing.T) {
 			mockTxBundlingModule := mock_builder.NewMockTxBundlingModule(ctrl)
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         make(map[common.Hash]txAndTime),
+				knownTxs:         make(map[common.Hash]knownTx),
 			}
 
 			// Create a test transaction map
@@ -483,19 +483,19 @@ func TestPreReset_Timeout(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		existingBundles      map[common.Hash]txAndTime
-		expectedBundles      map[common.Hash]txAndTime
+		existingBundles      map[common.Hash]knownTx
+		expectedBundles      map[common.Hash]knownTx
 		expectedUnexecutable bool
 	}{
 		{
 			name: "Bundle tx within PendingTimeout period",
-			existingBundles: map[common.Hash]txAndTime{
+			existingBundles: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
 				},
 			},
-			expectedBundles: map[common.Hash]txAndTime{
+			expectedBundles: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
@@ -505,13 +505,13 @@ func TestPreReset_Timeout(t *testing.T) {
 		},
 		{
 			name: "Bundle tx exceeds PendingTimeout period",
-			existingBundles: map[common.Hash]txAndTime{
+			existingBundles: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now.Add(-PendingTimeout),
 				},
 			},
-			expectedBundles: map[common.Hash]txAndTime{
+			expectedBundles: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now.Add(-PendingTimeout),
@@ -521,13 +521,13 @@ func TestPreReset_Timeout(t *testing.T) {
 		},
 		{
 			name: "Bundle tx exceeds KnownTxTimeout period",
-			existingBundles: map[common.Hash]txAndTime{
+			existingBundles: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now.Add(-KnownTxTimeout),
 				},
 			},
-			expectedBundles:      map[common.Hash]txAndTime{},
+			expectedBundles:      map[common.Hash]knownTx{},
 			expectedUnexecutable: false,
 		},
 	}
@@ -539,7 +539,7 @@ func TestPreReset_Timeout(t *testing.T) {
 			// Setup BuilderModule
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         copyTxAndTimeMap(tt.existingBundles),
+				knownTxs:         copyknownTxMap(tt.existingBundles),
 			}
 
 			builderModule.PreReset(nil, nil)
@@ -582,7 +582,7 @@ func TestPreReset_TxPoolModule(t *testing.T) {
 			mockTxBundlingModule := mock_builder.NewMockTxBundlingModule(ctrl)
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         make(map[common.Hash]txAndTime),
+				knownTxs:         make(map[common.Hash]knownTx),
 			}
 
 			mockTxPoolModule := mock_kaiax.NewMockTxPoolModule(ctrl)
@@ -609,20 +609,20 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 	tests := []struct {
 		name           string
 		maxBundleSize  uint
-		knownTxs       map[common.Hash]txAndTime
+		knownTxs       map[common.Hash]knownTx
 		readyTxs       []*types.Transaction
 		expectedResult bool
 	}{
 		{
 			name:           "Max bundle size is zero",
 			maxBundleSize:  0,
-			knownTxs:       make(map[common.Hash]txAndTime),
+			knownTxs:       make(map[common.Hash]knownTx),
 			expectedResult: false,
 		},
 		{
 			name:          "Below max bundle size limit",
 			maxBundleSize: 2,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: time.Now(),
@@ -633,7 +633,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		{
 			name:          "At max bundle size limit",
 			maxBundleSize: 2,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
@@ -648,7 +648,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		{
 			name:          "At max bundle size limit with ready txs",
 			maxBundleSize: 2,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
@@ -664,7 +664,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		{
 			name:          "Above max bundle size limit",
 			maxBundleSize: 2,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
@@ -683,7 +683,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		{
 			name:          "Above max bundle size limit with ready txs",
 			maxBundleSize: 2,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
@@ -703,7 +703,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		{
 			name:          "With unexecutable transactions",
 			maxBundleSize: 2,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
@@ -718,7 +718,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		{
 			name:          "Known transaction",
 			maxBundleSize: 2,
-			knownTxs: map[common.Hash]txAndTime{
+			knownTxs: map[common.Hash]knownTx{
 				createTestTransaction(0).Hash(): {
 					tx:   createTestTransaction(0),
 					time: now,
@@ -733,7 +733,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		{
 			name:           "No max bundle size limit",
 			maxBundleSize:  math.MaxUint64,
-			knownTxs:       make(map[common.Hash]txAndTime),
+			knownTxs:       make(map[common.Hash]knownTx),
 			expectedResult: true,
 		},
 	}
@@ -746,13 +746,13 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
-				knownTxs:         copyTxAndTimeMap(tt.knownTxs),
+				knownTxs:         copyknownTxMap(tt.knownTxs),
 			}
 
 			// Mark some transactions as unexecutable to test that they are not counted
-			for _, txAndTime := range tt.knownTxs {
-				if txAndTime.time.After(now) {
-					txAndTime.tx.MarkUnexecutable(true)
+			for _, knownTx := range tt.knownTxs {
+				if knownTx.time.After(now) {
+					knownTx.tx.MarkUnexecutable(true)
 				}
 			}
 
@@ -773,8 +773,8 @@ func createTestTransaction(nonce uint64) *types.Transaction {
 	)
 }
 
-func copyTxAndTimeMap(m map[common.Hash]txAndTime) map[common.Hash]txAndTime {
-	newMap := make(map[common.Hash]txAndTime)
+func copyknownTxMap(m map[common.Hash]knownTx) map[common.Hash]knownTx {
+	newMap := make(map[common.Hash]knownTx)
 	for k, v := range m {
 		newMap[k] = v
 	}

--- a/kaiax/builder/impl/tx_pool_wrapping_test.go
+++ b/kaiax/builder/impl/tx_pool_wrapping_test.go
@@ -389,7 +389,7 @@ func TestIsReady_KnownTxs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockTxBundlingModule := mock_builder.NewMockTxBundlingModule(ctrl)
 			mockTxBundlingModule.EXPECT().IsBundleTx(gomock.Any()).Return(tt.isBundleTxResult).AnyTimes()
-			mockTxBundlingModule.EXPECT().GetMaxBundleNum().Return(uint(math.MaxUint64)).AnyTimes()
+			mockTxBundlingModule.EXPECT().GetMaxBundleTxsInPending().Return(uint(math.MaxUint64)).AnyTimes()
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,
@@ -742,7 +742,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockTxBundlingModule := mock_builder.NewMockTxBundlingModule(ctrl)
 			mockTxBundlingModule.EXPECT().IsBundleTx(gomock.Any()).Return(true).AnyTimes()
-			mockTxBundlingModule.EXPECT().GetMaxBundleNum().Return(tt.maxBundleSize).AnyTimes()
+			mockTxBundlingModule.EXPECT().GetMaxBundleTxsInPending().Return(tt.maxBundleSize).AnyTimes()
 
 			builderModule := &BuilderWrappingModule{
 				txBundlingModule: mockTxBundlingModule,

--- a/kaiax/builder/impl/tx_pool_wrapping_test.go
+++ b/kaiax/builder/impl/tx_pool_wrapping_test.go
@@ -686,7 +686,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			name:          "Above max bundle size limit",
+			name:          "Above max bundle size limit with ready txs",
 			maxBundleSize: 2,
 			knownTxs: map[common.Hash]txAndTime{
 				createTestTransaction(0).Hash(): {

--- a/kaiax/builder/impl/tx_pool_wrapping_test.go
+++ b/kaiax/builder/impl/tx_pool_wrapping_test.go
@@ -61,7 +61,7 @@ func TestPreAddTx_KnownTxTimeout(t *testing.T) {
 					time: time.Now(),
 				},
 			},
-			expectedError: errors.New("Unable to add known bundle tx into tx pool during lock period"),
+			expectedError: ErrUnableToAddKnownBundleTx,
 		},
 		{
 			name: "Transaction after KnownTxTimeout period",

--- a/kaiax/builder/impl/tx_pool_wrapping_test.go
+++ b/kaiax/builder/impl/tx_pool_wrapping_test.go
@@ -663,7 +663,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 					time: now,
 				},
 			},
-			readyTxs:       []*types.Transaction{createTestTransaction(0)},
+			readyTxs:       []*types.Transaction{createTestTransaction(1000)},
 			expectedResult: true,
 		},
 		{
@@ -702,7 +702,7 @@ func TestIsReady_MaxBundleSize(t *testing.T) {
 					time: now,
 				},
 			},
-			readyTxs:       []*types.Transaction{createTestTransaction(0)},
+			readyTxs:       []*types.Transaction{createTestTransaction(1000)},
 			expectedResult: true,
 		},
 		{

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -42,6 +42,7 @@ type TxBundlingModule interface {
 
 	// GetMaxBundleSize returns the maximum number of transactions that can be bundled.
 	// if zero or minus value is returned, it means no limit.
+	// this limitation works properly only when a module bundles only txs by the same sender.
 	GetMaxBundleSize() int
 }
 

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -43,7 +43,7 @@ type TxBundlingModule interface {
 	// GetMaxBundleSize returns the maximum number of transactions that can be bundled.
 	// if zero or minus value is returned, it means no limit.
 	// this limitation works properly only when a module bundles only txs by the same sender.
-	GetMaxBundleSize() int
+	GetMaxBundleSize() uint
 }
 
 // Any component or module that accomodate tx bundling modules.

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -40,10 +40,10 @@ type TxBundlingModule interface {
 	// IsBundleTx returns true if the tx is a potential bundle tx.
 	IsBundleTx(tx *types.Transaction) bool
 
-	// GetMaxBundleNum returns the maximum number of transactions that can be bundled.
+	// GetMaxBundleTxsInPending returns the maximum number of transactions that can be bundled in pending.
 	// if zero or minus value is returned, it means no limit.
-	// this limitation works properly only when a module bundles only txs by the same sender.
-	GetMaxBundleNum() uint
+	// this limitation works properly only when a module bundles only sequential txs by the same sender.
+	GetMaxBundleTxsInPending() uint
 }
 
 // Any component or module that accomodate tx bundling modules.

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -40,10 +40,10 @@ type TxBundlingModule interface {
 	// IsBundleTx returns true if the tx is a potential bundle tx.
 	IsBundleTx(tx *types.Transaction) bool
 
-	// GetMaxBundleSize returns the maximum number of transactions that can be bundled.
+	// GetMaxBundleNum returns the maximum number of transactions that can be bundled.
 	// if zero or minus value is returned, it means no limit.
 	// this limitation works properly only when a module bundles only txs by the same sender.
-	GetMaxBundleSize() uint
+	GetMaxBundleNum() uint
 }
 
 // Any component or module that accomodate tx bundling modules.

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -39,6 +39,10 @@ type TxBundlingModule interface {
 
 	// IsBundleTx returns true if the tx is a potential bundle tx.
 	IsBundleTx(tx *types.Transaction) bool
+
+	// GetMaxBundleSize returns the maximum number of transactions that can be bundled.
+	// if zero or minus value is returned, it means no limit.
+	GetMaxBundleSize() int
 }
 
 // Any component or module that accomodate tx bundling modules.

--- a/kaiax/builder/mock/module.go
+++ b/kaiax/builder/mock/module.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	types "github.com/kaiachain/kaia/blockchain/types"
 	rpc "github.com/kaiachain/kaia/networks/rpc"
 )
 
@@ -47,74 +46,6 @@ func (m *MockBuilderModule) APIs() []rpc.API {
 func (mr *MockBuilderModuleMockRecorder) APIs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockBuilderModule)(nil).APIs))
-}
-
-// GetCheckBalance mocks base method.
-func (m *MockBuilderModule) GetCheckBalance() func(*types.Transaction) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCheckBalance")
-	ret0, _ := ret[0].(func(*types.Transaction) error)
-	return ret0
-}
-
-// GetCheckBalance indicates an expected call of GetCheckBalance.
-func (mr *MockBuilderModuleMockRecorder) GetCheckBalance() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckBalance", reflect.TypeOf((*MockBuilderModule)(nil).GetCheckBalance))
-}
-
-// IsModuleTx mocks base method.
-func (m *MockBuilderModule) IsModuleTx(arg0 *types.Transaction) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsModuleTx", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsModuleTx indicates an expected call of IsModuleTx.
-func (mr *MockBuilderModuleMockRecorder) IsModuleTx(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsModuleTx", reflect.TypeOf((*MockBuilderModule)(nil).IsModuleTx), arg0)
-}
-
-// IsReady mocks base method.
-func (m *MockBuilderModule) IsReady(arg0 map[uint64]*types.Transaction, arg1 uint64, arg2 types.Transactions) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsReady", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsReady indicates an expected call of IsReady.
-func (mr *MockBuilderModuleMockRecorder) IsReady(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReady", reflect.TypeOf((*MockBuilderModule)(nil).IsReady), arg0, arg1, arg2)
-}
-
-// PreAddTx mocks base method.
-func (m *MockBuilderModule) PreAddTx(arg0 *types.Transaction, arg1 bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreAddTx", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PreAddTx indicates an expected call of PreAddTx.
-func (mr *MockBuilderModuleMockRecorder) PreAddTx(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreAddTx", reflect.TypeOf((*MockBuilderModule)(nil).PreAddTx), arg0, arg1)
-}
-
-// PreReset mocks base method.
-func (m *MockBuilderModule) PreReset(arg0, arg1 *types.Header) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "PreReset", arg0, arg1)
-}
-
-// PreReset indicates an expected call of PreReset.
-func (mr *MockBuilderModuleMockRecorder) PreReset(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreReset", reflect.TypeOf((*MockBuilderModule)(nil).PreReset), arg0, arg1)
 }
 
 // Start mocks base method.

--- a/kaiax/builder/mock/tx_bundling_module.go
+++ b/kaiax/builder/mock/tx_bundling_module.go
@@ -49,6 +49,20 @@ func (mr *MockTxBundlingModuleMockRecorder) ExtractTxBundles(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractTxBundles", reflect.TypeOf((*MockTxBundlingModule)(nil).ExtractTxBundles), arg0, arg1)
 }
 
+// GetMaxBundleSize mocks base method.
+func (m *MockTxBundlingModule) GetMaxBundleSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxBundleSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetMaxBundleSize indicates an expected call of GetMaxBundleSize.
+func (mr *MockTxBundlingModuleMockRecorder) GetMaxBundleSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleSize", reflect.TypeOf((*MockTxBundlingModule)(nil).GetMaxBundleSize))
+}
+
 // IsBundleTx mocks base method.
 func (m *MockTxBundlingModule) IsBundleTx(arg0 *types.Transaction) bool {
 	m.ctrl.T.Helper()

--- a/kaiax/builder/mock/tx_bundling_module.go
+++ b/kaiax/builder/mock/tx_bundling_module.go
@@ -49,18 +49,18 @@ func (mr *MockTxBundlingModuleMockRecorder) ExtractTxBundles(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractTxBundles", reflect.TypeOf((*MockTxBundlingModule)(nil).ExtractTxBundles), arg0, arg1)
 }
 
-// GetMaxBundleNum mocks base method.
-func (m *MockTxBundlingModule) GetMaxBundleNum() uint {
+// GetMaxBundleTxsInPending mocks base method.
+func (m *MockTxBundlingModule) GetMaxBundleTxsInPending() uint {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMaxBundleNum")
+	ret := m.ctrl.Call(m, "GetMaxBundleTxsInPending")
 	ret0, _ := ret[0].(uint)
 	return ret0
 }
 
-// GetMaxBundleNum indicates an expected call of GetMaxBundleNum.
-func (mr *MockTxBundlingModuleMockRecorder) GetMaxBundleNum() *gomock.Call {
+// GetMaxBundleTxsInPending indicates an expected call of GetMaxBundleTxsInPending.
+func (mr *MockTxBundlingModuleMockRecorder) GetMaxBundleTxsInPending() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleNum", reflect.TypeOf((*MockTxBundlingModule)(nil).GetMaxBundleNum))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleTxsInPending", reflect.TypeOf((*MockTxBundlingModule)(nil).GetMaxBundleTxsInPending))
 }
 
 // IsBundleTx mocks base method.

--- a/kaiax/builder/mock/tx_bundling_module.go
+++ b/kaiax/builder/mock/tx_bundling_module.go
@@ -49,18 +49,18 @@ func (mr *MockTxBundlingModuleMockRecorder) ExtractTxBundles(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractTxBundles", reflect.TypeOf((*MockTxBundlingModule)(nil).ExtractTxBundles), arg0, arg1)
 }
 
-// GetMaxBundleSize mocks base method.
-func (m *MockTxBundlingModule) GetMaxBundleSize() uint {
+// GetMaxBundleNum mocks base method.
+func (m *MockTxBundlingModule) GetMaxBundleNum() uint {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMaxBundleSize")
+	ret := m.ctrl.Call(m, "GetMaxBundleNum")
 	ret0, _ := ret[0].(uint)
 	return ret0
 }
 
-// GetMaxBundleSize indicates an expected call of GetMaxBundleSize.
-func (mr *MockTxBundlingModuleMockRecorder) GetMaxBundleSize() *gomock.Call {
+// GetMaxBundleNum indicates an expected call of GetMaxBundleNum.
+func (mr *MockTxBundlingModuleMockRecorder) GetMaxBundleNum() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleSize", reflect.TypeOf((*MockTxBundlingModule)(nil).GetMaxBundleSize))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleNum", reflect.TypeOf((*MockTxBundlingModule)(nil).GetMaxBundleNum))
 }
 
 // IsBundleTx mocks base method.

--- a/kaiax/builder/mock/tx_bundling_module.go
+++ b/kaiax/builder/mock/tx_bundling_module.go
@@ -50,10 +50,10 @@ func (mr *MockTxBundlingModuleMockRecorder) ExtractTxBundles(arg0, arg1 interfac
 }
 
 // GetMaxBundleSize mocks base method.
-func (m *MockTxBundlingModule) GetMaxBundleSize() int {
+func (m *MockTxBundlingModule) GetMaxBundleSize() uint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaxBundleSize")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(uint)
 	return ret0
 }
 

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -38,27 +38,27 @@ var (
 		Aliases:  []string{"kaiax.module.gasless.disable"},
 		Category: "KAIAX",
 	}
-	MaxGaslessBundleNumFlag = &cli.IntFlag{
-		Name:     "gasless.max-gasless-bundle-num",
-		Usage:    "max number of gasless bundle. Default value is 100. No limit if negative value",
+	MaxBundleTxsInPendingFlag = &cli.IntFlag{
+		Name:     "gasless.max-bundle-txs-in-pending",
+		Usage:    "max number of gasless bundle txs in pending queue. Default value is 100. No limit if negative value",
 		Value:    100,
-		Aliases:  []string{"kaiax.module.gasless.max-gasless-bundle-num"},
+		Aliases:  []string{"kaiax.module.gasless.max-bundle-txs-in-pending"},
 		Category: "KAIAX",
 	}
 )
 
 type GaslessConfig struct {
 	// all tokens are allowed if AllowedTokens is nil while all are disallowed if empty slice
-	AllowedTokens       []common.Address `toml:",omitempty"`
-	Disable             bool
-	MaxGaslessBundleNum uint
+	AllowedTokens         []common.Address `toml:",omitempty"`
+	Disable               bool
+	MaxBundleTxsInPending uint
 }
 
 func DefaultGaslessConfig() *GaslessConfig {
 	return &GaslessConfig{
-		AllowedTokens:       nil,
-		Disable:             false,
-		MaxGaslessBundleNum: 100,
+		AllowedTokens:         nil,
+		Disable:               false,
+		MaxBundleTxsInPending: 100,
 	}
 }
 
@@ -77,9 +77,9 @@ func SetGaslessConfig(ctx *cli.Context, cfg *GaslessConfig) {
 	cfg.Disable = ctx.Bool(DisableFlag.Name)
 
 	// use default value if size is zero
-	if size := ctx.Int(MaxGaslessBundleNumFlag.Name); size > 0 {
-		cfg.MaxGaslessBundleNum = uint(size)
+	if size := ctx.Int(MaxBundleTxsInPendingFlag.Name); size > 0 {
+		cfg.MaxBundleTxsInPending = uint(size)
 	} else {
-		cfg.MaxGaslessBundleNum = math.MaxUint64
+		cfg.MaxBundleTxsInPending = math.MaxUint64
 	}
 }

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -17,6 +17,8 @@
 package gasless
 
 import (
+	"math"
+
 	"github.com/kaiachain/kaia/common"
 	"github.com/urfave/cli/v2"
 )
@@ -49,7 +51,7 @@ type GaslessConfig struct {
 	// all tokens are allowed if AllowedTokens is nil while all are disallowed if empty slice
 	AllowedTokens        []common.Address `toml:",omitempty"`
 	Disable              bool
-	MaxGaslessBundleSize int
+	MaxGaslessBundleSize uint
 }
 
 func DefaultGaslessConfig() *GaslessConfig {
@@ -74,7 +76,10 @@ func SetGaslessConfig(ctx *cli.Context, cfg *GaslessConfig) {
 
 	cfg.Disable = ctx.Bool(DisableFlag.Name)
 
-	if size := ctx.Int(MaxGaslessBundleSizeFlag.Name); size != 0 {
-		cfg.MaxGaslessBundleSize = size
+	// use default value if size is zero
+	if size := ctx.Int(MaxGaslessBundleSizeFlag.Name); size > 0 {
+		cfg.MaxGaslessBundleSize = uint(size)
+	} else {
+		cfg.MaxGaslessBundleSize = math.MaxUint64
 	}
 }

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -38,27 +38,27 @@ var (
 		Aliases:  []string{"kaiax.module.gasless.disable"},
 		Category: "KAIAX",
 	}
-	MaxGaslessBundleSizeFlag = &cli.IntFlag{
-		Name:     "gasless.max-gasless-bundle-size",
-		Usage:    "max size of gasless bundle. Default value is 0. No limit if negative value",
+	MaxGaslessBundleNumFlag = &cli.IntFlag{
+		Name:     "gasless.max-gasless-bundle-num",
+		Usage:    "max number of gasless bundle. Default value is 100. No limit if negative value",
 		Value:    100,
-		Aliases:  []string{"kaiax.module.gasless.max-gasless-bundle-size"},
+		Aliases:  []string{"kaiax.module.gasless.max-gasless-bundle-num"},
 		Category: "KAIAX",
 	}
 )
 
 type GaslessConfig struct {
 	// all tokens are allowed if AllowedTokens is nil while all are disallowed if empty slice
-	AllowedTokens        []common.Address `toml:",omitempty"`
-	Disable              bool
-	MaxGaslessBundleSize uint
+	AllowedTokens       []common.Address `toml:",omitempty"`
+	Disable             bool
+	MaxGaslessBundleNum uint
 }
 
 func DefaultGaslessConfig() *GaslessConfig {
 	return &GaslessConfig{
-		AllowedTokens:        nil,
-		Disable:              false,
-		MaxGaslessBundleSize: 100,
+		AllowedTokens:       nil,
+		Disable:             false,
+		MaxGaslessBundleNum: 100,
 	}
 }
 
@@ -77,9 +77,9 @@ func SetGaslessConfig(ctx *cli.Context, cfg *GaslessConfig) {
 	cfg.Disable = ctx.Bool(DisableFlag.Name)
 
 	// use default value if size is zero
-	if size := ctx.Int(MaxGaslessBundleSizeFlag.Name); size > 0 {
-		cfg.MaxGaslessBundleSize = uint(size)
+	if size := ctx.Int(MaxGaslessBundleNumFlag.Name); size > 0 {
+		cfg.MaxGaslessBundleNum = uint(size)
 	} else {
-		cfg.MaxGaslessBundleSize = math.MaxUint64
+		cfg.MaxGaslessBundleNum = math.MaxUint64
 	}
 }

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -38,7 +38,7 @@ var (
 	}
 	MaxGaslessBundleSizeFlag = &cli.IntFlag{
 		Name:     "gasless.max-gasless-bundle-size",
-		Usage:    "max size of gasless bundle, default value if 0, no limit if minus value",
+		Usage:    "max size of gasless bundle. Default value is 0. No limit if negative value",
 		Value:    100,
 		Aliases:  []string{"kaiax.module.gasless.max-gasless-bundle-size"},
 		Category: "KAIAX",

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -26,21 +26,21 @@ var (
 		Name:     "gasless.allowed-tokens",
 		Usage:    "allow token addresses for gasless module, allow all tokens if all",
 		Value:    cli.NewStringSlice("all"),
-		Aliases:  []string{"genesis.module.gasless.allowed-tokens"},
+		Aliases:  []string{"kaiax.module.gasless.allowed-tokens"},
 		Category: "KAIAX",
 	}
 	DisableFlag = &cli.BoolFlag{
 		Name:     "gasless.disable",
 		Usage:    "disable gasless module",
 		Value:    false,
-		Aliases:  []string{"genesis.module.gasless.disable"},
+		Aliases:  []string{"kaiax.module.gasless.disable"},
 		Category: "KAIAX",
 	}
 	MaxGaslessBundleSizeFlag = &cli.IntFlag{
 		Name:     "gasless.max-gasless-bundle-size",
 		Usage:    "max size of gasless bundle, default value if 0, no limit if minus value",
 		Value:    100,
-		Aliases:  []string{"genesis.module.gasless.max-gasless-bundle-size"},
+		Aliases:  []string{"kaiax.module.gasless.max-gasless-bundle-size"},
 		Category: "KAIAX",
 	}
 )

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -36,28 +36,45 @@ var (
 		Aliases:  []string{"genesis.module.gasless.disable"},
 		Category: "KAIAX",
 	}
+	MaxGaslessBundleSizeFlag = &cli.IntFlag{
+		Name:     "gasless.max-gasless-bundle-size",
+		Usage:    "max size of gasless bundle, default value if 0, no limit if minus value",
+		Value:    100,
+		Aliases:  []string{"genesis.module.gasless.max-gasless-bundle-size"},
+		Category: "KAIAX",
+	}
 )
 
 type GaslessConfig struct {
 	// all tokens are allowed if AllowedTokens is nil while all are disallowed if empty slice
-	AllowedTokens []common.Address `toml:",omitempty"`
-	Disable       bool
+	AllowedTokens        []common.Address `toml:",omitempty"`
+	Disable              bool
+	MaxGaslessBundleSize int
 }
 
-func GetGaslessConfig(ctx *cli.Context) *GaslessConfig {
-	allowedTokens := []common.Address(nil)
-	for _, addr := range ctx.StringSlice(AllowedTokensFlag.Name) {
-		if addr == "all" {
-			allowedTokens = nil
-			break
-		}
-		if allowedTokens == nil {
-			allowedTokens = []common.Address{}
-		}
-		allowedTokens = append(allowedTokens, common.HexToAddress(addr))
-	}
+func DefaultGaslessConfig() *GaslessConfig {
 	return &GaslessConfig{
-		AllowedTokens: allowedTokens,
-		Disable:       ctx.Bool(DisableFlag.Name),
+		AllowedTokens:        nil,
+		Disable:              false,
+		MaxGaslessBundleSize: 100,
+	}
+}
+
+func SetGaslessConfig(ctx *cli.Context, cfg *GaslessConfig) {
+	if tokens := ctx.StringSlice(AllowedTokensFlag.Name); tokens != nil {
+		cfg.AllowedTokens = []common.Address{}
+		for _, addr := range tokens {
+			if addr == "all" {
+				cfg.AllowedTokens = nil
+				break
+			}
+			cfg.AllowedTokens = append(cfg.AllowedTokens, common.HexToAddress(addr))
+		}
+	}
+
+	cfg.Disable = ctx.Bool(DisableFlag.Name)
+
+	if size := ctx.Int(MaxGaslessBundleSizeFlag.Name); size != 0 {
+		cfg.MaxGaslessBundleSize = size
 	}
 }

--- a/kaiax/gasless/impl/api.go
+++ b/kaiax/gasless/impl/api.go
@@ -129,6 +129,7 @@ type GaslessInfoResult struct {
 	IsDisabled    bool             `json:"isDisabled"`
 	SwapRouter    common.Address   `json:"swapRouter"`
 	AllowedTokens []common.Address `json:"allowedTokens"`
+	MaxBundleTxs  uint             `json:"maxBundleTxs"`
 }
 
 func (s *GaslessAPI) GaslessInfo() *GaslessInfoResult {
@@ -140,5 +141,6 @@ func (s *GaslessAPI) GaslessInfo() *GaslessInfoResult {
 		IsDisabled:    s.b.IsDisabled(),
 		SwapRouter:    s.b.swapRouter,
 		AllowedTokens: at,
+		MaxBundleTxs:  s.b.GetMaxBundleTxsInPending(),
 	}
 }

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -71,6 +71,6 @@ func (g *GaslessModule) IsBundleTx(tx *types.Transaction) bool {
 	return g.IsModuleTx(tx)
 }
 
-func (g *GaslessModule) GetMaxBundleSize() int {
+func (g *GaslessModule) GetMaxBundleSize() uint {
 	return g.GaslessConfig.MaxGaslessBundleSize
 }

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -71,6 +71,6 @@ func (g *GaslessModule) IsBundleTx(tx *types.Transaction) bool {
 	return g.IsModuleTx(tx)
 }
 
-func (g *GaslessModule) GetMaxBundleNum() uint {
-	return g.GaslessConfig.MaxGaslessBundleNum
+func (g *GaslessModule) GetMaxBundleTxsInPending() uint {
+	return g.GaslessConfig.MaxBundleTxsInPending
 }

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -71,6 +71,6 @@ func (g *GaslessModule) IsBundleTx(tx *types.Transaction) bool {
 	return g.IsModuleTx(tx)
 }
 
-func (g *GaslessModule) GetMaxBundleSize() uint {
-	return g.GaslessConfig.MaxGaslessBundleSize
+func (g *GaslessModule) GetMaxBundleNum() uint {
+	return g.GaslessConfig.MaxGaslessBundleNum
 }

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -72,5 +72,5 @@ func (g *GaslessModule) IsBundleTx(tx *types.Transaction) bool {
 }
 
 func (g *GaslessModule) GetMaxBundleSize() int {
-	return 100
+	return g.GaslessConfig.MaxGaslessBundleSize
 }

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -70,3 +70,7 @@ func (g *GaslessModule) ExtractTxBundles(txs []*types.Transaction, prevBundles [
 func (g *GaslessModule) IsBundleTx(tx *types.Transaction) bool {
 	return g.IsModuleTx(tx)
 }
+
+func (g *GaslessModule) GetMaxBundleSize() int {
+	return 100
+}

--- a/kaiax/gasless/impl/helper_test.go
+++ b/kaiax/gasless/impl/helper_test.go
@@ -215,6 +215,10 @@ func (pool *testTxPool) GetCurrentState() *state.StateDB {
 	return pool.statedb
 }
 
+func (pool *testTxPool) PendingUnlocked() (map[common.Address]types.Transactions, error) {
+	return nil, nil
+}
+
 func testAllocStorage() blockchain.GenesisAlloc {
 	allocStorage := system.AllocRegistry(&params.RegistryConfig{
 		Records: map[string]common.Address{

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -57,6 +57,8 @@ func (g *GaslessModule) IsReady(txs map[uint64]*types.Transaction, i uint64, rea
 
 func (g *GaslessModule) PreReset(oldHead, newHead *types.Header) {}
 
+func (g *GaslessModule) PostReset(oldHead, newHead *types.Header) {}
+
 // isApproveTxReady assumes that the caller checked `g.IsApproveTx(approveTx)`
 func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) bool {
 	addr, err := types.Sender(g.signer, approveTx)

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -30,6 +30,9 @@ func (g *GaslessModule) PreAddTx(tx *types.Transaction, local bool) error {
 }
 
 func (g *GaslessModule) IsModuleTx(tx *types.Transaction) bool {
+	if tx == nil {
+		return false
+	}
 	return g.IsApproveTx(tx) || g.IsSwapTx(tx)
 }
 

--- a/kaiax/gasless/impl/tx_pool_test.go
+++ b/kaiax/gasless/impl/tx_pool_test.go
@@ -68,6 +68,10 @@ func TestIsModuleTx(t *testing.T) {
 			makeTx(t, privkey, 0, common.HexToAddress("0xAAAA"), big.NewInt(0), 1000000, big.NewInt(1), nil),
 			false,
 		},
+		{
+			nil,
+			false,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -64,10 +64,10 @@ func (mr *MockGaslessModuleMockRecorder) GetCheckBalance() *gomock.Call {
 }
 
 // GetMaxBundleSize mocks base method.
-func (m *MockGaslessModule) GetMaxBundleSize() int {
+func (m *MockGaslessModule) GetMaxBundleSize() uint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaxBundleSize")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(uint)
 	return ret0
 }
 

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -63,18 +63,18 @@ func (mr *MockGaslessModuleMockRecorder) GetCheckBalance() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckBalance", reflect.TypeOf((*MockGaslessModule)(nil).GetCheckBalance))
 }
 
-// GetMaxBundleNum mocks base method.
-func (m *MockGaslessModule) GetMaxBundleNum() uint {
+// GetMaxBundleTxsInPending mocks base method.
+func (m *MockGaslessModule) GetMaxBundleTxsInPending() uint {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMaxBundleNum")
+	ret := m.ctrl.Call(m, "GetMaxBundleTxsInPending")
 	ret0, _ := ret[0].(uint)
 	return ret0
 }
 
-// GetMaxBundleNum indicates an expected call of GetMaxBundleNum.
-func (mr *MockGaslessModuleMockRecorder) GetMaxBundleNum() *gomock.Call {
+// GetMaxBundleTxsInPending indicates an expected call of GetMaxBundleTxsInPending.
+func (mr *MockGaslessModuleMockRecorder) GetMaxBundleTxsInPending() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleNum", reflect.TypeOf((*MockGaslessModule)(nil).GetMaxBundleNum))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleTxsInPending", reflect.TypeOf((*MockGaslessModule)(nil).GetMaxBundleTxsInPending))
 }
 
 // IsBundleTx mocks base method.

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -63,18 +63,18 @@ func (mr *MockGaslessModuleMockRecorder) GetCheckBalance() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckBalance", reflect.TypeOf((*MockGaslessModule)(nil).GetCheckBalance))
 }
 
-// GetMaxBundleSize mocks base method.
-func (m *MockGaslessModule) GetMaxBundleSize() uint {
+// GetMaxBundleNum mocks base method.
+func (m *MockGaslessModule) GetMaxBundleNum() uint {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMaxBundleSize")
+	ret := m.ctrl.Call(m, "GetMaxBundleNum")
 	ret0, _ := ret[0].(uint)
 	return ret0
 }
 
-// GetMaxBundleSize indicates an expected call of GetMaxBundleSize.
-func (mr *MockGaslessModuleMockRecorder) GetMaxBundleSize() *gomock.Call {
+// GetMaxBundleNum indicates an expected call of GetMaxBundleNum.
+func (mr *MockGaslessModuleMockRecorder) GetMaxBundleNum() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleSize", reflect.TypeOf((*MockGaslessModule)(nil).GetMaxBundleSize))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleNum", reflect.TypeOf((*MockGaslessModule)(nil).GetMaxBundleNum))
 }
 
 // IsBundleTx mocks base method.

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -133,6 +133,18 @@ func (mr *MockGaslessModuleMockRecorder) PostInsertBlock(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostInsertBlock", reflect.TypeOf((*MockGaslessModule)(nil).PostInsertBlock), arg0)
 }
 
+// PostReset mocks base method.
+func (m *MockGaslessModule) PostReset(arg0, arg1 *types.Header) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PostReset", arg0, arg1)
+}
+
+// PostReset indicates an expected call of PostReset.
+func (mr *MockGaslessModuleMockRecorder) PostReset(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostReset", reflect.TypeOf((*MockGaslessModule)(nil).PostReset), arg0, arg1)
+}
+
 // PreAddTx mocks base method.
 func (m *MockGaslessModule) PreAddTx(arg0 *types.Transaction, arg1 bool) error {
 	m.ctrl.T.Helper()

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -63,6 +63,20 @@ func (mr *MockGaslessModuleMockRecorder) GetCheckBalance() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCheckBalance", reflect.TypeOf((*MockGaslessModule)(nil).GetCheckBalance))
 }
 
+// GetMaxBundleSize mocks base method.
+func (m *MockGaslessModule) GetMaxBundleSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxBundleSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetMaxBundleSize indicates an expected call of GetMaxBundleSize.
+func (mr *MockGaslessModuleMockRecorder) GetMaxBundleSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleSize", reflect.TypeOf((*MockGaslessModule)(nil).GetMaxBundleSize))
+}
+
 // IsBundleTx mocks base method.
 func (m *MockGaslessModule) IsBundleTx(arg0 *types.Transaction) bool {
 	m.ctrl.T.Helper()

--- a/kaiax/interface.go
+++ b/kaiax/interface.go
@@ -165,6 +165,7 @@ type TxPoolModule interface {
 //go:generate mockgen -destination=./mock/tx_pool_for_caller.go -package=mock github.com/kaiachain/kaia/kaiax TxPoolForCaller
 type TxPoolForCaller interface {
 	GetCurrentState() *state.StateDB
+	PendingUnlocked() (map[common.Address]types.Transactions, error)
 }
 
 // Any component or module that accomodate txpool modules.

--- a/kaiax/interface.go
+++ b/kaiax/interface.go
@@ -157,6 +157,9 @@ type TxPoolModule interface {
 
 	// Additional actions to perform before the txpool is reset.
 	PreReset(oldHead, newHead *types.Header)
+
+	// Additional actions to perform after the txpool is reset.
+	PostReset(oldHead, newHead *types.Header)
 }
 
 //go:generate mockgen -destination=./mock/tx_pool_for_caller.go -package=mock github.com/kaiachain/kaia/kaiax TxPoolForCaller

--- a/kaiax/mock/tx_pool_for_caller.go
+++ b/kaiax/mock/tx_pool_for_caller.go
@@ -9,6 +9,8 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	state "github.com/kaiachain/kaia/blockchain/state"
+	types "github.com/kaiachain/kaia/blockchain/types"
+	common "github.com/kaiachain/kaia/common"
 )
 
 // MockTxPoolForCaller is a mock of TxPoolForCaller interface.
@@ -46,4 +48,19 @@ func (m *MockTxPoolForCaller) GetCurrentState() *state.StateDB {
 func (mr *MockTxPoolForCallerMockRecorder) GetCurrentState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentState", reflect.TypeOf((*MockTxPoolForCaller)(nil).GetCurrentState))
+}
+
+// PendingUnlocked mocks base method.
+func (m *MockTxPoolForCaller) PendingUnlocked() (map[common.Address]types.Transactions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PendingUnlocked")
+	ret0, _ := ret[0].(map[common.Address]types.Transactions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PendingUnlocked indicates an expected call of PendingUnlocked.
+func (mr *MockTxPoolForCallerMockRecorder) PendingUnlocked() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingUnlocked", reflect.TypeOf((*MockTxPoolForCaller)(nil).PendingUnlocked))
 }

--- a/kaiax/mock/tx_pool_module.go
+++ b/kaiax/mock/tx_pool_module.go
@@ -76,6 +76,18 @@ func (mr *MockTxPoolModuleMockRecorder) IsReady(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReady", reflect.TypeOf((*MockTxPoolModule)(nil).IsReady), arg0, arg1, arg2)
 }
 
+// PostReset mocks base method.
+func (m *MockTxPoolModule) PostReset(arg0, arg1 *types.Header) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "PostReset", arg0, arg1)
+}
+
+// PostReset indicates an expected call of PostReset.
+func (mr *MockTxPoolModuleMockRecorder) PostReset(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostReset", reflect.TypeOf((*MockTxPoolModule)(nil).PostReset), arg0, arg1)
+}
+
 // PreAddTx mocks base method.
 func (m *MockTxPoolModule) PreAddTx(arg0 *types.Transaction, arg1 bool) error {
 	m.ctrl.T.Helper()

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -568,7 +568,7 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 		mJsonRpc = append(mJsonRpc, mGasless)
 	}
 
-	mTxPool = builder_impl.WrapAndConcatenateBundlingModules(mTxBundling, mTxPool)
+	mTxPool = builder_impl.WrapAndConcatenateBundlingModules(mTxBundling, mTxPool, s.txPool)
 
 	// Register modules to respective components
 	// TODO-kaiax: Organize below lines.

--- a/node/cn/config.go
+++ b/node/cn/config.go
@@ -71,10 +71,7 @@ func GetDefaultConfig() *Config {
 		Istanbul:      *istanbul.DefaultConfig,
 		RPCEVMTimeout: 5 * time.Second,
 
-		Gasless: &gasless.GaslessConfig{
-			AllowedTokens: nil,
-			Disable:       false,
-		},
+		Gasless: gasless.DefaultGaslessConfig(),
 	}
 }
 

--- a/work/mocks/txpool_mock.go
+++ b/work/mocks/txpool_mock.go
@@ -166,6 +166,21 @@ func (mr *MockTxPoolMockRecorder) Pending() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pending", reflect.TypeOf((*MockTxPool)(nil).Pending))
 }
 
+// PendingUnlocked mocks base method.
+func (m *MockTxPool) PendingUnlocked() (map[common.Address]types.Transactions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PendingUnlocked")
+	ret0, _ := ret[0].(map[common.Address]types.Transactions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PendingUnlocked indicates an expected call of PendingUnlocked.
+func (mr *MockTxPoolMockRecorder) PendingUnlocked() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingUnlocked", reflect.TypeOf((*MockTxPool)(nil).PendingUnlocked))
+}
+
 // RegisterTxPoolModule mocks base method.
 func (m *MockTxPool) RegisterTxPoolModule(arg0 ...kaiax.TxPoolModule) {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -59,6 +59,7 @@ type TxPool interface {
 	// Pending should return pending transactions.
 	// The slice should be modifiable by the caller.
 	Pending() (map[common.Address]types.Transactions, error)
+	PendingUnlocked() (map[common.Address]types.Transactions, error)
 
 	CachedPendingTxsByCount(count int) types.Transactions
 


### PR DESCRIPTION
## Proposed changes

This PR mitigates overflow of invalid gasless transactions.

### Problem

Even if users don't have any tokens, their gasless transactions can be promoted to pending. If they send a lot of such transactions, empty blocks keep to be created because users can set huge amount of gas price and invalid gasless transactions can occupy the head of TransactionsByPriceAndNonce.

### Solution

All nodes limit the number of bundle txs in the pending. In the gasless module, this max number is 100 as default.

Let's take 3 as the max number for example about `IsReady(txs, next, ready)`, where bundle txs pair (An, Bn).

- `A1` will be promoted if `knownTxs: (), txs: (1: A1, 2: B1), next: 1, ready: ()`.
- `B1` will be promoted if `knownTxs: (A1), txs:(1: A1, 2: B1), next: 2, ready: (A1)`.
- `A2` will be rejected if `knownTxs: (A1, B1), txs:(1: A2, 2: B2), next: 1, ready: ()` because `B2` also need to be promoted but knownTxs `(A1, B1, A2, B2)` exceeds the limit.
- `B1` will be promoted if `knownTxs: (A1), txs:(1: A1, 2: B1, 3: T1, 4: T2), next: 1, ready: (A1)` because T1 and T2 aren't bundle txs.
- `A1` will be rejected if `knownTxs: (), txs: (1: A1), next: 1, ready: ()` because a child module rejects A1 due to lack of `B1`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
