### PR TITLE
Allow v3 keystore for new account

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -452,7 +452,7 @@ func (ks *KeyStore) expire(addr common.Address, u *unlocked, timeout time.Durati
 // NewAccount generates a new key and stores it into the key directory,
 // encrypting it with the passphrase.
 func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
-	_, account, err := storeNewKey(ks.storage, crand.Reader, passphrase)
+	_, account, err := storeNewKey(ks.storage, crand.Reader, passphrase, false)
 	if err != nil {
 		return accounts.Account{}, err
 	}

--- a/accounts/keystore/keystore_passphrase.go
+++ b/accounts/keystore/keystore_passphrase.go
@@ -95,12 +95,25 @@ func (ks keyStorePassphrase) GetKey(addr common.Address, filename, auth string) 
 
 // StoreKey generates a key, encrypts with 'auth' and stores in the given directory
 func StoreKey(dir, auth string, scryptN, scryptP int) (common.Address, error) {
-	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth)
+	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth, false /* v4 */)
+	return a.Address, err
+}
+
+// StoreKeyV3 generates a v3 key, encrypts with 'auth' and stores in the given directory
+func StoreKeyV3(dir, auth string, scryptN, scryptP int) (common.Address, error) {
+	_, a, err := storeNewKey(&keyStorePassphrase{dir, scryptN, scryptP, false}, rand.Reader, auth, true /* v3 */)
 	return a.Address, err
 }
 
 func (ks keyStorePassphrase) StoreKey(filename string, key Key, auth string) error {
-	keyjson, err := EncryptKey(key, auth, ks.scryptN, ks.scryptP)
+	var keyjson []byte
+	var err error
+
+	if _, isV3 := key.(*KeyV3); isV3 {
+		keyjson, err = EncryptKeyV3(key, auth, ks.scryptN, ks.scryptP)
+	} else {
+		keyjson, err = EncryptKey(key, auth, ks.scryptN, ks.scryptP)
+	}
 	if err != nil {
 		return err
 	}

--- a/accounts/keystore/keystore_plain_test.go
+++ b/accounts/keystore/keystore_plain_test.go
@@ -54,7 +54,7 @@ func TestKeyStorePlain(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	pass := "" // not used but required by API
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := storeNewKey(ks, rand.Reader, pass, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestKeyStorePassphrase(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	pass := "foo"
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := storeNewKey(ks, rand.Reader, pass, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestKeyStorePassphraseDecryptionFail(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	pass := "foo"
-	k1, account, err := storeNewKey(ks, rand.Reader, pass)
+	k1, account, err := storeNewKey(ks, rand.Reader, pass, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -65,6 +65,7 @@ var FlagGroups = []FlagGroup{
 			PasswordFileFlag,
 			LightKDFFlag,
 			KeyStoreDirFlag,
+			KeyStoreV3Flag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -133,6 +133,12 @@ var (
 		EnvVars:  []string{"KLAYTN_KEYSTORE", "KAIA_KEYSTORE"},
 		Category: "ACCOUNT",
 	}
+	KeyStoreV3Flag = &cli.BoolFlag{
+		Name:     "v3",
+		Usage:    "Create v3 keystore instead of the default v4 for new account",
+		EnvVars:  []string{"KLAYTN_KEYSTORE_V3", "KAIA_KEYSTORE_V3"},
+		Category: "ACCOUNT",
+	}
 	// TODO-Kaia-Bootnode: redefine networkid
 	NetworkIdFlag = &cli.Uint64Flag{
 		Name:     "networkid",

--- a/cmd/utils/nodecmd/accountcmd.go
+++ b/cmd/utils/nodecmd/accountcmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kaiachain/kaia/accounts/keystore"
 	"github.com/kaiachain/kaia/api/debug"
 	"github.com/kaiachain/kaia/cmd/utils"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/console"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/bls"
@@ -88,6 +89,7 @@ Print a short summary of all accounts`,
 				utils.KeyStoreDirFlag,
 				utils.PasswordFileFlag,
 				utils.LightKDFFlag,
+				utils.KeyStoreV3Flag,
 			},
 			Description: `
 Creates a new account and prints the address.
@@ -335,7 +337,13 @@ func accountCreate(ctx *cli.Context) error {
 
 	password := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 
-	address, err := keystore.StoreKey(keydir, password, scryptN, scryptP)
+	var address common.Address
+
+	if ctx.Bool(utils.KeyStoreV3Flag.Name) {
+		address, err = keystore.StoreKeyV3(keydir, password, scryptN, scryptP)
+	} else {
+		address, err = keystore.StoreKey(keydir, password, scryptN, scryptP)
+	}
 	if err != nil {
 		log.Fatalf("Failed to create account: %v", err)
 	}

--- a/cmd/utils/nodecmd/accountcmd_test.go
+++ b/cmd/utils/nodecmd/accountcmd_test.go
@@ -87,6 +87,18 @@ Repeat passphrase: {{.InputLine "foobar"}}
 	kaia.ExpectRegexp(`Address: \{[0-9a-f]{40}\}\n`)
 }
 
+func TestAccountNewV3(t *testing.T) {
+	kaia := runKaia(t, "kaia-test", "account", "new", "--v3", "--lightkdf")
+	defer kaia.ExpectExit()
+	kaia.Expect(`
+Your new account is locked with a password. Please give a password. Do not forget this password.
+!! Unsupported terminal, password will be echoed.
+Passphrase: {{.InputLine "foobar"}}
+Repeat passphrase: {{.InputLine "foobar"}}
+`)
+	kaia.ExpectRegexp(`Address: \{[0-9a-f]{40}\}\n`)
+}
+
 func TestAccountNewBadRepeat(t *testing.T) {
 	kaia := runKaia(t, "kaia-test", "account", "new", "--lightkdf")
 	defer kaia.ExpectExit()


### PR DESCRIPTION
## Proposed changes

- This PR adds `--v3` flag for `ken account` command so the user can create a v3 keystore when creating a new account using `ken account new`

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
