### PR TITLE
node/cn/filters: Check filter GetLogs args correctly and add test cases

### DIFF
--- a/node/cn/filters/api_kaia_filter.go
+++ b/node/cn/filters/api_kaia_filter.go
@@ -403,6 +403,9 @@ func (api *KaiaFilterAPI) GetLogs(ctx context.Context, crit FilterCriteria) ([]*
 
 	var filter *Filter
 	if crit.BlockHash != nil {
+		if crit.FromBlock != nil || crit.ToBlock != nil {
+			return nil, errors.New("can't specify fromBlock/toBlock with blockHash")
+		}
 		// Block filter requested, construct a single-shot filter
 		filter = NewBlockFilter(api.backend, *crit.BlockHash, crit.Addresses, crit.Topics)
 	} else {

--- a/node/cn/filters/filter_system_test.go
+++ b/node/cn/filters/filter_system_test.go
@@ -28,6 +28,7 @@ import (
 	"math/rand"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/bloombits"
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/gxhash"
@@ -404,27 +406,57 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 
 func TestInvalidGetLogsRequest(t *testing.T) {
 	var (
-		mux        = new(event.TypeMux)
-		db         = database.NewMemoryDBManager()
-		txFeed     = new(event.Feed)
-		rmLogsFeed = new(event.Feed)
-		logsFeed   = new(event.Feed)
-		chainFeed  = new(event.Feed)
-		backend    = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig, nil, nil, nil}
-		api        = NewKaiaFilterAPI(backend)
-		blockHash  = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+		mux              = new(event.TypeMux)
+		db               = database.NewMemoryDBManager()
+		genesis          = new(blockchain.Genesis).MustCommit(db)
+		blocks, _        = blockchain.GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 10, func(i int, gen *blockchain.BlockGen) {})
+		txFeed           = new(event.Feed)
+		rmLogsFeed       = new(event.Feed)
+		logsFeed         = new(event.Feed)
+		chainFeed        = new(event.Feed)
+		engine           = gxhash.NewFaker()
+		backend          = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig, nil, nil, engine}
+		api              = NewKaiaFilterAPI(backend)
+		blockHash        = blocks[0].Hash()
+		unknownBlockHash = common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
 	)
 
-	// Reason: Cannot specify both BlockHash and FromBlock/ToBlock)
-	testCases := []FilterCriteria{
-		0: {BlockHash: &blockHash, FromBlock: big.NewInt(100)},
-		1: {BlockHash: &blockHash, ToBlock: big.NewInt(500)},
-		2: {BlockHash: &blockHash, FromBlock: big.NewInt(rpc.LatestBlockNumber.Int64())},
+	// Insert the blocks into the chain so filter can look them up
+	blockchain, err := blockchain.NewBlockChain(db, nil, params.TestChainConfig, backend.Engine(), vm.Config{})
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	if n, err := blockchain.InsertChain(blocks); err != nil {
+		t.Fatalf("block %d: failed to insert into chain: %v", n, err)
+	}
+
+	type testcase struct {
+		f      FilterCriteria
+		errStr string
+	}
+	testCases := []testcase{
+		{
+			f:      FilterCriteria{BlockHash: &blockHash, FromBlock: big.NewInt(100)},
+			errStr: "can't specify fromBlock/toBlock with blockHash",
+		},
+		{
+			f:      FilterCriteria{BlockHash: &blockHash, ToBlock: big.NewInt(500)},
+			errStr: "can't specify fromBlock/toBlock with blockHash",
+		},
+		{
+			f:      FilterCriteria{BlockHash: &blockHash, FromBlock: big.NewInt(rpc.LatestBlockNumber.Int64())},
+			errStr: "can't specify fromBlock/toBlock with blockHash",
+		},
+		{
+			f:      FilterCriteria{BlockHash: &unknownBlockHash},
+			errStr: "unknown block",
+		},
 	}
 
 	for i, test := range testCases {
-		if _, err := api.GetLogs(context.Background(), test); err == nil {
-			t.Errorf("Expected Logs for case #%d to fail", i)
+		_, err := api.GetLogs(context.Background(), test.f)
+		if !strings.Contains(err.Error(), test.errStr) {
+			t.Errorf("case %d: wrong error: %q\nwant: %q", i, err, test.errStr)
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

- This PR brings ethereum/go-ethereum#31877
- The updates are:
   - add check for filter API arguments having both `blockHash` and `fromBlock`/`toBlock` specified and returns error accordingly (those are mutually exclusive)
   - existing test did not correctly check the returned error, so fix them

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
