### PR TITLE
state: remove the condition of tx type for AddAddressToAccessList

### DIFF
--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -379,6 +379,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// - reset transient storage(eip 1153)
 	st.state.Prepare(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Context.Coinbase, msgTo, vm.ActivePrecompiles(rules), msg.AccessList())
 
+        // skip when creating a new contract
 	if msgTo != nil {
 		// SetCode sender nonce increment should be done before set code process.
 		if msg.Type() == types.TxTypeEthereumSetCode {

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -338,11 +338,12 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	var (
-		msg          = st.msg
-		msgTo        = msg.To()
-		rules        = st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
-		floorDataGas uint64
-		err          error
+		msg              = st.msg
+		msgTo            = msg.To()
+		contractCreation = msgTo == nil
+		rules            = st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber)
+		floorDataGas     uint64
+		err              error
 	)
 
 	if st.evm.Config.Debug {
@@ -380,7 +381,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	st.state.Prepare(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Context.Coinbase, msgTo, vm.ActivePrecompiles(rules), msg.AccessList())
 
 	// skip when creating a new contract
-	if msgTo != nil {
+	if !contractCreation {
 		// Unlike other transaction types, where the sender nonce is incremented in msg.Execute(),
 		// SetCodeTx's sender nonce should be incremented before processing AuthList.
 		if msg.Type() == types.TxTypeEthereumSetCode {

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -410,7 +410,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	// Check whether the init code size has been exceeded.
-	if rules.IsShanghai && msgTo == nil && len(st.data) > params.MaxInitCodeSize {
+	if rules.IsShanghai && contractCreation && len(st.data) > params.MaxInitCodeSize {
 		return nil, fmt.Errorf("%w: code size %v limit %v", ErrMaxInitCodeSizeExceeded, len(st.data), params.MaxInitCodeSize)
 	}
 

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -379,7 +379,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// - reset transient storage(eip 1153)
 	st.state.Prepare(rules, msg.ValidatedSender(), msg.ValidatedFeePayer(), st.evm.Context.Coinbase, msgTo, vm.ActivePrecompiles(rules), msg.AccessList())
 
-        // skip when creating a new contract
+	// skip when creating a new contract
 	if msgTo != nil {
 		// SetCode sender nonce increment should be done before set code process.
 		if msg.Type() == types.TxTypeEthereumSetCode {

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -381,7 +381,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// skip when creating a new contract
 	if msgTo != nil {
-		// SetCode sender nonce increment should be done before set code process.
+		// Unlike other transaction types, where the sender nonce is incremented in msg.Execute(),
+		// SetCodeTx's sender nonce should be incremented before processing AuthList.
 		if msg.Type() == types.TxTypeEthereumSetCode {
 			// Increment the nonce for the next transaction.
 			// Note: EIP-7702 authorizations can also modify the nonce. We perform

--- a/blockchain/state_transition_test.go
+++ b/blockchain/state_transition_test.go
@@ -459,6 +459,7 @@ func TestStateTransition_EIP7623(t *testing.T) {
 	mockStateDB.EXPECT().GetNonce(gomock.Any()).Return(uint64(0)).AnyTimes()
 	mockStateDB.EXPECT().Prepare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	mockStateDB.EXPECT().IncNonce(gomock.Any()).Return().AnyTimes()
+	mockStateDB.EXPECT().GetCode(gomock.Any()).Return(nil).AnyTimes()
 	mockStateDB.EXPECT().Snapshot().Return(1).AnyTimes()
 	mockStateDB.EXPECT().Exist(gomock.Any()).Return(false).AnyTimes()
 	mockStateDB.EXPECT().GetRefund().Return(uint64(0)).AnyTimes()


### PR DESCRIPTION
## Proposed changes

For wide adoption of calling `AddAddressToAccessList`
* Remove the condition of `TxTypeEthereumSetCode` for `AddAddressToAccessList`
* Add the condition of `msgTo != nil` to call `AddAddressToAccessList` except `ContractCreation`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

