### PR TITLE
work: Add miner nodeAddr balance metric

### DIFF
--- a/work/work.go
+++ b/work/work.go
@@ -91,25 +91,22 @@ type Backend interface {
 
 // Miner creates blocks and searches for proof-of-work values.
 type Miner struct {
-	mux *event.TypeMux
-
-	worker *worker
-
-	rewardbase common.Address
-	mining     int32
-	backend    Backend
-	engine     consensus.Engine
+	mux     *event.TypeMux
+	worker  *worker
+	mining  int32
+	backend Backend
+	engine  consensus.Engine
 
 	canStart    int32 // can start indicates whether we can start the mining operation
 	shouldStart int32 // should start indicates whether we should start after sync
 }
 
-func New(backend Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, nodetype common.ConnType, rewardbase common.Address, TxResendUseLegacy bool, govModule gov.GovModule) *Miner {
+func New(backend Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, nodetype common.ConnType, nodeAddr common.Address, TxResendUseLegacy bool, govModule gov.GovModule) *Miner {
 	miner := &Miner{
 		backend:  backend,
 		mux:      mux,
 		engine:   engine,
-		worker:   newWorker(config, engine, rewardbase, backend, mux, nodetype, TxResendUseLegacy, govModule),
+		worker:   newWorker(config, engine, nodeAddr, backend, mux, nodetype, TxResendUseLegacy, govModule),
 		canStart: 1,
 	}
 	// TODO-Kaia drop or missing tx


### PR DESCRIPTION
## Proposed changes

- Measure CN's nodeAddr balance before mining a block. Useful for monitoring whether this CN can process gasless transactions.
- Rename `rewardbase` variable to `nodeAddr` throughout the `work` package.
  - The value comes from `crypto.PubkeyToAddress(ctx.NodeKey().PublicKey)` ([at cn.New()](https://github.com/kaiachain/kaia/blob/v2.0.2/node/cn/backend.go#L388))  
  - The value is passed on to `bc.ApplyTransaction(..., author, ...)` argument
  - The value is passed on to `txOrGen.GetTx(env.state.GetNonce(nodeAddr))`
- Delete an unused field Miner.rewardbase.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
