### PR TITLE
Fix rc log to print correct new proposer

### DIFF
--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -86,4 +86,6 @@ type Backend interface {
 	GetCommitteeState(num uint64) (*RoundCommitteeState, error)
 
 	GetCommitteeStateByRound(num uint64, round uint64) (*RoundCommitteeState, error)
+
+	GetProposerByRound(num uint64, round uint64) (common.Address, error)
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -440,6 +440,14 @@ func (sb *backend) GetCommitteeStateByRound(num uint64, round uint64) (*istanbul
 	return istanbul.NewRoundCommitteeState(blockValSet, committeeSize, committee, proposer), nil
 }
 
+func (sb *backend) GetProposerByRound(num uint64, round uint64) (common.Address, error) {
+	proposer, err := sb.valsetModule.GetProposer(num, round)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return proposer, nil
+}
+
 // GetProposer implements istanbul.Backend.GetProposer
 func (sb *backend) GetProposer(number uint64) common.Address {
 	if h := sb.chain.GetHeaderByNumber(number); h != nil {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -325,8 +325,14 @@ func (c *core) catchUpRound(view *istanbul.View) {
 	c.updateRoundState(view, c.currentCommittee, true)
 	c.roundChangeSet.Clear(view.Round)
 
+	newProposer, err := c.backend.GetProposerByRound(view.Sequence.Uint64(), view.Round.Uint64())
+	if err != nil {
+		logger.Error("Failed to get proposer by round", "new_round", view.Round, "new_seq", view.Sequence, "err", err)
+		return
+	}
+
 	c.newRoundChangeTimer()
-	logger.Warn("[RC] Catch up round", "new_round", view.Round, "new_seq", view.Sequence, "new_proposer", c.currentCommittee.Proposer())
+	logger.Warn("[RC] Catch up round", "new_round", view.Round, "new_seq", view.Sequence, "new_proposer", newProposer)
 }
 
 // updateRoundState updates round state by checking if locking block is necessary

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -314,7 +314,7 @@ func (c *core) startNewRound(round *big.Int) {
 }
 
 func (c *core) catchUpRound(view *istanbul.View) {
-	logger := c.logger.NewWith("old_round", c.current.Round(), "old_seq", c.current.Sequence(), "old_proposer", c.currentCommittee.Proposer())
+	cLogger := c.logger.NewWith("old_round", c.current.Round(), "old_seq", c.current.Sequence(), "old_proposer", c.currentCommittee.Proposer())
 
 	if view.Round.Cmp(c.current.Round()) > 0 {
 		c.roundMeter.Mark(new(big.Int).Sub(view.Round, c.current.Round()).Int64())
@@ -327,13 +327,13 @@ func (c *core) catchUpRound(view *istanbul.View) {
 
 	newProposer, err := c.backend.GetProposerByRound(view.Sequence.Uint64(), view.Round.Uint64())
 	if err != nil {
-		logger.Error("Failed to get proposer by round", "new_round", view.Round, "new_seq", view.Sequence, "err", err)
+		logger.Warn("Failed to get proposer by round", "err", err)
 		// The newProposer is only for logging purpose, so we don't need to return here.
 		// If there's error, it'll be handled in the `startNewRound` anyway.
 	}
 
 	c.newRoundChangeTimer()
-	logger.Warn("[RC] Catch up round", "new_round", view.Round, "new_seq", view.Sequence, "new_proposer", newProposer)
+	cLogger.Warn("[RC] Catch up round", "new_round", view.Round, "new_seq", view.Sequence, "new_proposer", newProposer)
 }
 
 // updateRoundState updates round state by checking if locking block is necessary

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -328,7 +328,8 @@ func (c *core) catchUpRound(view *istanbul.View) {
 	newProposer, err := c.backend.GetProposerByRound(view.Sequence.Uint64(), view.Round.Uint64())
 	if err != nil {
 		logger.Error("Failed to get proposer by round", "new_round", view.Round, "new_seq", view.Sequence, "err", err)
-		return
+		// The newProposer is only for logging purpose, so we don't need to return here.
+		// If there's error, it'll be handled in the `startNewRound` anyway.
 	}
 
 	c.newRoundChangeTimer()

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -87,6 +87,7 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 				mockValset, committeeSize, validatorAddrs[0:committeeSize], validatorAddrs[0],
 			), nil
 		}).AnyTimes()
+	mockBackend.EXPECT().GetProposerByRound(gomock.Any(), gomock.Any()).Return(validatorAddrs[0], nil).AnyTimes()
 	mockBackend.EXPECT().NodeType().Return(common.CONSENSUSNODE).AnyTimes()
 
 	// Set an eventMux in which istanbul core will subscribe istanbul events

--- a/consensus/istanbul/mocks/backend_mock.go
+++ b/consensus/istanbul/mocks/backend_mock.go
@@ -15,30 +15,30 @@ import (
 	event "github.com/kaiachain/kaia/event"
 )
 
-// MockBackend is a mock of Backend interface
+// MockBackend is a mock of Backend interface.
 type MockBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendMockRecorder
 }
 
-// MockBackendMockRecorder is the mock recorder for MockBackend
+// MockBackendMockRecorder is the mock recorder for MockBackend.
 type MockBackendMockRecorder struct {
 	mock *MockBackend
 }
 
-// NewMockBackend creates a new mock instance
+// NewMockBackend creates a new mock instance.
 func NewMockBackend(ctrl *gomock.Controller) *MockBackend {
 	mock := &MockBackend{ctrl: ctrl}
 	mock.recorder = &MockBackendMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 	return m.recorder
 }
 
-// Address mocks base method
+// Address mocks base method.
 func (m *MockBackend) Address() common.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Address")
@@ -46,13 +46,13 @@ func (m *MockBackend) Address() common.Address {
 	return ret0
 }
 
-// Address indicates an expected call of Address
+// Address indicates an expected call of Address.
 func (mr *MockBackendMockRecorder) Address() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockBackend)(nil).Address))
 }
 
-// Broadcast mocks base method
+// Broadcast mocks base method.
 func (m *MockBackend) Broadcast(arg0 common.Hash, arg1 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Broadcast", arg0, arg1)
@@ -60,13 +60,13 @@ func (m *MockBackend) Broadcast(arg0 common.Hash, arg1 []byte) error {
 	return ret0
 }
 
-// Broadcast indicates an expected call of Broadcast
+// Broadcast indicates an expected call of Broadcast.
 func (mr *MockBackendMockRecorder) Broadcast(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockBackend)(nil).Broadcast), arg0, arg1)
 }
 
-// CheckSignature mocks base method
+// CheckSignature mocks base method.
 func (m *MockBackend) CheckSignature(arg0 []byte, arg1 common.Address, arg2 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckSignature", arg0, arg1, arg2)
@@ -74,13 +74,13 @@ func (m *MockBackend) CheckSignature(arg0 []byte, arg1 common.Address, arg2 []by
 	return ret0
 }
 
-// CheckSignature indicates an expected call of CheckSignature
+// CheckSignature indicates an expected call of CheckSignature.
 func (mr *MockBackendMockRecorder) CheckSignature(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSignature", reflect.TypeOf((*MockBackend)(nil).CheckSignature), arg0, arg1, arg2)
 }
 
-// Commit mocks base method
+// Commit mocks base method.
 func (m *MockBackend) Commit(arg0 istanbul.Proposal, arg1 [][]byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Commit", arg0, arg1)
@@ -88,13 +88,13 @@ func (m *MockBackend) Commit(arg0 istanbul.Proposal, arg1 [][]byte) error {
 	return ret0
 }
 
-// Commit indicates an expected call of Commit
+// Commit indicates an expected call of Commit.
 func (mr *MockBackendMockRecorder) Commit(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockBackend)(nil).Commit), arg0, arg1)
 }
 
-// EventMux mocks base method
+// EventMux mocks base method.
 func (m *MockBackend) EventMux() *event.TypeMux {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventMux")
@@ -102,13 +102,13 @@ func (m *MockBackend) EventMux() *event.TypeMux {
 	return ret0
 }
 
-// EventMux indicates an expected call of EventMux
+// EventMux indicates an expected call of EventMux.
 func (mr *MockBackendMockRecorder) EventMux() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventMux", reflect.TypeOf((*MockBackend)(nil).EventMux))
 }
 
-// GetCommitteeState mocks base method
+// GetCommitteeState mocks base method.
 func (m *MockBackend) GetCommitteeState(arg0 uint64) (*istanbul.RoundCommitteeState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCommitteeState", arg0)
@@ -117,13 +117,13 @@ func (m *MockBackend) GetCommitteeState(arg0 uint64) (*istanbul.RoundCommitteeSt
 	return ret0, ret1
 }
 
-// GetCommitteeState indicates an expected call of GetCommitteeState
+// GetCommitteeState indicates an expected call of GetCommitteeState.
 func (mr *MockBackendMockRecorder) GetCommitteeState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommitteeState", reflect.TypeOf((*MockBackend)(nil).GetCommitteeState), arg0)
 }
 
-// GetCommitteeStateByRound mocks base method
+// GetCommitteeStateByRound mocks base method.
 func (m *MockBackend) GetCommitteeStateByRound(arg0, arg1 uint64) (*istanbul.RoundCommitteeState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCommitteeStateByRound", arg0, arg1)
@@ -132,13 +132,13 @@ func (m *MockBackend) GetCommitteeStateByRound(arg0, arg1 uint64) (*istanbul.Rou
 	return ret0, ret1
 }
 
-// GetCommitteeStateByRound indicates an expected call of GetCommitteeStateByRound
+// GetCommitteeStateByRound indicates an expected call of GetCommitteeStateByRound.
 func (mr *MockBackendMockRecorder) GetCommitteeStateByRound(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommitteeStateByRound", reflect.TypeOf((*MockBackend)(nil).GetCommitteeStateByRound), arg0, arg1)
 }
 
-// GetProposer mocks base method
+// GetProposer mocks base method.
 func (m *MockBackend) GetProposer(arg0 uint64) common.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProposer", arg0)
@@ -146,13 +146,28 @@ func (m *MockBackend) GetProposer(arg0 uint64) common.Address {
 	return ret0
 }
 
-// GetProposer indicates an expected call of GetProposer
+// GetProposer indicates an expected call of GetProposer.
 func (mr *MockBackendMockRecorder) GetProposer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposer", reflect.TypeOf((*MockBackend)(nil).GetProposer), arg0)
 }
 
-// GetRewardBase mocks base method
+// GetProposerByRound mocks base method.
+func (m *MockBackend) GetProposerByRound(arg0, arg1 uint64) (common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProposerByRound", arg0, arg1)
+	ret0, _ := ret[0].(common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProposerByRound indicates an expected call of GetProposerByRound.
+func (mr *MockBackendMockRecorder) GetProposerByRound(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposerByRound", reflect.TypeOf((*MockBackend)(nil).GetProposerByRound), arg0, arg1)
+}
+
+// GetRewardBase mocks base method.
 func (m *MockBackend) GetRewardBase() common.Address {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRewardBase")
@@ -160,13 +175,13 @@ func (m *MockBackend) GetRewardBase() common.Address {
 	return ret0
 }
 
-// GetRewardBase indicates an expected call of GetRewardBase
+// GetRewardBase indicates an expected call of GetRewardBase.
 func (mr *MockBackendMockRecorder) GetRewardBase() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRewardBase", reflect.TypeOf((*MockBackend)(nil).GetRewardBase))
 }
 
-// GetValidatorSet mocks base method
+// GetValidatorSet mocks base method.
 func (m *MockBackend) GetValidatorSet(arg0 uint64) (*istanbul.BlockValSet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidatorSet", arg0)
@@ -175,13 +190,13 @@ func (m *MockBackend) GetValidatorSet(arg0 uint64) (*istanbul.BlockValSet, error
 	return ret0, ret1
 }
 
-// GetValidatorSet indicates an expected call of GetValidatorSet
+// GetValidatorSet indicates an expected call of GetValidatorSet.
 func (mr *MockBackendMockRecorder) GetValidatorSet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorSet", reflect.TypeOf((*MockBackend)(nil).GetValidatorSet), arg0)
 }
 
-// Gossip mocks base method
+// Gossip mocks base method.
 func (m *MockBackend) Gossip(arg0 []byte) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Gossip", arg0)
@@ -189,25 +204,25 @@ func (m *MockBackend) Gossip(arg0 []byte) error {
 	return ret0
 }
 
-// Gossip indicates an expected call of Gossip
+// Gossip indicates an expected call of Gossip.
 func (mr *MockBackendMockRecorder) Gossip(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockBackend)(nil).Gossip), arg0)
 }
 
-// GossipSubPeer mocks base method
+// GossipSubPeer mocks base method.
 func (m *MockBackend) GossipSubPeer(arg0 common.Hash, arg1 []byte) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "GossipSubPeer", arg0, arg1)
 }
 
-// GossipSubPeer indicates an expected call of GossipSubPeer
+// GossipSubPeer indicates an expected call of GossipSubPeer.
 func (mr *MockBackendMockRecorder) GossipSubPeer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GossipSubPeer", reflect.TypeOf((*MockBackend)(nil).GossipSubPeer), arg0, arg1)
 }
 
-// HasBadProposal mocks base method
+// HasBadProposal mocks base method.
 func (m *MockBackend) HasBadProposal(arg0 common.Hash) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasBadProposal", arg0)
@@ -215,13 +230,13 @@ func (m *MockBackend) HasBadProposal(arg0 common.Hash) bool {
 	return ret0
 }
 
-// HasBadProposal indicates an expected call of HasBadProposal
+// HasBadProposal indicates an expected call of HasBadProposal.
 func (mr *MockBackendMockRecorder) HasBadProposal(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBadProposal", reflect.TypeOf((*MockBackend)(nil).HasBadProposal), arg0)
 }
 
-// HasPropsal mocks base method
+// HasPropsal mocks base method.
 func (m *MockBackend) HasPropsal(arg0 common.Hash, arg1 *big.Int) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasPropsal", arg0, arg1)
@@ -229,13 +244,13 @@ func (m *MockBackend) HasPropsal(arg0 common.Hash, arg1 *big.Int) bool {
 	return ret0
 }
 
-// HasPropsal indicates an expected call of HasPropsal
+// HasPropsal indicates an expected call of HasPropsal.
 func (mr *MockBackendMockRecorder) HasPropsal(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPropsal", reflect.TypeOf((*MockBackend)(nil).HasPropsal), arg0, arg1)
 }
 
-// LastProposal mocks base method
+// LastProposal mocks base method.
 func (m *MockBackend) LastProposal() (istanbul.Proposal, common.Address) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LastProposal")
@@ -244,13 +259,13 @@ func (m *MockBackend) LastProposal() (istanbul.Proposal, common.Address) {
 	return ret0, ret1
 }
 
-// LastProposal indicates an expected call of LastProposal
+// LastProposal indicates an expected call of LastProposal.
 func (mr *MockBackendMockRecorder) LastProposal() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastProposal", reflect.TypeOf((*MockBackend)(nil).LastProposal))
 }
 
-// NodeType mocks base method
+// NodeType mocks base method.
 func (m *MockBackend) NodeType() common.ConnType {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NodeType")
@@ -258,25 +273,25 @@ func (m *MockBackend) NodeType() common.ConnType {
 	return ret0
 }
 
-// NodeType indicates an expected call of NodeType
+// NodeType indicates an expected call of NodeType.
 func (mr *MockBackendMockRecorder) NodeType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeType", reflect.TypeOf((*MockBackend)(nil).NodeType))
 }
 
-// SetCurrentView mocks base method
+// SetCurrentView mocks base method.
 func (m *MockBackend) SetCurrentView(arg0 *istanbul.View) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetCurrentView", arg0)
 }
 
-// SetCurrentView indicates an expected call of SetCurrentView
+// SetCurrentView indicates an expected call of SetCurrentView.
 func (mr *MockBackendMockRecorder) SetCurrentView(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentView", reflect.TypeOf((*MockBackend)(nil).SetCurrentView), arg0)
 }
 
-// Sign mocks base method
+// Sign mocks base method.
 func (m *MockBackend) Sign(arg0 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sign", arg0)
@@ -285,13 +300,13 @@ func (m *MockBackend) Sign(arg0 []byte) ([]byte, error) {
 	return ret0, ret1
 }
 
-// Sign indicates an expected call of Sign
+// Sign indicates an expected call of Sign.
 func (mr *MockBackendMockRecorder) Sign(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sign", reflect.TypeOf((*MockBackend)(nil).Sign), arg0)
 }
 
-// Verify mocks base method
+// Verify mocks base method.
 func (m *MockBackend) Verify(arg0 istanbul.Proposal) (time.Duration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Verify", arg0)
@@ -300,7 +315,7 @@ func (m *MockBackend) Verify(arg0 istanbul.Proposal) (time.Duration, error) {
 	return ret0, ret1
 }
 
-// Verify indicates an expected call of Verify
+// Verify indicates an expected call of Verify.
 func (mr *MockBackendMockRecorder) Verify(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockBackend)(nil).Verify), arg0)


### PR DESCRIPTION
## Proposed changes

This PR fixed the log with the wrong proposer address when RC happened. It happened since the `currentCommittee` hasn't been updated, but it used it as a new round's state.

And it seems that the issue existed before the v2.0.0 refactoring https://github.com/kaiachain/kaia/blob/v1.0.3/consensus/istanbul/core/core.go#L304-L316

One possible caveat is that the current behavior of RC can be changed if the `GetProposerByRound` fails.

Before the patch
```
[RC] Catch up round                       address=0x70997970C51812dc3A010C7d01b50e0d17dc79C8 old_round=0 old_seq=79 old_proposer=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 new_round=1 new_seq=79 new_proposer=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266

> kaia.getBlockWithConsensusInfo(79).originProposer
"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
> kaia.getBlockWithConsensusInfo(79).proposer
"0x90f79bf6eb2c4f870365e785982e1f101e93b906"
```

After the patch
```
[RC] Catch up round                       address=0x70997970C51812dc3A010C7d01b50e0d17dc79C8 old_round=0 old_seq=58 old_proposer=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 new_round=1 new_seq=58 new_proposer=0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC

> kaia.getBlockWithConsensusInfo(58).originProposer
"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
> kaia.getBlockWithConsensusInfo(58).proposer
"0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc"
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
