### PR TITLE
contract: Correctly pass the searcher address for reservation check

### DIFF
--- a/contracts/contracts/system_contracts/auction/AuctionDepositVault.sol
+++ b/contracts/contracts/system_contracts/auction/AuctionDepositVault.sol
@@ -54,8 +54,8 @@ contract AuctionDepositVault is IAuctionDepositVault, AuctionError, Ownable {
         _;
     }
 
-    modifier noWithdrawReservation() {
-        if (withdrawReservations[msg.sender].at != 0)
+    modifier noWithdrawReservation(address searcher) {
+        if (withdrawReservations[searcher].at != 0)
             revert WithdrawReservationExists();
         _;
     }
@@ -72,18 +72,27 @@ contract AuctionDepositVault is IAuctionDepositVault, AuctionError, Ownable {
     /* ========== VAULT IMPLEMENTATION ========== */
 
     /// @dev Deposit KAIA into the vault
-    function deposit() external payable override noWithdrawReservation {
+    function deposit()
+        external
+        payable
+        override
+        noWithdrawReservation(msg.sender)
+    {
         _deposit(msg.sender, msg.value);
     }
 
     function depositFor(
         address searcher
-    ) external payable override noWithdrawReservation {
+    ) external payable override noWithdrawReservation(searcher) {
         _deposit(searcher, msg.value);
     }
 
     /// @dev Reserve a withdrawal
-    function reserveWithdraw() external override noWithdrawReservation {
+    function reserveWithdraw()
+        external
+        override
+        noWithdrawReservation(msg.sender)
+    {
         address searcher = msg.sender;
         uint256 amount = depositBalances[searcher];
         if (amount == 0) revert ZeroDepositAmount();

--- a/contracts/test/Auction/auctionDepositVault.test.ts
+++ b/contracts/test/Auction/auctionDepositVault.test.ts
@@ -243,6 +243,15 @@ describe("AuctionDepositVault", () => {
         auctionDepositVault,
         "WithdrawReservationExists"
       );
+
+      await expect(
+        auctionDepositVault.depositFor(user1.address, {
+          value: toPeb(10),
+        })
+      ).to.be.revertedWithCustomError(
+        auctionDepositVault,
+        "WithdrawReservationExists"
+      );
     });
     it("#withdraw: success", async () => {
       const { auctionDepositVault, user1 } = fixture;


### PR DESCRIPTION
## Proposed changes

Correctly pass the searcher address for the withdrawal reservation check in auction deposit vault contract.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
