### PR TITLE
node/cn: Broadcast bid if peer's protocol version is equal or higher than 66

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1382,7 +1382,9 @@ func (pm *ProtocolManager) BroadcastBid(bid *auction.Bid) {
 
 	cnWithoutBid := pm.peers.CNWithoutBid(bid.Hash())
 	for _, peer := range cnWithoutBid {
-		peer.AsyncSendBid(bid)
+		if peer.GetVersion() >= kaia66 {
+			peer.AsyncSendBid(bid)
+		}
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Do not broadcast bid message if peer's protocol version is less than 66.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
