### PR TITLE
Fix VRank concurency issue

### DIFF
--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -55,7 +55,7 @@ func TestVrank(t *testing.T) {
 		expectedLateCommits = append(expectedLateCommits, vrank.commitArrivalTimeMap[committee[i]])
 	}
 
-	bitmap, late := vrank.Bitmap(), vrank.LateCommits()
+	bitmap, late := vrank.bitmap(), vrank.lateCommits()
 	assert.Equal(t, hex.EncodeToString(compress(expectedAssessList)), bitmap)
 	assert.Equal(t, expectedLateCommits, late)
 }


### PR DESCRIPTION
## Proposed changes

This PR prevents concurrent access to VRank fields. It protects other fields as well.

Now all the public functions are mutex-protected, while non-protected functions become private.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
