### PR TITLE
ghaction: Use the latest testing container go1.25.3

### DIFF
--- a/.github/workflows/test-executor-template.yml
+++ b/.github/workflows/test-executor-template.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: kaiachain/build_base:go1.23.7-solc0.8.13-ubuntu-22.04
+      image: kaiachain/build_base:go1.25.3-solc0.8.13-ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test-other-executor-template.yml
+++ b/.github/workflows/test-other-executor-template.yml
@@ -38,7 +38,7 @@ jobs:
       localstack:
         image: localstack/localstack:3
     container:
-      image: kaiachain/build_base:go1.23.7-solc0.8.13-ubuntu-22.04
+      image: kaiachain/build_base:go1.25.3-solc0.8.13-ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Proposed changes

For fixing the GithubActions CI Lint error even if CircleCI Lint isn't failed
* Use the latest testing container
* https://github.com/kaiachain/kaia/blob/a0b9dd896926e1782195a78940c9d79dbb1e4102/.circleci/config.yml#L61

GithubActions CI Lint failure:
* https://app.circleci.com/pipelines/github/kaiachain/kaia/4227/workflows/81118a34-0ab6-44eb-8687-85fa5983757d/jobs/23496
```
>>> /go/bin/golangci-lint run --tests --timeout=10m -v --new-from-rev=dev --enable=bodyclose --enable=fatcontext --enable=noctx --enable=perfsprint --enable=prealloc ./...
level=info msg="golangci-lint has version 1.60.1 built with go1.23.0 from 3298c104 on 2024-08-14T01:15:05Z"
```

Ciricle CI Lint success:
* https://github.com/kaiachain/kaia/actions/runs/19163786567/job/54931282719?pr=620 
```
>>> /go/bin/golangci-lint run --tests --timeout=10m -v --new-from-rev=dev --enable=bodyclose --enable=fatcontext --enable=noctx --enable=perfsprint --enable=prealloc ./...
INFO golangci-lint has version 2.5.0 built with go1.25.1 from ff63786c on 2025-09-21T19:04:05Z 
```

## Types of changes

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- https://github.com/kaiachain/kaia/pull/613

## Further comments
