### PR TITLE
blockchain: Handle `ErrFloorDataGas` in `DoEstimateGas` for EIP-7623

### DIFF
--- a/api/api_ethereum.go
+++ b/api/api_ethereum.go
@@ -1488,7 +1488,7 @@ func EthDoEstimateGas(ctx context.Context, b Backend, args EthTransactionArgs, b
 		args.Gas = (*hexutil.Uint64)(&gas)
 		result, err := EthDoCall(ctx, b, args, blockNrOrHash, overrides, b.RPCEVMTimeout(), gasCap)
 		if err != nil {
-			if errors.Is(err, blockchain.ErrIntrinsicGas) {
+			if errors.Is(err, blockchain.ErrIntrinsicGas) || errors.Is(err, blockchain.ErrFloorDataGas) {
 				return true, nil, nil // Special case, raise gas limit
 			}
 			// Returns error when it is not VM error (less balance or wrong nonce, etc...).

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -2517,8 +2517,9 @@ func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimate
 	//     }
 	// }
 	code := hexutil.Bytes(common.Hex2Bytes("6080604052348015600e575f5ffd5b50600436106026575f3560e01c80632e64cec114602a575b5f5ffd5b60306044565b604051603b91906062565b60405180910390f35b5f5f54905090565b5f819050919050565b605c81604c565b82525050565b5f60208201905060735f8301846055565b9291505056fea26469706673582212206aeab8d313a899d42a212113167e622ff770e746a3c3d0596d15fe2551d2c97464736f6c634300081e0033"))
+	// retrieve() with long junk to increase floor data gas. 104 nonzero tokens = 4160 floor data gas = 25160 intrinsic gas
 	data := hexutil.Bytes(common.Hex2Bytes("2e64cec1"))
-	data = append(data, bytes.Repeat([]byte{0xff}, 100)...) // increase floor gas
+	data = append(data, bytes.Repeat([]byte{0xff}, 100)...)
 
 	testcases := []struct {
 		args      EthTransactionArgs

--- a/api/api_ethereum_test.go
+++ b/api/api_ethereum_test.go
@@ -2432,7 +2432,7 @@ func (mc *testChainContext) GetHeader(common.Hash, uint64) *types.Header {
 // Contract C { constructor() { revert("hello"); } }
 var codeRevertHello = "0x6080604052348015600f57600080fd5b5060405162461bcd60e51b815260206004820152600560248201526468656c6c6f60d81b604482015260640160405180910390fdfe"
 
-func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimateGas func(EthTransactionArgs) (hexutil.Uint64, error)) {
+func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimateGas func(EthTransactionArgs, *EthStateOverride) (hexutil.Uint64, error)) {
 	chainConfig := &params.ChainConfig{}
 	chainConfig.IstanbulCompatibleBlock = common.Big0
 	chainConfig.LondonCompatibleBlock = common.Big0
@@ -2494,10 +2494,37 @@ func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimate
 	mockBackend.EXPECT().GetEVM(any, any, any, any, any).DoAndReturn(getEVM).AnyTimes()
 	mockBackend.EXPECT().IsConsoleLogEnabled().Return(false).AnyTimes()
 
+	// For floor data gas error case (EIP-7623)
+	// // SPDX-License-Identifier: GPL-3.0
+
+	// pragma solidity >=0.8.2 <0.9.0;
+	//
+	// /**
+	//  * @title Storage
+	//  * @dev Store & retrieve value in a variable
+	//  * @custom:dev-run-script ./scripts/deploy_with_ethers.ts
+	//  */
+	// contract Storage {
+	//
+	//     uint256 number;
+	//
+	//     /**
+	//      * @dev Return value
+	//      * @return value of 'number'
+	//      */
+	//     function retrieve() public view returns (uint256){
+	//         return number;
+	//     }
+	// }
+	code := hexutil.Bytes(common.Hex2Bytes("6080604052348015600e575f5ffd5b50600436106026575f3560e01c80632e64cec114602a575b5f5ffd5b60306044565b604051603b91906062565b60405180910390f35b5f5f54905090565b5f819050919050565b605c81604c565b82525050565b5f60208201905060735f8301846055565b9291505056fea26469706673582212206aeab8d313a899d42a212113167e622ff770e746a3c3d0596d15fe2551d2c97464736f6c634300081e0033"))
+	data := hexutil.Bytes(common.Hex2Bytes("2e64cec1"))
+	data = append(data, bytes.Repeat([]byte{0xff}, 100)...) // increase floor gas
+
 	testcases := []struct {
 		args      EthTransactionArgs
 		expectErr string
 		expectGas uint64
+		overrides EthStateOverride
 	}{
 		{ // simple transfer
 			args: EthTransactionArgs{
@@ -2588,10 +2615,26 @@ func testEstimateGas(t *testing.T, mockBackend *mock_api.MockBackend, fnEstimate
 			},
 			expectGas: 21000,
 		},
+		{ // Should be able to handle EIP-7623.
+			args: EthTransactionArgs{
+				From: &account1,
+				To:   &account2,
+				Data: &data,
+			},
+			overrides: EthStateOverride{
+				account2: EthOverrideAccount{
+					Code: &code,
+				},
+			},
+			expectGas: 25160,
+			// We return ErrIntrinsicGas instead of ErrFloorDataGas when floor data gas hits the cap.
+			// So EstimateGas will be able to return expected gas instead of this error.
+			// expectErr: "insufficient gas for floor data gas cost",
+		},
 	}
 
 	for i, tc := range testcases {
-		gas, err := fnEstimateGas(tc.args)
+		gas, err := fnEstimateGas(tc.args, &tc.overrides)
 		t.Logf("tc[%02d] = %d %v", i, gas, err)
 		if len(tc.expectErr) > 0 {
 			require.NotNil(t, err)
@@ -2607,7 +2650,7 @@ func TestEthereumAPI_EstimateGas(t *testing.T) {
 	mockCtrl, mockBackend, api := testInitForEthApi(t)
 	defer mockCtrl.Finish()
 
-	testEstimateGas(t, mockBackend, func(args EthTransactionArgs) (hexutil.Uint64, error) {
-		return api.EstimateGas(context.Background(), args, nil, nil)
+	testEstimateGas(t, mockBackend, func(args EthTransactionArgs, overrides *EthStateOverride) (hexutil.Uint64, error) {
+		return api.EstimateGas(context.Background(), args, nil, overrides)
 	})
 }

--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -447,7 +447,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 		args.Gas = hexutil.Uint64(gas)
 		result, _, err := DoCall(ctx, b, args, blockNrOrHash, vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, timeout, gasCap)
 		if err != nil {
-			if errors.Is(err, blockchain.ErrIntrinsicGas) {
+			if errors.Is(err, blockchain.ErrIntrinsicGas) || errors.Is(err, blockchain.ErrFloorDataGas) {
 				return true, nil, nil // Special case, raise gas limit
 			}
 			return true, nil, err // Bail out

--- a/api/api_public_blockchain_test.go
+++ b/api/api_public_blockchain_test.go
@@ -43,7 +43,7 @@ func TestKaiaAPI_EstimateGas(t *testing.T) {
 	mockCtrl, mockBackend, api := testInitForKaiaApi(t)
 	defer mockCtrl.Finish()
 
-	testEstimateGas(t, mockBackend, func(ethArgs EthTransactionArgs) (hexutil.Uint64, error) {
+	testEstimateGas(t, mockBackend, func(ethArgs EthTransactionArgs, overrides *EthStateOverride) (hexutil.Uint64, error) {
 		// Testcases are written in EthTransactionArgs. Convert to Kaia CallArgs
 		args := CallArgs{
 			From:                 ethArgs.from(),
@@ -59,6 +59,6 @@ func TestKaiaAPI_EstimateGas(t *testing.T) {
 		if ethArgs.Value != nil {
 			args.Value = *ethArgs.Value
 		}
-		return api.EstimateGas(context.Background(), args, nil, nil)
+		return api.EstimateGas(context.Background(), args, nil, overrides)
 	})
 }

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -395,7 +395,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			return nil, err
 		}
 		if msg.Gas() < floorDataGas {
-			return nil, fmt.Errorf("%w: have %d, want %d", ErrFloorDataGas, st.gas, floorDataGas)
+			// To prevent EstimateGas returning ErrFloorDataGas, we return ErrIntrinsicGas instead
+			// so that EstimateGas gas would try with higher gas limit.
+			return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, floorDataGas)
 		}
 	}
 	// SigValidationGas is already inclduded in IntrinsicGas

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -395,9 +395,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 			return nil, err
 		}
 		if msg.Gas() < floorDataGas {
-			// To prevent EstimateGas returning ErrFloorDataGas, we return ErrIntrinsicGas instead
-			// so that EstimateGas gas would try with higher gas limit.
-			return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, floorDataGas)
+			return nil, fmt.Errorf("%w: have %d, want %d", ErrFloorDataGas, st.gas, floorDataGas)
 		}
 	}
 	// SigValidationGas is already inclduded in IntrinsicGas


### PR DESCRIPTION
## Proposed changes

- [KIP-223](https://github.com/kaiachain/kips/blob/main/KIPs/kip-223.md) brought [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623) to Kaia
- However our gas estimation logic is behind sync, and we experienced gas estimation not correctly calculating required gas for long calldata
   - `DoEstimateGas` only checks if its current attempt failed with `ErrInstrinsicGas` to try with a higher gas
   - When the floor data gas was hit, `DoEstimateGas` returned `ErrFloorDataGas` instead of trying with a higher gas
- Handle (or bail out) for `ErrFloorDataGas` too, like we bail out on `ErrInstrinsicGas`
- Thanks to @ian0371  for the test updates

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

