### PR TITLE
work/builder: Prevent asymmetry case for bundle.IsConflict

### DIFF
--- a/work/builder/bundle.go
+++ b/work/builder/bundle.go
@@ -90,10 +90,14 @@ func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 
 	// 2-3. Check for TargetTxHash breaking current bundle.
 	// If newBundle.TargetTxHash is equal to the last tx of current bundle, it is NOT a conflict.
+	// Check both direction to gaurantee symmetry.
 	// e.g.) b.txs = [0x1, 0x2] and newBundle's TargetTxHash is 0x2.
-	if idx := b.FindIdx(newBundle.TargetTxHash); idx == -1 || idx == len(b.BundleTxs)-1 {
-		return false
+	if idx := b.FindIdx(newBundle.TargetTxHash); idx != -1 && idx != len(b.BundleTxs)-1 {
+		return true
+	}
+	if idx := newBundle.FindIdx(b.TargetTxHash); idx != -1 && idx != len(newBundle.BundleTxs)-1 {
+		return true
 	}
 
-	return true
+	return false
 }


### PR DESCRIPTION
## Proposed changes

This PR fixes the asymmetrical logic of `bundle.IsConflict`.

In the actual case, since we have only GA and Auction bundles, the asymmetry can't happen, but for clarity.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
