### PR TITLE
kaiax/auction: Added missing bid cache init

### DIFF
--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -376,6 +376,7 @@ func newPeerWithRWs(version int, p *p2p.Peer, rws []p2p.MsgReadWriter) (Peer, er
 			id:               fmt.Sprintf("%x", id[:8]),
 			knownTxsCache:    newKnownTxCache(),
 			knownBlocksCache: newKnownBlockCache(),
+			knownBidsCache:   newKnownBidCache(),
 			queuedTxs:        make(chan []*types.Transaction, maxQueuedTxs),
 			queuedProps:      make(chan *propEvent, maxQueuedProps),
 			queuedAnns:       make(chan *types.Block, maxQueuedAnns),


### PR DESCRIPTION
## Proposed changes

We missed out to initialize bid cache in the function `newPeerWithRWs()`. 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1908958]

goroutine 1106 [running]:
kaia/node/cn.(*basePeer).KnowsBid(...)
    cn/peer.go:802
kaia/node/cn.(*peerSet).CNWithoutBid(0xc00141b860, {0x79, 0x29, 0x40, 0xe7, 0x2a, 0x4a, 0x1b, 0x95, 0x48, ...})
    cn/peer_set.go:321 +0x1aa
kaia/node/cn.(*ProtocolManager).BroadcastBid(0xc0179c2000, 0xc00e3020c0)
    cn/handler.go:1366 +0x67
kaia/node/cn.(*ProtocolManager).bidBroadcastLoop(0xc0179c2000)
    cn/handler.go:1525 +0x28
created by kaia/node/cn.(*ProtocolManager).Start in goroutine 1
    cn/handler.go:418 +0x25f

 ```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
