### PR TITLE
kaiax/gasless: Use separate read-only state

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1800,11 +1800,6 @@ func (pool *TxPool) demoteUnexecutables() {
 	}
 }
 
-// GetCurrentState returns the current stateDB.
-func (pool *TxPool) GetCurrentState() *state.StateDB {
-	return pool.currentState
-}
-
 // getNonce returns the nonce of the account from the cache. If it is not in the cache, it gets the nonce from the stateDB.
 func (pool *TxPool) getNonce(addr common.Address) uint64 {
 	return pool.currentState.GetNonce(addr)

--- a/kaiax/gasless/impl/execution.go
+++ b/kaiax/gasless/impl/execution.go
@@ -28,6 +28,6 @@ func (g *GaslessModule) PostInsertBlock(block *types.Block) error {
 	if err != nil {
 		return err
 	}
-	g.currentState = currentState
+	g.setCurrentState(currentState)
 	return g.updateAddresses(block.Header())
 }

--- a/kaiax/gasless/impl/execution.go
+++ b/kaiax/gasless/impl/execution.go
@@ -24,5 +24,10 @@ import (
 var _ kaiax.ExecutionModule = (*GaslessModule)(nil)
 
 func (g *GaslessModule) PostInsertBlock(block *types.Block) error {
+	currentState, err := g.Chain.StateAt(block.Header().Root)
+	if err != nil {
+		return err
+	}
+	g.currentState = currentState
 	return g.updateAddresses(block.Header())
 }

--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -240,12 +240,12 @@ func (g *GaslessModule) VerifyExecutable(approveTxOrNil, swapTx *types.Transacti
 		if approveTxOrNil.Nonce()+1 != swapTx.Nonce() {
 			return fmt.Errorf("%w: approve nonce %d, swap nonce %d (expected %d)", ErrNonSequentialNonce, approveTxOrNil.Nonce(), swapTx.Nonce(), approveTxOrNil.Nonce()+1)
 		}
-		if nonce := g.TxPool.GetCurrentState().GetNonce(approveArgs.Sender); nonce != approveTxOrNil.Nonce() {
+		if nonce := g.getCurrentStateNonce(approveArgs.Sender); nonce != approveTxOrNil.Nonce() {
 			return fmt.Errorf("%w: approve nonce %d, current nonce %d", ErrApproveNonceNotCurrent, approveTxOrNil.Nonce(), nonce)
 		}
 	} else {
 		// SP3.
-		if nonce := g.TxPool.GetCurrentState().GetNonce(swapArgs.Sender); nonce != swapTx.Nonce() {
+		if nonce := g.getCurrentStateNonce(swapArgs.Sender); nonce != swapTx.Nonce() {
 			return fmt.Errorf("%w: swap nonce %d, current nonce %d", ErrSwapNonceNotCurrent, swapTx.Nonce(), nonce)
 		}
 	}

--- a/kaiax/gasless/impl/helper_test.go
+++ b/kaiax/gasless/impl/helper_test.go
@@ -212,10 +212,6 @@ type testTxPool struct {
 	statedb *state.StateDB
 }
 
-func (pool *testTxPool) GetCurrentState() *state.StateDB {
-	return pool.statedb
-}
-
 func (pool *testTxPool) PendingUnlocked() (map[common.Address]types.Transactions, error) {
 	return nil, nil
 }

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -68,7 +68,7 @@ func (g *GaslessModule) isApproveTxReady(approveTx, nextTx *types.Transaction) b
 	if err != nil {
 		return false
 	}
-	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
+	nonce := g.getCurrentStateNonce(addr)
 
 	if approveTx.Nonce() != nonce {
 		return false
@@ -86,7 +86,7 @@ func (g *GaslessModule) isSwapTxReady(swapTx, prevTx *types.Transaction) bool {
 	if err != nil {
 		return false
 	}
-	nonce := g.TxPool.GetCurrentState().GetNonce(addr)
+	nonce := g.getCurrentStateNonce(addr)
 
 	var approveTx *types.Transaction
 	if swapTx.Nonce() == nonce {

--- a/kaiax/gasless/impl/tx_pool_test.go
+++ b/kaiax/gasless/impl/tx_pool_test.go
@@ -195,11 +195,12 @@ func TestIsReady(t *testing.T) {
 				GaslessConfig: testGaslessConfig,
 				NodeKey:       nodeKey,
 				Chain:         backend.BlockChain(),
-				TxPool:        &testTxPool{cdb},
+				TxPool:        &testTxPool{},
 				NodeType:      common.ENDPOINTNODE,
 			})
 			require.NoError(t, err)
 
+			g.setCurrentState(cdb)
 			ok := g.IsReady(tc.queue, tc.i, tc.ready)
 			require.Equal(t, tc.expected, ok)
 		})

--- a/kaiax/interface.go
+++ b/kaiax/interface.go
@@ -164,7 +164,6 @@ type TxPoolModule interface {
 
 //go:generate mockgen -destination=./mock/tx_pool_for_caller.go -package=mock github.com/kaiachain/kaia/kaiax TxPoolForCaller
 type TxPoolForCaller interface {
-	GetCurrentState() *state.StateDB
 	PendingUnlocked() (map[common.Address]types.Transactions, error)
 }
 

--- a/kaiax/mock/tx_pool_for_caller.go
+++ b/kaiax/mock/tx_pool_for_caller.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
 )
@@ -34,20 +33,6 @@ func NewMockTxPoolForCaller(ctrl *gomock.Controller) *MockTxPoolForCaller {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTxPoolForCaller) EXPECT() *MockTxPoolForCallerMockRecorder {
 	return m.recorder
-}
-
-// GetCurrentState mocks base method.
-func (m *MockTxPoolForCaller) GetCurrentState() *state.StateDB {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentState")
-	ret0, _ := ret[0].(*state.StateDB)
-	return ret0
-}
-
-// GetCurrentState indicates an expected call of GetCurrentState.
-func (mr *MockTxPoolForCallerMockRecorder) GetCurrentState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentState", reflect.TypeOf((*MockTxPoolForCaller)(nil).GetCurrentState))
 }
 
 // PendingUnlocked mocks base method.

--- a/work/mocks/txpool_mock.go
+++ b/work/mocks/txpool_mock.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	blockchain "github.com/kaiachain/kaia/blockchain"
-	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
 	event "github.com/kaiachain/kaia/event"
@@ -109,20 +108,6 @@ func (m *MockTxPool) Get(arg0 common.Hash) *types.Transaction {
 func (mr *MockTxPoolMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTxPool)(nil).Get), arg0)
-}
-
-// GetCurrentState mocks base method.
-func (m *MockTxPool) GetCurrentState() *state.StateDB {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentState")
-	ret0, _ := ret[0].(*state.StateDB)
-	return ret0
-}
-
-// GetCurrentState indicates an expected call of GetCurrentState.
-func (mr *MockTxPoolMockRecorder) GetCurrentState() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentState", reflect.TypeOf((*MockTxPool)(nil).GetCurrentState))
 }
 
 // GetPendingNonce mocks base method.

--- a/work/work.go
+++ b/work/work.go
@@ -77,7 +77,6 @@ type TxPool interface {
 	Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	StartSpamThrottler(conf *blockchain.ThrottlerConfig) error
 	StopSpamThrottler()
-	GetCurrentState() *state.StateDB
 
 	kaiax.TxPoolModuleHost
 }


### PR DESCRIPTION
## Proposed changes

- The kaiax/gasless module uses its own statedb `g.currentState` to query accounts.
- Previously, the module has been borrowing the txpool's `pool.currentState` variable without proper synchronization. There was a race condition hazard when accessing the statedb variable, and the values within.
- The `pool.currentState` is updated at `pool.reset()` which is triggered by ChainHeadEvent. The `g.currentState` is updated at `PostInsertBlock` which is also triggered after block insertion. These two are essentially updated at the same time, so this PR keeps the semantics.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
