### PR TITLE
types: Support "safe|finalized" alias for BlockNumber as the same as LatestBlockNumber

### DIFF
--- a/networks/rpc/types.go
+++ b/networks/rpc/types.go
@@ -76,9 +76,11 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
-	PendingBlockNumber  = BlockNumber(-2)
-	LatestBlockNumber   = BlockNumber(-1)
-	EarliestBlockNumber = BlockNumber(0)
+	SafeBlockNumber      = BlockNumber(-4)
+	FinalizedBlockNumber = BlockNumber(-3)
+	PendingBlockNumber   = BlockNumber(-2)
+	LatestBlockNumber    = BlockNumber(-1)
+	EarliestBlockNumber  = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
@@ -104,7 +106,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "earliest":
 		*bn = EarliestBlockNumber
 		return nil
-	case "latest":
+	case "safe", "finalized", "latest":
 		*bn = LatestBlockNumber
 		return nil
 	case "pending":
@@ -170,7 +172,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		bn := EarliestBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
-	case "latest":
+	case "safe", "finalized", "latest":
 		bn := LatestBlockNumber
 		bnh.BlockNumber = &bn
 		return nil

--- a/networks/rpc/types.go
+++ b/networks/rpc/types.go
@@ -76,11 +76,9 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
-	SafeBlockNumber      = BlockNumber(-4)
-	FinalizedBlockNumber = BlockNumber(-3)
-	PendingBlockNumber   = BlockNumber(-2)
-	LatestBlockNumber    = BlockNumber(-1)
-	EarliestBlockNumber  = BlockNumber(0)
+	PendingBlockNumber  = BlockNumber(-2)
+	LatestBlockNumber   = BlockNumber(-1)
+	EarliestBlockNumber = BlockNumber(0)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:

--- a/networks/rpc/types_test.go
+++ b/networks/rpc/types_test.go
@@ -45,19 +45,26 @@ func TestBlockNumberJSONUnmarshal(t *testing.T) {
 		6:  {`"0x12"`, false, BlockNumber(18)},
 		7:  {`"0x7fffffffffffffff"`, false, BlockNumber(math.MaxInt64)},
 		8:  {`"0x8000000000000000"`, true, BlockNumber(0)},
-		9:  {`"0"`, true, BlockNumber(0)},
+		9:  {"0", false, BlockNumber(0)}, // NOTE: This case is rpc.EarliestBlockNumber in Kaia
 		10: {`"ff"`, true, BlockNumber(0)},
 		11: {`"pending"`, false, PendingBlockNumber},
 		12: {`"latest"`, false, LatestBlockNumber},
 		13: {`"earliest"`, false, EarliestBlockNumber},
-		14: {`someString`, true, BlockNumber(0)},
-		15: {`""`, true, BlockNumber(0)},
-		16: {``, true, BlockNumber(0)},
-		17: {"0", false, BlockNumber(0)},
-		18: {"1", false, BlockNumber(1)},
-		19: {"10", false, BlockNumber(10)},
-		20: {"80000000", false, BlockNumber(80000000)},
-		21: {"-1", true, BlockNumber(0)},
+		14: {`"safe"`, false, LatestBlockNumber},      // NOTE: Kaia treats "safe" as "latest"
+		15: {`"finalized"`, false, LatestBlockNumber}, // NOTE: Kaia treats "finalized" as "latest"
+		16: {`someString`, true, BlockNumber(0)},
+		17: {`""`, true, BlockNumber(0)},
+		18: {``, true, BlockNumber(0)},
+
+		// NOTE: Kaia originil tests
+		19: {"1", false, BlockNumber(1)},
+		20: {"10", false, BlockNumber(10)},
+		21: {"80000000", false, BlockNumber(80000000)},
+		22: {"-1", true, BlockNumber(0)},
+		23: {"-2", true, BlockNumber(0)},
+		24: {"-3", true, BlockNumber(0)},
+		25: {"-4", true, BlockNumber(0)},
+		26: {"-5", true, BlockNumber(0)},
 	}
 
 	for i, test := range tests {
@@ -92,23 +99,35 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		6:  {`"0x12"`, false, NewBlockNumberOrHashWithNumber(18)},
 		7:  {`"0x7fffffffffffffff"`, false, NewBlockNumberOrHashWithNumber(math.MaxInt64)},
 		8:  {`"0x8000000000000000"`, true, BlockNumberOrHash{}},
-		9:  {`"0"`, true, BlockNumberOrHash{}},
+		9:  {"0", false, NewBlockNumberOrHashWithNumber(0)}, // NOTE: This case is rpc.EarliestBlockNumber in Kaia
 		10: {`"ff"`, true, BlockNumberOrHash{}},
 		11: {`"pending"`, false, NewBlockNumberOrHashWithNumber(PendingBlockNumber)},
 		12: {`"latest"`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)},
 		13: {`"earliest"`, false, NewBlockNumberOrHashWithNumber(EarliestBlockNumber)},
-		14: {`someString`, true, BlockNumberOrHash{}},
-		15: {`""`, true, BlockNumberOrHash{}},
-		16: {``, true, BlockNumberOrHash{}},
-		17: {`"0x0000000000000000000000000000000000000000000000000000000000000000"`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
-		18: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
-		19: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","requireCanonical":false}`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
-		20: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","requireCanonical":true}`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), true)},
-		21: {`{"blockNumber":"0x1"}`, false, NewBlockNumberOrHashWithNumber(1)},
-		22: {`{"blockNumber":"pending"}`, false, NewBlockNumberOrHashWithNumber(PendingBlockNumber)},
-		23: {`{"blockNumber":"latest"}`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)},
-		24: {`{"blockNumber":"earliest"}`, false, NewBlockNumberOrHashWithNumber(EarliestBlockNumber)},
-		25: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
+		14: {`"safe"`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)},      // NOTE: Kaia treats "safe" as "latest"
+		15: {`"finalized"`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)}, // NOTE: Kaia treats "finalized" as "latest"
+		16: {`someString`, true, BlockNumberOrHash{}},
+		17: {`""`, true, BlockNumberOrHash{}},
+		18: {``, true, BlockNumberOrHash{}},
+		19: {`"0x0000000000000000000000000000000000000000000000000000000000000000"`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
+		20: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
+		21: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","requireCanonical":false}`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), false)},
+		22: {`{"blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","requireCanonical":true}`, false, NewBlockNumberOrHashWithHash(common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), true)},
+		23: {`{"blockNumber":"0x1"}`, false, NewBlockNumberOrHashWithNumber(1)},
+		24: {`{"blockNumber":"pending"}`, false, NewBlockNumberOrHashWithNumber(PendingBlockNumber)},
+		25: {`{"blockNumber":"latest"}`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)},
+		26: {`{"blockNumber":"earliest"}`, false, NewBlockNumberOrHashWithNumber(EarliestBlockNumber)},
+		27: {`{"blockNumber":"safe"}`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)},      // NOTE: Kaia treats "safe" as "latest"
+		28: {`{"blockNumber":"finalized"}`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)}, // NOTE: Kaia treats "finalized" as "latest"
+		29: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
+
+		// NOTE: Kaia originil tests
+		30: {`"-1"`, true, BlockNumberOrHash{}},
+		31: {`"-2"`, true, BlockNumberOrHash{}},
+		32: {`"-3"`, true, BlockNumberOrHash{}},
+		33: {`{"blockNumber":"-1"}`, true, BlockNumberOrHash{}},
+		34: {`{"blockNumber":"-2"}`, true, BlockNumberOrHash{}},
+		35: {`{"blockNumber":"-3"}`, true, BlockNumberOrHash{}},
 	}
 
 	for i, test := range tests {

--- a/networks/rpc/types_test.go
+++ b/networks/rpc/types_test.go
@@ -56,7 +56,7 @@ func TestBlockNumberJSONUnmarshal(t *testing.T) {
 		17: {`""`, true, BlockNumber(0)},
 		18: {``, true, BlockNumber(0)},
 
-		// NOTE: Kaia originil tests
+		// NOTE: Kaia original tests
 		19: {"1", false, BlockNumber(1)},
 		20: {"10", false, BlockNumber(10)},
 		21: {"80000000", false, BlockNumber(80000000)},

--- a/networks/rpc/types_test.go
+++ b/networks/rpc/types_test.go
@@ -121,7 +121,7 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		28: {`{"blockNumber":"finalized"}`, false, NewBlockNumberOrHashWithNumber(LatestBlockNumber)}, // NOTE: Kaia treats "finalized" as "latest"
 		29: {`{"blockNumber":"0x1", "blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`, true, BlockNumberOrHash{}},
 
-		// NOTE: Kaia originil tests
+		// NOTE: Kaia original tests
 		30: {`"-1"`, true, BlockNumberOrHash{}},
 		31: {`"-2"`, true, BlockNumberOrHash{}},
 		32: {`"-3"`, true, BlockNumberOrHash{}},


### PR DESCRIPTION
## Proposed changes

Support `safe` and `finalized` block number for API and they treat as the same as `latest` because of Kaia [BFT](https://docs.kaia.io/learn/)

NOTE:
* `rpc.BlockNumber` and `rpc.BlockNumberOrHash` cannot specify the negative value
* All API parameter depends on `rpc.BlockNumber`
  * `rpc.BlockNumberOrHash` and `filters.FilterCriteria` also depends on `BlockNumber`
* But this PR don't change the magic number for Ethereum compatibility because of Kaia treat EarliestBlockNumber as the same as Genesis Block Number:
  * Kaia: https://github.com/kaiachain/kaia/blob/0f2059e82b30198bce1276d28eedd5907c52d349/networks/rpc/types.go#L79-L81
  * Geth: https://github.com/ethereum/go-ethereum/blob/792de5d2e3b40837aadb65993e387bf5aa5bce9f/rpc/types.go#L66-L70

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

* https://github.com/kaiachain/kaia/pull/260

## Further comments
