### PR TITLE
kaiax/auction: Introduce bid rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	go.uber.org/mock v0.5.0
 	golang.org/x/exp v0.0.0-20240318143956-a85f2c67cd81
 	golang.org/x/sync v0.12.0
+	golang.org/x/time v0.9.0
 )
 
 require (
@@ -151,7 +152,6 @@ require (
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -31,13 +31,17 @@ import (
 	"github.com/kaiachain/kaia/kaiax/auction"
 	"github.com/kaiachain/kaia/params"
 	"github.com/rcrowley/go-metrics"
+	"golang.org/x/time/rate"
 )
 
 const (
-	bidChSize        = 100
+	bidChSize        = 2048
 	allowFutureBlock = 2
 
 	BidTxMaxCallGasLimit = uint64(10_000_000)
+
+	// Rate limiting
+	bidsPerSecondPerPeer = 300 // Max bids per second per peer
 )
 
 var numBidsGauge = metrics.NewRegisteredGauge("kaiax/auction/bidpool/num/bids", nil)
@@ -56,6 +60,10 @@ type BidPool struct {
 	bidTargetMap map[uint64]map[common.Hash]*auction.Bid   // (blockNum, targetTxHash) -> Bid
 	bidWinnerMap map[uint64]map[common.Address]common.Hash // (blockNum, sender) -> bidHash
 
+	// Rate limiting per peer
+	peerRateLimiterMu sync.RWMutex
+	peerRateLimiter   map[string]*rate.Limiter // peerID -> rate limiter
+
 	bidMsgCh   chan *auction.Bid
 	newBidCh   chan *auction.Bid
 	newBidFeed event.Feed
@@ -73,16 +81,17 @@ func NewBidPool(chainConfig *params.ChainConfig, chain backends.BlockChainForCal
 	}
 
 	bp := &BidPool{
-		ChainConfig:    chainConfig,
-		Chain:          chain,
-		bidMap:         make(map[common.Hash]*auction.Bid),
-		bidTargetMap:   make(map[uint64]map[common.Hash]*auction.Bid),
-		bidWinnerMap:   make(map[uint64]map[common.Address]common.Hash),
-		bidMsgCh:       make(chan *auction.Bid, bidChSize),
-		newBidCh:       make(chan *auction.Bid, bidChSize),
-		maxBidPoolSize: auctionConfig.MaxBidPoolSize,
-		running:        0, // not running yet
-		stopped:        0, // not stopped
+		ChainConfig:     chainConfig,
+		Chain:           chain,
+		bidMap:          make(map[common.Hash]*auction.Bid),
+		bidTargetMap:    make(map[uint64]map[common.Hash]*auction.Bid),
+		bidWinnerMap:    make(map[uint64]map[common.Address]common.Hash),
+		peerRateLimiter: make(map[string]*rate.Limiter),
+		bidMsgCh:        make(chan *auction.Bid, bidChSize),
+		newBidCh:        make(chan *auction.Bid, bidChSize),
+		maxBidPoolSize:  auctionConfig.MaxBidPoolSize,
+		running:         0, // not running yet
+		stopped:         0, // not stopped
 	}
 
 	return bp
@@ -380,11 +389,36 @@ func (bp *BidPool) validateBidSigs(bid *auction.Bid) error {
 	return nil
 }
 
-func (bp *BidPool) HandleBid(bid *auction.Bid) {
+func (bp *BidPool) HandleBid(peerID string, bid *auction.Bid) {
 	if atomic.LoadUint32(&bp.running) == 0 || bid == nil {
 		return
 	}
+
+	// Check rate limit for this peer
+	if !bp.checkRateLimit(peerID) {
+		logger.Trace("Rate limit exceeded for peer", "peerID", peerID)
+		return
+	}
+
 	bp.bidMsgCh <- bid
+}
+
+// checkRateLimit checks if the peer is within rate limit
+func (bp *BidPool) checkRateLimit(peerID string) bool {
+	bp.peerRateLimiterMu.Lock()
+	defer bp.peerRateLimiterMu.Unlock()
+
+	limiter, exists := bp.peerRateLimiter[peerID]
+	if !exists {
+		// Create new rate limiter for this peer
+		// Allow burst equal to the rate limit
+		limiter = rate.NewLimiter(rate.Limit(bidsPerSecondPerPeer), bidsPerSecondPerPeer)
+		bp.peerRateLimiter[peerID] = limiter
+	}
+
+	// The Auctioneer will send bid to every CN in the network
+	// So we don't need to reserve a token and wait for it here, but just check if allowed
+	return limiter.Allow()
 }
 
 func (bp *BidPool) handleBidMsg() {

--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -411,13 +411,13 @@ func (bp *BidPool) checkRateLimit(peerID string) bool {
 	limiter, exists := bp.peerRateLimiter[peerID]
 	if !exists {
 		// Create new rate limiter for this peer
-		// Allow burst equal to the rate limit
+		// Use burst equal to the rate limit (we only use rate limit, not the burst)
 		limiter = rate.NewLimiter(rate.Limit(bidsPerSecondPerPeer), bidsPerSecondPerPeer)
 		bp.peerRateLimiter[peerID] = limiter
 	}
 
-	// The Auctioneer will send bid to every CN in the network
-	// So we don't need to reserve a token and wait for it here, but just check if allowed
+	// It'll simply discard the bid if the rate limit is exceeded
+	// We don't need to reserve for a bid here because the original bid will be sent from auctioneer through different channel (see #api.SubmitBid)
 	return limiter.Allow()
 }
 

--- a/kaiax/auction/impl/handler.go
+++ b/kaiax/auction/impl/handler.go
@@ -21,8 +21,8 @@ import (
 	"github.com/kaiachain/kaia/kaiax/auction"
 )
 
-func (a *AuctionModule) HandleBid(bid *auction.Bid) {
-	a.bidPool.HandleBid(bid)
+func (a *AuctionModule) HandleBid(peerID string, bid *auction.Bid) {
+	a.bidPool.HandleBid(peerID, bid)
 }
 
 func (a *AuctionModule) SubscribeNewBid(sink chan<- *auction.Bid) event.Subscription {

--- a/kaiax/auction/impl/handler_test.go
+++ b/kaiax/auction/impl/handler_test.go
@@ -201,33 +201,23 @@ func TestHandler_RateLimit(t *testing.T) {
 	}
 
 	// Test rate limiting for peer1
-	// Send 350 bids rapidly (should be limited to 300)
+	// Send 350 bids rapidly (should be limited to 300 by rate limit)
 	for i := 0; i < 350; i++ {
 		module.HandleBid(testPeerID1, testBids[i])
 	}
 
-	// Wait for processing
-	time.Sleep(200 * time.Millisecond)
-
-	// Should have accepted around 300 bids (rate limit)
-	bidCount1 := len(module.bidPool.bidMap)
-	assert.Equal(t, bidCount1, 300)
-
-	// Test that peer2 is not affected by peer1's rate limit
-	// Clear the bid pool first
-	module.bidPool.clearBidPool()
-
 	// Send bids from peer2
-	for i := 0; i < 50; i++ {
+	// All bids from peer2 should be accepted because peer2 is not affected by peer1's rate limit
+	for i := 300; i < 400; i++ {
 		module.HandleBid(testPeerID2, testBids[i])
 	}
 
 	// Wait for processing
 	time.Sleep(200 * time.Millisecond)
 
-	// Peer2 should have all its bids accepted
-	bidCount2 := len(module.bidPool.bidMap)
-	assert.Equal(t, 50, bidCount2)
+	// Should have accepted all bids
+	bidCount := len(module.bidPool.bidMap)
+	assert.Equal(t, bidCount, 400)
 
 	// Test rate limit recovery after 1 second
 	module.bidPool.clearBidPool()
@@ -242,8 +232,8 @@ func TestHandler_RateLimit(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Should accept new bids after rate limit reset
-	bidCount3 := len(module.bidPool.bidMap)
-	assert.Equal(t, 100, bidCount3)
+	bidCount = len(module.bidPool.bidMap)
+	assert.Equal(t, 100, bidCount)
 }
 
 func TestHandler_SubscribeNewBid(t *testing.T) {

--- a/kaiax/auction/interface.go
+++ b/kaiax/auction/interface.go
@@ -28,7 +28,7 @@ type AuctionModule interface {
 	kaiax.ExecutionModule
 	kaiax.TxBundlingModule
 
-	HandleBid(bid *Bid)
+	HandleBid(peerID string, bid *Bid)
 	SubscribeNewBid(sink chan<- *Bid) event.Subscription
 
 	gasless.GaslessModuleHost

--- a/kaiax/auction/mock/auction_module_mock.go
+++ b/kaiax/auction/mock/auction_module_mock.go
@@ -109,15 +109,15 @@ func (mr *MockAuctionModuleMockRecorder) GetMaxBundleTxsInQueue() *gomock.Call {
 }
 
 // HandleBid mocks base method.
-func (m *MockAuctionModule) HandleBid(arg0 *auction.Bid) {
+func (m *MockAuctionModule) HandleBid(arg0 string, arg1 *auction.Bid) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "HandleBid", arg0)
+	m.ctrl.Call(m, "HandleBid", arg0, arg1)
 }
 
 // HandleBid indicates an expected call of HandleBid.
-func (mr *MockAuctionModuleMockRecorder) HandleBid(arg0 interface{}) *gomock.Call {
+func (mr *MockAuctionModuleMockRecorder) HandleBid(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBid", reflect.TypeOf((*MockAuctionModule)(nil).HandleBid), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBid", reflect.TypeOf((*MockAuctionModule)(nil).HandleBid), arg0, arg1)
 }
 
 // IsBundleTx mocks base method.
@@ -158,30 +158,6 @@ func (m *MockAuctionModule) RegisterGaslessModule(arg0 gasless.GaslessModule) {
 func (mr *MockAuctionModuleMockRecorder) RegisterGaslessModule(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterGaslessModule", reflect.TypeOf((*MockAuctionModule)(nil).RegisterGaslessModule), arg0)
-}
-
-// RewindDelete mocks base method.
-func (m *MockAuctionModule) RewindDelete(arg0 common.Hash, arg1 uint64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RewindDelete", arg0, arg1)
-}
-
-// RewindDelete indicates an expected call of RewindDelete.
-func (mr *MockAuctionModuleMockRecorder) RewindDelete(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RewindDelete", reflect.TypeOf((*MockAuctionModule)(nil).RewindDelete), arg0, arg1)
-}
-
-// RewindTo mocks base method.
-func (m *MockAuctionModule) RewindTo(arg0 *types.Block) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RewindTo", arg0)
-}
-
-// RewindTo indicates an expected call of RewindTo.
-func (mr *MockAuctionModuleMockRecorder) RewindTo(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RewindTo", reflect.TypeOf((*MockAuctionModule)(nil).RewindTo), arg0)
 }
 
 // Start mocks base method.

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1157,7 +1157,7 @@ func handleBidMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 
-	pm.auctionModule.HandleBid(data)
+	pm.auctionModule.HandleBid(p.GetID(), data)
 
 	return nil
 }

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -117,7 +117,7 @@ func prepareBlockChain(t *testing.T) (*gomock.Controller, *mocks.MockBlockChain,
 	mockBlockChain := mocks.NewMockBlockChain(mockCtrl)
 	mockAuctionModule := auction_mock.NewMockAuctionModule(mockCtrl)
 
-	mockAuctionModule.EXPECT().HandleBid(gomock.Any()).AnyTimes()
+	mockAuctionModule.EXPECT().HandleBid(gomock.Any(), gomock.Any()).AnyTimes()
 
 	mockPeer := NewMockPeer(mockCtrl)
 	mockPeer.EXPECT().GetID().Return(nodeids[0].String()).AnyTimes()


### PR DESCRIPTION
## Proposed changes

This PR introduces a bid rate limiter for each peer. The bidpool records `peerID -> limiter` to keep track of bids from peer.
It also increases the bidMsg channel size from 100 to 2048.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
