### PR TITLE
kaiax/valset,gov: improve migration threads

### DIFF
--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -20,6 +20,11 @@ import (
 var (
 	_ headergov.HeaderGovModule = (*headerGovModule)(nil)
 
+	// A background migration thread scans the epoch and stores all votes in DB.
+	// To prevent high CPU usage, the migration loop is throttled with a 50ms delay per iteration.
+	// For example, if migration starts at block 180,000,000, the entire process will take at least 0.5 hour.
+	migrationThrottlingDelay = 50 * time.Millisecond
+
 	logger = log.NewModuleLogger(log.KaiaxGov)
 )
 
@@ -156,7 +161,7 @@ func (h *headerGovModule) migrate() {
 			return
 		}
 
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(migrationThrottlingDelay)
 
 		border -= 1
 		h.accumulateVotesInEpoch(border)

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -151,38 +151,16 @@ func (h *headerGovModule) migrate() {
 
 	border := *pBorder
 
-	isThrottled := &atomic.Bool{}
-	done := make(chan struct{})
-
-	go func() {
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				blockTime := time.Unix(h.Chain.CurrentBlock().Time().Int64(), 0)
-				isThrottled.Store(time.Now().UTC().After(blockTime.UTC().Add(100 * time.Second)))
-			case <-done:
-				return
-			}
-		}
-	}()
-
 	for int64(border) > 0 {
 		if h.quit.Load() == 1 {
 			return
 		}
 
-		if isThrottled.Load() {
-			time.Sleep(50 * time.Millisecond)
-		}
+		time.Sleep(50 * time.Millisecond)
 
 		border -= 1
 		h.accumulateVotesInEpoch(border)
 	}
-
-	close(done)
 
 	if border == 0 {
 		logger.Info("HeaderGovModule migrate complete")

--- a/kaiax/valset/impl/getter_council.go
+++ b/kaiax/valset/impl/getter_council.go
@@ -61,10 +61,7 @@ func (v *ValsetModule) getCouncilDB(num uint64) (*valset.AddressSet, bool, error
 	if pMinVoteNum == nil {
 		return nil, false, errNoLowestScannedNum
 	}
-	if v.validatorVoteBlockNumsCache == nil {
-		v.validatorVoteBlockNumsCache = ReadValidatorVoteBlockNums(v.ChainKv)
-	}
-	nums := v.validatorVoteBlockNumsCache
+	nums := v.readValidatorVoteBlockNumsCached()
 	if nums == nil {
 		return nil, false, errNoVoteBlockNums
 	}
@@ -85,6 +82,19 @@ func (v *ValsetModule) readLowestScannedVoteNumCached() *uint64 {
 		v.lowestScannedVoteNumCache = ReadLowestScannedVoteNum(v.ChainKv)
 	}
 	return v.lowestScannedVoteNumCache
+}
+
+func (v *ValsetModule) readValidatorVoteBlockNumsCached() []uint64 {
+	if v.validatorVoteBlockNumsCache == nil {
+		v.validatorVoteBlockNumsCache = ReadValidatorVoteBlockNums(v.ChainKv)
+		if v.validatorVoteBlockNumsCache == nil {
+			return nil
+		}
+	}
+
+	nums := make([]uint64, len(v.validatorVoteBlockNumsCache))
+	copy(nums, v.validatorVoteBlockNumsCache)
+	return nums
 }
 
 // lastNumLessThan returns the last (rightmost) number in the list that is less than the given number.
@@ -182,10 +192,7 @@ func (v *ValsetModule) getValidIstanbulSnapshotBefore(snapshotNum uint64) (*vals
 	}
 
 	pMinVoteNum := v.readLowestScannedVoteNumCached()
-	if v.validatorVoteBlockNumsCache == nil {
-		v.validatorVoteBlockNumsCache = ReadValidatorVoteBlockNums(v.ChainKv)
-	}
-	nums := v.validatorVoteBlockNumsCache
+	nums := v.readValidatorVoteBlockNumsCached()
 	if nums == nil {
 		return nil, errNoVoteBlockNums
 	}

--- a/kaiax/valset/impl/getter_council.go
+++ b/kaiax/valset/impl/getter_council.go
@@ -191,17 +191,18 @@ func (v *ValsetModule) getValidIstanbulSnapshotBefore(snapshotNum uint64) (*vals
 		return v.getCouncilGenesis()
 	}
 
-	pMinVoteNum := v.readLowestScannedVoteNumCached()
 	nums := v.readValidatorVoteBlockNumsCached()
 	if nums == nil {
 		return nil, errNoVoteBlockNums
 	}
-	header := v.Chain.GetHeaderByNumber(snapshotNum)
 
 	// If there were no votes in the range [lowestScannedVoteNum, snapshotNum],
 	// we fall back to the nearest snapshot *before* `lowestScannedVoteNum`.
-	if pMinVoteNum != nil && *pMinVoteNum < snapshotNum && lastNumLessThan(nums, snapshotNum) < *pMinVoteNum {
+	var header *types.Header
+	if pMinVoteNum := v.readLowestScannedVoteNumCached(); pMinVoteNum != nil && *pMinVoteNum < snapshotNum && lastNumLessThan(nums, snapshotNum) < *pMinVoteNum {
 		header = v.Chain.GetHeaderByNumber(roundDown(*pMinVoteNum, istanbulCheckpointInterval))
+	} else {
+		header = v.Chain.GetHeaderByNumber(snapshotNum)
 	}
 
 	if header == nil {

--- a/kaiax/valset/impl/getter_proposers.go
+++ b/kaiax/valset/impl/getter_proposers.go
@@ -102,8 +102,7 @@ func (v *ValsetModule) scanBlocks(pUpdateNum, pUpdateInterval uint64) []uint64 {
 	scanBlocks := make([]uint64, 0)
 
 	// if migrated, scanBlocks is set as voteBlockNums between [pUpdateNum, pUpdateNum+pUpdateInterval)
-	pMinVoteNum := ReadLowestScannedVoteNum(v.ChainKv)
-
+	pMinVoteNum := v.readLowestScannedVoteNumCached()
 	if pMinVoteNum != nil && *pMinVoteNum <= pUpdateNum {
 		if v.validatorVoteBlockNumsCache != nil {
 			scanBlocks = make([]uint64, len(v.validatorVoteBlockNumsCache))

--- a/kaiax/valset/impl/getter_proposers.go
+++ b/kaiax/valset/impl/getter_proposers.go
@@ -104,16 +104,9 @@ func (v *ValsetModule) scanBlocks(pUpdateNum, pUpdateInterval uint64) []uint64 {
 	// if migrated, scanBlocks is set as voteBlockNums between [pUpdateNum, pUpdateNum+pUpdateInterval)
 	pMinVoteNum := v.readLowestScannedVoteNumCached()
 	if pMinVoteNum != nil && *pMinVoteNum <= pUpdateNum {
-		if v.validatorVoteBlockNumsCache != nil {
-			scanBlocks = make([]uint64, len(v.validatorVoteBlockNumsCache))
-			copy(scanBlocks, v.validatorVoteBlockNumsCache)
-		} else {
-			scanBlocks = ReadValidatorVoteBlockNums(v.ChainKv)
-		}
-		scanBlocks = slices.DeleteFunc(scanBlocks, func(n uint64) bool {
+		return slices.DeleteFunc(v.readValidatorVoteBlockNumsCached(), func(n uint64) bool {
 			return !(n >= pUpdateNum && n < pUpdateNum+pUpdateInterval)
 		})
-		return scanBlocks
 	}
 
 	// if not migrated, scanBlocks is set as blocknums between [updateNum, pUpdateNum+pUpdateInterval)

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -19,6 +19,7 @@ package impl
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -152,10 +153,34 @@ func (v *ValsetModule) migrate() {
 
 	targetNum := *pMinVoteNum
 	logger.Info("ValsetModule migrate start", "targetNum", targetNum)
+
+	isThrottled := &atomic.Bool{}
+	done := make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				blockTime := time.Unix(v.Chain.CurrentBlock().Time().Int64(), 0)
+				isThrottled.Store(time.Now().UTC().After(blockTime.UTC().Add(100 * time.Second)))
+			case <-done:
+				return
+			}
+		}
+	}()
+
 	for targetNum > 0 {
 		if v.quit.Load() == 1 {
 			break
 		}
+
+		if isThrottled.Load() {
+			time.Sleep(50 * time.Millisecond)
+		}
+
 		// At each iteration, targetNum should decrease like ... -> 2048 -> 1024 -> 0.
 		// get(2048,true) scans [1025, 2048] and returns snapshotNum=1024. So we write lowestScannedVoteNum=1025.
 		// get(1024,true) scans [1, 1024] and returns snapshotNum=0. So we write lowestScannedVoteNum=1.
@@ -171,6 +196,10 @@ func (v *ValsetModule) migrate() {
 		writeLowestScannedVoteNum(v.ChainKv, snapshotNum+1)
 		targetNum = snapshotNum
 	}
+
+	// Signal the goroutine to stop
+	close(done)
+
 	if targetNum == 0 {
 		logger.Info("ValsetModule migrate complete")
 		// Now the migration is complete.

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -66,6 +66,7 @@ type ValsetModule struct {
 	// cache for weightedRandom and uniformRandom proposerLists.
 	proposerListCache *lru.Cache // uint64 -> []common.Address
 	removeVotesCache  *lru.Cache // uint64 -> removeVoteList
+	councilCache      *lru.Cache // uint64 -> *valset.AddressSet
 
 	validatorVoteBlockNumsCache []uint64
 }
@@ -73,9 +74,11 @@ type ValsetModule struct {
 func NewValsetModule() *ValsetModule {
 	pListCache, _ := lru.New(128)
 	rVoteCache, _ := lru.New(128)
+	councilCache, _ := lru.New(128)
 	return &ValsetModule{
 		proposerListCache: pListCache,
 		removeVotesCache:  rVoteCache,
+		councilCache:      councilCache,
 	}
 }
 

--- a/tests/kaia_test_blockchain_test.go
+++ b/tests/kaia_test_blockchain_test.go
@@ -191,6 +191,7 @@ func NewBCData(maxAccounts, numValidators int) (*BCData, error) {
 
 func (bcdata *BCData) Shutdown() {
 	bcdata.bc.Stop()
+	bcdata.engine.Stop()
 
 	bcdata.db.Close()
 	// Remove leveldb dir which was created for this test.


### PR DESCRIPTION
## Proposed changes

- Use Snapshot of the `lowestScannedVoteNum` block to prevent bad block during the migration due to empty istanbul snapshot if no vote between (lowestScannedVoteNum, snapshot)
- Throttle migration threads (valset, gov)
- Add in-memory council cache (valset) to speed up syncing during migration.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
