### PR TITLE
kaiax/supply: Fix cache condition

### DIFF
--- a/kaiax/supply/impl/getter.go
+++ b/kaiax/supply/impl/getter.go
@@ -75,7 +75,10 @@ func (s *SupplyModule) GetTotalSupply(num uint64) (*supply.TotalSupply, error) {
 		kip103Burn,
 		kip160Burn,
 	)
-	s.supplyCache.Add(num, ts)
+	// Only cache if no error
+	if len(errs) == 0 {
+		s.supplyCache.Add(num, ts)
+	}
 	return ts, errors.Join(errs...)
 }
 


### PR DESCRIPTION
## Proposed changes

Currently, `GetTotalSupply` caches the value regardless of error. 

The problematic flow can be:
1. First call: upstream works, so it returns the correct value. But the node already caches the wrong value.
2. Second call: Since the node has cached the "wrong" value, it returns the cached value -> doesn't trigger upstream logic.

```
// before
> kaia.getTotalSupply(10)
Error: cannot determine canonical (0x0, 0xdead) burn amount: missing trie node b0cfdd439f23eee870d59d8ca715c3f3b301b1fce3b060036e105fdc2f453e4f (path )
	at web3.js:6814:9(39)
	at send (web3.js:5225:62(29))
	at <eval>:1:20(3)

> kaia.getTotalSupply(10)
{
  burntFee: "0x0",
  deadBurn: null,
  kip103Burn: "0x0",
  kip160Burn: "0x0",
  number: "0xa",
  totalBurnt: null,
  totalMinted: "0x111b0ec57e6499a1f4b1014d3fc09d4835ec5800000",
  totalSupply: null,
  zeroBurn: null
}
```

```
// after
> kaia.getTotalSupply(10)
Error: cannot determine canonical (0x0, 0xdead) burn amount: missing trie node b0cfdd439f23eee870d59d8ca715c3f3b301b1fce3b060036e105fdc2f453e4f (path )
	at web3.js:6814:9(39)
	at send (web3.js:5225:62(29))
	at <eval>:1:20(3)

> kaia.getTotalSupply(10)
Error: cannot determine canonical (0x0, 0xdead) burn amount: missing trie node b0cfdd439f23eee870d59d8ca715c3f3b301b1fce3b060036e105fdc2f453e4f (path )
	at web3.js:6814:9(39)
	at send (web3.js:5225:62(29))
	at <eval>:1:20(3)
```

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
