### PR TITLE
database: Revert disk correctly

### DIFF
--- a/blockchain/state/prune_test.go
+++ b/blockchain/state/prune_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+// Modified and improved for the Kaia development.
+
+package state
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/kaiachain/kaia/storage/statedb"
+)
+
+// TestRollBack tests whether pruningMarks are recorded correctly during bundle execution
+// 1. make statedb copy thorugh state.Copy()
+// 2. let pruning module mark candidates
+// 3. check copied if statedb is not reflected
+func TestRollback(t *testing.T) {
+	// worker.go:commitBundleTransactiond
+	dbm := database.NewMemoryDBManager()
+	opts := &statedb.TrieOpts{}
+	dbm.WritePruningEnabled()
+	opts.PruningBlockNumber = 1
+
+	sdb := NewDatabase(dbm)
+	sdb.TrieDB().SavePruningMarksInBundle()
+	state, _ := New(common.Hash{}, sdb, nil, opts)
+
+	var (
+		acc  = common.HexToAddress("0x0000000000000000000000000000000000000aaa")
+		acc2 = common.HexToAddress("0x0000000000000000000000000000000000000bbb")
+		acc3 = common.HexToAddress("0x0000000000000000000000000000000000000ccc")
+	)
+	// set retention
+	// insert block required
+
+	// ACC == 10
+	state.AddBalance(acc2, big.NewInt(30))
+	state.AddBalance(acc3, big.NewInt(40))
+	state.AddBalance(acc, big.NewInt(10))
+	root10, _ := state.Commit(true)
+	t.Log("root", root10.Hex())
+
+	state, _ = New(root10, sdb, nil, opts)
+	snapshot := state.Copy()
+
+	// ACC == 200
+	state.SetBalance(acc, big.NewInt(200))
+
+	root200, _ := state.Commit(true)
+	t.Log("root", root200.Hex())
+	state.Database().TrieDB().Cap(0)
+
+	// ACC == 10
+	sdb.TrieDB().RevertPruningMarksInBundle()
+	state.Set(snapshot)
+
+	marks := dbm.ReadPruningMarks(0, 2)
+	for _, mark := range marks {
+		t.Log("delete", mark.Hash.Hex())
+		dbm.DeleteTrieNode(mark.Hash)
+	}
+
+	// Already opened
+	t.Log("balance", state.GetBalance(acc))
+
+	// Newly opening
+	state, err := New(root10, sdb, nil, opts)
+	if err != nil {
+		t.Log("err", err)
+		t.Fail()
+	}
+	if state != nil {
+		t.Log("balance", state.GetBalance(acc))
+	}
+}

--- a/work/worker.go
+++ b/work/worker.go
@@ -884,6 +884,7 @@ func (env *Task) commitTransaction(tx *types.Transaction, bc BlockChain, rewardb
 }
 
 func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, rewardbase common.Address, vmConfig *vm.Config) (error, *types.Transaction, []*types.Log) {
+	env.state.Database().TrieDB().SavePruningMarksInBundle()
 	lastSnapshot := env.state.Copy()
 	gasUsedSnapshot := env.header.GasUsed
 	tcountSnapshot := env.tcount
@@ -901,6 +902,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 	}
 
 	restoreEnv := func() {
+		env.state.Database().TrieDB().RevertPruningMarksInBundle()
 		env.state.Set(lastSnapshot)
 		env.header.GasUsed = gasUsedSnapshot
 		env.tcount = tcountSnapshot
@@ -937,6 +939,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 		logs = append(logs, receipt.Logs...)
 	}
 
+	env.state.Database().TrieDB().CompleteBundle()
 	env.txs = append(env.txs, txs...)
 	env.receipts = append(env.receipts, receipts...)
 


### PR DESCRIPTION
## Proposed changes

PruningMarks added during bundling may result in pruningMarks being recorded on required nodes after live-pruning is run.
This PR is a patch to delete pruningMarks recorded during bundle execution on revert.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
