### PR TITLE
Fix spelling errors

### DIFF
--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -65,7 +65,7 @@ const (
 	// and waste round trip times. If it's too high, we're capping responses and
 	// waste bandwidth.
 	//
-	// Depoyed bytecodes are currently capped at 24KB, so the minimum request
+	// Deployed bytecodes are currently capped at 24KB, so the minimum request
 	// size should be maxRequestSize / 24K. Assuming that most contracts do not
 	// come close to that, requesting 4x should be a good approximation.
 	maxCodeRequestCount = maxRequestSize / (24 * 1024) * 4
@@ -364,7 +364,7 @@ type SyncPeer interface {
 	RequestAccountRange(id uint64, root, origin, limit common.Hash, bytes uint64) error
 
 	// RequestStorageRanges fetches a batch of storage slots belonging to one or
-	// more accounts. If slots from only one accout is requested, an origin marker
+	// more accounts. If slots from only one account is requested, an origin marker
 	// may also be used to retrieve from there.
 	RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error
 

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -607,7 +607,7 @@ func (api *UnsafeAPI) StandardTraceBadBlockToFile(ctx context.Context, hash comm
 
 // traceBlock configures a new tracer according to the provided configuration, and
 // executes all the transactions contained within. The return value will be one item
-// per transaction, dependent on the requestd tracer.
+// per transaction, dependent on the requested tracer.
 func (api *CommonAPI) traceBlock(ctx context.Context, block *types.Block, config *TraceConfig) ([]*txTraceResult, error) {
 	if !api.unsafeTrace {
 		if atomic.LoadInt32(&heavyAPIRequestCount) >= HeavyAPIRequestLimit {

--- a/node/cn/tracers/internal/tracers/4byte_tracer.js
+++ b/node/cn/tracers/internal/tracers/4byte_tracer.js
@@ -46,7 +46,7 @@
 		return false;
 	},
 
-	// store save the given indentifier and datasize.
+	// store save the given identifier and datasize.
 	store: function(id, size){
 		var key = "" + toHex(id) + "-" + size;
 		this.ids[key] = this.ids[key] + 1 || 1;

--- a/node/cn/tracers/internal/tracers/evmdis_tracer.js
+++ b/node/cn/tracers/internal/tracers/evmdis_tracer.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// evmdisTracer returns sufficent information from a trace to perform evmdis-style
+// evmdisTracer returns sufficient information from a trace to perform evmdis-style
 // disassembly.
 {
 	stack: [{ops: []}],


### PR DESCRIPTION
Fixed 5 spelling errors in comments:
- `Depoyed` → `Deployed` (sync.go)
- `accout` → `account` (sync.go)
- `requestd` → `requested` (api.go)
- `indentifier` → `identifier` (4byte_tracer.js)
- `sufficent` → `sufficient` (evmdis_tracer.js)
These typos in documentation comments could cause confusion for developers reading the code.