### PR TITLE
kaiax/gasless: Prevent concurrency at PostInsertBlock

### DIFF
--- a/kaiax/gasless/impl/api.go
+++ b/kaiax/gasless/impl/api.go
@@ -133,6 +133,9 @@ type GaslessInfoResult struct {
 }
 
 func (s *GaslessAPI) GaslessInfo() *GaslessInfoResult {
+	s.b.gaslessInfoMu.RLock()
+	defer s.b.gaslessInfoMu.RUnlock()
+
 	at := []common.Address{}
 	for addr := range s.b.allowedTokens {
 		at = append(at, addr)

--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -77,6 +77,9 @@ func (g *GaslessModule) IsApproveTx(tx *types.Transaction) bool {
 }
 
 func (g *GaslessModule) isApproveTx(args *ApproveArgs) bool {
+	g.gaslessInfoMu.RLock()
+	defer g.gaslessInfoMu.RUnlock()
+
 	return g.allowedTokens[args.Token] && // A1
 		g.swapRouter == args.Spender && // A3
 		args.Amount.Cmp(abi.MaxUint256) == 0 // A4
@@ -92,6 +95,9 @@ func (g *GaslessModule) IsSwapTx(tx *types.Transaction) bool {
 }
 
 func (g *GaslessModule) isSwapTx(args *SwapArgs) bool {
+	g.gaslessInfoMu.RLock()
+	defer g.gaslessInfoMu.RUnlock()
+
 	return g.swapRouter == args.Router && // S1
 		g.allowedTokens[args.Token] // S3
 }
@@ -307,6 +313,9 @@ func (g *GaslessModule) GetLendTxGenerator(approveTxOrNil, swapTx *types.Transac
 }
 
 func (g *GaslessModule) updateAddresses(header *types.Header) error {
+	g.gaslessInfoMu.Lock()
+	defer g.gaslessInfoMu.Unlock()
+
 	swapRouter, tokens, err := getGaslessInfo(g.Chain, header)
 	// proceed even if there is something wrong with multicall contract
 	if err != nil {

--- a/kaiax/gasless/impl/init.go
+++ b/kaiax/gasless/impl/init.go
@@ -51,6 +51,8 @@ type InitOpts struct {
 
 type GaslessModule struct {
 	InitOpts
+
+	gaslessInfoMu sync.RWMutex
 	swapRouter    common.Address
 	allowedTokens map[common.Address]bool
 	signer        types.Signer


### PR DESCRIPTION
## Proposed changes

Protect `g.swapRouter` and `g.allowedTokens` from concurrency. It can occur during the `PostInsertBlock`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
