### PR TITLE
rlpx: Optimize xor using bitutil.XORBytes

### DIFF
--- a/networks/p2p/rlpx/rlpx.go
+++ b/networks/p2p/rlpx/rlpx.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/bitutil"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/ecies"
 	"github.com/kaiachain/kaia/crypto/secp256k1"
@@ -711,8 +712,6 @@ func exportPubkey(pub *ecies.PublicKey) []byte {
 
 func xor(one, other []byte) (xor []byte) {
 	xor = make([]byte, len(one))
-	for i := 0; i < len(one); i++ {
-		xor[i] = one[i] ^ other[i]
-	}
+	bitutil.XORBytes(xor, one, other)
 	return xor
 }


### PR DESCRIPTION
## Proposed changes

- This PR optimizes `rlpx.xor` using `bitutil.XORBytes` according to ethereum/go-ethereum#32217
- Benchmark result:
   ```
   BenchmarkManualXOR-10             789076              1510 ns/op
   BenchmarkBitutilXORBytes-10      1762501               669.5 ns/op
   ```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- none

## Further comments

<details>
<summary>benchmark code</summary>

```
package yourpkg

import (
        "math/rand"
        "testing"

        "github.com/ethereum/go-ethereum/common/bitutil"
)

var (
        srcA = make([]byte, 1024)
        srcB = make([]byte, 1024)
        dst  = make([]byte, 1024)
)

func init() {
        rand.Read(srcA)
        rand.Read(srcB)
}

func BenchmarkManualXOR(b *testing.B) {
        for n := 0; n < b.N; n++ {
                for i := 0; i < len(srcA); i++ {
                        dst[i] = srcA[i] ^ srcB[i]
                }
        }
}

func BenchmarkBitutilXORBytes(b *testing.B) {
        for n := 0; n < b.N; n++ {
                bitutil.XORBytes(dst, srcA, srcB)
        }
}
```

To test, `go test -bench=.`

</details>