### PR TITLE
blockchain/system: prevent overflow from uint64 to int64

### DIFF
--- a/blockchain/system/auction.go
+++ b/blockchain/system/auction.go
@@ -55,12 +55,12 @@ func ReadGasBufferEstimate(backend bind.ContractCaller, contractAddr common.Addr
 func EncodeAuctionCallData(bid *auction.Bid) ([]byte, error) {
 	input := contracts.IAuctionEntryPointAuctionTx{
 		TargetTxHash:  bid.TargetTxHash,
-		BlockNumber:   big.NewInt(int64(bid.BlockNumber)),
+		BlockNumber:   new(big.Int).SetUint64(bid.BlockNumber),
 		Sender:        bid.Sender,
 		To:            bid.To,
-		Nonce:         big.NewInt(int64(bid.Nonce)),
+		Nonce:         new(big.Int).SetUint64(bid.Nonce),
 		Bid:           bid.Bid,
-		CallGasLimit:  big.NewInt(int64(bid.CallGasLimit)),
+		CallGasLimit:  new(big.Int).SetUint64(bid.CallGasLimit),
 		Data:          bid.Data,
 		SearcherSig:   bid.SearcherSig,
 		AuctioneerSig: bid.AuctioneerSig,


### PR DESCRIPTION
## Proposed changes

The PR fixes the potential overflow when encoding calldata for Auction.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
