### PR TITLE
refactor(cn): consolidate netAPI initialization pattern

### DIFF
--- a/api/api_net.go
+++ b/api/api_net.go
@@ -47,11 +47,17 @@ func (s *NetAPI) Listening() bool {
 
 // PeerCount returns the number of connected peers.
 func (s *NetAPI) PeerCount() hexutil.Uint {
+	if s.net == nil {
+		return 0
+	}
 	return hexutil.Uint(s.net.PeerCount())
 }
 
 // PeerCountByType returns the number of connected specific types of nodes.
 func (s *NetAPI) PeerCountByType() map[string]uint {
+	if s.net == nil {
+		return make(map[string]uint)
+	}
 	return s.net.PeerCountByType()
 }
 


### PR DESCRIPTION
This PR is related to https://github.com/kaiachain/kaia/pull/444#discussion_r2189012234

## Proposed changes

- Move netAPI declaration to `APIs()` method to match other API patterns and remove the `netRPCService` struct field.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
