### PR TITLE
kaiax/auction: Limit the bid data size to 64KB

### DIFF
--- a/contracts/contracts/system_contracts/auction/AuctionEntryPoint.sol
+++ b/contracts/contracts/system_contracts/auction/AuctionEntryPoint.sol
@@ -46,7 +46,7 @@ contract AuctionEntryPoint is
     string public constant AUCTION_NAME = "KAIA_AUCTION";
     string public constant AUCTION_VERSION = "0.0.1";
 
-    uint256 public constant MAX_DATA_SIZE = 16 * 1024; // 16KB
+    uint256 public constant MAX_DATA_SIZE = 64 * 1024; // 64KB
 
     /* ========== STATE VARIABLES ========== */
 
@@ -56,7 +56,7 @@ contract AuctionEntryPoint is
     uint256 public gasPerByteIntrinsic = 16; // Base gas cost per byte of msg.data (approximated from 16 gas per non-zero byte + 4 gas per zero byte)
     uint256 public gasPerByteEip7623 = 40; // Minimum gas cost per byte of msg.data under EIP-7623 (approximated from 40 gas per non-zero byte + 10 gas per zero byte)
     uint256 public gasContractExecution = 21_000; // Default transaction gas cost
-    uint256 public gasBufferEstimate = 180_000; // Buffer for gas calculation except for the main call
+    uint256 public gasBufferEstimate = 200_000; // Buffer for gas calculation except for the main call
     uint256 public gasBufferUnmeasured = 35_000; // Buffer for gas calculation that `gasleft()` can't capture after the main call
 
     /* ========== MODIFIER ========== */

--- a/contracts/contracts/system_contracts/auction/AuctionEntryPoint.sol
+++ b/contracts/contracts/system_contracts/auction/AuctionEntryPoint.sol
@@ -46,6 +46,8 @@ contract AuctionEntryPoint is
     string public constant AUCTION_NAME = "KAIA_AUCTION";
     string public constant AUCTION_VERSION = "0.0.1";
 
+    uint256 public constant MAX_DATA_SIZE = 16 * 1024; // 16KB
+
     /* ========== STATE VARIABLES ========== */
 
     IAuctionDepositVault public depositVault;
@@ -222,7 +224,12 @@ contract AuctionEntryPoint is
             return false;
         }
 
-        /// 3. Check if the auctioneer signature is valid
+        /// 3. Check if the data size is less than the maximum limit
+        if (auctionTx.data.length > MAX_DATA_SIZE) {
+            return false;
+        }
+
+        /// 4. Check if the auctioneer signature is valid
         bytes32 digest = MessageHashUtils.toEthSignedMessageHash(
             auctionTx.searcherSig
         );
@@ -233,7 +240,7 @@ contract AuctionEntryPoint is
             return false;
         }
 
-        /// 4. Check if the searcher signature is valid
+        /// 5. Check if the searcher signature is valid
         bytes32 structHash = _getAuctionTxHash(auctionTx);
         // Compute the final digest
         digest = _hashTypedDataV4(structHash);

--- a/contracts/test/Auction/auctionEntryPoint.test.ts
+++ b/contracts/test/Auction/auctionEntryPoint.test.ts
@@ -77,8 +77,10 @@ describe("AuctionEntryPoint", () => {
       expect(await auctionEntryPoint.gasPerByteIntrinsic()).to.equal(16);
       expect(await auctionEntryPoint.gasPerByteEip7623()).to.equal(40);
       expect(await auctionEntryPoint.gasContractExecution()).to.equal(21_000);
-      expect(await auctionEntryPoint.gasBufferEstimate()).to.equal(180_000);
+      expect(await auctionEntryPoint.gasBufferEstimate()).to.equal(200_000);
       expect(await auctionEntryPoint.gasBufferUnmeasured()).to.equal(35_000);
+
+      expect(await auctionEntryPoint.MAX_DATA_SIZE()).to.equal(64 * 1024);
     });
     it("Check initialize", async () => {
       const { auctionEntryPoint, deployer, auctionDepositVault } =
@@ -357,7 +359,7 @@ describe("AuctionEntryPoint", () => {
         user1,
         deployer,
         testReceiver.address,
-        "0x" + "ff".repeat(16 * 1024) + "ff", // 16KB + 1 byte
+        "0x" + "ff".repeat(64 * 1024) + "ff", // 64KB + 1 byte
         (await nowBlock()) + 1,
         10_000_000,
         toPeb(10n),

--- a/contracts/test/Auction/auctionEntryPoint.test.ts
+++ b/contracts/test/Auction/auctionEntryPoint.test.ts
@@ -351,6 +351,21 @@ describe("AuctionEntryPoint", () => {
 
       await expect(auctionEntryPoint.connect(coinbase).call(auctionTx2)).to.be
         .reverted;
+
+      const { auctionTx: auctionTx3 } = await generateAuctionTx(
+        auctionEntryPoint.address,
+        user1,
+        deployer,
+        testReceiver.address,
+        "0x" + "ff".repeat(16 * 1024) + "ff", // 16KB + 1 byte
+        (await nowBlock()) + 1,
+        10_000_000,
+        toPeb(10n),
+        0
+      );
+
+      await expect(auctionEntryPoint.connect(coinbase).call(auctionTx3)).to.be
+        .reverted;
     });
     it("#call: should take bid and gas reimbursement if failed to call the target", async () => {
       const {

--- a/kaiax/auction/README.md
+++ b/kaiax/auction/README.md
@@ -12,11 +12,12 @@ Note that the bid comes from the `Auctioneer`, which is an independent service t
 
 A bid pool is responsible for managing the valid bids from the auctioneer. The bid must satisfy the following rules:
 
-1. The `bid.BlockNumber` must be in range of `[currentBlockNumber + 1, currentBlockNumber + allowFutureBlock]`.
-2. The `bid.Bid` must be greater than 0.
-3. The `bid.CallGasLimit` must be less or equal to `BidTxMaxCallGasLimit`.
-4. The `bid.Sender` must not be in the winner list of the same block number if the new bid doesn't have the same target block and hash as the previous bid.
-5. The `bid.SearcherSig` and `bid.AuctioneerSig` must be valid.
+1. The `bid.Sender` must not be in the winner list of the same block number if the new bid doesn't have the same target block and hash as the previous bid.
+2. The `bid.BlockNumber` must be in range of `[currentBlockNumber + 1, currentBlockNumber + allowFutureBlock]`.
+3. The `bid.Bid` must be greater than 0.
+4. The `bid.Data` size must be less than or equal to `BidTxMaxDataSize`.
+5. The `bid.CallGasLimit` must be less or equal to `BidTxMaxCallGasLimit`.
+6. The `bid.SearcherSig` and `bid.AuctioneerSig` must be valid.
 
 ## Block building rules
 

--- a/kaiax/auction/errors.go
+++ b/kaiax/auction/errors.go
@@ -30,6 +30,7 @@ var (
 	ErrInvalidTargetTxHash   = errors.New("invalid target tx hash")
 	ErrAuctionDisabled       = errors.New("auction is disabled")
 	ErrExceedMaxCallGasLimit = errors.New("gas limit exceeds the maximum limit")
+	ErrExceedMaxDataSize     = errors.New("data size exceeds the maximum limit")
 
 	ErrBidAlreadyExists        = errors.New("bid already exists")
 	ErrBidSenderExists         = errors.New("bid sender already exists")

--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -39,6 +39,7 @@ const (
 	allowFutureBlock = 2
 
 	BidTxMaxCallGasLimit = uint64(10_000_000)
+	BidTxMaxDataSize     = uint64(16 * 1024) // 16KB
 
 	// Rate limiting
 	bidsPerSecondPerPeer = 300 // Max bids per second per peer
@@ -352,12 +353,17 @@ func (bp *BidPool) validateBid(bid *auction.Bid) error {
 		return auction.ErrZeroBid
 	}
 
-	// 4. The gas limit must be less than the maximum limit.
+	// 4. The data size must be less than the maximum limit.
+	if uint64(len(bid.Data)) > BidTxMaxDataSize {
+		return auction.ErrExceedMaxDataSize
+	}
+
+	// 5. The gas limit must be less than the maximum limit.
 	if bid.CallGasLimit > BidTxMaxCallGasLimit {
 		return auction.ErrExceedMaxCallGasLimit
 	}
 
-	// 5. The `bid.SearcherSig` and `bid.AuctioneerSig` must be valid.
+	// 6. The `bid.SearcherSig` and `bid.AuctioneerSig` must be valid.
 	if err := bp.validateBidSigs(bid); err != nil {
 		return err
 	}

--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -39,7 +39,7 @@ const (
 	allowFutureBlock = 2
 
 	BidTxMaxCallGasLimit = uint64(10_000_000)
-	BidTxMaxDataSize     = uint64(16 * 1024) // 16KB
+	BidTxMaxDataSize     = uint64(64 * 1024) // 64KB
 
 	// Rate limiting
 	bidsPerSecondPerPeer = 300 // Max bids per second per peer

--- a/kaiax/auction/impl/bid_pool_test.go
+++ b/kaiax/auction/impl/bid_pool_test.go
@@ -70,7 +70,7 @@ func init() {
 			bid.CallGasLimit = 15_000_000
 		}
 		if i == 6 {
-			bid.Data = make([]byte, 16*1024+1)
+			bid.Data = make([]byte, 64*1024+1)
 		}
 
 		// Set searcher address


### PR DESCRIPTION
## Proposed changes

Similar to the tx size limit (128KB), introduce a bid data size limit to 64KB. It prevents consuming too much data gas and potential DoS.

Increase a `gasBufferEstimate` to `200,000` to secure an enough margin with intensive bid tx. It doesn't charge the actual bid and can be decreased after the stabilization.

```
// bid.Data = 4 bytes (only selector), callGasLimit = 3.5M (consume all gas internally)
> intinsicGas = 26684
> gasUsed = 3645813
> gasUsed - intrinsicGas - callGasLimit = 119,129 (<= gas buffer)

// bid.Data = 64KB, callGasLimit = 2M (consume all gas internally)
> intinsicGas = 1075320
> gasUsed = 4717666
> gasUsed - intrinsicGas - callGasLimit = 142,346 (<= gas buffer)
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
