### PR TITLE
kaiax/valset: Address.Hex() cache for AddressSet

### DIFF
--- a/kaiax/valset/address_set_test.go
+++ b/kaiax/valset/address_set_test.go
@@ -135,12 +135,12 @@ func TestAddressHexCache(t *testing.T) {
 	addr := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 
 	// Test that cache returns correct hex strings
-	got := cache.Get(addr)
+	got := hexCache.Get(addr)
 	want := addr.String()
 	assert.Equal(t, want, got)
 
 	// Test cache hit consistency
-	gotAgain := cache.Get(addr)
+	gotAgain := hexCache.Get(addr)
 	assert.Equal(t, want, gotAgain)
 
 	// Test cache concurrency safety
@@ -158,7 +158,7 @@ func TestAddressHexCache(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
 				addr := addrs[(id+j)%len(addrs)]
-				got := cache.Get(addr)
+				got := hexCache.Get(addr)
 				want := addr.String()
 				if got != want {
 					errCh <- fmt.Errorf("goroutine %d: expected %s, got %s", id, want, got)


### PR DESCRIPTION
## Proposed changes

### Motivation
- During block sync, there are large overhead in heap alloc because of `Address.Hex()` (about 34% of heap alloc was caused by `Address.Hex()`)
- The main usage is from `valset.NewAddressSet`

### Solution
- This PR adds cache for `Address.Hex()` in valset module. This is to directly reduce the redundancy for addresses used in valset, not for general addresses.
- Since the address set is static, we simply use map. When the set become dynamic (after Kaia goes permissionless) we could use a proper cache.

<details>
<summary>profile result</summary>

Here are some profiles during the block sync. We can see lots of `Hex()` before this PR

- heap alloc before this PR
<img width="1512" height="610" alt="image" src="https://github.com/user-attachments/assets/15dc2857-5a3f-4943-a920-64e536651a2a" />

After this PR, we no longer see `Hex()`.

- heap alloc after this PR
<img width="1512" height="634" alt="image" src="https://github.com/user-attachments/assets/b2fc1920-30f0-4da9-bc94-b2db336b6ed4" />


The CPU overhead from the cache seems negligible, as the two results are almost identical.
- CPU profile before this PR
<img width="1512" height="636" alt="image" src="https://github.com/user-attachments/assets/9db98532-e053-4351-8e43-dc594d7930f0" />


- CPU profile after this PR
<img width="1512" height="632" alt="image" src="https://github.com/user-attachments/assets/ba369aac-a634-4ae3-b280-ef95c5489734" />


</details>

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
