### PR TITLE
txpool: add prague validation in txpool for TxTypeEthereumSetCode

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -707,7 +707,12 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 		return ErrTxTypeNotSupported
 	}
 	// Reject dynamic fee transactions until EIP-1559 activates.
-	if !pool.rules.IsEthTxType && (tx.Type() == types.TxTypeEthereumDynamicFee || tx.Type() == types.TxTypeEthereumSetCode) {
+	if !pool.rules.IsEthTxType && tx.Type() == types.TxTypeEthereumDynamicFee {
+		return ErrTxTypeNotSupported
+	}
+
+	// Reject set code transactions until EIP-7600(prague) activates.
+	if !pool.rules.IsEthTxType && !pool.rules.IsPrague && tx.Type() == types.TxTypeEthereumSetCode {
 		return ErrTxTypeNotSupported
 	}
 

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -712,7 +712,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction) error {
 	}
 
 	// Reject set code transactions until EIP-7600(prague) activates.
-	if !pool.rules.IsEthTxType && !pool.rules.IsPrague && tx.Type() == types.TxTypeEthereumSetCode {
+	if !pool.rules.IsPrague && tx.Type() == types.TxTypeEthereumSetCode {
 		return ErrTxTypeNotSupported
 	}
 

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -1988,7 +1988,10 @@ func TestSetCodeTransactions(t *testing.T) {
 	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 	blockchain := &testBlockChain{statedb, 1000000, new(event.Feed)}
 
-	pool := NewTxPool(testTxPoolConfig, kip71Config, blockchain, &dummyGovModule{chainConfig: kip71Config})
+	eip7600Config := kip71Config.Copy()
+	eip7600Config.PragueCompatibleBlock = common.Big0
+
+	pool := NewTxPool(testTxPoolConfig, eip7600Config, blockchain, &dummyGovModule{chainConfig: eip7600Config})
 	defer pool.Stop()
 
 	// Create the test accounts

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -1987,7 +1987,7 @@ func TestValidationTxSizeAfterRLP(t *testing.T) {
 	}
 }
 
-func TestValidationTxSizeAfterRLPShanghai(t *testing.T) {
+func TestValidationTxSizeAfterRLPPrague(t *testing.T) {
 	testTxTypes := []types.TxType{}
 	for i := types.TxTypeLegacyTransaction; i < types.TxTypeEthereumLast; i++ {
 		if i == types.TxTypeKaiaLast {
@@ -2006,7 +2006,7 @@ func TestValidationTxSizeAfterRLPShanghai(t *testing.T) {
 	prof := profile.NewProfiler()
 
 	// Initialize blockchain
-	bcdata, err := NewBCDataWithForkConfig(6, 4, Forks["Shanghai"])
+	bcdata, err := NewBCDataWithForkConfig(6, 4, Forks["Prague"])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/tx_validation_test.go
+++ b/tests/tx_validation_test.go
@@ -1940,7 +1940,7 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 	prof := profile.NewProfiler()
 
 	// Initialize blockchain
-	bcdata, err := NewBCDataWithForkConfig(6, 4, Forks["EthTxType"])
+	bcdata, err := NewBCDataWithForkConfig(6, 4, Forks["Prague"])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1975,7 +1975,7 @@ func TestValidationPoolResetAfterSenderKeyChange(t *testing.T) {
 			types.TxValueKeyTo:            (*common.Address)(nil),
 			types.TxValueKeyAmount:        big.NewInt(0),
 			types.TxValueKeyGasLimit:      gasLimit,
-			types.TxValueKeyGasPrice:      big.NewInt(0),
+			types.TxValueKeyGasPrice:      big.NewInt(25 * params.Gkei),
 			types.TxValueKeyHumanReadable: false,
 			types.TxValueKeyData:          common.FromHex(code),
 			types.TxValueKeyCodeFormat:    params.CodeFormatEVM,


### PR DESCRIPTION
## Proposed changes

Add Prague validation in txpool for TxTypeEthereumSetCode, which must be rejected before Prague activation

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
