### PR TITLE
[Auction] Added bid request metric

### DIFF
--- a/kaiax/auction/impl/api.go
+++ b/kaiax/auction/impl/api.go
@@ -112,6 +112,7 @@ func toTx(targetTxRaw []byte) (*types.Transaction, error) {
 }
 
 func (api *AuctionAPI) SubmitBid(ctx context.Context, bidInput BidInput) RPCOutput {
+	numBidRequestCounter.Inc(1)
 	if api.a.IsDisabled() {
 		return makeRPCOutput(EMPTY_HASH, auction.ErrAuctionDisabled)
 	}

--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -30,7 +30,6 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/auction"
 	"github.com/kaiachain/kaia/params"
-	"github.com/rcrowley/go-metrics"
 )
 
 const (
@@ -40,8 +39,6 @@ const (
 	BidTxMaxCallGasLimit = uint64(10_000_000)
 	BidTxGasBuffer       = uint64(180_000)
 )
-
-var numBidsGauge = metrics.NewRegisteredGauge("kaiax/auction/bidpool/num/bids", nil)
 
 type BidPool struct {
 	ChainConfig *params.ChainConfig

--- a/kaiax/auction/impl/metric.go
+++ b/kaiax/auction/impl/metric.go
@@ -1,0 +1,8 @@
+package impl
+
+import "github.com/rcrowley/go-metrics"
+
+var (
+	numBidsGauge         = metrics.NewRegisteredGauge("kaiax/auction/bidpool/num/bids", nil)
+	numBidRequestCounter = metrics.NewRegisteredCounter("kaiax/auction/bidpool/num/bidreqs", nil)
+)


### PR DESCRIPTION
## Proposed changes

### Metrics
- `auction_submitBid`
   - Number of bid request metric is added.
- For subscription:
   -   Use existing metrics: https://github.com/kaiachain/kaia/blob/dev/networks/rpc/metrics.go#L26-L28

### Restriction of Subscription
- Number of websocket connections is managed by node configuration: https://github.com/kaiachain/kaia/blob/v2.1.0-rc.3/cmd/utils/flags.go#L956-L987



## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
