### PR TITLE
worker: CN log subscription keeps the execution order

### DIFF
--- a/work/worker.go
+++ b/work/worker.go
@@ -404,14 +404,14 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 
 			// Update the block hash in all logs since it is now available and not when the
 			// receipt/log of individual transactions were created.
-			for _, r := range work.receipts {
-				for _, l := range r.Logs {
-					l.BlockHash = block.Hash()
-				}
-			}
 			work.stateMu.Lock()
 			for _, log := range work.state.Logs() {
 				log.BlockHash = block.Hash()
+			}
+
+			var logs []*types.Log
+			for _, r := range work.receipts {
+				logs = append(logs, r.Logs...)
 			}
 
 			start := time.Now()
@@ -442,7 +442,6 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 			var events []interface{}
 
 			work.stateMu.RLock()
-			logs := work.state.Logs()
 			work.stateMu.RUnlock()
 
 			events = append(events, blockchain.ChainEvent{Block: block, Hash: block.Hash(), Logs: logs})

--- a/work/worker.go
+++ b/work/worker.go
@@ -408,12 +408,10 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 			for _, log := range work.state.Logs() {
 				log.BlockHash = block.Hash()
 			}
-
 			var logs []*types.Log
 			for _, r := range work.receipts {
 				logs = append(logs, r.Logs...)
 			}
-
 			start := time.Now()
 			result, err := self.chain.WriteBlockWithState(block, work.receipts, work.state)
 			work.stateMu.Unlock()
@@ -440,10 +438,6 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 			self.mux.Post(blockchain.NewMinedBlockEvent{Block: block})
 
 			var events []interface{}
-
-			work.stateMu.RLock()
-			work.stateMu.RUnlock()
-
 			events = append(events, blockchain.ChainEvent{Block: block, Hash: block.Hash(), Logs: logs})
 			if result.Status == blockchain.CanonStatTy {
 				events = append(events, blockchain.ChainHeadEvent{Block: block})


### PR DESCRIPTION
## Proposed changes

Pulling events via subscription is a common way in EVM-compatible chains, including Kaia.
All events occurred in a block must be in order.
- Ordering in a single transaction (events)
    - Ordered during EVM execution (https://github.com/kaiachain/kaia/blob/dev/blockchain/state/statedb.go#L202, https://github.com/kaiachain/kaia/blob/891ffd6ee8d3b486e8cf8472b33b38e8575c71de/blockchain/vm/instructions.go#L889)
- Ordering in a block (transactions)
   - Ordered during process (EN, PN) (https://github.com/kaiachain/kaia/blob/dev/blockchain/blockchain.go#L2127, https://github.com/kaiachain/kaia/blob/dev/blockchain/state_processor.go#L92)


However, when subscription is established with CN, the ordering is not guaranteed because of  (https://github.com/kaiachain/kaia/blob/dev/blockchain/state_processor.go#L92, https://github.com/kaiachain/kaia/blob/dev/blockchain/state/statedb.go#L217)

The [Logs()](https://github.com/kaiachain/kaia/blob/dev/blockchain/state/statedb.go#L217) function just only collect all logs and breaks the ordering at this moment by iterating a primitive map (unordered map). This PR aligns with the ordering process of PN and EN.

PoC 
```go
package main

import (
	"bytes"
	"context"
	"fmt"
	"math/big"

	"github.com/kaiachain/kaia"
	"github.com/kaiachain/kaia/accounts/abi"
	"github.com/kaiachain/kaia/blockchain/types"
	"github.com/kaiachain/kaia/client"
	"github.com/kaiachain/kaia/common"
	"github.com/kaiachain/kaia/common/hexutil"
	"github.com/kaiachain/kaia/crypto"
)

var (
	CHAIN_ID             = big.NewInt(8127)
	signer               = types.LatestSignerForChainID(CHAIN_ID)
	GAS_LIMIT            = uint64(10000000)
	UPPER_BOUND_BASE_GAS = big.NewInt(750000000000)

	c, _        = client.Dial("ws://localhost:8146")
	key, _      = crypto.HexToECDSA("60761275248599b446345c5ca2070ed5f4a531332a2aa8b9734d204693abf711")
	addr        = crypto.PubkeyToAddress(key.PublicKey)
	to          = common.HexToAddress("0xb9c3C3Cf068BD916b6B4D4a8AEB913cA0b1f1C3C")
	calldata, _ = hexutil.Decode("0x371303c0")
	evHash      = common.HexToHash("0x34ca302bc0955408399d40201f4db198dbee6e855591e0c64116281c7e1aa117")
	evCh        = make(chan types.Log, 128)
	sub         = subscribe()

	// // SPDX-License-Identifier: LGPL-3.0-only
	// pragma solidity ^0.8.18;

	// contract C {
	//     event INC(uint256 counter);

	//     uint256 counter = 0;

	//     function inc() public {
	//         counter += 1;
	//         emit INC(counter);
	//     }

	//     function get() public view returns (uint256) {
	//         return counter;
	//     }
	// }

	ABI_STR = `
[{
  "anonymous": false,
  "inputs": [
    {
      "indexed": false,
      "internalType": "uint256",
      "name": "counter",
      "type": "uint256"
    }
  ],
  "name": "INC",
  "type": "event"
}]
	`
	ABI, _ = abi.JSON(bytes.NewReader([]byte(ABI_STR)))
)

func subscribe() kaia.Subscription {
	filterQuery := kaia.FilterQuery{
		Addresses: []common.Address{to},
		Topics: [][]common.Hash{
			{
				evHash,
			},
		},
	}
	sub, err := c.SubscribeFilterLogs(context.Background(), filterQuery, evCh)
	if err != nil {
		panic(err)
	}
	return sub
}

func genTx(nonce uint64) *types.Transaction {
	tx, err := types.SignTx(types.NewTransaction(nonce, to, nil, GAS_LIMIT, UPPER_BOUND_BASE_GAS, calldata), signer, key)
	if err != nil {
		panic(err)
	}
	if err := c.SendTransaction(context.Background(), tx); err != nil {
		panic(err)
	}
	return tx
}

func main() {
	var (
		nonce, _ = c.PendingNonceAt(context.Background(), addr)
		n        = 3
	)

	for range n {
		tx := genTx(nonce)
		fmt.Println(tx.Hash().String())
		nonce++
// expected print:
// n
// n+1
// n+2

// actual print:
// n
// n+1
// n+2
// or
// n+1
// n+2
// n
// or
// n+2
// n+1
// n
// .. and so on

	}

	cnt := 0
	for log := range evCh {
		fmt.Println(decodeEv(log.Data), log.BlockHash.String())
		cnt++
		if cnt == n {
			break
		}
	}
}

func decodeEv(data []byte) *big.Int {
	var counter *big.Int
	err := ABI.UnpackIntoInterface(&counter, "INC", data)
	if err != nil {
		panic(err)
	}
	return counter
}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
