### PR TITLE
kaiax/auction: Check bid pool size when bid isn't replaceable

### DIFF
--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -275,6 +275,11 @@ func (bp *BidPool) insertBid(bid *auction.Bid) error {
 		logger.Trace("Replace bid", "old", existingBid.Hash(), "new", bid.Hash())
 		delete(bp.bidMap, existingBid.Hash())
 		delete(bp.bidWinnerMap[blockNumber], existingBid.Sender)
+	} else {
+		if int64(len(bp.bidMap)) >= bp.maxBidPoolSize {
+			logger.Info("Bid pool is full", "maxBidPoolSize", bp.maxBidPoolSize, "bid", bid.Hash())
+			return auction.ErrBidPoolFull
+		}
 	}
 
 	hash := bid.Hash()
@@ -306,11 +311,6 @@ func (bp *BidPool) validateBid(bid *auction.Bid) error {
 	sender := bid.Sender
 
 	bp.bidMu.RLock()
-	if int64(len(bp.bidMap)) >= bp.maxBidPoolSize {
-		logger.Info("Bid pool is full", "maxBidPoolSize", bp.maxBidPoolSize, "bid", bid.Hash())
-		bp.bidMu.RUnlock()
-		return auction.ErrBidPoolFull
-	}
 
 	// Check if the auction tx is already in the pool.
 	if _, ok := bp.bidMap[bid.Hash()]; ok {

--- a/kaiax/auction/impl/bid_pool_test.go
+++ b/kaiax/auction/impl/bid_pool_test.go
@@ -236,7 +236,7 @@ func TestBidPool_AddBid_MaxBidPoolSize(t *testing.T) {
 	pool := NewBidPool(testChainConfig, chain, &auction.AuctionConfig{MaxBidPoolSize: 1})
 	require.NotNil(t, pool)
 
-	chain.EXPECT().CurrentBlock().Return(block1).Times(1)
+	chain.EXPECT().CurrentBlock().Return(block1).Times(2)
 
 	// Start the auction
 	pool.start()


### PR DESCRIPTION
## Proposed changes

This PR checks the global size limit after checking the replacement of bid.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
