### PR TITLE
kaiax/gasless: Check Registry before calling Multicall

### DIFF
--- a/kaiax/gasless/impl/getter.go
+++ b/kaiax/gasless/impl/getter.go
@@ -372,6 +372,11 @@ func getGaslessInfo(bc backends.BlockChainForCaller, header *types.Header) (comm
 		return common.Address{}, nil, err
 	}
 
+	// If Registry is not installed, do not query GaslessSwapRouter contract.
+	if statedb.GetCode(system.RegistryAddr) == nil || bc.Config().IsRandaoForkBlockParent(header.Number) {
+		return common.Address{}, nil, nil
+	}
+
 	caller, err := system.NewMultiCallContractCaller(statedb, bc, header)
 	if err != nil {
 		return common.Address{}, nil, err


### PR DESCRIPTION
## Proposed changes

- Stop the following log before Randao fork.
```
WARN[09/02,00:31:46 +09] [64] there is something wrong with multicall contract  err="abi: attempting to unmarshall an empty string while arguments are expected"
```
- c.f. https://github.com/kaiachain/kaia/blob/v2.0.3/kaiax/staking/impl/getter.go#L132

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
