### PR TITLE
kaiax/auction: Introduce bid signature cacher

### DIFF
--- a/kaiax/auction/bid_test.go
+++ b/kaiax/auction/bid_test.go
@@ -54,15 +54,23 @@ func TestBidGetEthSignedMessageHash(t *testing.T) {
 	require.Equal(t, common.Hex2Bytes("a328ed8cc9e6941076a892efd7687278bfd6f85b4b89ad196d0eef5215eb0059"), digest)
 }
 
+func TestBidValidateSig(t *testing.T) {
+	err := testBid.ValidateSig(big.NewInt(31337), common.HexToAddress("0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"), common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"))
+	require.NoError(t, err)
+
+	require.True(t, testBid.validated.Load())
+	require.Nil(t, testBid.validationError.Load())
+}
+
 func TestBidValidateSearcherSig(t *testing.T) {
-	err := testBid.ValidateSearcherSig(big.NewInt(31337), common.HexToAddress("0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"))
+	err := testBid.validateSearcherSig(big.NewInt(31337), common.HexToAddress("0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"))
 	require.NoError(t, err)
 	// Do not modify the original bid.
 	require.Equal(t, uint8(27), testBid.SearcherSig[crypto.RecoveryIDOffset])
 }
 
 func TestBidValidateAuctioneerSig(t *testing.T) {
-	err := testBid.ValidateAuctioneerSig(common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"))
+	err := testBid.validateAuctioneerSig(common.HexToAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"))
 	require.NoError(t, err)
 	// Do not modify the original bid.
 	require.Equal(t, uint8(27), testBid.AuctioneerSig[crypto.RecoveryIDOffset])

--- a/kaiax/auction/errors.go
+++ b/kaiax/auction/errors.go
@@ -26,6 +26,7 @@ var (
 	ErrInvalidAuctioneerSig  = errors.New("invalid auctioneer sig")
 	ErrNilChainId            = errors.New("chainId is nil")
 	ErrNilVerifyingContract  = errors.New("verifyingContract is nil")
+	ErrNilAuctioneer         = errors.New("auctioneer is nil")
 	ErrInvalidTargetTxHash   = errors.New("invalid target tx hash")
 	ErrAuctionDisabled       = errors.New("auction is disabled")
 	ErrExceedMaxCallGasLimit = errors.New("gas limit exceeds the maximum limit")

--- a/kaiax/auction/impl/bid_cacher.go
+++ b/kaiax/auction/impl/bid_cacher.go
@@ -1,0 +1,87 @@
+// Copyright 2025 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"math"
+	"math/big"
+	"runtime"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/auction"
+)
+
+// bidSigCacher is a concurrent bid recoverer and cacher.
+var bidSigCacher = newBidCacher(calcNumBidCachers())
+
+func calcNumBidCachers() int {
+	numWorkers := math.Ceil(float64(runtime.NumCPU()) * 2.0 / 3.0)
+	return int(numWorkers)
+}
+
+// bidCacherRequest is a request for recovering bid with a
+// specific signature scheme and caching it into the bid itself.
+type bidCacherRequest struct {
+	bid *auction.Bid
+
+	chainID           *big.Int
+	verifyingContract common.Address
+	auctioneer        common.Address
+}
+
+// bidCacher is a helper structure to concurrently ecrecover transaction
+// bids from digital signatures on background threads.
+type bidCacher struct {
+	threads int
+	taskCh  chan *bidCacherRequest
+}
+
+// newBidCacher creates a new bid background cacher and starts
+// as many processing goroutines as allowed by the GOMAXPROCS on construction.
+func newBidCacher(threads int) *bidCacher {
+	cacher := &bidCacher{
+		taskCh:  make(chan *bidCacherRequest, threads),
+		threads: threads,
+	}
+	for range threads {
+		go cacher.cache()
+	}
+	return cacher
+}
+
+// cache is an infinite loop, caching bids from various forms of
+// data structures.
+func (cacher *bidCacher) cache() {
+	for task := range cacher.taskCh {
+		task.bid.ValidateSig(task.chainID, task.verifyingContract, task.auctioneer)
+	}
+}
+
+// recover verifies the signatures and caches the bid.
+func (cacher *bidCacher) recover(bid *auction.Bid, chainID *big.Int, verifyingContract common.Address, auctioneer common.Address) {
+	// Early return if bid is nil.
+	if bid == nil {
+		return
+	}
+
+	cacher.taskCh <- &bidCacherRequest{
+		bid:               bid,
+		chainID:           chainID,
+		verifyingContract: verifyingContract,
+		auctioneer:        auctioneer,
+	}
+}


### PR DESCRIPTION
## Proposed changes

This PR introduces the bid signature cache. It starts caching the signature validation results of the searcher and auctioneer signatures and returns an error if they have already been validated.

In benchmarks, under 1,000 bids, it shows 10 times faster than sequential verification.

```
// For 1k bid
// BenchmarkAddBid-11    	      10	 100902779 ns/op	20257707 B/op	  224003 allocs/op
// BenchmarkAddBid-11    	     104	  10733456 ns/op	 9953972 B/op	  145805 allocs/op
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
