### PR TITLE
feat: clarify eth_syncing and subscribe[syncing] APIs

### DIFF
--- a/api/api_kaia.go
+++ b/api/api_kaia.go
@@ -111,6 +111,10 @@ func (s *KaiaAPI) FeeHistory(ctx context.Context, blockCount DecimalOrHex, lastB
 // - highestBlock:  block number of the highest block header this node has received from peers
 // - pulledStates:  number of state entries processed until now
 // - knownStates:   number of known state entries that still need to be pulled
+//
+// HTTP API:
+// http   EthAPI.Syncing()      eth_syncing     = `SyncProgress` || `false`
+// http   KaiaAPI.Syncing()     kaia_syncing 	= `SyncProgress` || `false`
 func (s *KaiaAPI) Syncing() (interface{}, error) {
 	progress := s.b.Progress()
 

--- a/datasync/downloader/api_kaia_downloader.go
+++ b/datasync/downloader/api_kaia_downloader.go
@@ -31,6 +31,16 @@ import (
 	"github.com/kaiachain/kaia/networks/rpc"
 )
 
+// EthDownloaderAPI wraps KaiaDownloaderAPI for eth namespace compatibility.
+type EthDownloaderAPI struct {
+	*KaiaDownloaderAPI
+}
+
+// NewEthDownloaderAPI creates a new EthDownloaderAPI.
+func NewEthDownloaderAPI(d downloader, m *event.TypeMux) *EthDownloaderAPI {
+	return &EthDownloaderAPI{NewKaiaDownloaderAPI(d, m)}
+}
+
 // KaiaDownloaderAPI provides an API which gives information about the current synchronisation status.
 // It offers only methods that operates on data that can be available to anyone without security risks.
 type KaiaDownloaderAPI struct {
@@ -102,6 +112,10 @@ func (api *KaiaDownloaderAPI) eventLoop() {
 }
 
 // Syncing provides information when this nodes starts synchronising with the Kaia network and when it's finished.
+//
+// WebSocket API:
+// ws  EthDownloaderAPI.Syncing    eth_syncing  = `{ syncing: true, status: SyncProgress }` || `false`
+// ws  KaiaDownloaderAPI.Syncing   kaia_syncing = `{ syncing: true, status: SyncProgress }` || `false`
 func (api *KaiaDownloaderAPI) Syncing(ctx context.Context) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -726,6 +726,7 @@ func (s *CN) APIs() []rpc.API {
 	kaiaFilterAPI := filters.NewKaiaFilterAPI(s.APIBackend)
 	ethFilterAPI := filters.NewEthFilterAPI(s.APIBackend)
 	kaiaDownloaderAPI := downloader.NewKaiaDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
+	ethDownloaderAPI := downloader.NewEthDownloaderAPI(s.protocolManager.Downloader(), s.eventMux)
 	kaiaDownloaderSyncAPI := downloader.NewKaiaDownloaderSyncAPI(s.protocolManager.Downloader())
 
 	ethAPI := api.NewEthAPI(
@@ -761,7 +762,7 @@ func (s *CN) APIs() []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   kaiaDownloaderAPI,
+			Service:   ethDownloaderAPI,
 			Public:    true,
 		}, {
 			Namespace: "admin",


### PR DESCRIPTION
# ATTENSION
Copy commits from https://github.com/kaiachain/kaia/pull/529 because its PR cannot pass the "ci/circleci: pass-testsExpected — Waiting for status to be reported"

## Proposed changes

This PR clarifies the eth_syncing and subscribe["syncing"] APIs by separating the implementation into distinct types while maintaining the same functionality.

### Changes:

- Add `EthDownloaderAPI` that wraps `KaiaDownloaderAPI` for eth namespace clarity
- Add API comparison comments in `KaiaDownloaderAPI.Syncing()` and `KaiaAPI.Syncing()` to document the differences between HTTP and WebSocket versions
- Maintain same functionality using pointer embedding to share the same instance

No functional changes - existing behavior is preserved

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
a
- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/kaiachain/kaia/pull/529

## Further comments

