### PR TITLE
api: fix getReceiptByTxHash error message

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1028,7 +1028,7 @@ func (bc *BlockChain) GetReceiptByTxHash(txHash common.Hash) *types.Receipt {
 
 	receipts := bc.GetReceiptsByBlockHash(blockHash)
 	if len(receipts) <= int(index) {
-		logger.Error("receipt index exceeds the size of receipts", "receiptIndex", index, "receiptsSize", len(receipts), "txHash", txHash, "blockHash", blockHash)
+		logger.Error("receipt index exceeds the size of receipts", "receiptIndex", index, "receiptsSize", len(receipts), "txHash", txHash.String(), "blockHash", blockHash.String())
 		return nil
 	}
 	return receipts[index]


### PR DESCRIPTION
## Proposed changes
Previously, https://github.com/kaiachain/kaia/pull/437 PR adds txHash and blockHash when logging getReceiptsByTxHash failure, but it turns out it only shows abbreviated values. This PR fixes it to show full contents of txHash and blockHash.

AS-IS
```
txHash=b5c63d…cfe6d9 blockHash=60319d…29d41e
```

TO-BE
```
txHash=0xb5c63d449888f2d62222f660ba31510798f6823d4128ab8a55e60feae5cfe6d9 blockHash=0x60319dcac9c952052c6b8c7dc895671ae074b8f18c0fcc417ec6415ca829d41e
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
