### PR TITLE
kaiax/gov: Check vote data against block proposer

### DIFF
--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -91,14 +91,13 @@ func (h *headerGovModule) VerifyVote(header *types.Header) error {
 	}
 
 	// check if Voter is the block proposer.
-	// TODO-kaia: derive author from header
-	//author, err := h.Chain.Engine().Author(header)
-	//if err != nil {
-	//	return err
-	//}
-	//if author != vote.Voter() {
-	//	return ErrInvalidVoter
-	//}
+	author, err := h.Chain.Engine().Author(header)
+	if err != nil {
+		return err
+	}
+	if author != vote.Voter() {
+		return ErrInvalidVoter
+	}
 	return h.checkConsistency(blockNum, vote)
 }
 

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	"github.com/kaiachain/kaia/log"
@@ -26,6 +27,7 @@ type chain interface {
 	GetHeaderByNumber(number uint64) *types.Header
 	CurrentBlock() *types.Block
 	State() (*state.StateDB, error)
+	Engine() consensus.Engine
 }
 
 type ValsetModule interface {

--- a/kaiax/gov/headergov/impl/init_test.go
+++ b/kaiax/gov/headergov/impl/init_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
+	mock_consensus "github.com/kaiachain/kaia/consensus/mocks"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
@@ -47,6 +48,7 @@ func newHeaderGovModule(t *testing.T, config *params.ChainConfig) *headerGovModu
 	var (
 		chain  = mocks.NewMockBlockChain(gomock.NewController(t))
 		valSet = mock_valset.NewMockValsetModule(gomock.NewController(t))
+		engine = mock_consensus.NewMockEngine(gomock.NewController(t))
 		dbm    = database.NewMemoryDBManager()
 		db     = dbm.GetMemDB()
 		b      = GetGenesisGovBytes(config)
@@ -70,6 +72,8 @@ func newHeaderGovModule(t *testing.T, config *params.ChainConfig) *headerGovModu
 	statedb, _ := state.New(common.Hash{}, cachingDb, nil, nil)
 	chain.EXPECT().State().Return(statedb, nil).AnyTimes()
 	chain.EXPECT().CurrentBlock().Return(types.NewBlockWithHeader(genesisHeader)).AnyTimes()
+	chain.EXPECT().Engine().Return(engine).AnyTimes()
+	engine.EXPECT().Author(gomock.Any()).Return(validVoter, nil).AnyTimes()
 
 	valSet.EXPECT().GetCouncil(uint64(0)).Return([]common.Address{validVoter}, nil).AnyTimes()
 	valSet.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{validVoter}, nil).AnyTimes()


### PR DESCRIPTION
## Proposed changes

- kaiax/gov will validate the header.voteData's validator field (the voter address) equals the block's proposer. Prevents a validator forging a header governance vote.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
