### PR TITLE
consensus: introduce faker and replace gxhash with faker

### DIFF
--- a/accounts/abi/bind/backends/blockchain_test.go
+++ b/accounts/abi/bind/backends/blockchain_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/gov"
@@ -83,11 +83,11 @@ func newTestBlockchainWithConfig(config *params.ChainConfig) *blockchain.BlockCh
 	genesis := blockchain.Genesis{Config: config, Alloc: alloc}
 	genesis.MustCommit(db)
 
-	bc, _ := blockchain.NewBlockChain(db, nil, genesis.Config, gxhash.NewFaker(), vm.Config{})
+	bc, _ := blockchain.NewBlockChain(db, nil, genesis.Config, faker.NewFaker(), vm.Config{})
 
 	// Append 10 blocks to test with block numbers other than 0
 	block := bc.CurrentBlock()
-	blocks, _ := blockchain.GenerateChain(config, block, gxhash.NewFaker(), db, 10, func(i int, b *blockchain.BlockGen) {})
+	blocks, _ := blockchain.GenerateChain(config, block, faker.NewFaker(), db, 10, func(i int, b *blockchain.BlockGen) {})
 	bc.InsertChain(blocks)
 
 	return bc
@@ -304,7 +304,7 @@ func TestBlockChainSendTransaction(t *testing.T) {
 		t.Errorf("could not add tx to pending block: %v", err)
 	}
 
-	blocks, _ := blockchain.GenerateChain(bc.Config(), block, gxhash.NewFaker(), state.Database().TrieDB().DiskDB(), 1, func(i int, b *blockchain.BlockGen) {
+	blocks, _ := blockchain.GenerateChain(bc.Config(), block, faker.NewFaker(), state.Database().TrieDB().DiskDB(), 1, func(i int, b *blockchain.BlockGen) {
 		txs, err := txPool.Pending()
 		if err != nil {
 			t.Errorf("could not get pending txs: %v", err)
@@ -353,7 +353,7 @@ func initBackendForFiltererTests(t *testing.T, bc *blockchain.BlockChain) *Block
 		t.Errorf("could not sign tx: %v", err)
 	}
 
-	blocks, _ := blockchain.GenerateChain(bc.Config(), block, gxhash.NewFaker(), state.Database().TrieDB().DiskDB(), 1, func(i int, b *blockchain.BlockGen) {
+	blocks, _ := blockchain.GenerateChain(bc.Config(), block, faker.NewFaker(), state.Database().TrieDB().DiskDB(), 1, func(i int, b *blockchain.BlockGen) {
 		b.AddTx(signedTx)
 	})
 	bc.InsertChain(blocks)
@@ -440,7 +440,7 @@ func TestBlockChainSubscribeFilterLogs(t *testing.T) {
 
 		block := bc.CurrentBlock()
 
-		blocks, _ := blockchain.GenerateChain(c.bc.Config(), block, gxhash.NewFaker(), state.Database().TrieDB().DiskDB(), 1, func(i int, b *blockchain.BlockGen) {
+		blocks, _ := blockchain.GenerateChain(c.bc.Config(), block, faker.NewFaker(), state.Database().TrieDB().DiskDB(), 1, func(i int, b *blockchain.BlockGen) {
 			b.AddTx(signedTx)
 		})
 		bc.InsertChain(blocks)

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -40,7 +40,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/math"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/node/cn/filters"
@@ -81,7 +81,7 @@ type SimulatedBackend struct {
 func NewSimulatedBackendWithDatabase(database database.DBManager, alloc blockchain.GenesisAlloc, cfg *params.ChainConfig) *SimulatedBackend {
 	genesis := blockchain.Genesis{Config: cfg, Alloc: alloc}
 	genesis.MustCommit(database)
-	blockchain, _ := blockchain.NewBlockChain(database, nil, genesis.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := blockchain.NewBlockChain(database, nil, genesis.Config, faker.NewFaker(), vm.Config{})
 
 	backend := &SimulatedBackend{
 		database:   database,
@@ -134,7 +134,7 @@ func (b *SimulatedBackend) Rollback() {
 }
 
 func (b *SimulatedBackend) rollback() {
-	blocks, receipts := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), gxhash.NewFaker(), b.database, 1, func(int, *blockchain.BlockGen) {})
+	blocks, receipts := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), faker.NewFaker(), b.database, 1, func(int, *blockchain.BlockGen) {})
 	stateDB, _ := b.blockchain.State()
 
 	b.pendingBlock = blocks[0]
@@ -534,7 +534,7 @@ func (b *SimulatedBackend) SendTransaction(_ context.Context, tx *types.Transact
 	}
 
 	// Include tx in chain.
-	blocks, receipts := blockchain.GenerateChain(b.config, block, gxhash.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
+	blocks, receipts := blockchain.GenerateChain(b.config, block, faker.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
 		for _, tx := range b.pendingBlock.Transactions() {
 			block.AddTxWithChain(b.blockchain, tx)
 		}
@@ -658,7 +658,7 @@ func (b *SimulatedBackend) AdjustTime(adjustment time.Duration) error {
 		return errors.New("Could not adjust time on non-empty block")
 	}
 
-	blocks, receipts := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), gxhash.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
+	blocks, receipts := blockchain.GenerateChain(b.config, b.blockchain.CurrentBlock(), faker.NewFaker(), b.database, 1, func(number int, block *blockchain.BlockGen) {
 		block.OffsetTime(int64(adjustment.Seconds()))
 	})
 	stateDB, _ := b.blockchain.State()

--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/consensus/mocks"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -2450,7 +2450,7 @@ type testChainContext struct {
 }
 
 func (mc *testChainContext) Engine() consensus.Engine {
-	return gxhash.NewFaker()
+	return faker.NewFaker()
 }
 
 func (mc *testChainContext) GetHeader(common.Hash, uint64) *types.Header {

--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/math"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
@@ -175,11 +175,11 @@ func benchInsertChain(b *testing.B, dbType database.DBType, gen func(int, *Block
 		Alloc:  GenesisAlloc{benchRootAddr: {Balance: benchRootFunds}},
 	}
 	genesis := gspec.MustCommit(db)
-	chain, _ := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, b.N, gen)
+	chain, _ := GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, b.N, gen)
 
 	// Time the insertion of the new chain.
 	// State and blocks are stored in the same DB.
-	chainman, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	chainman, _ := NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer chainman.Stop()
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -341,7 +341,7 @@ func benchReadChain(b *testing.B, full bool, databaseType database.DBType, count
 
 		db = genDBManagerForTest(dir, databaseType)
 
-		chain, err := NewBlockChain(db, nil, params.TestChainConfig, gxhash.NewFaker(), vm.Config{})
+		chain, err := NewBlockChain(db, nil, params.TestChainConfig, faker.NewFaker(), vm.Config{})
 		if err != nil {
 			b.Fatalf("error creating chain: %v", err)
 		}

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
@@ -45,14 +45,14 @@ func TestHeaderVerification(t *testing.T) {
 		testdb    = database.NewMemoryDBManager()
 		gspec     = &Genesis{Config: params.TestChainConfig}
 		genesis   = gspec.MustCommit(testdb)
-		blocks, _ = GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), testdb, 8, nil)
+		blocks, _ = GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), testdb, 8, nil)
 	)
 	headers := make([]*types.Header, len(blocks))
 	for i, block := range blocks {
 		headers[i] = block.Header()
 	}
 	// Run the header checker for blocks one-by-one, checking for both valid and invalid nonces
-	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, gxhash.NewFaker(), vm.Config{})
+	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, faker.NewFaker(), vm.Config{})
 	defer chain.Stop()
 
 	for i := 0; i < len(blocks); i++ {
@@ -60,10 +60,10 @@ func TestHeaderVerification(t *testing.T) {
 			var results <-chan error
 
 			if valid {
-				engine := gxhash.NewFaker()
+				engine := faker.NewFaker()
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
 			} else {
-				engine := gxhash.NewFakeFailer(headers[i].Number.Uint64())
+				engine := faker.NewFakeFailer(headers[i].Number.Uint64())
 				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
 			}
 			// Wait for the verification result
@@ -144,8 +144,8 @@ func TestVerifyBlockBody(t *testing.T) {
 	)
 
 	// We don't need istanbul instance here because validateBody is in BlockValidator instance
-	GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), testdb, 8, nil)
-	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, gxhash.NewFaker(), vm.Config{})
+	GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), testdb, 8, nil)
+	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, faker.NewFaker(), vm.Config{})
 	defer chain.Stop()
 
 	// Generate a batch of accounts to start with
@@ -185,7 +185,7 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 		testdb    = database.NewMemoryDBManager()
 		gspec     = &Genesis{Config: params.TestChainConfig}
 		genesis   = gspec.MustCommit(testdb)
-		blocks, _ = GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), testdb, 8, nil)
+		blocks, _ = GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), testdb, 8, nil)
 	)
 	headers := make([]*types.Header, len(blocks))
 	seals := make([]bool, len(blocks))
@@ -204,11 +204,11 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 		var results <-chan error
 
 		if valid {
-			chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, gxhash.NewFaker(), vm.Config{})
+			chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, faker.NewFaker(), vm.Config{})
 			_, results = chain.engine.VerifyHeaders(chain, headers, seals)
 			chain.Stop()
 		} else {
-			chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, gxhash.NewFakeFailer(uint64(len(headers)-1)), vm.Config{})
+			chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, faker.NewFakeFailer(uint64(len(headers)-1)), vm.Config{})
 			_, results = chain.engine.VerifyHeaders(chain, headers, seals)
 			chain.Stop()
 		}
@@ -257,7 +257,7 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 		testdb    = database.NewMemoryDBManager()
 		gspec     = &Genesis{Config: params.TestChainConfig}
 		genesis   = gspec.MustCommit(testdb)
-		blocks, _ = GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), testdb, 1024, nil)
+		blocks, _ = GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), testdb, 1024, nil)
 	)
 	headers := make([]*types.Header, len(blocks))
 	seals := make([]bool, len(blocks))
@@ -271,7 +271,7 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	defer runtime.GOMAXPROCS(old)
 
 	// Start the verifications and immediately abort
-	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, gxhash.NewFakeDelayer(time.Millisecond), vm.Config{})
+	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, faker.NewFakeDelayer(time.Millisecond), vm.Config{})
 	defer chain.Stop()
 
 	abort, results := chain.engine.VerifyHeaders(chain, headers, seals)

--- a/blockchain/blockchain_sethead_test.go
+++ b/blockchain/blockchain_sethead_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/blockchain/types"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
 )
@@ -122,7 +122,7 @@ func testLongDeepSetHead(t *testing.T, snapshots bool) {
 }
 
 func testSetHead(t *testing.T, tt *rewindTest) {
-	db, chain, err := newCanonical(gxhash.NewFullFaker(), 0, true)
+	db, chain, err := newCanonical(faker.NewFullFaker(), 0, true)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
@@ -132,13 +132,13 @@ func testSetHead(t *testing.T, tt *rewindTest) {
 	// If sidechain blocks are needed, make a light chain and import it
 	var sideblocks types.Blocks
 	if tt.sidechainBlocks > 0 {
-		sideblocks, _ = GenerateChain(params.TestChainConfig, chain.CurrentBlock(), gxhash.NewFaker(), db, tt.canonicalBlocks, func(i int, b *BlockGen) {})
+		sideblocks, _ = GenerateChain(params.TestChainConfig, chain.CurrentBlock(), faker.NewFaker(), db, tt.canonicalBlocks, func(i int, b *BlockGen) {})
 		if _, err := chain.InsertChain(sideblocks); err != nil {
 			t.Fatalf("Failed to import side chain: %v", err)
 		}
 	}
 
-	canonblocks, _ := GenerateChain(params.TestChainConfig, chain.CurrentBlock(), gxhash.NewFaker(), db, tt.canonicalBlocks, func(i int, b *BlockGen) {})
+	canonblocks, _ := GenerateChain(params.TestChainConfig, chain.CurrentBlock(), faker.NewFaker(), db, tt.canonicalBlocks, func(i int, b *BlockGen) {})
 	if _, err := chain.InsertChain(canonblocks[:tt.commitBlock]); err != nil {
 		t.Fatalf("Failed to import canonical chain start: %v", err)
 	}
@@ -290,14 +290,14 @@ func TestSetHeadEarlyExit(t *testing.T) {
 }
 
 func testSetHeadEarlyExit(t *testing.T, tt *rewindTest) {
-	db, chain, err := newCanonical(gxhash.NewFullFaker(), 0, true)
+	db, chain, err := newCanonical(faker.NewFullFaker(), 0, true)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
 	defer chain.Stop()
 	chain.Config().Istanbul = params.GetDefaultIstanbulConfig()
 
-	canonblocks, _ := GenerateChain(params.TestChainConfig, chain.CurrentBlock(), gxhash.NewFaker(), db, tt.canonicalBlocks, func(i int, b *BlockGen) {})
+	canonblocks, _ := GenerateChain(params.TestChainConfig, chain.CurrentBlock(), faker.NewFaker(), db, tt.canonicalBlocks, func(i int, b *BlockGen) {})
 	if _, err := chain.InsertChain(canonblocks); err != nil {
 		t.Fatalf("Failed to import canonical chain start: %v", err)
 	}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/kaiachain/kaia/common/compiler"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
@@ -92,7 +92,7 @@ func newCanonical(engine consensus.Engine, n int, full bool) (database.DBManager
 // Test fork of length N starting from block i
 func testFork(t *testing.T, blockchain *BlockChain, i, n int, full bool, comparator func(td1, td2 *big.Int)) {
 	// Copy old chain up to #i into a new db
-	db, blockchain2, err := newCanonical(gxhash.NewFaker(), i, full)
+	db, blockchain2, err := newCanonical(faker.NewFaker(), i, full)
 	if err != nil {
 		t.Fatal("could not make new canonical in testFork", err)
 	}
@@ -116,12 +116,12 @@ func testFork(t *testing.T, blockchain *BlockChain, i, n int, full bool, compara
 		headerChainB []*types.Header
 	)
 	if full {
-		blockChainB = MakeBlockChain(blockchain2.CurrentBlock(), n, gxhash.NewFaker(), db, forkSeed)
+		blockChainB = MakeBlockChain(blockchain2.CurrentBlock(), n, faker.NewFaker(), db, forkSeed)
 		if _, err := blockchain2.InsertChain(blockChainB); err != nil {
 			t.Fatalf("failed to insert forking chain: %v", err)
 		}
 	} else {
-		headerChainB = MakeHeaderChain(blockchain2.CurrentHeader(), n, gxhash.NewFaker(), db, forkSeed)
+		headerChainB = MakeHeaderChain(blockchain2.CurrentHeader(), n, faker.NewFaker(), db, forkSeed)
 		if _, err := blockchain2.InsertHeaderChain(headerChainB, 1); err != nil {
 			t.Fatalf("failed to insert forking chain: %v", err)
 		}
@@ -218,13 +218,13 @@ func insertChain(done chan bool, blockchain *BlockChain, chain types.Blocks, t *
 }
 
 func TestLastBlock(t *testing.T) {
-	_, blockchain, err := newCanonical(gxhash.NewFaker(), 0, true)
+	_, blockchain, err := newCanonical(faker.NewFaker(), 0, true)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
 	defer blockchain.Stop()
 
-	blocks := MakeBlockChain(blockchain.CurrentBlock(), 1, gxhash.NewFullFaker(), blockchain.db, 0)
+	blocks := MakeBlockChain(blockchain.CurrentBlock(), 1, faker.NewFullFaker(), blockchain.db, 0)
 	if _, err := blockchain.InsertChain(blocks); err != nil {
 		t.Fatalf("Failed to insert block: %v", err)
 	}
@@ -242,7 +242,7 @@ func testExtendCanonical(t *testing.T, full bool) {
 	length := 5
 
 	// Make first chain starting from genesis
-	_, processor, err := newCanonical(gxhash.NewFaker(), length, full)
+	_, processor, err := newCanonical(faker.NewFaker(), length, full)
 	if err != nil {
 		t.Fatalf("failed to make new canonical chain: %v", err)
 	}
@@ -270,7 +270,7 @@ func testShorterFork(t *testing.T, full bool) {
 	length := 10
 
 	// Make first chain starting from genesis
-	_, processor, err := newCanonical(gxhash.NewFaker(), length, full)
+	_, processor, err := newCanonical(faker.NewFaker(), length, full)
 	if err != nil {
 		t.Fatalf("failed to make new canonical chain: %v", err)
 	}
@@ -300,7 +300,7 @@ func testLongerFork(t *testing.T, full bool) {
 	length := 10
 
 	// Make first chain starting from genesis
-	_, processor, err := newCanonical(gxhash.NewFaker(), length, full)
+	_, processor, err := newCanonical(faker.NewFaker(), length, full)
 	if err != nil {
 		t.Fatalf("failed to make new canonical chain: %v", err)
 	}
@@ -330,7 +330,7 @@ func testEqualFork(t *testing.T, full bool) {
 	length := 10
 
 	// Make first chain starting from genesis
-	_, processor, err := newCanonical(gxhash.NewFaker(), length, full)
+	_, processor, err := newCanonical(faker.NewFaker(), length, full)
 	if err != nil {
 		t.Fatalf("failed to make new canonical chain: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestBrokenBlockChain(t *testing.T)  { testBrokenChain(t, true) }
 
 func testBrokenChain(t *testing.T, full bool) {
 	// Make chain starting from genesis
-	db, blockchain, err := newCanonical(gxhash.NewFaker(), 10, full)
+	db, blockchain, err := newCanonical(faker.NewFaker(), 10, full)
 	if err != nil {
 		t.Fatalf("failed to make new canonical chain: %v", err)
 	}
@@ -365,12 +365,12 @@ func testBrokenChain(t *testing.T, full bool) {
 
 	// Create a forked chain, and try to insert with a missing link
 	if full {
-		chain := MakeBlockChain(blockchain.CurrentBlock(), 5, gxhash.NewFaker(), db, forkSeed)[1:]
+		chain := MakeBlockChain(blockchain.CurrentBlock(), 5, faker.NewFaker(), db, forkSeed)[1:]
 		if err := testBlockChainImport(chain, blockchain); err == nil {
 			t.Errorf("broken block chain not reported")
 		}
 	} else {
-		chain := MakeHeaderChain(blockchain.CurrentHeader(), 5, gxhash.NewFaker(), db, forkSeed)[1:]
+		chain := MakeHeaderChain(blockchain.CurrentHeader(), 5, faker.NewFaker(), db, forkSeed)[1:]
 		if err := testHeaderChainImport(chain, blockchain); err == nil {
 			t.Errorf("broken header chain not reported")
 		}
@@ -408,17 +408,17 @@ func testReorgShort(t *testing.T, full bool) {
 
 func testReorg(t *testing.T, first, second []int64, td int64, full bool) {
 	// Create a pristine chain and database
-	db, blockchain, err := newCanonical(gxhash.NewFaker(), 0, full)
+	db, blockchain, err := newCanonical(faker.NewFaker(), 0, full)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
 	defer blockchain.Stop()
 
 	// Insert an easy and a difficult chain afterwards
-	easyBlocks, _ := GenerateChain(params.TestChainConfig, blockchain.CurrentBlock(), gxhash.NewFaker(), db, len(first), func(i int, b *BlockGen) {
+	easyBlocks, _ := GenerateChain(params.TestChainConfig, blockchain.CurrentBlock(), faker.NewFaker(), db, len(first), func(i int, b *BlockGen) {
 		b.OffsetTime(first[i])
 	})
-	diffBlocks, _ := GenerateChain(params.TestChainConfig, blockchain.CurrentBlock(), gxhash.NewFaker(), db, len(second), func(i int, b *BlockGen) {
+	diffBlocks, _ := GenerateChain(params.TestChainConfig, blockchain.CurrentBlock(), faker.NewFaker(), db, len(second), func(i int, b *BlockGen) {
 		b.OffsetTime(second[i])
 	})
 	if full {
@@ -479,7 +479,7 @@ func TestBadBlockHashes(t *testing.T)  { testBadHashes(t, true) }
 
 func testBadHashes(t *testing.T, full bool) {
 	// Create a pristine chain and database
-	db, blockchain, err := newCanonical(gxhash.NewFaker(), 0, full)
+	db, blockchain, err := newCanonical(faker.NewFaker(), 0, full)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
@@ -487,14 +487,14 @@ func testBadHashes(t *testing.T, full bool) {
 
 	// Create a chain, ban a hash and try to import
 	if full {
-		blocks := MakeBlockChain(blockchain.CurrentBlock(), 3, gxhash.NewFaker(), db, 10)
+		blocks := MakeBlockChain(blockchain.CurrentBlock(), 3, faker.NewFaker(), db, 10)
 
 		BadHashes[blocks[2].Header().Hash()] = true
 		defer func() { delete(BadHashes, blocks[2].Header().Hash()) }()
 
 		_, err = blockchain.InsertChain(blocks)
 	} else {
-		headers := MakeHeaderChain(blockchain.CurrentHeader(), 3, gxhash.NewFaker(), db, 10)
+		headers := MakeHeaderChain(blockchain.CurrentHeader(), 3, faker.NewFaker(), db, 10)
 
 		BadHashes[headers[2].Hash()] = true
 		defer func() { delete(BadHashes, headers[2].Hash()) }()
@@ -513,14 +513,14 @@ func TestReorgBadBlockHashes(t *testing.T)  { testReorgBadHashes(t, true) }
 
 func testReorgBadHashes(t *testing.T, full bool) {
 	// Create a pristine chain and database
-	db, blockchain, err := newCanonical(gxhash.NewFaker(), 0, full)
+	db, blockchain, err := newCanonical(faker.NewFaker(), 0, full)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
 	blockchain.Config().Istanbul = params.GetDefaultIstanbulConfig()
 	// Create a chain, import and ban afterwards
-	headers := MakeHeaderChain(blockchain.CurrentHeader(), 4, gxhash.NewFaker(), db, 10)
-	blocks := MakeBlockChain(blockchain.CurrentBlock(), 4, gxhash.NewFaker(), db, 10)
+	headers := MakeHeaderChain(blockchain.CurrentHeader(), 4, faker.NewFaker(), db, 10)
+	blocks := MakeBlockChain(blockchain.CurrentBlock(), 4, faker.NewFaker(), db, 10)
 
 	if full {
 		if _, err = blockchain.InsertChain(blocks); err != nil {
@@ -544,7 +544,7 @@ func testReorgBadHashes(t *testing.T, full bool) {
 	blockchain.Stop()
 
 	// Create a new BlockChain and check that it rolled back the state.
-	ncm, err := NewBlockChain(blockchain.db, nil, blockchain.chainConfig, gxhash.NewFaker(), vm.Config{})
+	ncm, err := NewBlockChain(blockchain.db, nil, blockchain.chainConfig, faker.NewFaker(), vm.Config{})
 	if err != nil {
 		t.Fatalf("failed to create new chain manager: %v", err)
 	}
@@ -567,7 +567,7 @@ func TestBlocksInsertNonceError(t *testing.T)  { testInsertNonceError(t, true) }
 func testInsertNonceError(t *testing.T, full bool) {
 	for i := 1; i < 25 && !t.Failed(); i++ {
 		// Create a pristine chain and database
-		db, blockchain, err := newCanonical(gxhash.NewFaker(), 0, full)
+		db, blockchain, err := newCanonical(faker.NewFaker(), 0, full)
 		if err != nil {
 			t.Fatalf("failed to create pristine chain: %v", err)
 		}
@@ -580,20 +580,20 @@ func testInsertNonceError(t *testing.T, full bool) {
 			failNum uint64
 		)
 		if full {
-			blocks := MakeBlockChain(blockchain.CurrentBlock(), i, gxhash.NewFaker(), db, 0)
+			blocks := MakeBlockChain(blockchain.CurrentBlock(), i, faker.NewFaker(), db, 0)
 
 			failAt = rand.Int() % len(blocks)
 			failNum = blocks[failAt].NumberU64()
 
-			blockchain.engine = gxhash.NewFakeFailer(failNum)
+			blockchain.engine = faker.NewFakeFailer(failNum)
 			failRes, err = blockchain.InsertChain(blocks)
 		} else {
-			headers := MakeHeaderChain(blockchain.CurrentHeader(), i, gxhash.NewFaker(), db, 0)
+			headers := MakeHeaderChain(blockchain.CurrentHeader(), i, faker.NewFaker(), db, 0)
 
 			failAt = rand.Int() % len(headers)
 			failNum = headers[failAt].Number.Uint64()
 
-			blockchain.engine = gxhash.NewFakeFailer(failNum)
+			blockchain.engine = faker.NewFakeFailer(failNum)
 			blockchain.hc.engine = blockchain.engine
 			failRes, err = blockchain.InsertHeaderChain(headers, 1)
 		}
@@ -632,7 +632,7 @@ func TestFastVsFullChains(t *testing.T) {
 		genesis = gspec.MustCommit(gendb)
 		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
-	blocks, receipts := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), gendb, 1024, func(i int, block *BlockGen) {
+	blocks, receipts := GenerateChain(gspec.Config, genesis, faker.NewFaker(), gendb, 1024, func(i int, block *BlockGen) {
 		// If the block number is multiple of 3, send a few bonus transactions to the miner
 		if i%3 == 2 {
 			for j := 0; j < i%4+1; j++ {
@@ -647,7 +647,7 @@ func TestFastVsFullChains(t *testing.T) {
 	// Import the chain as an archive node for the comparison baseline
 	archiveDb := database.NewMemoryDBManager()
 	gspec.MustCommit(archiveDb)
-	archive, _ := NewBlockChain(archiveDb, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	archive, _ := NewBlockChain(archiveDb, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer archive.Stop()
 
 	if n, err := archive.InsertChain(blocks); err != nil {
@@ -656,7 +656,7 @@ func TestFastVsFullChains(t *testing.T) {
 	// Fast import the chain as a non-archive node to test
 	fastDb := database.NewMemoryDBManager()
 	gspec.MustCommit(fastDb)
-	fast, _ := NewBlockChain(fastDb, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	fast, _ := NewBlockChain(fastDb, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer fast.Stop()
 
 	headers := make([]*types.Header, len(blocks))
@@ -711,7 +711,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 		genesis = gspec.MustCommit(gendb)
 	)
 	height := uint64(1024)
-	blocks, receipts := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), gendb, int(height), nil)
+	blocks, receipts := GenerateChain(gspec.Config, genesis, faker.NewFaker(), gendb, int(height), nil)
 
 	// Configure a subchain to roll back
 	remove := []common.Hash{}
@@ -734,7 +734,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	archiveDb := database.NewMemoryDBManager()
 	gspec.MustCommit(archiveDb)
 
-	archive, _ := NewBlockChain(archiveDb, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	archive, _ := NewBlockChain(archiveDb, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	if n, err := archive.InsertChain(blocks); err != nil {
 		t.Fatalf("failed to process block %d: %v", n, err)
 	}
@@ -747,7 +747,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	// Import the chain as a non-archive node and ensure all pointers are updated
 	fastDb := database.NewMemoryDBManager()
 	gspec.MustCommit(fastDb)
-	fast, _ := NewBlockChain(fastDb, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	fast, _ := NewBlockChain(fastDb, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer fast.Stop()
 
 	headers := make([]*types.Header, len(blocks))
@@ -768,7 +768,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	lightDb := database.NewMemoryDBManager()
 	gspec.MustCommit(lightDb)
 
-	light, _ := NewBlockChain(lightDb, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	light, _ := NewBlockChain(lightDb, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	if n, err := light.InsertHeaderChain(headers, 1); err != nil {
 		t.Fatalf("failed to insert header %d: %v", n, err)
 	}
@@ -818,7 +818,7 @@ func TestChainTxReorgs(t *testing.T) {
 	//  - futureAdd: transaction added after the reorg has already finished
 	var pastAdd, freshAdd, futureAdd *types.Transaction
 
-	chain, _ := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, 3, func(i int, gen *BlockGen) {
+	chain, _ := GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, 3, func(i int, gen *BlockGen) {
 		switch i {
 		case 0:
 			pastDrop, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr2), addr2, big.NewInt(1000), params.TxGas, nil, nil), signer, key2)
@@ -836,14 +836,14 @@ func TestChainTxReorgs(t *testing.T) {
 		}
 	})
 	// Import the chain. This runs all block validation rules.
-	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	if i, err := blockchain.InsertChain(chain); err != nil {
 		t.Fatalf("failed to insert original chain[%d]: %v", i, err)
 	}
 	defer blockchain.Stop()
 
 	// overwrite the old chain
-	chain, _ = GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, 5, func(i int, gen *BlockGen) {
+	chain, _ = GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, 5, func(i int, gen *BlockGen) {
 		switch i {
 		case 0:
 			pastAdd, _ = types.SignTx(types.NewTransaction(gen.TxNonce(addr3), addr3, big.NewInt(1000), params.TxGas, nil, nil), signer, key3)
@@ -906,12 +906,12 @@ func TestLogReorgs(t *testing.T) {
 		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 
-	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer blockchain.Stop()
 
 	rmLogsCh := make(chan RemovedLogsEvent)
 	blockchain.SubscribeRemovedLogsEvent(rmLogsCh)
-	chain, _ := GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 2, func(i int, gen *BlockGen) {
+	chain, _ := GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), db, 2, func(i int, gen *BlockGen) {
 		if i == 1 {
 			tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), code), signer, key1)
 			if err != nil {
@@ -924,7 +924,7 @@ func TestLogReorgs(t *testing.T) {
 		t.Fatalf("failed to insert chain: %v", err)
 	}
 
-	chain, _ = GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 3, func(i int, gen *BlockGen) {})
+	chain, _ = GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), db, 3, func(i int, gen *BlockGen) {})
 	if _, err := blockchain.InsertChain(chain); err != nil {
 		t.Fatalf("failed to insert forked chain: %v", err)
 	}
@@ -953,15 +953,15 @@ func TestReorgSideEvent(t *testing.T) {
 		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 
-	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer blockchain.Stop()
 
-	chain, _ := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, 3, func(i int, gen *BlockGen) {})
+	chain, _ := GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, 3, func(i int, gen *BlockGen) {})
 	if _, err := blockchain.InsertChain(chain); err != nil {
 		t.Fatalf("failed to insert chain: %v", err)
 	}
 
-	replacementBlocks, _ := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, 4, func(i int, gen *BlockGen) {
+	replacementBlocks, _ := GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, 4, func(i int, gen *BlockGen) {
 		tx, err := types.SignTx(types.NewContractCreation(gen.TxNonce(addr1), new(big.Int), 1000000, new(big.Int), nil), signer, key1)
 		if i == 2 {
 			gen.OffsetTime(-9)
@@ -1024,13 +1024,13 @@ done:
 
 // Tests if the canonical block can be fetched from the database during chain insertion.
 func TestCanonicalBlockRetrieval(t *testing.T) {
-	_, blockchain, err := newCanonical(gxhash.NewFaker(), 0, true)
+	_, blockchain, err := newCanonical(faker.NewFaker(), 0, true)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
 	defer blockchain.Stop()
 
-	chain, _ := GenerateChain(blockchain.chainConfig, blockchain.genesisBlock, gxhash.NewFaker(), blockchain.db, 10, func(i int, gen *BlockGen) {})
+	chain, _ := GenerateChain(blockchain.chainConfig, blockchain.genesisBlock, faker.NewFaker(), blockchain.db, 10, func(i int, gen *BlockGen) {})
 
 	var pend sync.WaitGroup
 	pend.Add(len(chain))
@@ -1084,12 +1084,12 @@ func TestEIP155Transition(t *testing.T) {
 		genesis = gspec.MustCommit(db)
 	)
 
-	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer blockchain.Stop()
 
 	// generate an invalid chain id transaction
 	config := &params.ChainConfig{ChainID: big.NewInt(2)}
-	blocks, _ := GenerateChain(config, genesis, gxhash.NewFaker(), db, 4, func(i int, block *BlockGen) {
+	blocks, _ := GenerateChain(config, genesis, faker.NewFaker(), db, 4, func(i int, block *BlockGen) {
 		var (
 			tx      *types.Transaction
 			err     error
@@ -1127,10 +1127,10 @@ func TestEIP161AccountRemoval(t *testing.T) {
 		}
 		genesis = gspec.MustCommit(db)
 	)
-	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer blockchain.Stop()
 
-	blocks, _ := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, 3, func(i int, block *BlockGen) {
+	blocks, _ := GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, 3, func(i int, block *BlockGen) {
 		var (
 			tx     *types.Transaction
 			err    error
@@ -1182,7 +1182,7 @@ func TestEIP161AccountRemoval(t *testing.T) {
 // https://github.com/ethereum/go-ethereum/pull/15941
 func TestBlockchainHeaderchainReorgConsistency(t *testing.T) {
 	// Generate a canonical chain to act as the main dataset
-	engine := gxhash.NewFaker()
+	engine := faker.NewFaker()
 
 	db := database.NewMemoryDBManager()
 	genesis := new(Genesis).MustCommit(db)
@@ -1227,7 +1227,7 @@ func TestBlockchainHeaderchainReorgConsistency(t *testing.T) {
 // cache (which would eventually cause memory issues).
 func TestTrieForkGC(t *testing.T) {
 	// Generate a canonical chain to act as the main dataset
-	engine := gxhash.NewFaker()
+	engine := faker.NewFaker()
 
 	db := database.NewMemoryDBManager()
 	genesis := new(Genesis).MustCommit(db)
@@ -1284,7 +1284,7 @@ func TestStatePruning(t *testing.T) {
 		}
 		genesis = gspec.MustCommit(db)
 		signer  = types.LatestSignerForChainID(gspec.Config.ChainID)
-		engine  = gxhash.NewFaker()
+		engine  = faker.NewFaker()
 
 		// Latest `retention` blocks survive.
 		// Blocks 1..7 are pruned, blocks 8..10 are kept.
@@ -1352,7 +1352,7 @@ func TestStatePruning(t *testing.T) {
 // forking point is not available any more.
 func TestLargeReorgTrieGC(t *testing.T) {
 	// Generate the original common chain segment and the two competing forks
-	engine := gxhash.NewFaker()
+	engine := faker.NewFaker()
 
 	db := database.NewMemoryDBManager()
 	genesis := new(Genesis).MustCommit(db)
@@ -1417,7 +1417,7 @@ func TestAccessListTx(t *testing.T) {
 	config.Governance.KIP71.LowerBoundBaseFee = 0
 	var (
 		contractAddr = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
-		engine       = gxhash.NewFaker()
+		engine       = faker.NewFaker()
 		signer       = types.LatestSigner(config)
 
 		// A sender who makes transactions, has some funds
@@ -1495,7 +1495,7 @@ func TestEIP3651(t *testing.T) {
 	var (
 		aa     = params.AuthorAddressForTesting
 		bb     = common.HexToAddress("0x000000000000000000000000000000000000bbbb")
-		engine = gxhash.NewFaker()
+		engine = faker.NewFaker()
 		db     = database.NewMemoryDBManager()
 
 		// A sender who makes transactions, has some funds
@@ -1594,7 +1594,7 @@ func TestEIP3651(t *testing.T) {
 
 	// 3: Ensure that miner received only the mining fee (consensus is gxHash, so 3 KAIA is the total reward)
 	actual := state.GetBalance(params.AuthorAddressForTesting)
-	expected := gxhash.ByzantiumBlockReward
+	expected := faker.ByzantiumBlockReward
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("miner balance incorrect: expected %d, got %d", expected, actual)
 	}
@@ -1626,7 +1626,7 @@ func benchmarkLargeNumberOfValueToNonexisting(b *testing.B, numTxs, numBlocks in
 		signer = types.LatestSignerForChainID(gspec.Config.ChainID)
 	)
 	// Generate the original common chain segment and the two competing forks
-	engine := gxhash.NewFaker()
+	engine := faker.NewFaker()
 	db := database.NewMemoryDBManager()
 	genesis := gspec.MustCommit(db)
 
@@ -1841,7 +1841,7 @@ func TestCallTraceChainEventSubscription(t *testing.T) {
 	testGenesis.MustCommit(db)
 
 	// create new blockchain with enabled internal tx tracing option
-	blockchain, _ := NewBlockChain(db, nil, testGenesis.Config, gxhash.NewFaker(), vm.Config{Debug: true, EnableInternalTxTracing: true})
+	blockchain, _ := NewBlockChain(db, nil, testGenesis.Config, faker.NewFaker(), vm.Config{Debug: true, EnableInternalTxTracing: true})
 	defer blockchain.Stop()
 
 	// subscribe a new chain event channel
@@ -1850,7 +1850,7 @@ func TestCallTraceChainEventSubscription(t *testing.T) {
 	defer subscription.Unsubscribe()
 
 	// generate blocks
-	blocks, _ := GenerateChain(testGenesis.Config, genesis, gxhash.NewFaker(), gendb, 1, func(i int, block *BlockGen) {
+	blocks, _ := GenerateChain(testGenesis.Config, genesis, faker.NewFaker(), gendb, 1, func(i int, block *BlockGen) {
 		// Deploy a contract which can trigger internal transactions
 		genInternalTxTransaction(t, block, address, signer, key)
 	})
@@ -1913,13 +1913,13 @@ func TestBlockChain_SetCanonicalBlock(t *testing.T) {
 		SnapshotCacheSize:   512,
 	}
 	// create new blockchain with enabled internal tx tracing option
-	blockchain, _ := NewBlockChain(db, cacheConfig, testGenesis.Config, gxhash.NewFaker(), vm.Config{Debug: true, EnableInternalTxTracing: true})
+	blockchain, _ := NewBlockChain(db, cacheConfig, testGenesis.Config, faker.NewFaker(), vm.Config{Debug: true, EnableInternalTxTracing: true})
 	defer blockchain.Stop()
 
 	chainLength := rand.Int63n(500) + 100
 
 	// generate blocks
-	blocks, _ := GenerateChain(testGenesis.Config, genesis, gxhash.NewFaker(), gendb, int(chainLength), func(i int, block *BlockGen) {
+	blocks, _ := GenerateChain(testGenesis.Config, genesis, faker.NewFaker(), gendb, int(chainLength), func(i int, block *BlockGen) {
 		// Deploy a contract which can trigger internal transactions
 		genInternalTxTransaction(t, block, address, signer, key)
 	})
@@ -2001,7 +2001,7 @@ func TestDeleteCreateRevert(t *testing.T) {
 		aa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
 		bb = common.HexToAddress("0x000000000000000000000000000000000000bbbb")
 		// Generate a canonical chain to act as the main dataset
-		engine = gxhash.NewFaker()
+		engine = faker.NewFaker()
 		db     = database.NewMemoryDBManager()
 
 		// A sender who makes transactions, has some funds
@@ -2093,11 +2093,11 @@ func TestBlockChain_InsertChain_InsertFutureBlocks(t *testing.T) {
 	cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker = 3
 
 	// create new blockchain with enabled internal tx tracing option
-	blockchain, _ := NewBlockChain(db, cacheConfig, testGenesis.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := NewBlockChain(db, cacheConfig, testGenesis.Config, faker.NewFaker(), vm.Config{})
 	defer blockchain.Stop()
 
 	// generate blocks
-	blocks, _ := GenerateChain(testGenesis.Config, genesis, gxhash.NewFaker(), db, 10, func(i int, block *BlockGen) {})
+	blocks, _ := GenerateChain(testGenesis.Config, genesis, faker.NewFaker(), db, 10, func(i int, block *BlockGen) {})
 
 	// insert the generated blocks into the test chain
 	if n, err := blockchain.InsertChain(blocks[:2]); err != nil {
@@ -2122,7 +2122,7 @@ func TestTransientStorageReset(t *testing.T) {
 		destAddress = crypto.CreateAddress(address, 0)
 		funds       = big.NewInt(1000000000000000000)
 
-		testEngine = gxhash.NewFaker()
+		testEngine = faker.NewFaker()
 	)
 	code := append([]byte{
 		// TLoad value with location 1
@@ -2271,7 +2271,7 @@ func newGkei(n int64) *big.Int {
 func TestEIP7702(t *testing.T) {
 	var (
 		// Generate a canonical chain to act as the main dataset
-		engine  = gxhash.NewFaker()
+		engine  = faker.NewFaker()
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
 		addr1   = crypto.PubkeyToAddress(key1.PublicKey)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -383,7 +383,8 @@ func TestReorgLongHeaders(t *testing.T) { testReorgLong(t, false) }
 func TestReorgLongBlocks(t *testing.T)  { testReorgLong(t, true) }
 
 func testReorgLong(t *testing.T, full bool) {
-	testReorg(t, []int64{0, 0, -9}, []int64{0, 0, 0, -9}, 393280, full)
+	// With faker consensus, each block adds 1 to blockscore
+	testReorg(t, []int64{0, 0, -9}, []int64{0, 0, 0, -9}, 4, full)
 }
 
 // Tests that reorganising a short difficult chain after a long easy one
@@ -403,7 +404,8 @@ func testReorgShort(t *testing.T, full bool) {
 	for i := 0; i < len(diff); i++ {
 		diff[i] = -9
 	}
-	testReorg(t, easy, diff, 12615120, full)
+	// With faker, the longer chain (96 blocks) wins
+	testReorg(t, easy, diff, 96, full)
 }
 
 func testReorg(t *testing.T, first, second []int64, td int64, full bool) {
@@ -461,7 +463,7 @@ func testReorg(t *testing.T, first, second []int64, td int64, full bool) {
 		}
 	}
 	// Make sure the chain total blockscore is the correct one
-	want := new(big.Int).Add(blockchain.genesisBlock.BlockScore(), big.NewInt(td))
+	want := big.NewInt(td)
 	if full {
 		if have := blockchain.GetTdByHash(blockchain.CurrentBlock().Hash()); have.Cmp(want) != 0 {
 			t.Errorf("total blockscore mismatch: have %v, want %v", have, want)

--- a/blockchain/chain_makers_test.go
+++ b/blockchain/chain_makers_test.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/crypto"
@@ -58,7 +58,7 @@ func ExampleGenerateChain() {
 	// each block and adds different features to gen based on the
 	// block index.
 	signer := types.HomesteadSigner{}
-	chain, _ := GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, 5, func(i int, gen *BlockGen) {
+	chain, _ := GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, 5, func(i int, gen *BlockGen) {
 		switch i {
 		case 0:
 			// In block 1, addr1 sends addr2 some KAIA.
@@ -87,7 +87,7 @@ func ExampleGenerateChain() {
 	})
 
 	// Import the chain. This runs all block validation rules.
-	blockchain, _ := NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	blockchain, _ := NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	defer blockchain.Stop()
 
 	if i, err := blockchain.InsertChain(chain); err != nil {

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
@@ -119,10 +119,10 @@ func TestHardCodedChainConfigUpdate(t *testing.T) {
 				genesis := genMainnetGenesisBlock()
 				genesisBlock := genesis.MustCommit(db)
 
-				bc, _ := NewBlockChain(db, nil, genesis.Config, gxhash.NewFullFaker(), vm.Config{})
+				bc, _ := NewBlockChain(db, nil, genesis.Config, faker.NewFullFaker(), vm.Config{})
 				defer bc.Stop()
 
-				blocks, _ := GenerateChain(genesis.Config, genesisBlock, gxhash.NewFaker(), db, 4, nil)
+				blocks, _ := GenerateChain(genesis.Config, genesisBlock, faker.NewFaker(), db, 4, nil)
 				bc.InsertChain(blocks)
 				// This should return a compatibility error.
 				newConfig := *genesis
@@ -310,10 +310,10 @@ func TestSetupGenesis(t *testing.T) {
 				// Advance to block #4, past the Istanbul transition block of customGenesis.
 				genesis := customGenesis.MustCommit(db)
 
-				bc, _ := NewBlockChain(db, nil, customGenesis.Config, gxhash.NewFullFaker(), vm.Config{})
+				bc, _ := NewBlockChain(db, nil, customGenesis.Config, faker.NewFullFaker(), vm.Config{})
 				defer bc.Stop()
 
-				blocks, _ := GenerateChain(customGenesis.Config, genesis, gxhash.NewFaker(), db, 4, nil)
+				blocks, _ := GenerateChain(customGenesis.Config, genesis, faker.NewFaker(), db, 4, nil)
 				bc.InsertChain(blocks)
 				// This should return a compatibility error.
 				newConfig := *customGenesis

--- a/blockchain/state_migration_test.go
+++ b/blockchain/state_migration_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
@@ -53,7 +53,7 @@ func TestBlockChain_migrateState(t *testing.T) {
 		_     = gspec.MustCommit(testdb)
 	)
 
-	chain, err := NewBlockChain(testdb, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	chain, err := NewBlockChain(testdb, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	if err != nil {
 		t.Fatalf("Failed to create local chain, %v", err)
 	}

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -1,0 +1,206 @@
+// Copyright 2025 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package faker implements a fake consensus engine for testing purposes.
+// It accepts all blocks as valid, with optional failure conditions.
+package faker
+
+import (
+	"errors"
+	"math/big"
+	"time"
+
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus"
+	"github.com/kaiachain/kaia/networks/rpc"
+	"github.com/kaiachain/kaia/params"
+)
+
+// ByzantiumBlockReward is the block reward for testing purposes.
+var ByzantiumBlockReward = big.NewInt(3e+18)
+
+// Faker is a consensus engine that accepts all blocks as valid.
+type Faker struct {
+	failBlock uint64        // Block number to fail at (0 = no failure)
+	failDelay time.Duration // Delay before returning in Seal
+	fullFake  bool          // Accept all blocks without validation
+}
+
+// NewFaker creates a fake consensus engine that accepts all blocks.
+func NewFaker() *Faker {
+	return &Faker{}
+}
+
+// NewFakeFailer creates a fake consensus engine that fails at a specific block.
+func NewFakeFailer(fail uint64) *Faker {
+	return &Faker{failBlock: fail}
+}
+
+// NewFakeDelayer creates a fake consensus engine that delays block sealing.
+func NewFakeDelayer(delay time.Duration) *Faker {
+	return &Faker{failDelay: delay}
+}
+
+// NewFullFaker creates a fake consensus engine that accepts all blocks without any validation.
+func NewFullFaker() *Faker {
+	return &Faker{fullFake: true}
+}
+
+// NewShared creates a shared fake consensus engine.
+func NewShared() *Faker {
+	return &Faker{}
+}
+
+// Author returns a fixed address for testing.
+func (f *Faker) Author(header *types.Header) (common.Address, error) {
+	return params.AuthorAddressForTesting, nil
+}
+
+// CanVerifyHeadersConcurrently returns true for concurrent verification.
+func (f *Faker) CanVerifyHeadersConcurrently() bool {
+	return true
+}
+
+// PreprocessHeaderVerification is not used for faker.
+func (f *Faker) PreprocessHeaderVerification(headers []*types.Header) (chan<- struct{}, <-chan error) {
+	panic("not implemented for faker")
+}
+
+// GetConsensusInfo returns empty consensus info.
+func (f *Faker) GetConsensusInfo(block *types.Block) (consensus.ConsensusInfo, error) {
+	return consensus.ConsensusInfo{}, nil
+}
+
+// VerifyHeader checks whether a header conforms to the consensus rules.
+func (f *Faker) VerifyHeader(chain consensus.ChainReader, header *types.Header, seal bool) error {
+	// If we're running a full engine faking, accept any input as valid
+	if f.fullFake {
+		return nil
+	}
+	// Check if we should fail this block
+	if f.failBlock != 0 && header.Number.Uint64() == f.failBlock {
+		return consensus.ErrUnknownAncestor
+	}
+	// All other headers are valid in fake mode - we're only testing, not verifying actual consensus
+	return nil
+}
+
+// VerifyHeaders verifies a batch of headers concurrently.
+func (f *Faker) VerifyHeaders(chain consensus.ChainReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	abort, results := make(chan struct{}), make(chan error, len(headers))
+	// If we're running a full engine faking, accept all headers as valid
+	if f.fullFake || len(headers) == 0 {
+		go func() {
+			for i := 0; i < len(headers); i++ {
+				results <- nil
+			}
+		}()
+		return abort, results
+	}
+	go func() {
+		for i := range headers {
+			select {
+			case <-abort:
+				return
+			default:
+				err := f.VerifyHeader(chain, headers[i], seals[i])
+				results <- err
+			}
+		}
+	}()
+	return abort, results
+}
+
+// VerifySeal implements consensus.Engine, checking the seal validity.
+func (f *Faker) VerifySeal(chain consensus.ChainReader, header *types.Header) error {
+	if f.failBlock != 0 && header.Number.Uint64() == f.failBlock {
+		return errors.New("seal verification failed")
+	}
+	return nil
+}
+
+// Prepare prepares the header for mining.
+func (f *Faker) Prepare(chain consensus.ChainReader, header *types.Header) error {
+	// Set BlockScore to block number for simplicity in testing
+	header.BlockScore = new(big.Int).Set(header.Number)
+	return nil
+}
+
+// Initialize runs any pre-transaction state modifications.
+func (f *Faker) Initialize(chain consensus.ChainReader, header *types.Header, state *state.StateDB) {
+	// No initialization needed for faker
+}
+
+// Finalize processes the block without modifying state.
+func (f *Faker) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) (*types.Block, error) {
+	// Accumulate block rewards
+	f.accumulateRewards(state, header)
+
+	// Set header fields
+	header.Root = state.IntermediateRoot(true)
+	header.ReceiptHash = types.DeriveSha(types.Receipts(receipts), header.Number)
+	header.Bloom = types.CreateBloom(receipts)
+
+	return types.NewBlock(header, txs, receipts), nil
+}
+
+// accumulateRewards credits the coinbase of the given block with the mining reward.
+func (f *Faker) accumulateRewards(state *state.StateDB, header *types.Header) {
+	reward := ByzantiumBlockReward
+	state.AddBalance(params.AuthorAddressForTesting, reward)
+}
+
+// Seal generates a new sealing request for the given block.
+func (f *Faker) Seal(chain consensus.ChainReader, block *types.Block, stop <-chan struct{}) (*types.Block, error) {
+	// Add delay if configured
+	if f.failDelay > 0 {
+		select {
+		case <-time.After(f.failDelay):
+		case <-stop:
+			return nil, nil
+		}
+	}
+
+	// Check if we should fail
+	if f.failBlock != 0 && block.NumberU64() == f.failBlock {
+		return nil, errors.New("seal failed")
+	}
+
+	return block, nil
+}
+
+// CalcBlockScore calculates the block score.
+func (f *Faker) CalcBlockScore(chain consensus.ChainReader, time uint64, parent *types.Header) *big.Int {
+	// Return parent block score + 1 for simplicity
+	return new(big.Int).Add(parent.BlockScore, big.NewInt(1))
+}
+
+// APIs returns RPC APIs (none for faker).
+func (f *Faker) APIs(chain consensus.ChainReader) []rpc.API {
+	return nil
+}
+
+// Protocol returns the consensus protocol.
+func (f *Faker) Protocol() consensus.Protocol {
+	return consensus.KaiaProtocol
+}
+
+// PurgeCache is a no-op for faker.
+func (f *Faker) PurgeCache() {
+	// No cache to purge for faker
+}

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -195,6 +195,11 @@ func (f *Faker) VerifySeal(chain consensus.ChainReader, header *types.Header) er
 
 // Prepare prepares the header for mining.
 func (f *Faker) Prepare(chain consensus.ChainReader, header *types.Header) error {
+	// Handle nil Number field
+	if header.Number == nil {
+		return errors.New("header number is nil")
+	}
+
 	parent := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
 	header.BlockScore = f.CalcBlockScore(chain, header.Time.Uint64(), parent)
 	return nil
@@ -245,14 +250,7 @@ func (f *Faker) Seal(chain consensus.ChainReader, block *types.Block, stop <-cha
 
 // CalcBlockScore calculates the block score.
 func (f *Faker) CalcBlockScore(chain consensus.ChainReader, time uint64, parent *types.Header) *big.Int {
-	// Handle nil parent or nil BlockScore
-	if parent == nil || parent.BlockScore == nil {
-		return big.NewInt(131072) // Default difficulty
-	}
-
-	// For faker, just use a fixed increment for simplicity and test predictability
-	// This matches the expected behavior in tests
-	return big.NewInt(131072)
+	return big.NewInt(1)
 }
 
 // APIs returns RPC APIs (none for faker).

--- a/consensus/faker/faker_test.go
+++ b/consensus/faker/faker_test.go
@@ -1,0 +1,229 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package faker
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/consensus"
+	"github.com/kaiachain/kaia/params"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewFaker tests the creation of different faker instances
+func TestNewFaker(t *testing.T) {
+	// Test NewFaker
+	f := NewFaker()
+	assert.NotNil(t, f)
+	assert.Equal(t, uint64(0), f.failBlock)
+	assert.Equal(t, time.Duration(0), f.failDelay)
+	assert.False(t, f.fullFake)
+
+	// Test NewFakeFailer
+	f2 := NewFakeFailer(10)
+	assert.NotNil(t, f2)
+	assert.Equal(t, uint64(10), f2.failBlock)
+
+	// Test NewFakeDelayer
+	delay := 5 * time.Second
+	f3 := NewFakeDelayer(delay)
+	assert.NotNil(t, f3)
+	assert.Equal(t, delay, f3.failDelay)
+
+	// Test NewFullFaker
+	f4 := NewFullFaker()
+	assert.NotNil(t, f4)
+	assert.True(t, f4.fullFake)
+}
+
+// TestAuthor tests the Author method
+func TestAuthor(t *testing.T) {
+	f := NewFaker()
+	header := &types.Header{Number: big.NewInt(1)}
+
+	author, err := f.Author(header)
+	assert.NoError(t, err)
+	assert.Equal(t, params.AuthorAddressForTesting, author)
+}
+
+// TestVerifyHeader tests header verification
+func TestVerifyHeader(t *testing.T) {
+	f := NewFaker()
+
+	// Test with fullFake mode - should accept everything
+	f2 := NewFullFaker()
+	err := f2.VerifyHeader(nil, &types.Header{Number: big.NewInt(1)}, true)
+	assert.NoError(t, err)
+
+	// Test with failBlock
+	f3 := NewFakeFailer(5)
+	header := &types.Header{Number: big.NewInt(5)}
+	err = f3.VerifyHeader(nil, header, true)
+	assert.Equal(t, consensus.ErrUnknownAncestor, err)
+
+	// Test normal case - should pass
+	header = &types.Header{Number: big.NewInt(3)}
+	err = f.VerifyHeader(nil, header, true)
+	assert.NoError(t, err)
+}
+
+// TestPrepare tests the Prepare method
+func TestPrepare(t *testing.T) {
+	f := NewFaker()
+	header := &types.Header{Number: big.NewInt(5)}
+
+	err := f.Prepare(nil, header)
+	assert.NoError(t, err)
+	assert.Equal(t, big.NewInt(5), header.BlockScore)
+}
+
+// TestSeal tests the Seal method
+func TestSeal(t *testing.T) {
+	// Test normal seal
+	f := NewFaker()
+	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
+	stop := make(chan struct{})
+
+	sealed, err := f.Seal(nil, block, stop)
+	assert.NoError(t, err)
+	assert.Equal(t, block, sealed)
+
+	// Test seal with failure
+	f2 := NewFakeFailer(5)
+	block2 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(5)})
+	sealed, err = f2.Seal(nil, block2, stop)
+	assert.Error(t, err)
+	assert.Nil(t, sealed)
+
+	// Test seal with delay
+	f3 := NewFakeDelayer(100 * time.Millisecond)
+	start := time.Now()
+	sealed, err = f3.Seal(nil, block, stop)
+	elapsed := time.Since(start)
+	assert.NoError(t, err)
+	assert.NotNil(t, sealed)
+	assert.True(t, elapsed >= 100*time.Millisecond)
+}
+
+// TestVerifySeal tests seal verification
+func TestVerifySeal(t *testing.T) {
+	f := NewFaker()
+	header := &types.Header{Number: big.NewInt(3)}
+
+	// Normal case - should pass
+	err := f.VerifySeal(nil, header)
+	assert.NoError(t, err)
+
+	// Test with failBlock
+	f2 := NewFakeFailer(5)
+	header2 := &types.Header{Number: big.NewInt(5)}
+	err = f2.VerifySeal(nil, header2)
+	assert.Error(t, err)
+}
+
+// TestVerifyHeaders tests batch header verification
+func TestVerifyHeaders(t *testing.T) {
+	f := NewFaker()
+
+	// Test with empty headers
+	headers := []*types.Header{}
+	seals := []bool{}
+	abort, results := f.VerifyHeaders(nil, headers, seals)
+	assert.NotNil(t, abort)
+	assert.NotNil(t, results)
+
+	// Test with fullFake mode
+	f2 := NewFullFaker()
+	headers = []*types.Header{
+		{Number: big.NewInt(1)},
+		{Number: big.NewInt(2)},
+	}
+	seals = []bool{true, true}
+	abort, results = f2.VerifyHeaders(nil, headers, seals)
+	assert.NotNil(t, abort)
+	assert.NotNil(t, results)
+
+	// Read results
+	for i := 0; i < len(headers); i++ {
+		err := <-results
+		assert.NoError(t, err)
+	}
+}
+
+// TestNewShared tests the NewShared constructor
+func TestNewShared(t *testing.T) {
+	f := NewShared()
+	assert.NotNil(t, f)
+	assert.Equal(t, uint64(0), f.failBlock)
+	assert.Equal(t, time.Duration(0), f.failDelay)
+	assert.False(t, f.fullFake)
+}
+
+// TestHeaderValidation tests various header validation scenarios
+func TestHeaderValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		faker     *Faker
+		header    *types.Header
+		expectErr bool
+	}{
+		{
+			name:      "normal header passes",
+			faker:     NewFaker(),
+			header:    &types.Header{Number: big.NewInt(100)},
+			expectErr: false,
+		},
+		{
+			name:      "fullFake accepts anything",
+			faker:     NewFullFaker(),
+			header:    &types.Header{Number: big.NewInt(999)},
+			expectErr: false,
+		},
+		{
+			name:      "failBlock triggers error",
+			faker:     NewFakeFailer(50),
+			header:    &types.Header{Number: big.NewInt(50)},
+			expectErr: true,
+		},
+		{
+			name:      "before failBlock passes",
+			faker:     NewFakeFailer(50),
+			header:    &types.Header{Number: big.NewInt(49)},
+			expectErr: false,
+		},
+		{
+			name:      "after failBlock passes",
+			faker:     NewFakeFailer(50),
+			header:    &types.Header{Number: big.NewInt(51)},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.faker.VerifyHeader(nil, tt.header, true)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/consensus/faker/faker_test.go
+++ b/consensus/faker/faker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2025 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/datasync/chaindatafetcher/kas/repository_test.go
+++ b/datasync/chaindatafetcher/kas/repository_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/sha3"
 	"github.com/kaiachain/kaia/params"
@@ -88,7 +88,7 @@ func makeChainEventsWithInternalTraces(numBlocks int, genTxs func(i int, block *
 	testGenesis.MustCommit(db)
 
 	// create new blockchain with enabled internal tx tracing option
-	b, _ := blockchain.NewBlockChain(db, nil, testGenesis.Config, gxhash.NewFaker(), vm.Config{Debug: true, EnableInternalTxTracing: true})
+	b, _ := blockchain.NewBlockChain(db, nil, testGenesis.Config, faker.NewFaker(), vm.Config{Debug: true, EnableInternalTxTracing: true})
 	defer b.Stop()
 
 	// subscribe a new chain event channel
@@ -97,7 +97,7 @@ func makeChainEventsWithInternalTraces(numBlocks int, genTxs func(i int, block *
 	defer subscription.Unsubscribe()
 
 	// generate blocks
-	blocks, _ := blockchain.GenerateChain(testGenesis.Config, genesis, gxhash.NewFaker(), gendb, numBlocks, genTxs)
+	blocks, _ := blockchain.GenerateChain(testGenesis.Config, genesis, faker.NewFaker(), gendb, numBlocks, genTxs)
 
 	// insert the generated blocks into the test chain
 	if _, err := b.InsertChain(blocks); err != nil {

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
@@ -186,7 +186,7 @@ func (dl *downloadTester) makeStakingInfoData(blockNumber uint64) (*staking.P2PS
 func (dl *downloadTester) makeChain(n int, seed byte, parent *types.Block, parentReceipts types.Receipts, heavy bool) ([]common.Hash, map[common.Hash]*types.Header, map[common.Hash]*types.Block, map[common.Hash]types.Receipts, map[common.Hash]*staking.P2PStakingInfo) {
 	stakingUpdatedBlocks := make(map[uint64]*staking.P2PStakingInfo)
 	// Generate the block chain
-	blocks, receipts := blockchain.GenerateChain(params.TestChainConfig, parent, gxhash.NewFaker(), dl.peerDb, n, func(i int, block *blockchain.BlockGen) {
+	blocks, receipts := blockchain.GenerateChain(params.TestChainConfig, parent, faker.NewFaker(), dl.peerDb, n, func(i int, block *blockchain.BlockGen) {
 		block.SetRewardbase(common.Address{seed})
 		// If a heavy chain is requested, delay blocks to raise blockscore
 		if heavy {

--- a/datasync/downloader/queue_test.go
+++ b/datasync/downloader/queue_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/kaiax/staking"
 	"github.com/kaiachain/kaia/log"
@@ -50,7 +50,7 @@ var (
 // the returned hash chain is ordered head->parent. In addition, every 2nd block
 // contains a transaction.
 func makeChain(n int, seed byte, parent *types.Block, empty bool) ([]*types.Block, []types.Receipts) {
-	blocks, receipts := blockchain.GenerateChain(params.TestChainConfig, parent, gxhash.NewFaker(), testdb, n, func(i int, block *blockchain.BlockGen) {
+	blocks, receipts := blockchain.GenerateChain(params.TestChainConfig, parent, faker.NewFaker(), testdb, n, func(i int, block *blockchain.BlockGen) {
 		block.SetRewardbase(common.Address{seed})
 		// Add one tx to every second block
 		if !empty && i%2 == 0 {

--- a/datasync/downloader/testchain_test.go
+++ b/datasync/downloader/testchain_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
@@ -127,7 +127,7 @@ func (tc *testChain) generate(n int, seed byte, parent *types.Block, heavy bool)
 	start := time.Now()
 	defer func() { fmt.Printf("test chain generated in %v\n", time.Since(start)) }()
 
-	blocks, receipts := blockchain.GenerateChain(params.TestChainConfig, parent, gxhash.NewFaker(), testDB, n, func(i int, block *blockchain.BlockGen) {
+	blocks, receipts := blockchain.GenerateChain(params.TestChainConfig, parent, faker.NewFaker(), testDB, n, func(i int, block *blockchain.BlockGen) {
 		block.SetRewardbase(common.Address{seed})
 		// If a heavy chain is requested, delay blocks to raise blockscore
 		if heavy {

--- a/datasync/fetcher/fetcher_test.go
+++ b/datasync/fetcher/fetcher_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
@@ -52,7 +52,7 @@ var (
 // contains a transaction to allow testing correct block
 // reassembly.
 func makeChain(n int, seed byte, parent *types.Block) ([]common.Hash, map[common.Hash]*types.Block) {
-	blocks, _ := blockchain.GenerateChain(params.TestChainConfig, parent, gxhash.NewFaker(), testdb, n, func(i int, block *blockchain.BlockGen) {
+	blocks, _ := blockchain.GenerateChain(params.TestChainConfig, parent, faker.NewFaker(), testdb, n, func(i int, block *blockchain.BlockGen) {
 		block.SetRewardbase(common.Address{seed})
 		// If the block number is multiple of 3, send a bonus transaction to the miner
 		if parent == genesis && i%3 == 0 {

--- a/node/cn/api_backend_test.go
+++ b/node/cn/api_backend_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	mocks3 "github.com/kaiachain/kaia/event/mocks"
 	headergov_impl "github.com/kaiachain/kaia/kaiax/gov/headergov/impl"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
@@ -191,7 +191,7 @@ func TestCNAPIBackend_SetHead(t *testing.T) {
 	mockDownloader.EXPECT().Cancel().Times(1)
 	pm := &ProtocolManager{downloader: mockDownloader}
 	api.cn.protocolManager = pm
-	api.cn.engine = gxhash.NewFullFaker()
+	api.cn.engine = faker.NewFullFaker()
 	govModule := testGovModule(mockBlockChain)
 	api.gpo = gasprice.NewOracle(api, gasprice.Config{}, nil, govModule)
 
@@ -749,7 +749,7 @@ func testCfg(epoch uint64) *params.ChainConfig {
 
 func headerGovSetHeadTest(t *testing.T, tt *rewindTest) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlError)
-	db, chain, err := newCanonical(gxhash.NewFullFaker(), 0, true)
+	db, chain, err := newCanonical(faker.NewFullFaker(), 0, true)
 	if err != nil {
 		t.Fatalf("failed to create pristine chain: %v", err)
 	}
@@ -776,7 +776,7 @@ func headerGovSetHeadTest(t *testing.T, tt *rewindTest) {
 	chain.RegisterRewindableModule(govModule)
 	chain.RegisterExecutionModule(govModule)
 
-	canonblocks, _ := blockchain.GenerateChain(params.TestChainConfig, chain.CurrentBlock(), gxhash.NewFaker(), db, tt.canonicalBlocks, func(i int, b *blockchain.BlockGen) {
+	canonblocks, _ := blockchain.GenerateChain(params.TestChainConfig, chain.CurrentBlock(), faker.NewFaker(), db, tt.canonicalBlocks, func(i int, b *blockchain.BlockGen) {
 		if i == govBlockNum-1 { // Subtract 1, because the callback starts to enumerate from zero
 			// "reward.mintingamount" = 123
 			govData := hexutil.MustDecode("0x9e7b227265776172642e6d696e74696e67616d6f756e74223a22313233227d")

--- a/node/cn/filters/filter_system_test.go
+++ b/node/cn/filters/filter_system_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
@@ -186,7 +186,7 @@ func (b *testBackend) notifyPending(logs []*types.Log) {
 	}
 	db := database.NewMemoryDBManager()
 	genesisBlock := genesis.MustCommit(db)
-	blocks, _ := blockchain.GenerateChain(genesis.Config, genesisBlock, gxhash.NewFaker(), db, 2, func(i int, b *blockchain.BlockGen) {})
+	blocks, _ := blockchain.GenerateChain(genesis.Config, genesisBlock, faker.NewFaker(), db, 2, func(i int, b *blockchain.BlockGen) {})
 	b.setPending(blocks[1], []*types.Receipt{{Logs: logs}})
 	b.chainFeed.Send(blockchain.ChainEvent{Block: blocks[0]})
 }
@@ -217,7 +217,7 @@ func TestBlockSubscription(t *testing.T) {
 		backend     = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig, nil, nil, nil}
 		api         = NewKaiaFilterAPI(backend)
 		genesis     = new(blockchain.Genesis).MustCommit(db)
-		chain, _    = blockchain.GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 10, func(i int, gen *blockchain.BlockGen) {})
+		chain, _    = blockchain.GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), db, 10, func(i int, gen *blockchain.BlockGen) {})
 		chainEvents []blockchain.ChainEvent
 	)
 
@@ -409,12 +409,12 @@ func TestInvalidGetLogsRequest(t *testing.T) {
 		mux              = new(event.TypeMux)
 		db               = database.NewMemoryDBManager()
 		genesis          = new(blockchain.Genesis).MustCommit(db)
-		blocks, _        = blockchain.GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 10, func(i int, gen *blockchain.BlockGen) {})
+		blocks, _        = blockchain.GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), db, 10, func(i int, gen *blockchain.BlockGen) {})
 		txFeed           = new(event.Feed)
 		rmLogsFeed       = new(event.Feed)
 		logsFeed         = new(event.Feed)
 		chainFeed        = new(event.Feed)
-		engine           = gxhash.NewFaker()
+		engine           = faker.NewFaker()
 		backend          = &testBackend{mux, db, 0, txFeed, rmLogsFeed, logsFeed, chainFeed, params.TestChainConfig, nil, nil, engine}
 		api              = NewKaiaFilterAPI(backend)
 		blockHash        = blocks[0].Hash()

--- a/node/cn/filters/filter_test.go
+++ b/node/cn/filters/filter_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -189,7 +189,7 @@ func BenchmarkFilters(b *testing.B) {
 	defer db.Close()
 
 	genesis := blockchain.GenesisBlockForTesting(db, addr1, big.NewInt(1000000))
-	chain, receipts := blockchain.GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 100010, func(i int, gen *blockchain.BlockGen) {
+	chain, receipts := blockchain.GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), db, 100010, func(i int, gen *blockchain.BlockGen) {
 		switch i {
 		case 2403:
 			receipt := makeReceipt(addr1)
@@ -254,7 +254,7 @@ func TestFilters(t *testing.T) {
 	defer db.Close()
 
 	genesis := blockchain.GenesisBlockForTesting(db, addr, big.NewInt(1000000))
-	chain, receipts := blockchain.GenerateChain(params.TestChainConfig, genesis, gxhash.NewFaker(), db, 1000, func(i int, gen *blockchain.BlockGen) {
+	chain, receipts := blockchain.GenerateChain(params.TestChainConfig, genesis, faker.NewFaker(), db, 1000, func(i int, gen *blockchain.BlockGen) {
 		switch i {
 		case 1:
 			receipt := genReceipt(false, 0)

--- a/node/cn/gasprice/gasprice_test.go
+++ b/node/cn/gasprice/gasprice_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/math"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
@@ -135,7 +135,7 @@ func newTestBackend(t *testing.T, magmaBlock, kaiaBlock *big.Int, pending bool) 
 	config.KaiaCompatibleBlock = kaiaBlock
 	config.Governance = params.GetDefaultGovernanceConfig()
 	config.Istanbul = params.GetDefaultIstanbulConfig()
-	blocks, _ := blockchain.GenerateChain(gspec.Config, genesis, gxhash.NewFaker(), db, testHead+1, func(i int, b *blockchain.BlockGen) {
+	blocks, _ := blockchain.GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, testHead+1, func(i int, b *blockchain.BlockGen) {
 		toaddr := common.Address{}
 		// To test fee history, rewardbase should be different from the sender address
 		b.SetRewardbase(toaddr)
@@ -167,7 +167,7 @@ func newTestBackend(t *testing.T, magmaBlock, kaiaBlock *big.Int, pending bool) 
 		b.AddTx(tx)
 	})
 	// Construct testing chain
-	chain, err := blockchain.NewBlockChain(db, nil, gspec.Config, gxhash.NewFaker(), vm.Config{})
+	chain, err := blockchain.NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
 	if err != nil {
 		t.Fatalf("Failed to create local chain, %v", err)
 	}

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	consensusmocks "github.com/kaiachain/kaia/consensus/mocks"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/datasync/downloader"
@@ -1179,7 +1179,7 @@ func newTestBackendWithGenerator(blocks int, generator func(int, *blockchain.Blo
 		// Create a database pre-initialize with a genesis block
 		db     = database.NewMemoryDBManager()
 		config = params.TestChainConfig
-		engine = gxhash.NewFaker()
+		engine = faker.NewFaker()
 	)
 
 	gspec := &blockchain.Genesis{

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
@@ -68,7 +68,7 @@ type testBackend struct {
 func newTestBackend(t *testing.T, n int, gspec *blockchain.Genesis, generator func(i int, b *blockchain.BlockGen)) *testBackend {
 	backend := &testBackend{
 		chainConfig: params.TestChainConfig,
-		engine:      gxhash.NewFaker(),
+		engine:      faker.NewFaker(),
 		chaindb:     database.NewMemoryDBManager(),
 	}
 	// Generate blocks for testing

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -39,7 +39,7 @@ import (
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/common/math"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/consensus/gxhash"
+	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
 	"github.com/kaiachain/kaia/storage/database"
@@ -115,7 +115,7 @@ type btHeaderMarshaling struct {
 // eestEngine is a test engine to absorb the difference in gas calculation and gas limit
 // between Kaia and Ethereum. This includes the distribution of rewards.
 type eestEngine struct {
-	*gxhash.Gxhash
+	*faker.Faker
 	baseFee  *big.Int
 	gasLimit uint64
 	coinbase common.Address
@@ -227,7 +227,7 @@ func (t *BlockTest) Run() error {
 	}
 
 	tracer := vm.NewStructLogger(nil)
-	chain, err := blockchain.NewBlockChain(db, nil, config, &eestEngine{Gxhash: gxhash.NewShared()}, vm.Config{Debug: true, Tracer: tracer, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
+	chain, err := blockchain.NewBlockChain(db, nil, config, &eestEngine{Faker: faker.NewShared()}, vm.Config{Debug: true, Tracer: tracer, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
 	if err != nil {
 		return err
 	}

--- a/work/remote_agent.go
+++ b/work/remote_agent.go
@@ -110,6 +110,7 @@ func (a *RemoteAgent) GetHashRate() (tot int64) {
 	return
 }
 
+// TODO-Kaia remove this function
 func (a *RemoteAgent) GetWork() ([3]string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()


### PR DESCRIPTION
## Proposed changes

- This PR introduces faker which is derived from gxhash. The consensus engine for tests are replaced to faker.
- In later PR, the gxhash and clique will be removed.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
