### PR TITLE
circleci: update the version of test-executor docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ executors:
     working_directory: ~/go/src/github.com/kaiachain/kaia
     resource_class: medium
     docker:
-      - image: kaiachain/build_base:go1.23-solc0.8.13-ubuntu-22.04
+      - image: kaiachain/build_base:go1.23.7-solc0.8.13-ubuntu-22.04
   test-tests-executor: # this executor is for test-tests job
     working_directory: ~/go/src/github.com/kaiachain/kaia
     resource_class: medium+
@@ -325,12 +325,11 @@ commands:
             cd ..
             cp config_template.json config.json
             apt update
-            apt install python3.8 python3-venv -y
-            python3.8 -m venv --without-pip venv
+            apt install python3-venv -y
+            python3 -m venv venv
             source venv/bin/activate
-            curl https://bootstrap.pypa.io/get-pip.py | python
             pip3 install -r requirements.txt
-            python3 main.py --protocol rpc
+            python main.py --protocol rpc
 
 jobs:
   build:


### PR DESCRIPTION
## Proposed changes

- This PR updates the version of `test-executor`'s docker image. It fixes the nightly-rpc failure.

Tested through next script
```
circleci local execute test-rpc
circleci local execute test-networks
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
