### PR TITLE
fix: fix slice init length

### DIFF
--- a/node/sc/bridgepool/bridge_tx_pool.go
+++ b/node/sc/bridgepool/bridge_tx_pool.go
@@ -288,7 +288,7 @@ func (pool *BridgeTxPool) PendingTxHashesByAddress(from *common.Address, limit i
 	defer pool.mu.Unlock()
 
 	if list, exist := pool.queue[*from]; exist {
-		pendingTxHashes := make([]common.Hash, limit)
+		pendingTxHashes := make([]common.Hash, 0, limit)
 		txs := list.FlattenByCount(limit)
 		for _, tx := range txs {
 			pendingTxHashes = append(pendingTxHashes, tx.(*types.Transaction).Hash())


### PR DESCRIPTION
## Proposed changes

The purpose here should be to initialize a slice with a capacity of len(call.Arguments) and a length of 0, and then append it later. Instead of initializing the length to len(call.Arguments) from the beginning, the resulting slice will not meet expectations.

The online demo: https://go.dev/play/p/q1BcVCmvidW

Inspired by https://github.com/kaiachain/kaia/pull/108 and replace all.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
