### PR TITLE
contract: Use call for validator payback

### DIFF
--- a/contracts/contracts/system_contracts/auction/AuctionFeeVault.sol
+++ b/contracts/contracts/system_contracts/auction/AuctionFeeVault.sol
@@ -83,7 +83,11 @@ contract AuctionFeeVault is IAuctionFeeVault, Ownable, AuctionError {
             if (rewardAddr != address(0)) {
                 /// @dev Do not revert if the validator payback fails
                 /// Need to restrict the gas limit for deterministic gas calculation
-                if (!payable(rewardAddr).send(validatorPayback)) {
+                (bool success, ) = payable(rewardAddr).call{
+                    value: validatorPayback,
+                    gas: 5000
+                }("");
+                if (!success) {
                     validatorPayback = 0;
                     emit FeeDepositFailed(block.coinbase, originalAmount);
                 }


### PR DESCRIPTION
## Proposed changes

For the validator payback, use `.call` with an additional 5000 gas to allow validators to register a Multisig wallet (e.g., Safe).

Currently, it requires 6329 gas for KaiaSafe to receive KAIA. So `2300 + 5000` will be sufficient for the KAIA payment. Please note that `.call` will add default `2300` gas when `value != 0`.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
