### PR TITLE
kaiax/auction: Fix auction concurrency issue

### DIFF
--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -220,7 +220,12 @@ func (bp *BidPool) GetTargetTxMap(num uint64) map[common.Hash]*auction.Bid {
 	bp.bidMu.RLock()
 	defer bp.bidMu.RUnlock()
 
-	return bp.bidTargetMap[num]
+	targetTxMap := make(map[common.Hash]*auction.Bid)
+	for hash, bid := range bp.bidTargetMap[num] {
+		targetTxMap[hash] = bid
+	}
+
+	return targetTxMap
 }
 
 // AddBid adds a bid to the bid pool.

--- a/kaiax/auction/impl/builder.go
+++ b/kaiax/auction/impl/builder.go
@@ -37,7 +37,7 @@ func (a *AuctionModule) ExtractTxBundles(txs []*types.Transaction, prevBundles [
 
 	miningBlock := curBlock.NumberU64() + 1
 	bidTargetMap := a.bidPool.GetTargetTxMap(miningBlock)
-	if bidTargetMap == nil {
+	if len(bidTargetMap) == 0 {
 		return bundles
 	}
 


### PR DESCRIPTION
## Proposed changes

This PR makes `GetTargetTxMap` to return copied map, not original map.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
