### PR TITLE
blockchain: fix TestReorgSideEvent

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -943,6 +943,11 @@ func TestLogReorgs(t *testing.T) {
 }
 
 func TestReorgSideEvent(t *testing.T) {
+	// Fix random seed for deterministic behavior in reorg decision
+	// This prevents flaky test failures due to random tie-breaking
+	rand.Seed(1)
+	defer rand.Seed(time.Now().UnixNano())
+
 	var (
 		db      = database.NewMemoryDBManager()
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")


### PR DESCRIPTION
## Proposed changes

- This PR fixes random seed at TestReorgSideEvent for deterministic behavior in reorg decision. This prevents flaky test failures.

```
// dev
> go test ./blockchain -run TestReorgSideEvent -count=5000
...
FAIL
FAIL    github.com/kaiachain/kaia/blockchain    575.469s
FAIL

// PR
> go test ./blockchain -run TestReorgSideEvent -count=5000
ok      github.com/kaiachain/kaia/blockchain    576.356s
```
## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
