### PR TITLE
kaiax/auction: Add duplicate check in #insertBid

### DIFF
--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -265,6 +265,11 @@ func (bp *BidPool) insertBid(bid *auction.Bid) error {
 	if existingBid, ok := bp.bidTargetMap[blockNumber][targetTxHash]; ok {
 		// FCFS if the bid is the same.
 		if existingBid.Bid.Cmp(bid.Bid) >= 0 {
+			// Since we allow the parallel bid validation, the previous duplicate bid check at #validateBid might be skipped.
+			// So we need to check the bid map again to return the correct error.
+			if _, ok := bp.bidMap[bid.Hash()]; ok {
+				return auction.ErrBidAlreadyExists
+			}
 			return auction.ErrLowBid
 		}
 


### PR DESCRIPTION
## Proposed changes

Add duplicate check again at `#insertBid`. It's required since we allowed parallel bid validation, so the first duplicate check might be skipped if two identical bids are being processed.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
