### PR TITLE
blockchain/vm: Add configurable jumpdest analysis cache

### DIFF
--- a/blockchain/vm/analysis.go
+++ b/blockchain/vm/analysis.go
@@ -22,31 +22,31 @@
 
 package vm
 
-// bitvec is a bit vector which maps bytes in a program.
+// Bitvec is a bit vector which maps bytes in a program.
 // An unset bit means the byte is an opcode, a set bit means
 // it's data (i.e. argument of PUSHxx).
-type bitvec []byte
+type BitVec []byte
 
-func (bits *bitvec) set(pos uint64) {
+func (bits *BitVec) set(pos uint64) {
 	(*bits)[pos/8] |= 0x80 >> (pos % 8)
 }
 
-func (bits *bitvec) set8(pos uint64) {
+func (bits *BitVec) set8(pos uint64) {
 	(*bits)[pos/8] |= 0xFF >> (pos % 8)
 	(*bits)[pos/8+1] |= ^(0xFF >> (pos % 8))
 }
 
 // codeSegment checks if the position is in a code segment.
-func (bits *bitvec) codeSegment(pos uint64) bool {
+func (bits *BitVec) codeSegment(pos uint64) bool {
 	return ((*bits)[pos/8] & (0x80 >> (pos % 8))) == 0
 }
 
 // codeBitmap collects data locations in code.
-func codeBitmap(code []byte) bitvec {
+func codeBitmap(code []byte) BitVec {
 	// The bitmap is 4 bytes longer than necessary, in case the code
 	// ends with a PUSH32, the algorithm will push zeroes onto the
 	// bitvector outside the bounds of the actual code.
-	bits := make(bitvec, len(code)/8+1+4)
+	bits := make(BitVec, len(code)/8+1+4)
 	for pc := uint64(0); pc < uint64(len(code)); {
 		op := OpCode(code[pc])
 

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -121,7 +121,7 @@ var blake2FMalformedInputTests = []precompiledFailureTest{
 func prepare(reqGas uint64) (*Contract, *EVM, error) {
 	// Generate Contract
 	contract := NewContract(types.NewAccountRefWithFeePayer(common.HexToAddress("1337"), common.HexToAddress("133773")),
-		nil, new(big.Int), reqGas)
+		nil, new(big.Int), reqGas, nil)
 
 	// Generate EVM
 	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -79,7 +79,7 @@ func TestOpTstore(t *testing.T) {
 		caller         = common.Address{}
 		to             = common.Address{1}
 		contractRef    = contractRef{caller}
-		contract       = NewContract(contractRef, AccountRef(to), new(big.Int), 0)
+		contract       = NewContract(contractRef, AccountRef(to), new(big.Int), 0, nil)
 		scopeContext   = ScopeContext{mem, stack, contract}
 		value          = common.Hex2Bytes("abcdef00000000000000abba000000000deaf000000c0de00100000000133700")
 	)
@@ -461,7 +461,7 @@ func opBenchmark(bench *testing.B, op func(pc *uint64, evm *EVMInterpreter, scop
 
 	caller := types.NewAccountRefWithFeePayer(senderAddress, payerAddress)
 	object := types.NewAccountRefWithFeePayer(payerAddress, senderAddress)
-	contract := NewContract(caller, object, big.NewInt(0), uint64(1000))
+	contract := NewContract(caller, object, big.NewInt(0), uint64(1000), nil)
 	contract.Input = senderAddress.Bytes()
 	contract.Gas = uint64(1000)
 	contract.Code = common.Hex2Bytes("60ca60205260005b612710811015630000004557602051506020515060205150602051506020515060205150602051506020515060205150602051506001016300000007565b00")
@@ -997,7 +997,7 @@ func BenchmarkOpSstore(bench *testing.B) {
 
 	caller := types.NewAccountRefWithFeePayer(senderAddress, payerAddress)
 	object := types.NewAccountRefWithFeePayer(payerAddress, senderAddress)
-	contract := NewContract(caller, object, big.NewInt(0), uint64(1000))
+	contract := NewContract(caller, object, big.NewInt(0), uint64(1000), nil)
 
 	// convert args
 	byteArgs := make([][]byte, 2)

--- a/blockchain/vm/jumpdests.go
+++ b/blockchain/vm/jumpdests.go
@@ -1,0 +1,47 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import "github.com/kaiachain/kaia/common"
+
+// JumpDestCache represents the cache of jumpdest analysis results.
+type JumpDestCache interface {
+	// Load retrieves the cached jumpdest analysis for the given code hash.
+	// Returns the BitVec and true if found, or nil and false if not cached.
+	Load(codeHash common.Hash) (BitVec, bool)
+
+	// Store saves the jumpdest analysis for the given code hash.
+	Store(codeHash common.Hash, vec BitVec)
+}
+
+// mapJumpDests is the default implementation of JumpDests using a map.
+// This implementation is not thread-safe and is meant to be used per EVM instance.
+type mapJumpDests map[common.Hash]BitVec
+
+// newMapJumpDests creates a new map-based JumpDests implementation.
+func newMapJumpDests() JumpDestCache {
+	return make(mapJumpDests)
+}
+
+func (j mapJumpDests) Load(codeHash common.Hash) (BitVec, bool) {
+	vec, ok := j[codeHash]
+	return vec, ok
+}
+
+func (j mapJumpDests) Store(codeHash common.Hash, vec BitVec) {
+	j[codeHash] = vec
+}

--- a/blockchain/vm/jumpdests.go
+++ b/blockchain/vm/jumpdests.go
@@ -1,3 +1,4 @@
+// Modifications Copyright 2025 The Kaia Authors
 // Copyright 2024 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //

--- a/blockchain/vm/logger_test.go
+++ b/blockchain/vm/logger_test.go
@@ -62,7 +62,7 @@ func TestStoreCapture(t *testing.T) {
 		logger   = NewStructLogger(nil)
 		mem      = NewMemory()
 		stack    = newstack()
-		contract = NewContract(&dummyContractRef{}, &dummyContractRef{}, new(big.Int), 0)
+		contract = NewContract(&dummyContractRef{}, &dummyContractRef{}, new(big.Int), 0, nil)
 	)
 
 	stack.push(uint256.NewInt(1))

--- a/node/cn/tracers/tracer_test.go
+++ b/node/cn/tracers/tracer_test.go
@@ -68,7 +68,7 @@ func testCtx() *vmContext {
 func runTrace(tracer *Tracer) (json.RawMessage, error) {
 	env := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, vm.TxContext{}, &dummyStatedb{}, params.TestChainConfig, &vm.Config{Debug: true, Tracer: tracer})
 
-	contract := vm.NewContract(account{}, account{}, big.NewInt(0), 10000)
+	contract := vm.NewContract(account{}, account{}, big.NewInt(0), 10000, nil)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x1, 0x0}
 
 	_, err := env.Interpreter().Run(contract, []byte{})
@@ -203,7 +203,7 @@ func TestHaltBetweenSteps(t *testing.T) {
 	}
 
 	env := vm.NewEVM(vm.BlockContext{BlockNumber: big.NewInt(1)}, vm.TxContext{}, &dummyStatedb{}, params.TestChainConfig, &vm.Config{Debug: true, Tracer: tracer})
-	contract := vm.NewContract(&account{}, &account{}, big.NewInt(0), 0)
+	contract := vm.NewContract(&account{}, &account{}, big.NewInt(0), 0, nil)
 
 	tracer.CaptureState(env, 0, 0, 0, 0, 0, 0, &vm.ScopeContext{Contract: contract}, 0, nil)
 	timeout := errors.New("stahp")
@@ -231,7 +231,7 @@ func TestEnterExit(t *testing.T) {
 	}
 
 	scope := &vm.ScopeContext{
-		Contract: vm.NewContract(&account{}, &account{}, big.NewInt(0), 0),
+		Contract: vm.NewContract(&account{}, &account{}, big.NewInt(0), 0, nil),
 	}
 
 	tracer.CaptureEnter(vm.CALL, scope.Contract.Caller(), scope.Contract.Address(), []byte{}, 1000, new(big.Int))

--- a/tests/benchmarks/benchmarks_test_utils.go
+++ b/tests/benchmarks/benchmarks_test_utils.go
@@ -102,7 +102,7 @@ func prepareInterpreterAndContract(code []byte) (*vm.EVMInterpreter, *vm.Contrac
 	value := cfg.Value
 	gas := cfg.GasLimit
 
-	contract := vm.NewContract(caller, to, value, gas)
+	contract := vm.NewContract(caller, to, value, gas, nil)
 
 	contract.SetCallCode(&address, evm.StateDB.GetCodeHash(address), evm.StateDB.GetCode(address))
 


### PR DESCRIPTION
## Proposed changes

- This PR makes jumpdest analysis cache to be configurable in EVM ([geth#32143](/ethereum/go-ethereum/pull/32143))
- It provides an abstraction for the cache, not a better implementation of the cache. However I got better benchmark result:
   ```
   # before
   BenchmarkJumpdestAnalysisCache/CacheEnabled-10            432151              2460 ns/op         3389 B/op         43 allocs/op
   # after
   BenchmarkJumpdestAnalysisCache/CacheEnabled-10            722662              1553 ns/op         2778 B/op         40 allocs/op
   ```
   see below for more info on the benchmark.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- [geth#32137](/ethereum/go-ethereum/pull/32137)

## Further comments

<details>
<summary>Benchmark code and pprof result</summary>

### Benchmark code

The code used to benchmark this PR is:

```
package blockchain

import (
	"math/big"
	"testing"

	"github.com/kaiachain/kaia/blockchain/state"
	"github.com/kaiachain/kaia/blockchain/types"
	"github.com/kaiachain/kaia/blockchain/vm"
	"github.com/kaiachain/kaia/common"
	"github.com/kaiachain/kaia/common/hexutil"
	"github.com/kaiachain/kaia/consensus/gxhash"
	"github.com/kaiachain/kaia/crypto"
	"github.com/kaiachain/kaia/params"
	"github.com/kaiachain/kaia/storage/database"
)

// Simple contract with valid jumpdest analysis requirements
/*
contract JumpStress {
    // A complex function to generate more internal JUMPDESTs from loops and conditionals.
    function triggerAnalysis(uint256 n) public pure returns (uint256) {
        uint256 result = 0;
        for (uint256 i = 0; i < n; i++) {
            if (i % 10 == 0) {
                result += 10;
            } else if (i % 10 == 1) {
                result += 11;
            } else if (i % 10 == 2) {
                result += 12;
            } else if (i % 10 == 3) {
                result += 13;
            } else {
                result += 1;
            }
        }
        return result;
    }

    // Proliferation of simple functions to create a large bytecode and function dispatcher.
    function f1() public pure {} function f2() public pure {}
}
*/
var simpleJumpContract = "608060405234801561001057600080fd5b50610365806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c80639942ec6f14610046578063c27fc30514610050578063ffa55f9d1461005a575b600080fd5b61004e61008a565b005b61005861008c565b005b610074600480360381019061006f91906101ab565b61008e565b60405161008191906101e7565b60405180910390f35b565b565b6000806000905060005b83811015610166576000600a826100af9190610231565b036100c857600a826100c19190610291565b9150610153565b6001600a826100d79190610231565b036100f057600b826100e99190610291565b9150610152565b6002600a826100ff9190610231565b0361011857600c826101119190610291565b9150610151565b6003600a826101279190610231565b0361014057600d826101399190610291565b9150610150565b60018261014d9190610291565b91505b5b5b5b808061015e906102e7565b915050610098565b5080915050919050565b600080fd5b6000819050919050565b61018881610175565b811461019357600080fd5b50565b6000813590506101a58161017f565b92915050565b6000602082840312156101c1576101c0610170565b5b60006101cf84828501610196565b91505092915050565b6101e181610175565b82525050565b60006020820190506101fc60008301846101d8565b92915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b600061023c82610175565b915061024783610175565b92508261025757610256610202565b5b828206905092915050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b600061029c82610175565b91506102a783610175565b9250827fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff038211156102dc576102db610262565b5b828201905092915050565b60006102f282610175565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff820361032457610323610262565b5b60018201905091905056fea2646970667358221220d1c64e18ed25b3f75123e7b41a0e305266b0aca657e650156d7fbd7f4bf5b2c064736f6c634300080f0033"

// BenchmarkJumpdestAnalysisCache measures the performance impact of the jumpdest analysis cache.
// It runs two sub-benchmarks: one with the cache disabled and one with it enabled.
func BenchmarkJumpdestAnalysisCache(b *testing.B) {
	// Decode the contract bytecode
	code, err := hexutil.Decode("0x" + simpleJumpContract)
	if err != nil {
		b.Fatalf("failed to decode contract bytecode: %v", err)
	}

	// Setup blockchain and state
	db := database.NewMemoryDBManager()
	defer db.Close()

	gspec := &Genesis{Config: params.TestChainConfig}
	genesis := gspec.MustCommit(db)

	bc, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
	defer bc.Stop()

	testAddress := common.HexToAddress("aaaa")
	initialBalance := new(big.Int).SetUint64(1000000000000000000) // 1 ETH

	// Deploy the contract
	statedb, _ := state.New(genesis.Root(), state.NewDatabase(db), nil, nil)
	statedb.SetBalance(testAddress, initialBalance)

	contractAddr := deployContract(statedb, testAddress, code)

	// Setup block context
	block := bc.GetBlock(genesis.Hash(), genesis.Number().Uint64())
	header := block.Header()
	header.Number = big.NewInt(1)
	header.ParentHash = block.Hash()

	// Empty call data (just execute fallback)
	callData := common.Hex2Bytes("c27fc305")

	// Sub-benchmark: Cache Disabled
	/*b.Run("CacheDisabled", func(b *testing.B) {
		freshStatedb, _ := state.New(genesis.Root(), state.NewDatabase(db), nil, nil)
		freshStatedb.SetBalance(testAddress, initialBalance)
		deployContract(freshStatedb, testAddress, code)

		msg := types.NewMessage(testAddress, &contractAddr, 0, big.NewInt(0), 1000000, big.NewInt(0), nil, nil, callData, false, 0, nil, nil, nil)
		blockContext := NewEVMBlockContext(header, bc, nil)
		txContext := NewEVMTxContext(msg, header, gspec.Config)

		vmConfig := &vm.Config{}
		evm := vm.NewEVM(blockContext, txContext, freshStatedb, gspec.Config, vmConfig)
		//evm.SetJumpDestCache(nil) // Disable cache

		b.ReportAllocs()
		b.ResetTimer()

		for i := 0; i < b.N; i++ {
			_, _, err := evm.Call(vm.AccountRef(testAddress), contractAddr, callData, 1000000, big.NewInt(0))
			if err != nil {
				b.Fatalf("evm call failed: %v", err)
			}
		}
	})*/

	// Sub-benchmark: Cache Enabled
	b.Run("CacheEnabled", func(b *testing.B) {
		freshStatedb, _ := state.New(genesis.Root(), state.NewDatabase(db), nil, nil)
		freshStatedb.SetBalance(testAddress, initialBalance)
		deployContract(freshStatedb, testAddress, code)

		msg := types.NewMessage(testAddress, &contractAddr, 0, big.NewInt(0), 1000000, big.NewInt(0), nil, nil, callData, false, 0, nil, nil, nil)
		blockContext := NewEVMBlockContext(header, bc, nil)
		txContext := NewEVMTxContext(msg, header, gspec.Config)

		vmConfig := &vm.Config{}
		evm := vm.NewEVM(blockContext, txContext, freshStatedb, gspec.Config, vmConfig)
		// Default jump dest cache is enabled

		b.ReportAllocs()
		b.ResetTimer()

		for i := 0; i < b.N; i++ {
			_, _, err := evm.Call(vm.AccountRef(testAddress), contractAddr, callData, 1000000, big.NewInt(0))
			if err != nil {
				b.Fatalf("evm call failed: %v", err)
			}
		}
	})
}

// deployContract is a helper function to create a contract on the test state
func deployContract(statedb *state.StateDB, from common.Address, code []byte) common.Address {
	nonce := statedb.GetNonce(from)
	addr := crypto.CreateAddress(from, nonce)
	statedb.CreateAccount(addr)
	statedb.SetCode(addr, code)
	return addr
}
```

Also, in order to avoid computation cost error, I had to comment ignore `ErrOpcodeComputationCostLimitReached`.

```
diff --git a/blockchain/vm/interpreter.go b/blockchain/vm/interpreter.go
index 965cbe7ae..be5e94d00 100644
--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -254,7 +254,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
                // We limit tx's execution time using the sum of computation cost of opcodes.
                in.evm.opcodeComputationCostSum += operation.computationCost
                if in.evm.opcodeComputationCostSum > in.evm.Config.ComputationCostLimit {
-                       return nil, ErrOpcodeComputationCostLimitReached
+                       //return nil, ErrOpcodeComputationCostLimitReached
                }
                ccOpcode = operation.computationCost
                var memorySize uint64
```

### pprof result

[geth#32137](/ethereum/go-ethereum/pull/32137) shows pprof result that `codeBitmap` is consuming ~20% of CPU time when the EVM is used in simulation heavy workloads.

For our case, it was 10%.

```
go test -bench='^BenchmarkJumpdestAnalysisCache' -c ./blockchain
go test -bench='^BenchmarkJumpdestAnalysisCache' -run=^$ -cpuprofile=cpu.prof -timeout=30h ./blockchain
go tool pprof -http=:8080 ./blockchain.test cpu.prof
```

<img width="805" height="738" alt="image" src="https://github.com/user-attachments/assets/1da2b89f-1312-4961-9514-9098f208e6fa" />

After this PR, `codeBitmap` was not showing up in the pprof result.
<img width="679" height="760" alt="image" src="https://github.com/user-attachments/assets/086a1f74-a880-48c7-b629-5ad1b8fa3dc9" />

We can see that `Run` takes up 22% -> 12%, backing up the benchmark result.
</details>
