### PR TITLE
api: improve treating gas=0 when DoCall via kaia_estimateGas as the same as eth_estimateGas

### DIFF
--- a/api/api_public_blockchain.go
+++ b/api/api_public_blockchain.go
@@ -282,7 +282,7 @@ func (s *PublicBlockChainAPI) IsConsoleLogEnabled() bool {
 type CallArgs struct {
 	From                 common.Address  `json:"from"`
 	To                   *common.Address `json:"to"`
-	Gas                  hexutil.Uint64  `json:"gas"`
+	Gas                  *hexutil.Uint64 `json:"gas"`
 	GasPrice             *hexutil.Big    `json:"gasPrice"`
 	MaxFeePerGas         *hexutil.Big    `json:"maxFeePerGas"`
 	MaxPriorityFeePerGas *hexutil.Big    `json:"maxPriorityFeePerGas"`
@@ -426,6 +426,11 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs, bl
 }
 
 func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *EthStateOverride, timeout time.Duration, gasCap *big.Int) (hexutil.Uint64, error) {
+	var gasLimit uint64 = 0
+	if args.Gas != nil {
+		gasLimit = uint64(*args.Gas)
+	}
+
 	var feeCap *big.Int
 	if args.GasPrice != nil {
 		feeCap = args.GasPrice.ToInt()
@@ -444,7 +449,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 
 	// Create a helper to check if a gas allowance results in an executable transaction
 	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
-		args.Gas = hexutil.Uint64(gas)
+		args.Gas = (*hexutil.Uint64)(&gas)
 		result, _, err := DoCall(ctx, b, args, blockNrOrHash, vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, timeout, gasCap)
 		if err != nil {
 			if errors.Is(err, blockchain.ErrIntrinsicGas) || errors.Is(err, blockchain.ErrFloorDataGas) {
@@ -455,7 +460,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 		return result.Failed(), result, nil
 	}
 
-	return blockchain.DoEstimateGas(ctx, uint64(args.Gas), gasCap.Uint64(), args.Value.ToInt(), feeCap, balance, executable)
+	return blockchain.DoEstimateGas(ctx, gasLimit, gasCap.Uint64(), args.Value.ToInt(), feeCap, balance, executable)
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM
@@ -711,8 +716,8 @@ func (args *CallArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, intrinsic
 	if gas == 0 {
 		gas = params.UpperGasLimit
 	}
-	if args.Gas != 0 {
-		gas = uint64(args.Gas)
+	if args.Gas != nil {
+		gas = uint64(*args.Gas)
 	}
 	if globalGasCap != 0 && globalGasCap < gas {
 		logger.Warn("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)

--- a/api/api_public_blockchain_test.go
+++ b/api/api_public_blockchain_test.go
@@ -54,7 +54,7 @@ func TestKaiaAPI_EstimateGas(t *testing.T) {
 			Data:                 ethArgs.data(),
 		}
 		if ethArgs.Gas != nil {
-			args.Gas = *ethArgs.Gas
+			args.Gas = ethArgs.Gas
 		}
 		if ethArgs.Value != nil {
 			args.Value = *ethArgs.Value


### PR DESCRIPTION
## Proposed changes

Improve the same behavior when the TX sender has the balance and sends TX without `args.Gas`:
* ASIS
  * eth_estimateGas: add balance = 0, and then `estimateGas` <ins>**fails**</ins>
  * kaia_estimateGas: add balance = `enough value`, and then `estimateGas` <ins>**succeed**</ins>

---
Here are the each sequence path:
* eth_estimateGas
```go
// EthereumAPI.EstimateGas
// EthDoEstimateGas
...
	var gasLimit uint64 = 0
	if args.Gas != nil {
		gasLimit = uint64(*args.Gas)
	}
...
// #####: args.Gas = nil, gasLimit = 0
	return blockchain.DoEstimateGas(ctx, gasLimit, gasCap, args.Value.ToInt(), feeCap, balance, executable)
// blockchain.DoEstimateGas
// #####: gasLimit = 0
	if gasLimit >= params.TxGas {
		hi = gasLimit
	}
...
// #####: call the `executable` function
// #####: hi = gasLimit = 0
	if hi == cap {
		failed, result, err := test(hi)
// EthDoEstimateGas
// #####: gas = hi = gasLimit = 0
	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
		args.Gas = (*hexutil.Uint64)(&gas)
		result, err := EthDoCall(ctx, b, args, blockNrOrHash, overrides, b.RPCEVMTimeout(), gasCap)
// EthDoCall
// #####: add balance = 0
// #####: msg.Gas() = gas = args.Gas = gas = hi = gasLimit = 0
	msg, err := args.ToMessage(globalGasCap, baseFee, intrinsicGas)
	if err != nil {
		return nil, err
	}

	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
	state.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.EffectiveGasPrice(header, b.ChainConfig())))
// EthTransactionArgs.ToMessage
// #####: Set zero when `args.Gas != nil`
// #####: gas = args.Gas = gas = hi = gasLimit = 0
	gas := globalGasCap
	if gas == 0 {
		gas = params.UpperGasLimit
	}
	if args.Gas != nil {
		gas = uint64(*args.Gas)
	}
```
  * kaia_estimateGas
```go
// PublicBlockChainAPI.EstimateGas
// DoEstimateGas
// #####: args.Gas = 0
	return blockchain.DoEstimateGas(ctx, uint64(args.Gas), gasCap.Uint64(), args.Value.ToInt(), feeCap, balance, executable)
// blockchain.DoEstimateGas
// #####: gasLimit = args.Gas = 0
	if gasLimit >= params.TxGas {
		hi = gasLimit
	}
...
// #####: call the `executable` function
// #####: hi = gasLimit = args.Gas = 0
	if hi == cap {
		failed, result, err := test(hi)
// DoEstimateGas
// #####: gas = hi = gasLimit = args.Gas = `0`
	executable := func(gas uint64) (bool, *blockchain.ExecutionResult, error) {
		args.Gas = hexutil.Uint64(gas)
		result, _, err := DoCall(ctx, b, args, blockNrOrHash, vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite}, timeout, gasCap)
// DoCall
// #####: add balance = `params.UpperGasLimit/msg.EffectiveGasPrice(header, b.ChainConfig())`
// #####: msg.Gas() = gas = params.UpperGasLimit
	msg, err := args.ToMessage(globalGasCap.Uint64(), baseFee, intrinsicGas)
	if err != nil {
		return nil, 0, err
	}

	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
	state.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.EffectiveGasPrice(header, b.ChainConfig())))
// CallArgs.ToMessage
// #####: Don't set zero when `args.Gas = 0`
// #####: gas = params.UpperGasLimit
	gas := globalGasCap
	if gas == 0 {
		gas = params.UpperGasLimit
	}
	if args.Gas != 0 {
		gas = uint64(*args.Gas)
	}
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

