### PR TITLE
abi/bind: Precompile regex

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -44,6 +44,11 @@ const (
 	LangObjC
 )
 
+var (
+	intRegex                  = regexp.MustCompile(`(u)?int([0-9]*)`)
+	intWithOptionalArrayRegex = regexp.MustCompile(`(u)?int([0-9]*)(\[[0-9]*\])?`)
+)
+
 func isKeyWord(arg string) bool {
 	switch arg {
 	case "break":
@@ -298,7 +303,7 @@ func bindBasicTypeGo(kind abi.Type) string {
 	case abi.AddressTy:
 		return "common.Address"
 	case abi.IntTy, abi.UintTy:
-		parts := regexp.MustCompile(`(u)?int([0-9]*)`).FindStringSubmatch(kind.String())
+		parts := intRegex.FindStringSubmatch(kind.String())
 		switch parts[2] {
 		case "8", "16", "32", "64":
 			return fmt.Sprintf("%sint%s", parts[1], parts[2])
@@ -340,7 +345,7 @@ func bindBasicTypeJava(kind abi.Type) string {
 	case abi.IntTy, abi.UintTy:
 		// Note that uint and int (without digits) are also matched,
 		// these are size 256, and will translate to BigInt (the default).
-		parts := regexp.MustCompile(`(u)?int([0-9]*)`).FindStringSubmatch(kind.String())
+		parts := intRegex.FindStringSubmatch(kind.String())
 		if len(parts) != 3 {
 			return kind.String()
 		}
@@ -547,7 +552,7 @@ func namedTypeJava(javaKind string, solKind abi.Type) string {
 	case "boolean":
 		return "Bool"
 	default:
-		parts := regexp.MustCompile(`(u)?int([0-9]*)(\[[0-9]*\])?`).FindStringSubmatch(solKind.String())
+		parts := intWithOptionalArrayRegex.FindStringSubmatch(solKind.String())
 		if len(parts) != 4 {
 			return javaKind
 		}


### PR DESCRIPTION
## Proposed changes

- This PR precompiles regex used in `accounts/abi/bind`
- Follw-up PR for ethereum/go-ethereum#32301

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- none

## Further comments

none
