### PR TITLE
kaiax/auction: Enhance bidpool lock

### DIFF
--- a/kaiax/auction/impl/bid_pool_test.go
+++ b/kaiax/auction/impl/bid_pool_test.go
@@ -456,3 +456,72 @@ func TestBidPool_UpdateAuctionInfo(t *testing.T) {
 	assert.Equal(t, newAuctioneer, pool.auctioneer)
 	assert.Equal(t, newAuctionEntryPoint, pool.auctionEntryPoint)
 }
+
+func BenchmarkAddBidParallel(b *testing.B) {
+	benchmarkAddBidParallel(b, 1000)
+}
+
+func benchmarkAddBidParallel(b *testing.B, numBids int) {
+	var (
+		mockCtrl = gomock.NewController(b)
+		chain    = chain_mock.NewMockBlockChain(mockCtrl)
+	)
+	defer mockCtrl.Finish()
+
+	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
+	chain.EXPECT().CurrentBlock().Return(block).AnyTimes()
+
+	pool := NewBidPool(testChainConfig, chain, &auction.AuctionConfig{MaxBidPoolSize: int64(numBids * 10)}) // Increase pool size for concurrent adds
+
+	pool.auctioneer = testAuctioneer
+	pool.auctionEntryPoint = testAuctionEntryPoint
+
+	// Start the auction
+	pool.start()
+	atomic.StoreUint32(&pool.running, 1)
+	defer pool.stop()
+
+	// Pre-generate bids
+	bids := make([]*auction.Bid, numBids)
+	for i := 0; i < numBids; i++ {
+		searcherKey, _ := crypto.GenerateKey()
+		tx := types.NewTransaction(uint64(i), testSearcher1, big.NewInt(10000000), 10000000, big.NewInt(10000000), []byte{})
+		bid := &auction.Bid{BidData: auction.BidData{
+			TargetTxHash: tx.Hash(),
+			BlockNumber:  2,
+			Sender:       crypto.PubkeyToAddress(searcherKey.PublicKey),
+			To:           crypto.PubkeyToAddress(searcherKey.PublicKey),
+			Nonce:        uint64(i),
+			Bid:          big.NewInt(10),
+			CallGasLimit: 100,
+			Data:         common.Hex2Bytes("d09de08a"),
+		}}
+
+		// Generate searcher signature (EIP-712)
+		digest := bid.GetHashTypedData(testChainConfig.ChainID, testAuctionEntryPoint)
+		sig, _ := crypto.Sign(digest, searcherKey)
+		sig[crypto.RecoveryIDOffset] += 27
+		bid.SearcherSig = sig
+
+		// Generate auctioneer signature
+		searcherSig := bid.SearcherSig
+		msg := fmt.Appendf(nil, "\x19Ethereum Signed Message:\n%d%s", len(searcherSig), searcherSig)
+		digest = crypto.Keccak256(msg)
+		sig, _ = crypto.Sign(digest, testAuctioneerKey)
+		sig[crypto.RecoveryIDOffset] += 27
+		bid.AuctioneerSig = sig
+
+		bids[i] = bid
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		bidIndex := 0
+		for pb.Next() {
+			// Round-robin through bids
+			bid := bids[bidIndex%numBids]
+			pool.AddBid(bid)
+			bidIndex++
+		}
+	})
+}


### PR DESCRIPTION
## Proposed changes

This PR enhances the mutex lock in bid pool.

1. Fix the potential deadlock between `updateAuctionInfo` and `AddBid`
2. Enable parallel signature validation

The potential deadlock can happen when:
1. `AddBid` holds `bidMu`
2. `updateAuctionInfo` holds `auctionInfoMu` and waits for `bidMu`
3. `validateBidSigs` tries to get `auctionInfoMu` <- deadlock occurs

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
