### PR TITLE
api: Update wrong log at GetBlockWithConsensusInfoByNumberRange

### DIFF
--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -318,7 +318,7 @@ func (s *KaiaBlockChainAPI) GetBlockWithConsensusInfoByNumberRange(ctx context.C
 	}
 
 	if (endNum - startNum) > 50 {
-		logger.Trace("number of requested blocks should be smaller than 50", "start", startNum, "end", endNum)
+		logger.Trace("number of requested blocks should be smaller than 51 (inclusive)", "start", startNum, "end", endNum)
 		return nil, errRequestedBlocksTooLarge
 	}
 


### PR DESCRIPTION
## Proposed changes

The `GetBlockWithConsensusInfoByNumberRange` API returns the inclusive range of request block, so the number of returning block is `end - start + 1`, not `end - start`. And it's intentional since we need a state at `N-1` block to get `N` block's info.

This PR updates the log to be aligned with the implementation.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
