### PR TITLE
build: Align linter version to v1.60.1

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -391,8 +391,17 @@ func doLint(cmdline []string, exitOnError bool) {
 	// linters for "lint" command
 	lintersSet := [][]string{
 		{
-			"--presets=format",
-			"--presets=performance",
+			//"--presets=format", // presets are removed from v2
+			"--enable=gci",       // should be moved into formatter configuration from v2
+			"--enable=gofmt",     // should be moved into formatter configuration from v2
+			"--enable=gofumpt",   // should be moved into formatter configuration from v2
+			"--enable=goimports", // should be moved into formatter configuration from v2
+			//"--presets=performance", // presets are removed from v2
+			"--enable=bodyclose",
+			"--enable=fatcontext",
+			"--enable=noctx",
+			"--enable=perfsprint",
+			"--enable=prealloc",
 		},
 	}
 
@@ -427,7 +436,7 @@ func doLint(cmdline []string, exitOnError bool) {
 				"--enable=unused",
 			},
 			{"--enable=unconvert"},
-			{"--enable=gosimple"},
+			{"--enable=gosimple"}, // should be removed since it's merged into staticcheck from v2
 			{"--enable=staticcheck"},
 			{"--enable=gocyclo"},
 		}
@@ -437,7 +446,7 @@ func doLint(cmdline []string, exitOnError bool) {
 		configs := []string{
 			"run",
 			"--tests",
-			"--disable-all",
+			"--disable-all", // should be updated to default=none from v2
 			"--timeout=10m",
 		}
 		if *vFlag {
@@ -1031,8 +1040,8 @@ func installLinter() string {
 	if err != nil {
 		fmt.Println("Installing golangci-lint.")
 
-		cmdCurl := exec.Command("curl", "-sSfL", "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh")
-		cmdSh := exec.Command("sh", "-s", "--", "-b", filepath.Join(build.GOPATH(), "bin"), "v1.52.0")
+		cmdCurl := exec.Command("curl", "-sSfL", "https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh")
+		cmdSh := exec.Command("sh", "-s", "--", "-b", filepath.Join(build.GOPATH(), "bin"), "v1.60.1")
 		cmdSh.Stdin, err = cmdCurl.StdoutPipe()
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
## Proposed changes

- Align linter-v1.60.1 as the default version as the same as `.circleci/config.yml` and `.github/workflows/*.yml` when linter doesn't install
- And prepare for using linter-v2.5.x with Golang-v1.25.x

## Types of changes

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/kaiachain/kaia/pull/583

## Further comments

- Ref: https://golangci-lint.run/docs/product/migration-guide/#linterspresets
- Ref: https://golangci-lint.run/docs/product/migration-guide/#--disable-all-and---enable-all
- Ref: https://golangci-lint.run/docs/product/migration-guide/#lintersenablestylecheckgosimplestaticcheck
- Ref: https://golangci-lint.run/docs/configuration/cli/ (can't configure format linters by run CLI options)
