### PR TITLE
Upgrade Go to 1.25

### DIFF
--- a/build/Dockerfile-go1.23.3-rpmbuild-gcc7
+++ b/build/Dockerfile-go1.23.3-rpmbuild-gcc7
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN curl https://dl.google.com/go/go1.23.3.linux-amd64.tar.gz | tar xzvf - -C /usr/local
+RUN curl https://dl.google.com/go/go1.25.linux-amd64.tar.gz | tar xzvf - -C /usr/local
 RUN yum install -y make rpm-build git createrepo python3 gcc unzip gdb which
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip
 ENV PATH=$PATH:/usr/local/go/bin

--- a/build/Dockerfile-go1.23.3-rpmbuild-gcc7-arm
+++ b/build/Dockerfile-go1.23.3-rpmbuild-gcc7-arm
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN curl https://dl.google.com/go/go1.23.3.linux-arm64.tar.gz | tar xzvf - -C /usr/local
+RUN curl https://dl.google.com/go/go1.25.linux-arm64.tar.gz | tar xzvf - -C /usr/local
 RUN yum install -y make rpm-build git createrepo python3 gcc unzip gdb which
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip
 ENV PATH=$PATH:/usr/local/go/bin

--- a/build/Dockerfile-go1.23.3-solc0.8.13-ubuntu-22.04
+++ b/build/Dockerfile-go1.23.3-solc0.8.13-ubuntu-22.04
@@ -19,7 +19,7 @@ RUN add-apt-repository ppa:longsleep/golang-backports -y && \
     ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata
 RUN apt install -y build-essential bash gcc musl-dev openssl wget golang golang-1.17
-RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.23.3.src.tar.gz
+RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.25.src.tar.gz
 RUN tar -C /usr/local -xzf go.src.tar.gz
 RUN cd /usr/local/go/src/ && \
     ./make.bash

--- a/build/Dockerfile-go1.23.3-solc0.8.13-ubuntu-22.04-arm
+++ b/build/Dockerfile-go1.23.3-solc0.8.13-ubuntu-22.04-arm
@@ -19,7 +19,7 @@ RUN add-apt-repository ppa:longsleep/golang-backports -y && \
     ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata
 RUN apt install -y build-essential bash gcc musl-dev openssl wget golang golang-1.17
-RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.23.3.src.tar.gz
+RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.25.src.tar.gz
 RUN tar -C /usr/local -xzf go.src.tar.gz
 RUN cd /usr/local/go/src/ && \
     ./make.bash

--- a/build/Dockerfile-go1.23.7-rpmbuild-gcc11-arm-el9
+++ b/build/Dockerfile-go1.23.7-rpmbuild-gcc11-arm-el9
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN curl https://dl.google.com/go/go1.23.7.linux-arm64.tar.gz | tar xzvf - -C /usr/local
+RUN curl https://dl.google.com/go/go1.25.linux-arm64.tar.gz | tar xzvf - -C /usr/local
 RUN yum install -y make rpm-build git createrepo python3 gcc unzip gdb which
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip
 ENV PATH=$PATH:/usr/local/go/bin

--- a/build/Dockerfile-go1.23.7-rpmbuild-gcc11-el9
+++ b/build/Dockerfile-go1.23.7-rpmbuild-gcc11-el9
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN curl https://dl.google.com/go/go1.23.7.linux-amd64.tar.gz | tar xzvf - -C /usr/local
+RUN curl https://dl.google.com/go/go1.25.linux-amd64.tar.gz | tar xzvf - -C /usr/local
 RUN yum install -y make rpm-build git createrepo python3 gcc unzip gdb which
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install && rm awscliv2.zip
 ENV PATH=$PATH:/usr/local/go/bin

--- a/build/Dockerfile-go1.23.7-rpmbuild-gcc7-arm-el7
+++ b/build/Dockerfile-go1.23.7-rpmbuild-gcc7-arm-el7
@@ -3,7 +3,7 @@ FROM centos:centos7
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
-RUN curl https://dl.google.com/go/go1.23.7.linux-arm64.tar.gz | tar xzvf - -C /usr/local
+RUN curl https://dl.google.com/go/go1.25.linux-arm64.tar.gz | tar xzvf - -C /usr/local
 ENV PATH=$PATH:/usr/local/go/bin
 
 RUN echo -e '[devtoolset-7]\n\

--- a/build/Dockerfile-go1.23.7-rpmbuild-gcc7-el7
+++ b/build/Dockerfile-go1.23.7-rpmbuild-gcc7-el7
@@ -3,7 +3,7 @@ FROM centos:centos7
 RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
 RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
-RUN curl https://dl.google.com/go/go1.23.7.linux-amd64.tar.gz | tar xzvf - -C /usr/local
+RUN curl https://dl.google.com/go/go1.25.linux-amd64.tar.gz | tar xzvf - -C /usr/local
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Manually add SCL repo (EOL ?~]??~[~D ?~H~X?~O~Y ?~C~]?~D?)

--- a/build/Dockerfile-go1.23.7-solc0.8.13-ubuntu-22.04
+++ b/build/Dockerfile-go1.23.7-solc0.8.13-ubuntu-22.04
@@ -19,7 +19,7 @@ RUN add-apt-repository ppa:longsleep/golang-backports -y && \
     ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata
 RUN apt install -y build-essential bash gcc musl-dev openssl wget golang golang-1.17
-RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.23.7.src.tar.gz
+RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.25.src.tar.gz
 RUN tar -C /usr/local -xzf go.src.tar.gz
 RUN cd /usr/local/go/src/ && \
     ./make.bash

--- a/build/Dockerfile-go1.23.7-solc0.8.13-ubuntu-22.04-arm
+++ b/build/Dockerfile-go1.23.7-solc0.8.13-ubuntu-22.04-arm
@@ -19,7 +19,7 @@ RUN add-apt-repository ppa:longsleep/golang-backports -y && \
     ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata
 RUN apt install -y build-essential bash gcc musl-dev openssl wget golang golang-1.17
-RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.23.7.src.tar.gz
+RUN wget -O go.src.tar.gz https://dl.google.com/go/go1.25.src.tar.gz
 RUN tar -C /usr/local -xzf go.src.tar.gz
 RUN cd /usr/local/go/src/ && \
     ./make.bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaiachain/kaia
 
-go 1.23.7
+go 1.25
 
 require (
 	github.com/Shopify/sarama v1.26.4


### PR DESCRIPTION
Upgrade the project to Go 1.25 to resolve toolchain incompatibilities and align builds.