### PR TITLE
blockchain/types: Replace FillContractAddress with CreateAddress

### DIFF
--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -1297,7 +1297,7 @@ func createTestData(t *testing.T, header *types.Header) (*types.Block, types.Tra
 		if err != nil {
 			t.Fatal(err)
 		}
-		tx.FillContractAddress(fromAddress, r)
+		r.ContractAddress = crypto.CreateAddress(fromAddress, tx.Nonce())
 		receiptMap[tx.Hash()] = r
 		receipts = append(receipts, receiptMap[tx.Hash()])
 	}
@@ -1508,7 +1508,7 @@ func createTestData(t *testing.T, header *types.Header) (*types.Block, types.Tra
 		if err != nil {
 			t.Fatal(err)
 		}
-		tx.FillContractAddress(fromAddress, r)
+		r.ContractAddress = crypto.CreateAddress(fromAddress, tx.Nonce())
 		receiptMap[tx.Hash()] = r
 		receipts = append(receipts, receiptMap[tx.Hash()])
 	}
@@ -1744,7 +1744,7 @@ func createTestData(t *testing.T, header *types.Header) (*types.Block, types.Tra
 		if err != nil {
 			t.Fatal(err)
 		}
-		tx.FillContractAddress(fromAddress, r)
+		r.ContractAddress = crypto.CreateAddress(fromAddress, tx.Nonce())
 		receiptMap[tx.Hash()] = r
 		receipts = append(receipts, receiptMap[tx.Hash()])
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2802,7 +2802,9 @@ func (bc *BlockChain) ApplyTransaction(chainConfig *params.ChainConfig, author *
 
 	receipt := types.NewReceipt(result.VmExecutionStatus, tx.Hash(), result.UsedGas)
 	// if the transaction created a contract, store the creation address in the receipt.
-	msg.FillContractAddress(vmenv.Origin, receipt)
+	if msg.To() == nil {
+		receipt.ContractAddress = crypto.CreateAddress(vmenv.Origin, tx.Nonce())
+	}
 	// Set the receipt logs and create a bloom for filtering
 	receipt.Logs = statedb.GetLogs(tx.Hash())
 	receipt.Bloom = types.CreateBloom(types.Receipts{receipt})

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -599,13 +599,6 @@ func (tx *Transaction) Time() time.Time {
 	return tx.time
 }
 
-// FillContractAddress fills contract address to receipt. This only works for types deploying a smart contract.
-func (tx *Transaction) FillContractAddress(from common.Address, r *Receipt) {
-	if filler, ok := tx.data.(TxInternalDataContractAddressFiller); ok {
-		filler.FillContractAddress(from, r)
-	}
-}
-
 // Execute performs execution of the transaction. This function will be called from StateTransition.TransitionDb().
 // Since each transaction type performs different execution, this function calls TxInternalData.TransitionDb().
 func (tx *Transaction) Execute(vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) ([]byte, uint64, error) {

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -372,11 +372,6 @@ type TxInternalData interface {
 	MakeRPCOutput() map[string]interface{}
 }
 
-type TxInternalDataContractAddressFiller interface {
-	// FillContractAddress fills contract address to receipt. This only works for types deploying a smart contract.
-	FillContractAddress(from common.Address, r *Receipt)
-}
-
 type TxInternalDataSerializeForSignToByte interface {
 	SerializeForSignToBytes() []byte
 }

--- a/blockchain/types/tx_internal_data_ethereum_access_list.go
+++ b/blockchain/types/tx_internal_data_ethereum_access_list.go
@@ -440,12 +440,6 @@ func (t *TxInternalDataEthereumAccessList) ValidateMutableValue(stateDB StateDB,
 	return nil
 }
 
-func (t *TxInternalDataEthereumAccessList) FillContractAddress(from common.Address, r *Receipt) {
-	if t.Recipient == nil {
-		r.ContractAddress = crypto.CreateAddress(from, t.AccountNonce)
-	}
-}
-
 func (t *TxInternalDataEthereumAccessList) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
 	///////////////////////////////////////////////////////
 	// OpcodeComputationCostLimit: The below code is commented and will be usd for debugging purposes.

--- a/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
+++ b/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
@@ -440,12 +440,6 @@ func (t *TxInternalDataEthereumDynamicFee) IsLegacyTransaction() bool {
 	return false
 }
 
-func (t *TxInternalDataEthereumDynamicFee) FillContractAddress(from common.Address, r *Receipt) {
-	if t.Recipient == nil {
-		r.ContractAddress = crypto.CreateAddress(from, t.AccountNonce)
-	}
-}
-
 func (t *TxInternalDataEthereumDynamicFee) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
 	///////////////////////////////////////////////////////
 	// OpcodeComputationCostLimit: The below code is commented and will be usd for debugging purposes.

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy.go
@@ -411,14 +411,6 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeploy) ValidateMutableValue(sta
 	return nil
 }
 
-func (t *TxInternalDataFeeDelegatedSmartContractDeploy) FillContractAddress(from common.Address, r *Receipt) {
-	if t.Recipient == nil {
-		r.ContractAddress = crypto.CreateAddress(from, t.AccountNonce)
-	} else {
-		r.ContractAddress = *t.Recipient
-	}
-}
-
 func (t *TxInternalDataFeeDelegatedSmartContractDeploy) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
 	///////////////////////////////////////////////////////
 	// OpcodeComputationCostLimit: The below code is commented and will be usd for debugging purposes.

--- a/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
+++ b/blockchain/types/tx_internal_data_fee_delegated_smart_contract_deploy_with_ratio.go
@@ -435,14 +435,6 @@ func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) ValidateMutable
 	return nil
 }
 
-func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) FillContractAddress(from common.Address, r *Receipt) {
-	if t.Recipient == nil {
-		r.ContractAddress = crypto.CreateAddress(from, t.AccountNonce)
-	} else {
-		r.ContractAddress = *t.Recipient
-	}
-}
-
 func (t *TxInternalDataFeeDelegatedSmartContractDeployWithRatio) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
 	///////////////////////////////////////////////////////
 	// OpcodeComputationCostLimit: The below code is commented and will be usd for debugging purposes.

--- a/blockchain/types/tx_internal_data_legacy.go
+++ b/blockchain/types/tx_internal_data_legacy.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
-	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/sha3"
 	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/kerrors"
@@ -370,12 +369,6 @@ func (t *TxInternalDataLegacy) Validate(stateDB StateDB, currentBlockNumber uint
 
 func (t *TxInternalDataLegacy) ValidateMutableValue(stateDB StateDB, currentBlockNumber uint64) error {
 	return nil
-}
-
-func (t *TxInternalDataLegacy) FillContractAddress(from common.Address, r *Receipt) {
-	if t.Recipient == nil {
-		r.ContractAddress = crypto.CreateAddress(from, t.AccountNonce)
-	}
 }
 
 func (t *TxInternalDataLegacy) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {

--- a/blockchain/types/tx_internal_data_smart_contract_deploy.go
+++ b/blockchain/types/tx_internal_data_smart_contract_deploy.go
@@ -376,14 +376,6 @@ func (t *TxInternalDataSmartContractDeploy) ValidateMutableValue(stateDB StateDB
 	return nil
 }
 
-func (t *TxInternalDataSmartContractDeploy) FillContractAddress(from common.Address, r *Receipt) {
-	if t.Recipient == nil {
-		r.ContractAddress = crypto.CreateAddress(from, t.AccountNonce)
-	} else {
-		r.ContractAddress = *t.Recipient
-	}
-}
-
 func (t *TxInternalDataSmartContractDeploy) Execute(sender ContractRef, vm VM, stateDB StateDB, currentBlockNumber uint64, gas uint64, value *big.Int) (ret []byte, usedGas uint64, err error) {
 	///////////////////////////////////////////////////////
 	// OpcodeComputationCostLimit: The below code is commented and will be usd for debugging purposes.


### PR DESCRIPTION
## Proposed changes

- tx.FillContractAddress is equivalent to crypto.CreateAddress.
- Kaia SmartContractDeploy tx types has the `else { r.ContractAddress = *t.Recipient }` clause. But that path is unreachable because SmartContractDeploy tx types require Recipient to be `nil`. See [here](https://github.com/kaiachain/kaia/blob/v2.1.0/blockchain/types/tx_internal_data_smart_contract_deploy.go#L43) and [here](https://github.com/kaiachain/kaia/blob/v2.1.0/blockchain/types/tx_internal_data_smart_contract_deploy.go#L354).
- Now ApplyTransaction's relevant part is same as [geth](https://github.com/ethereum/go-ethereum/blob/v1.16.7/core/state_processor.go#L192-L195).

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
