### PR TITLE
kaiax: Limit the number of bundletxs in a pool

### DIFF
--- a/kaiax/builder/impl/tx_pool_wrapping.go
+++ b/kaiax/builder/impl/tx_pool_wrapping.go
@@ -60,6 +60,11 @@ func (b *BuilderWrappingModule) PreAddTx(tx *types.Transaction, local bool) erro
 	if knownTx, ok := b.knownTxs.get(tx.Hash()); ok && knownTx.elapsedTime() < KnownTxTimeout {
 		return ErrUnableToAddKnownBundleTx
 	}
+
+	if uint(len(b.knownTxs)) >= b.txBundlingModule.GetMaxBundleTxsInPool() {
+		return ErrUnableToAddKnownBundleTx
+	}
+
 	if b.txPoolModule != nil {
 		return b.txPoolModule.PreAddTx(tx, local)
 	}

--- a/kaiax/builder/interface.go
+++ b/kaiax/builder/interface.go
@@ -44,6 +44,10 @@ type TxBundlingModule interface {
 	// if zero or minus value is returned, it means no limit.
 	// this limitation works properly only when a module bundles only sequential txs by the same sender.
 	GetMaxBundleTxsInPending() uint
+
+	// GetMaxBundleTxsInPool returns the maximum number of transactions that can be bundled in txpool.
+	// if zero or minus value is returned, it means no limit.
+	GetMaxBundleTxsInPool() uint
 }
 
 // Any component or module that accomodate tx bundling modules.

--- a/kaiax/builder/mock/tx_bundling_module.go
+++ b/kaiax/builder/mock/tx_bundling_module.go
@@ -63,6 +63,20 @@ func (mr *MockTxBundlingModuleMockRecorder) GetMaxBundleTxsInPending() *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleTxsInPending", reflect.TypeOf((*MockTxBundlingModule)(nil).GetMaxBundleTxsInPending))
 }
 
+// GetMaxBundleTxsInPool mocks base method.
+func (m *MockTxBundlingModule) GetMaxBundleTxsInPool() uint {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxBundleTxsInPool")
+	ret0, _ := ret[0].(uint)
+	return ret0
+}
+
+// GetMaxBundleTxsInPool indicates an expected call of GetMaxBundleTxsInPool.
+func (mr *MockTxBundlingModuleMockRecorder) GetMaxBundleTxsInPool() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleTxsInPool", reflect.TypeOf((*MockTxBundlingModule)(nil).GetMaxBundleTxsInPool))
+}
+
 // IsBundleTx mocks base method.
 func (m *MockTxBundlingModule) IsBundleTx(arg0 *types.Transaction) bool {
 	m.ctrl.T.Helper()

--- a/kaiax/gasless/config.go
+++ b/kaiax/gasless/config.go
@@ -45,6 +45,13 @@ var (
 		Aliases:  []string{"kaiax.module.gasless.max-bundle-txs-in-pending"},
 		Category: "KAIAX",
 	}
+	MaxBundleTxsInPoolFlag = &cli.IntFlag{
+		Name:     "gasless.max-bundle-txs-in-pool",
+		Usage:    "max number of gasless bundle txs in txpool. Default value is 1000. No limit if negative value",
+		Value:    1000,
+		Aliases:  []string{"kaiax.module.gasless.max-bundle-txs-in-pool"},
+		Category: "KAIAX",
+	}
 )
 
 type GaslessConfig struct {
@@ -52,6 +59,7 @@ type GaslessConfig struct {
 	AllowedTokens         []common.Address `toml:",omitempty"`
 	Disable               bool
 	MaxBundleTxsInPending uint
+	MaxBundleTxsInPool    uint
 }
 
 func DefaultGaslessConfig() *GaslessConfig {
@@ -59,6 +67,7 @@ func DefaultGaslessConfig() *GaslessConfig {
 		AllowedTokens:         nil,
 		Disable:               false,
 		MaxBundleTxsInPending: 100,
+		MaxBundleTxsInPool:    1000,
 	}
 }
 
@@ -81,5 +90,12 @@ func SetGaslessConfig(ctx *cli.Context, cfg *GaslessConfig) {
 		cfg.MaxBundleTxsInPending = uint(size)
 	} else {
 		cfg.MaxBundleTxsInPending = math.MaxUint64
+	}
+
+	// use default value if size is zero
+	if size := ctx.Int(MaxBundleTxsInPoolFlag.Name); size > 0 {
+		cfg.MaxBundleTxsInPool = uint(size)
+	} else {
+		cfg.MaxBundleTxsInPool = math.MaxUint64
 	}
 }

--- a/kaiax/gasless/impl/builder.go
+++ b/kaiax/gasless/impl/builder.go
@@ -74,3 +74,7 @@ func (g *GaslessModule) IsBundleTx(tx *types.Transaction) bool {
 func (g *GaslessModule) GetMaxBundleTxsInPending() uint {
 	return g.GaslessConfig.MaxBundleTxsInPending
 }
+
+func (g *GaslessModule) GetMaxBundleTxsInPool() uint {
+	return g.GaslessConfig.MaxBundleTxsInPool
+}

--- a/kaiax/gasless/mock/module.go
+++ b/kaiax/gasless/mock/module.go
@@ -78,6 +78,20 @@ func (mr *MockGaslessModuleMockRecorder) GetMaxBundleTxsInPending() *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleTxsInPending", reflect.TypeOf((*MockGaslessModule)(nil).GetMaxBundleTxsInPending))
 }
 
+// GetMaxBundleTxsInPool mocks base method.
+func (m *MockGaslessModule) GetMaxBundleTxsInPool() uint {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxBundleTxsInPool")
+	ret0, _ := ret[0].(uint)
+	return ret0
+}
+
+// GetMaxBundleTxsInPool indicates an expected call of GetMaxBundleTxsInPool.
+func (mr *MockGaslessModuleMockRecorder) GetMaxBundleTxsInPool() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxBundleTxsInPool", reflect.TypeOf((*MockGaslessModule)(nil).GetMaxBundleTxsInPool))
+}
+
 // IsBundleTx mocks base method.
 func (m *MockGaslessModule) IsBundleTx(arg0 *types.Transaction) bool {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Proposed changes

Limit the number of bundletxs in a pool.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
