### PR TITLE
kaiax/builder: Add metrics for knownTxs

### DIFF
--- a/kaiax/builder/impl/init.go
+++ b/kaiax/builder/impl/init.go
@@ -85,6 +85,16 @@ func (k knownTxs) markDemoted(hash common.Hash) {
 	}
 }
 
+func (k knownTxs) getTimeOfOldestKnownTx() int64 {
+	var oldestTime float64 = 0
+	for _, knownTx := range k {
+		if oldestTime < knownTx.elapsedTime().Seconds() {
+			oldestTime = knownTx.elapsedTime().Seconds()
+		}
+	}
+	return int64(oldestTime)
+}
+
 type knownTx struct {
 	tx        *types.Transaction
 	time      time.Time


### PR DESCRIPTION
## Proposed changes

This request adds the following metrics:
- Number of knownTxs
  - ![2025-06-13 12 19 32](https://github.com/user-attachments/assets/0b4d3384-f23a-41b4-a7a0-7b3b3af6aef7)
- The time of the oldest knownTx in knownTxs
  - ![2025-06-13 12 19 57](https://github.com/user-attachments/assets/06d0ff76-504c-47f8-b8ab-506790fe7525)

These updates occur immediately after additions and deletions to knownTxs.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
