### PR TITLE
database: Change default LevelDB compression flag to 2 (all except statetrie)

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -336,11 +336,10 @@ var (
 		EnvVars:  []string{"KLAYTN_DB_LEVELDB_CACHE_SIZE", "KAIA_DB_LEVELDB_CACHE_SIZE"},
 		Category: "DATABASE",
 	}
-	// TODO-Kaia-Database LevelDBCompressionTypeFlag should be removed before main-net release.
 	LevelDBCompressionTypeFlag = &cli.IntFlag{
 		Name:     "db.leveldb.compression",
 		Usage:    "Determines the compression method for LevelDB. 0=AllNoCompression, 1=ReceiptOnlySnappyCompression, 2=StateTrieOnlyNoCompression, 3=AllSnappyCompression",
-		Value:    0,
+		Value:    2,
 		Aliases:  []string{"migration.src.db.leveldb.compression"},
 		EnvVars:  []string{"KLAYTN_DB_LEVELDB_COMPRESSION", "KAIA_DB_LEVELDB_COMPRESSION"},
 		Category: "DATABASE",


### PR DESCRIPTION
## Proposed changes

- Enabling LevelDB compression can reduce chaindata size with a little performance degradation.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
