### PR TITLE
Cherry-pick: Fix ABI uint packing and negative value bug from upstream (#26568, #31790)

### DIFF
--- a/accounts/abi/error_handling.go
+++ b/accounts/abi/error_handling.go
@@ -23,15 +23,16 @@ import (
 )
 
 var (
-	errBadBool   = errors.New("abi: improperly encoded boolean value")
-	errBadUint8  = errors.New("abi: improperly encoded uint8 value")
-	errBadUint16 = errors.New("abi: improperly encoded uint16 value")
-	errBadUint32 = errors.New("abi: improperly encoded uint32 value")
-	errBadUint64 = errors.New("abi: improperly encoded uint64 value")
-	errBadInt8   = errors.New("abi: improperly encoded int8 value")
-	errBadInt16  = errors.New("abi: improperly encoded int16 value")
-	errBadInt32  = errors.New("abi: improperly encoded int32 value")
-	errBadInt64  = errors.New("abi: improperly encoded int64 value")
+	errBadBool     = errors.New("abi: improperly encoded boolean value")
+	errBadUint8    = errors.New("abi: improperly encoded uint8 value")
+	errBadUint16   = errors.New("abi: improperly encoded uint16 value")
+	errBadUint32   = errors.New("abi: improperly encoded uint32 value")
+	errBadUint64   = errors.New("abi: improperly encoded uint64 value")
+	errBadInt8     = errors.New("abi: improperly encoded int8 value")
+	errBadInt16    = errors.New("abi: improperly encoded int16 value")
+	errBadInt32    = errors.New("abi: improperly encoded int32 value")
+	errBadInt64    = errors.New("abi: improperly encoded int64 value")
+	errInvalidSign = errors.New("abi: negatively-signed value cannot be packed into uint parameter")
 )
 
 // formatSliceString formats the reflection kind with the given slice size

--- a/accounts/abi/error_handling.go
+++ b/accounts/abi/error_handling.go
@@ -22,7 +22,17 @@ import (
 	"reflect"
 )
 
-var errBadBool = errors.New("abi: improperly encoded boolean value")
+var (
+	errBadBool   = errors.New("abi: improperly encoded boolean value")
+	errBadUint8  = errors.New("abi: improperly encoded uint8 value")
+	errBadUint16 = errors.New("abi: improperly encoded uint16 value")
+	errBadUint32 = errors.New("abi: improperly encoded uint32 value")
+	errBadUint64 = errors.New("abi: improperly encoded uint64 value")
+	errBadInt8   = errors.New("abi: improperly encoded int8 value")
+	errBadInt16  = errors.New("abi: improperly encoded int16 value")
+	errBadInt32  = errors.New("abi: improperly encoded int32 value")
+	errBadInt64  = errors.New("abi: improperly encoded int64 value")
+)
 
 // formatSliceString formats the reflection kind with the given slice size
 // and returns a formatted string representation.

--- a/accounts/abi/pack_test.go
+++ b/accounts/abi/pack_test.go
@@ -179,6 +179,11 @@ func TestMethodPack(t *testing.T) {
 	if !bytes.Equal(packed, sig) {
 		t.Errorf("expected %x got %x", sig, packed)
 	}
+
+	// test that we can't pack a negative value for a parameter that is specified as a uint
+	if _, err := abi.Pack("send", big.NewInt(-1)); err == nil {
+		t.Fatal("expected error when trying to pack negative big.Int into uint256 value")
+	}
 }
 
 func TestPackNumber(t *testing.T) {

--- a/accounts/abi/type.go
+++ b/accounts/abi/type.go
@@ -344,7 +344,7 @@ func (t Type) pack(v reflect.Value) ([]byte, error) {
 		return append(ret, tail...), nil
 
 	default:
-		return packElement(t, v), nil
+		return packElement(t, v)
 	}
 }
 

--- a/accounts/abi/unpack.go
+++ b/accounts/abi/unpack.go
@@ -25,6 +25,7 @@ package abi
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 
@@ -38,44 +39,73 @@ var (
 	MaxInt256 = new(big.Int).Sub(new(big.Int).Lsh(common.Big1, 255), common.Big1)
 )
 
-// ReadInteger reads the integer based on its kind and returns the appropriate value
-func ReadInteger(typ Type, b []byte) interface{} {
+// ReadInteger reads the integer based on its kind and returns the appropriate value.
+func ReadInteger(typ Type, b []byte) (interface{}, error) {
+	ret := new(big.Int).SetBytes(b)
+
 	if typ.T == UintTy {
+		u64, isu64 := ret.Uint64(), ret.IsUint64()
 		switch typ.Size {
 		case 8:
-			return b[len(b)-1]
+			if !isu64 || u64 > math.MaxUint8 {
+				return nil, errBadUint8
+			}
+			return byte(u64), nil
 		case 16:
-			return binary.BigEndian.Uint16(b[len(b)-2:])
+			if !isu64 || u64 > math.MaxUint16 {
+				return nil, errBadUint16
+			}
+			return uint16(u64), nil
 		case 32:
-			return binary.BigEndian.Uint32(b[len(b)-4:])
+			if !isu64 || u64 > math.MaxUint32 {
+				return nil, errBadUint32
+			}
+			return uint32(u64), nil
 		case 64:
-			return binary.BigEndian.Uint64(b[len(b)-8:])
+			if !isu64 {
+				return nil, errBadUint64
+			}
+			return u64, nil
 		default:
 			// the only case left for unsigned integer is uint256.
-			return new(big.Int).SetBytes(b)
+			return ret, nil
 		}
 	}
+
+	// big.SetBytes can't tell if a number is negative or positive in itself.
+	// On EVM, if the returned number > max int256, it is negative.
+	// A number is > max int256 if the bit at position 255 is set.
+	if ret.Bit(255) == 1 {
+		ret.Add(MaxUint256, new(big.Int).Neg(ret))
+		ret.Add(ret, common.Big1)
+		ret.Neg(ret)
+	}
+	i64, isi64 := ret.Int64(), ret.IsInt64()
 	switch typ.Size {
 	case 8:
-		return int8(b[len(b)-1])
+		if !isi64 || i64 < math.MinInt8 || i64 > math.MaxInt8 {
+			return nil, errBadInt8
+		}
+		return int8(i64), nil
 	case 16:
-		return int16(binary.BigEndian.Uint16(b[len(b)-2:]))
+		if !isi64 || i64 < math.MinInt16 || i64 > math.MaxInt16 {
+			return nil, errBadInt16
+		}
+		return int16(i64), nil
 	case 32:
-		return int32(binary.BigEndian.Uint32(b[len(b)-4:]))
+		if !isi64 || i64 < math.MinInt32 || i64 > math.MaxInt32 {
+			return nil, errBadInt32
+		}
+		return int32(i64), nil
 	case 64:
-		return int64(binary.BigEndian.Uint64(b[len(b)-8:]))
+		if !isi64 {
+			return nil, errBadInt64
+		}
+		return i64, nil
 	default:
 		// the only case left for integer is int256
-		// big.SetBytes can't tell if a number is negative or positive in itself.
-		// On EVM, if the returned number > max int256, it is negative.
-		// A number is > max int256 if the bit at position 255 is set.
-		ret := new(big.Int).SetBytes(b)
-		if ret.Bit(255) == 1 {
-			ret.Add(MaxUint256, new(big.Int).Neg(ret))
-			ret.Add(ret, common.Big1)
-			ret.Neg(ret)
-		}
-		return ret
+
+		return ret, nil
 	}
 }
 
@@ -239,7 +269,7 @@ func toGoType(index int, t Type, output []byte) (interface{}, error) {
 	case StringTy: // variable arrays are written at the end of the return bytes
 		return string(output[begin : begin+length]), nil
 	case IntTy, UintTy:
-		return ReadInteger(t, returnOutput), nil
+		return ReadInteger(t, returnOutput)
 	case BoolTy:
 		return readBool(returnOutput)
 	case AddressTy:

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -946,128 +946,134 @@ func TestPackAndUnpackIncompatibleNumber(t *testing.T) {
 	cases := []struct {
 		decodeType  string
 		inputValue  *big.Int
-		err         error
+		unpackErr   error
+		packErr     error
 		expectValue interface{}
 	}{
 		{
 			decodeType: "uint8",
 			inputValue: big.NewInt(math.MaxUint8 + 1),
-			err:        errBadUint8,
+			unpackErr:  errBadUint8,
 		},
 		{
 			decodeType:  "uint8",
 			inputValue:  big.NewInt(math.MaxUint8),
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: uint8(math.MaxUint8),
 		},
 		{
 			decodeType: "uint16",
 			inputValue: big.NewInt(math.MaxUint16 + 1),
-			err:        errBadUint16,
+			unpackErr:  errBadUint16,
 		},
 		{
 			decodeType:  "uint16",
 			inputValue:  big.NewInt(math.MaxUint16),
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: uint16(math.MaxUint16),
 		},
 		{
 			decodeType: "uint32",
 			inputValue: big.NewInt(math.MaxUint32 + 1),
-			err:        errBadUint32,
+			unpackErr:  errBadUint32,
 		},
 		{
 			decodeType:  "uint32",
 			inputValue:  big.NewInt(math.MaxUint32),
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: uint32(math.MaxUint32),
 		},
 		{
 			decodeType: "uint64",
 			inputValue: maxU64Plus1,
-			err:        errBadUint64,
+			unpackErr:  errBadUint64,
 		},
 		{
 			decodeType:  "uint64",
 			inputValue:  maxU64,
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: uint64(math.MaxUint64),
 		},
 		{
 			decodeType:  "uint256",
 			inputValue:  maxU64Plus1,
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: maxU64Plus1,
 		},
 		{
 			decodeType: "int8",
 			inputValue: big.NewInt(math.MaxInt8 + 1),
-			err:        errBadInt8,
+			unpackErr:  errBadInt8,
 		},
 		{
-			decodeType: "int8",
 			inputValue: big.NewInt(math.MinInt8 - 1),
-			err:        errBadInt8,
+			packErr:    errInvalidSign,
 		},
 		{
 			decodeType:  "int8",
 			inputValue:  big.NewInt(math.MaxInt8),
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: int8(math.MaxInt8),
 		},
 		{
 			decodeType: "int16",
 			inputValue: big.NewInt(math.MaxInt16 + 1),
-			err:        errBadInt16,
+			unpackErr:  errBadInt16,
 		},
 		{
-			decodeType: "int16",
 			inputValue: big.NewInt(math.MinInt16 - 1),
-			err:        errBadInt16,
+			packErr:    errInvalidSign,
 		},
 		{
 			decodeType:  "int16",
 			inputValue:  big.NewInt(math.MaxInt16),
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: int16(math.MaxInt16),
 		},
 		{
 			decodeType: "int32",
 			inputValue: big.NewInt(math.MaxInt32 + 1),
-			err:        errBadInt32,
+			unpackErr:  errBadInt32,
 		},
 		{
-			decodeType: "int32",
 			inputValue: big.NewInt(math.MinInt32 - 1),
-			err:        errBadInt32,
+			packErr:    errInvalidSign,
 		},
 		{
 			decodeType:  "int32",
 			inputValue:  big.NewInt(math.MaxInt32),
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: int32(math.MaxInt32),
 		},
 		{
 			decodeType: "int64",
 			inputValue: new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1)),
-			err:        errBadInt64,
+			unpackErr:  errBadInt64,
 		},
 		{
-			decodeType: "int64",
 			inputValue: new(big.Int).Sub(big.NewInt(math.MinInt64), big.NewInt(1)),
-			err:        errBadInt64,
+			packErr:    errInvalidSign,
 		},
 		{
 			decodeType:  "int64",
 			inputValue:  big.NewInt(math.MaxInt64),
-			err:         nil,
+			unpackErr:   nil,
 			expectValue: int64(math.MaxInt64),
 		},
 	}
 	for i, testCase := range cases {
 		packed, err := encodeABI.Pack(testCase.inputValue)
-		if err != nil {
-			panic(err)
+		if testCase.packErr != nil {
+			if err == nil {
+				t.Fatalf("expected packing of testcase input value to fail")
+			}
+			if err != testCase.packErr {
+				t.Fatalf("expected error '%v', got '%v'", testCase.packErr, err)
+			}
+			continue
+		}
+		if err != nil && err != testCase.packErr {
+			panic(fmt.Errorf("unexpected error packing test-case input: %v", err))
 		}
 		ty, err := NewType(testCase.decodeType, "", nil)
 		if err != nil {
@@ -1077,8 +1083,8 @@ func TestPackAndUnpackIncompatibleNumber(t *testing.T) {
 			{Type: ty},
 		}
 		decoded, err := decodeABI.Unpack(packed)
-		if err != testCase.err {
-			t.Fatalf("Expected error %v, actual error %v. case %d", testCase.err, err, i)
+		if err != testCase.unpackErr {
+			t.Fatalf("Expected error %v, actual error %v. case %d", testCase.unpackErr, err, i)
 		}
 		if err != nil {
 			continue

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -923,6 +924,167 @@ func TestOOMMaliciousInput(t *testing.T) {
 		_, err = abi.Methods["method"].Outputs.UnpackValues(encb)
 		if err == nil {
 			t.Fatalf("Expected error on malicious input, test %d", i)
+		}
+	}
+}
+
+func TestPackAndUnpackIncompatibleNumber(t *testing.T) {
+	var encodeABI Arguments
+	uint256Ty, err := NewType("uint256", "", nil)
+	if err != nil {
+		panic(err)
+	}
+	encodeABI = Arguments{
+		{Type: uint256Ty},
+	}
+
+	maxU64, ok := new(big.Int).SetString(strconv.FormatUint(math.MaxUint64, 10), 10)
+	if !ok {
+		panic("bug")
+	}
+	maxU64Plus1 := new(big.Int).Add(maxU64, big.NewInt(1))
+	cases := []struct {
+		decodeType  string
+		inputValue  *big.Int
+		err         error
+		expectValue interface{}
+	}{
+		{
+			decodeType: "uint8",
+			inputValue: big.NewInt(math.MaxUint8 + 1),
+			err:        errBadUint8,
+		},
+		{
+			decodeType:  "uint8",
+			inputValue:  big.NewInt(math.MaxUint8),
+			err:         nil,
+			expectValue: uint8(math.MaxUint8),
+		},
+		{
+			decodeType: "uint16",
+			inputValue: big.NewInt(math.MaxUint16 + 1),
+			err:        errBadUint16,
+		},
+		{
+			decodeType:  "uint16",
+			inputValue:  big.NewInt(math.MaxUint16),
+			err:         nil,
+			expectValue: uint16(math.MaxUint16),
+		},
+		{
+			decodeType: "uint32",
+			inputValue: big.NewInt(math.MaxUint32 + 1),
+			err:        errBadUint32,
+		},
+		{
+			decodeType:  "uint32",
+			inputValue:  big.NewInt(math.MaxUint32),
+			err:         nil,
+			expectValue: uint32(math.MaxUint32),
+		},
+		{
+			decodeType: "uint64",
+			inputValue: maxU64Plus1,
+			err:        errBadUint64,
+		},
+		{
+			decodeType:  "uint64",
+			inputValue:  maxU64,
+			err:         nil,
+			expectValue: uint64(math.MaxUint64),
+		},
+		{
+			decodeType:  "uint256",
+			inputValue:  maxU64Plus1,
+			err:         nil,
+			expectValue: maxU64Plus1,
+		},
+		{
+			decodeType: "int8",
+			inputValue: big.NewInt(math.MaxInt8 + 1),
+			err:        errBadInt8,
+		},
+		{
+			decodeType: "int8",
+			inputValue: big.NewInt(math.MinInt8 - 1),
+			err:        errBadInt8,
+		},
+		{
+			decodeType:  "int8",
+			inputValue:  big.NewInt(math.MaxInt8),
+			err:         nil,
+			expectValue: int8(math.MaxInt8),
+		},
+		{
+			decodeType: "int16",
+			inputValue: big.NewInt(math.MaxInt16 + 1),
+			err:        errBadInt16,
+		},
+		{
+			decodeType: "int16",
+			inputValue: big.NewInt(math.MinInt16 - 1),
+			err:        errBadInt16,
+		},
+		{
+			decodeType:  "int16",
+			inputValue:  big.NewInt(math.MaxInt16),
+			err:         nil,
+			expectValue: int16(math.MaxInt16),
+		},
+		{
+			decodeType: "int32",
+			inputValue: big.NewInt(math.MaxInt32 + 1),
+			err:        errBadInt32,
+		},
+		{
+			decodeType: "int32",
+			inputValue: big.NewInt(math.MinInt32 - 1),
+			err:        errBadInt32,
+		},
+		{
+			decodeType:  "int32",
+			inputValue:  big.NewInt(math.MaxInt32),
+			err:         nil,
+			expectValue: int32(math.MaxInt32),
+		},
+		{
+			decodeType: "int64",
+			inputValue: new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1)),
+			err:        errBadInt64,
+		},
+		{
+			decodeType: "int64",
+			inputValue: new(big.Int).Sub(big.NewInt(math.MinInt64), big.NewInt(1)),
+			err:        errBadInt64,
+		},
+		{
+			decodeType:  "int64",
+			inputValue:  big.NewInt(math.MaxInt64),
+			err:         nil,
+			expectValue: int64(math.MaxInt64),
+		},
+	}
+	for i, testCase := range cases {
+		packed, err := encodeABI.Pack(testCase.inputValue)
+		if err != nil {
+			panic(err)
+		}
+		ty, err := NewType(testCase.decodeType, "", nil)
+		if err != nil {
+			panic(err)
+		}
+		decodeABI := Arguments{
+			{Type: ty},
+		}
+		decoded, err := decodeABI.Unpack(packed)
+		if err != testCase.err {
+			t.Fatalf("Expected error %v, actual error %v. case %d", testCase.err, err, i)
+		}
+		if err != nil {
+			continue
+		}
+		if !reflect.DeepEqual(decoded[0], testCase.expectValue) {
+			t.Fatalf("Expected value %v, actual value %v", testCase.expectValue, decoded[0])
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR cherry-picks two upstream changes from go-ethereum to fix unsafe behavior when ABI-encoding values.

Specifically:
- #26568: Prevents packing of negative values into unsigned types (`uint`) during ABI encoding.
- #31790: Adds stricter input validation to avoid unintended encoding of negative values as large uints.

These changes improve the correctness and safety of contract interactions by eliminating edge cases that could result in invalid transaction data or runtime errors.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
