### PR TITLE
Add pruning snapshot

### DIFF
--- a/blockchain/state/database.go
+++ b/blockchain/state/database.go
@@ -75,6 +75,13 @@ type Database interface {
 
 // Trie is a Kaia Merkle Patricia trie.
 type Trie interface {
+	// StartPruningSnapshot starts a pruning snapshot.
+	StartPruningSnapshot()
+	// EndPruningSnapshot ends a pruning snapshot.
+	EndPruningSnapshot()
+	// RevertPruningSnapshot reverts a pruning snapshot.
+	RevertPruningSnapshot()
+
 	// GetKey returns the sha3 preimage of a hashed key that was previously used
 	// to store a value.
 	//

--- a/blockchain/state/prune_test.go
+++ b/blockchain/state/prune_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+// Modified and improved for the Kaia development.
+
+package state
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/kaiachain/kaia/storage/statedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This test mimics the behavior of a block miner with live pruning enabled.
+func TestRollback(t *testing.T) {
+	dbm := database.NewMemoryDBManager()
+	dbm.WritePruningEnabled()
+
+	var (
+		sdb  = NewDatabase(dbm)
+		acc1 = common.HexToAddress("0x0000000000000000000000000000000000000aaa")
+		acc2 = common.HexToAddress("0x0000000000000000000000000000000000000bbb")
+		acc3 = common.HexToAddress("0x0000000000000000000000000000000000000ccc")
+
+		root1 common.Hash
+		root2 common.Hash
+	)
+
+	{ // Block 1: Store baseline state.
+		state, _ := New(common.Hash{}, sdb, nil, nil)
+		state.AddBalance(acc1, big.NewInt(10))
+		state.AddBalance(acc2, big.NewInt(20))
+		state.AddBalance(acc3, big.NewInt(30))
+		root1, _ = state.Commit(true)
+		t.Logf("end block 1, root %x", root1)
+	}
+
+	{ // Block 2: Build a bundle-containing block.
+		// worker.makeCurrent: PrunableStateAt(parentHash, parentNum)
+		state, err := New(root1, sdb, nil, &statedb.TrieOpts{PruningBlockNumber: 1})
+		assert.NoError(t, err)
+
+		{ // Tx 0: Regular transaction that succeeds
+			txSnap := state.Snapshot()              // EVM.Call: StateDB.Snapshot()
+			state.AddBalance(acc1, big.NewInt(100)) // bc.ApplyTransaction: ApplyMessage()
+			_ = txSnap                              // EVM.Call: no RevertToSnapshot()
+			state.Finalise(true, false)             // bc.ApplyTransaction: Finalise(true, false)
+		}
+
+		{ // Tx 1: Regular transaction that fails
+			txSnap := state.Snapshot()              // EVM.Call: StateDB.Snapshot()
+			state.AddBalance(acc1, big.NewInt(999)) // bc.ApplyTransaction: ApplyMessage()
+			state.RevertToSnapshot(txSnap)          // EVM.Call: RevertToSnapshot()
+			state.Finalise(true, false)             // bc.ApplyTransaction: Finalise(true, false)
+		}
+
+		{ // Execute bundle transactions.
+			// worker.commitBundleTransaction
+			snapshot := state.Copy()
+			state.StartPruningSnapshot()
+
+			{ // Tx 2: Bundle transaction that succeeds
+				txSnap := state.Snapshot()              // EVM.Call: StateDB.Snapshot()
+				state.AddBalance(acc2, big.NewInt(100)) // bc.ApplyTransaction: ApplyMessage()
+				_ = txSnap                              // EVM.Call: no RevertToSnapshot()
+				state.Finalise(true, false)             // bc.ApplyTransaction: Finalise(true, false)
+			}
+
+			{ // Tx 3: Bundle transaction that fails
+				txSnap := state.Snapshot()              // EVM.Call: StateDB.Snapshot()
+				state.AddBalance(acc3, big.NewInt(100)) // bc.ApplyTransaction: ApplyMessage()
+				state.RevertToSnapshot(txSnap)          // EVM.Call: RevertToSnapshot()
+				state.Finalise(true, false)             // bc.ApplyTransaction: Finalise(true, false)
+			}
+
+			// worker.commitBundleTransaction: restoreEnv
+			state.RevertPruningSnapshot()
+			state.Set(snapshot)
+		}
+
+		// At the end of the day, only Tx 0 is applied.
+		assert.Equal(t, uint64(110), state.GetBalance(acc1).Uint64())
+		assert.Equal(t, uint64(20), state.GetBalance(acc2).Uint64())
+		assert.Equal(t, uint64(30), state.GetBalance(acc3).Uint64())
+
+		// Finalize the block.
+		root2 = state.IntermediateRoot(true) // worker.commitNewWork: engine.Finalize
+		assert.NoError(t, err)
+
+		// After consensus, commit the block.
+		// worker.wait: bc.WriteBlockWithState: bc.writeStateTrie
+		root22, err := state.Commit(true)
+		assert.NoError(t, err)
+		assert.Equal(t, root2, root22)
+
+		err = sdb.TrieDB().Commit(root2, true, 2)
+		assert.NoError(t, err)
+
+		t.Logf("end block 2, root %s", root2.Hex())
+	}
+
+	{ // Simulate the passage of time, in that
+		// - db.pruningMarks are eventually written to the diskDB.
+		sdb.TrieDB().Cap(0)
+
+		// - in-memory trie cache is evicted (governed by --state.cache-size).
+		sdb = NewDatabase(dbm)
+
+		// - bc.pruneTrieNodeLoop() deleted (after retention) as dictated by the pruning marks.
+		marks := dbm.ReadPruningMarks(0, 99)
+		for _, mark := range marks {
+			t.Logf("delete trie node (%s, %d)", mark.Hash.Hex(), mark.Number)
+			// NOTE: if you keep the root node (e.g. if it survives in in-memory trie cache),
+			// you can observe that GetBalance() below returns 0.
+			// if mark.Hash.IsZeroExtended() {
+			//   continue
+			// }
+			dbm.DeleteTrieNode(mark.Hash)
+		}
+	}
+
+	{ // After that, some trie nodes that represent the latest state, must be intact.
+		// i.e. the states must not be pruned.
+		t.Log("query block 2")
+		state, err := New(root2, sdb, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(110), state.GetBalance(acc1).Uint64(), "acc1")
+		assert.Equal(t, uint64(20), state.GetBalance(acc2).Uint64(), "acc2")
+		assert.Equal(t, uint64(30), state.GetBalance(acc3).Uint64(), "acc3")
+		assert.NoError(t, state.Error()) // No error during GetBalance() calls.
+	}
+}

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -995,6 +995,18 @@ func deepCopyLogs(from, to *StateDB) {
 	}
 }
 
+func (s *StateDB) StartPruningSnapshot() {
+	s.trie.StartPruningSnapshot()
+}
+
+func (s *StateDB) EndPruningSnapshot() {
+	s.trie.EndPruningSnapshot()
+}
+
+func (s *StateDB) RevertPruningSnapshot() {
+	s.trie.RevertPruningSnapshot()
+}
+
 // Snapshot returns an identifier for the current revision of the state.
 func (s *StateDB) Snapshot() int {
 	id := s.nextRevisionId

--- a/storage/statedb/secure_trie.go
+++ b/storage/statedb/secure_trie.go
@@ -235,3 +235,15 @@ func (t *SecureTrie) getSecKeyCache() map[string][]byte {
 	}
 	return t.secKeyCache
 }
+
+func (t *SecureTrie) StartPruningSnapshot() {
+	t.trie.StartPruningSnapshot()
+}
+
+func (t *SecureTrie) EndPruningSnapshot() {
+	t.trie.EndPruningSnapshot()
+}
+
+func (t *SecureTrie) RevertPruningSnapshot() {
+	t.trie.RevertPruningSnapshot()
+}

--- a/work/worker.go
+++ b/work/worker.go
@@ -887,6 +887,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 	lastSnapshot := env.state.Copy()
 	gasUsedSnapshot := env.header.GasUsed
 	tcountSnapshot := env.tcount
+	env.state.StartPruningSnapshot()
 	txs := []*types.Transaction{}
 	receipts := []*types.Receipt{}
 	logs := []*types.Log{}
@@ -901,6 +902,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 	}
 
 	restoreEnv := func() {
+		env.state.RevertPruningSnapshot()
 		env.state.Set(lastSnapshot)
 		env.header.GasUsed = gasUsedSnapshot
 		env.tcount = tcountSnapshot
@@ -939,6 +941,7 @@ func (env *Task) commitBundleTransaction(bundle *builder.Bundle, bc BlockChain, 
 
 	env.txs = append(env.txs, txs...)
 	env.receipts = append(env.receipts, receipts...)
+	env.state.EndPruningSnapshot()
 
 	return nil, nil, logs
 }


### PR DESCRIPTION
## Proposed changes

A node that enables live pruning will mark the obsolete node and prune it in real-time. This might cause issues when a node executes the bundle transactions. In the below example, the state of `Acc` has been updated during the bundle transaction. But if bundle reverted, both `Node 1, 2` will not be available since we already marked `Node 1` to be pruned.

```
<Execution>
Acc -> Node 1: Makred to be pruned
    -> Node 2: New node

<Revert>
Acc -> Node 1: Still marked
```

In this PR, we borrow the concept of `stateDB.Snapshot` to live pruning, and we can effectively avoid the original nodes from being pruned even if the bundle reverts.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
