### PR TITLE
kaiax/auction: Enable subscribe_log in auction namespace

### DIFF
--- a/client/kaia_client.go
+++ b/client/kaia_client.go
@@ -372,7 +372,11 @@ func (ec *Client) FilterLogs(ctx context.Context, q kaia.FilterQuery) ([]types.L
 
 // SubscribeFilterLogs subscribes to the results of a streaming filter query.
 func (ec *Client) SubscribeFilterLogs(ctx context.Context, q kaia.FilterQuery, ch chan<- types.Log) (kaia.Subscription, error) {
-	return ec.c.KaiaSubscribe(ctx, ch, "logs", toFilterArg(q))
+	sub, err := ec.c.KaiaSubscribe(ctx, ch, "logs", toFilterArg(q))
+	if err == nil {
+		return sub, err
+	}
+	return ec.c.AuctionSubscribe(ctx, ch, "logs", toFilterArg(q))
 }
 
 func toFilterArg(q kaia.FilterQuery) interface{} {

--- a/kaiax/auction/impl/api.go
+++ b/kaiax/auction/impl/api.go
@@ -143,6 +143,10 @@ func (api *AuctionAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) 
 	return api.f.NewHeads(ctx)
 }
 
+func (api *AuctionAPI) Logs(ctx context.Context, crit filters.FilterCriteria) (*rpc.Subscription, error) {
+	return api.f.Logs(ctx, crit)
+}
+
 func makeRPCOutput(bidHash common.Hash, err error) RPCOutput {
 	m := make(map[string]any)
 	if err != nil {


### PR DESCRIPTION
## Proposed changes

This PR enables the subscribe_log method in the auction namespace.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
