### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/consensus/gxhash/algorithm.go
+++ b/consensus/gxhash/algorithm.go
@@ -312,10 +312,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 			// Calculate the data segment this thread should generate
 			batch := uint32((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
 			first := uint32(id) * batch
-			limit := first + batch
-			if limit > uint32(size/hashBytes) {
-				limit = uint32(size / hashBytes)
-			}
+			limit := min(first+batch, uint32(size/hashBytes))
 			// Calculate the dataset segment
 			percent := uint32(size / hashBytes / 100)
 			for index := first; index < limit; index++ {

--- a/consensus/gxhash/consensus.go
+++ b/consensus/gxhash/consensus.go
@@ -108,10 +108,7 @@ func (gxhash *Gxhash) VerifyHeaders(chain consensus.ChainReader, headers []*type
 	}
 
 	// Spawn as many workers as allowed threads
-	workers := runtime.GOMAXPROCS(0)
-	if len(headers) < workers {
-		workers = len(headers)
-	}
+	workers := min(len(headers), runtime.GOMAXPROCS(0))
 
 	// Create a task channel and spawn the verifiers
 	var (

--- a/consensus/gxhash/gxhash_test.go
+++ b/consensus/gxhash/gxhash_test.go
@@ -69,10 +69,7 @@ func verifyTest(wg *sync.WaitGroup, e *Gxhash, workerIndex, epochs int) {
 	const wiggle = 4 * epochLength
 	r := rand.New(rand.NewSource(int64(workerIndex)))
 	for epoch := 0; epoch < epochs; epoch++ {
-		block := int64(epoch)*epochLength - wiggle/2 + r.Int63n(wiggle)
-		if block < 0 {
-			block = 0
-		}
+		block := max(int64(epoch)*epochLength-wiggle/2+r.Int63n(wiggle), 0)
 		head := &types.Header{Number: big.NewInt(block), BlockScore: big.NewInt(100)}
 		e.VerifySeal(nil, head)
 	}

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -93,11 +93,7 @@ func (cs *RoundCommitteeState) F() int                              { return cs.
 // requiredMessageCount returns a minimum required number of consensus messages to proceed
 func requiredMessageCount(qualifiedSize int, committeeSize uint64) int {
 	var size int
-	if qualifiedSize > int(committeeSize) {
-		size = int(committeeSize)
-	} else {
-		size = qualifiedSize
-	}
+	size = min(qualifiedSize, int(committeeSize))
 	// For less than 4 validators, quorum size equals validator count.
 	if size < 4 {
 		return size

--- a/consensus/misc/kip71.go
+++ b/consensus/misc/kip71.go
@@ -91,11 +91,8 @@ func nextBlockBaseFee(parentHeader *types.Header, kip71Config *params.KIP71Confi
 		parentBaseFee = lowerBoundBaseFee
 	}
 
-	parentGasUsed := parentHeader.GasUsed
 	// upper gas limit cut off the impulse of used gas to upper bound
-	if parentGasUsed > upperGasLimit {
-		parentGasUsed = upperGasLimit
-	}
+	parentGasUsed := min(parentHeader.GasUsed, upperGasLimit)
 	if parentGasUsed == gasTarget {
 		return parentBaseFee
 	} else if parentGasUsed > gasTarget {


### PR DESCRIPTION
## Proposed changes


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
