### PR TITLE
istanbul/backend: return null OriginProposer when state not available at ConsensusInfo

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -181,7 +181,7 @@ type ConsensusInfo struct {
 	// Proposer signs [sigHash] to make seal; Validators signs [block.Hash + msgCommit] to make committedSeal
 	SigHash        common.Hash
 	Proposer       common.Address
-	OriginProposer common.Address // the proposer of 0th round at the same block number
+	OriginProposer *common.Address // the proposer of 0th round at the same block number
 	Committee      []common.Address
 	Committers     []common.Address
 	Round          byte

--- a/datasync/chaindatafetcher/kafka/repository.go
+++ b/datasync/chaindatafetcher/kafka/repository.go
@@ -76,7 +76,7 @@ func (r *repository) HandleChainEvent(event blockchain.ChainEvent, dataType type
 	switch dataType {
 	case types.RequestTypeBlockGroup:
 		cInfo, err := r.engine.GetConsensusInfo(event.Block)
-		if err != nil {
+		if err != nil || cInfo.OriginProposer == nil {
 			return fmt.Errorf("failed to retrieve consensusinfo with the given block number: %v", event.Block.Number())
 		}
 		result := &blockGroupResult{


### PR DESCRIPTION
## Proposed changes

- Since kaia hardfork, `getBlockWithConsensusInfo` returns `missing trie node` error when state is unavailable. However, except originProposer and committee, the other information is still available even state is unavailable. So this PR modifies the getBlockWithConsensusInfo API to return null originProposer and Committee when state is unavailable.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
