### PR TITLE
api: Allow pending block for `GetBlockWithConsensusInfoByNumber`

### DIFF
--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -228,9 +228,7 @@ func (s *KaiaBlockChainAPI) GetBlockByNumber(ctx context.Context, blockNr rpc.Bl
 		response, err := s.rpcOutputBlock(block, true, fullTx)
 		if err == nil && blockNr == rpc.PendingBlockNumber {
 			// Pending blocks need to nil out a few fields
-			for _, field := range []string{"hash", "nonce", "miner"} {
-				response[field] = nil
-			}
+			s.nullifyPendingBlockFields(response)
 		}
 		return response, err
 	}
@@ -257,8 +255,15 @@ func (s *KaiaBlockChainAPI) GetBlockWithConsensusInfoByNumber(ctx context.Contex
 	}
 
 	if *number == rpc.PendingBlockNumber {
-		logger.Trace("Cannot get consensus information of the PendingBlock.")
-		return nil, errPendingNotAllowed
+		block, receipts, _ := s.b.Pending()
+		cInfo, err := s.b.Engine().GetConsensusInfo(block)
+		if err != nil {
+			logger.Error("Getting consensus information failed", "blockHash", block.Hash(), "err", err)
+			return nil, errInternalError
+		}
+		resp := s.makeRPCBlockOutputWithConsensusInfo(block, cInfo, block.Transactions(), receipts)
+		s.nullifyPendingBlockFields(resp)
+		return resp, nil
 	}
 
 	if *number == rpc.LatestBlockNumber {
@@ -282,12 +287,20 @@ func (s *KaiaBlockChainAPI) GetBlockWithConsensusInfoByNumber(ctx context.Contex
 		return nil, errInternalError
 	}
 
-	receipts := s.b.GetBlockReceipts(ctx, blockHash)
+	receipts := s.b.GetBlockReceiptsInCache(blockHash)
 	if receipts == nil {
 		receipts = s.b.GetBlockReceipts(ctx, blockHash)
 	}
 
 	return s.makeRPCBlockOutputWithConsensusInfo(block, cInfo, block.Transactions(), receipts), nil
+}
+
+// nullifyPendingBlockFields sets specific fields to nil for pending blocks
+func (s *KaiaBlockChainAPI) nullifyPendingBlockFields(response map[string]interface{}) {
+	pendingBlockNilFields := []string{"hash", "nonce", "miner"}
+	for _, field := range pendingBlockNilFields {
+		response[field] = nil
+	}
 }
 
 func (s *KaiaBlockChainAPI) GetBlockWithConsensusInfoByNumberRange(ctx context.Context, start *rpc.BlockNumber, end *rpc.BlockNumber) (map[string]interface{}, error) {


### PR DESCRIPTION
## Proposed changes

- This PR replace #543 with correct target branch `feat/v2.1.0`, not `feat/v3.0.0`.
- This PR make `GetBlockWithConsensusInfoByNumber` to accept pending block.
- as-is:
   ```
   > klay.getBlockWithConsensusInfo("pending")
   Error: pending is not allowed
           at web3.js:6814:9(39)
           at send (web3.js:5225:62(29))
           at <eval>:1:31(3)
   ``` 
- to-be: (note that `committee` is null and `committers` is empty)
    ```
    > klay.getBlockWithConsensusInfo("pending")
    {
      baseFeePerGas: "0x5d21dba00",
      blockScore: "0x1",
      committee: null,
      committers: [],
      extraData: "0xd883020100846b6c617988676f312e32332e37856c696e757800000000000000d8d594b1e5a9c4a8bbaf241b2f9d8d60375c8cea9c27bc80c0",
      gasUsed: "0x0",
      governanceData: "0x",
      hash: null,
      logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      miner: null,
      mixHash: "0xdc034544441105723fb73de5f5d12a296b9ec506479aea2cc17e8480e1af994a",
      nonce: null,
      number: "0x4",
      originProposer: "0xb1e5a9c4a8bbaf241b2f9d8d60375c8cea9c27bc",
      parentHash: "0xc203c161349176c6c804b47bab4bee359a157c566ded33013b3a63ff8f7fcd26",
      proposer: "0xb1e5a9c4a8bbaf241b2f9d8d60375c8cea9c27bc",
      randomReveal: "0x8554f2ba8279f4633cfecf1754ee514d193d0d263a5408a5af96a317ec4b715c109090db6a414373976d81050047ebbe11b71ba0a9659f53d9889dcce8ca58b9c345bf7f702d0ea99faf687f57c82f8e8371d89326eabbe2c58eb03d74cc0ad6",
      receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      reward: "0xb1e5a9c4a8bbaf241b2f9d8d60375c8cea9c27bc",
      round: 0,
      sigHash: "0x20e19489f4d1b30e42e7d13427c80dabd9586a81360ee65198b013dda02bf12a",
      size: "0x272",
      stateRoot: "0x2755aac278918a404c4b400b60ea1d958f2eaccf14175e3a7cdbffee5a572650",
      timestamp: "0x68cc90b6",
      timestampFoS: "0x0",
      transactions: [],
      transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
      voteData: "0x"
    }
    ```
- The block contents (fields except for consensus info) matches the output of `GetBlockByNumber`; that is, the fields `hash`, `nonce`, and `miner` is nullified.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules