### PR TITLE
blockchain: Remove deprecated gxhash

### DIFF
--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -225,8 +225,8 @@ func TestVerifyBlockBodyForOsakaFork(t *testing.T) {
 		gspec   = &Genesis{Config: config}
 		genesis = gspec.MustCommit(testdb)
 	)
-	GenerateChain(config, genesis, gxhash.NewFaker(), testdb, 8, nil)
-	chain, _ := NewBlockChain(testdb, nil, config, gxhash.NewFaker(), vm.Config{})
+	GenerateChain(config, genesis, faker.NewFaker(), testdb, 8, nil)
+	chain, _ := NewBlockChain(testdb, nil, config, faker.NewFaker(), vm.Config{})
 	defer chain.Stop()
 
 	// Generate a batch of accounts to start with


### PR DESCRIPTION
## Proposed changes

- This PR replaces deprecated `gxhash` with `faker`
- `gxhash` was removed in `dev`, but a new test in `feat/v3.0.0` that depends on the deprecated `gxhash` was merged into `dev`.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
