### PR TITLE
fix klay_getRewards upstream-en redirection problem

### DIFF
--- a/kaiax/staking/impl/getter.go
+++ b/kaiax/staking/impl/getter.go
@@ -91,7 +91,7 @@ func (s *StakingModule) getFromStateByNumber(num uint64) (*staking.StakingInfo, 
 	// Otherwise bring up the state from the database.
 	statedb, err := s.Chain.StateAt(header.Root)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get state for block number %d: %v", num, err)
+		return nil, fmt.Errorf("failed to get state for block number %d: %w", num, err)
 	}
 	return s.getFromState(header, statedb)
 }


### PR DESCRIPTION
## Proposed changes

Fix klay_getRewards upstream-en redirection problem. When a full node is running with --upstream-en configured to an archive node. It is supposed that state data not available locally will be redirected upstream. While klay_getRewards do not, since there is a bug in error wrapping. Fix issue [480](https://github.com/kaiachain/kaia/issues/480)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
