### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -203,7 +203,7 @@ func abigen(c *cli.Context) error {
 	} else {
 		// Generate the list of types to exclude from binding
 		exclude := make(map[string]bool)
-		for _, kind := range strings.Split(c.String(excFlag.Name), ",") {
+		for kind := range strings.SplitSeq(c.String(excFlag.Name), ",") {
 			exclude[strings.ToLower(kind)] = true
 		}
 		var err error

--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -82,7 +82,7 @@ func GenerateKeys(num int) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs [
 func GenerateKeysFromMnemonic(num int, mnemonic, path string) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs []common.Address) {
 	var key *bip32.Key
 
-	for _, level := range strings.Split(path, "/") {
+	for level := range strings.SplitSeq(path, "/") {
 		if len(level) == 0 {
 			continue
 		}

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -502,7 +502,7 @@ func allocGenesisFund(ctx *cli.Context, genesisJson *blockchain.Genesis) {
 	}
 
 	balance := new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil)
-	for _, item := range strings.Split(fundingAddr, ",") {
+	for item := range strings.SplitSeq(fundingAddr, ",") {
 		if !common.IsHexAddress(item) {
 			log.Fatalf("'%s' is not a valid hex address", item)
 		}

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -197,8 +197,8 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	cfg.NoDiscovery = ctx.Bool(NoDiscoverFlag.Name)
 
 	if ctx.IsSet(DiscoverTypesFlag.Name) {
-		nodetypes := strings.Split(ctx.String(DiscoverTypesFlag.Name), ",")
-		for _, nodetype := range nodetypes {
+		nodetypes := strings.SplitSeq(ctx.String(DiscoverTypesFlag.Name), ",")
+		for nodetype := range nodetypes {
 			switch strings.ToLower(nodetype) {
 			case "auto":
 				setDefaultDiscoverTypes(cfg)

--- a/cmd/utils/customflags.go
+++ b/cmd/utils/customflags.go
@@ -121,15 +121,15 @@ func (self DirectoryFlag) Apply(set *flag.FlagSet) {
 }
 
 func eachName(longName string, fn func(string)) {
-	parts := strings.Split(longName, ",")
-	for _, name := range parts {
+	parts := strings.SplitSeq(longName, ",")
+	for name := range parts {
 		name = strings.Trim(name, " ")
 		fn(name)
 	}
 }
 
 func isEnvVarSet(envVars string) bool {
-	for _, envVar := range strings.Split(envVars, ",") {
+	for envVar := range strings.SplitSeq(envVars, ",") {
 		envVar = strings.TrimSpace(envVar)
 		if env, ok := syscall.Getenv(envVar); ok {
 			// TODO: Can't use this for bools as

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2168,7 +2168,7 @@ func MakeConsolePreloads(ctx *cli.Context) []string {
 	var preloads []string
 
 	assets := ctx.String(JSpathFlag.Name)
-	for _, file := range strings.Split(ctx.String(PreloadJSFlag.Name), ",") {
+	for file := range strings.SplitSeq(ctx.String(PreloadJSFlag.Name), ",") {
 		preloads = append(preloads, common.AbsolutePath(assets, strings.TrimSpace(file)))
 	}
 	return preloads

--- a/cmd/utils/testcmd.go
+++ b/cmd/utils/testcmd.go
@@ -232,8 +232,8 @@ type testlogger struct {
 }
 
 func (tl *testlogger) Write(b []byte) (n int, err error) {
-	lines := bytes.Split(b, []byte("\n"))
-	for _, line := range lines {
+	lines := bytes.SplitSeq(b, []byte("\n"))
+	for line := range lines {
 		if len(line) > 0 {
 			tl.t.Logf("(stderr) %s", line)
 		}

--- a/kaiax/gov/param.go
+++ b/kaiax/gov/param.go
@@ -44,7 +44,7 @@ var (
 	validatorAddressListCanonicalizer canonicalizerT = func(v any) (any, error) {
 		stringToAddressList := func(v string) ([]common.Address, error) {
 			ret := []common.Address{}
-			for _, address := range strings.Split(v, ",") {
+			for address := range strings.SplitSeq(v, ",") {
 				if !common.IsHexAddress(address) {
 					return nil, ErrCanonicalizeStringToAddress
 				}

--- a/log/handler_glog.go
+++ b/log/handler_glog.go
@@ -93,7 +93,7 @@ func (h *GlogHandler) Verbosity(level Lvl) {
 //	 sets V to 3 in all files of any packages whose import path contains "foo"
 func (h *GlogHandler) Vmodule(ruleset string) error {
 	var filter []pattern
-	for _, rule := range strings.Split(ruleset, ",") {
+	for rule := range strings.SplitSeq(ruleset, ",") {
 		// Empty strings such as from a trailing comma can be ignored
 		if len(rule) == 0 {
 			continue
@@ -118,7 +118,7 @@ func (h *GlogHandler) Vmodule(ruleset string) error {
 		}
 		// Compile the rule pattern into a regular expression
 		matcher := ".*"
-		for _, comp := range strings.Split(parts[0], "/") {
+		for comp := range strings.SplitSeq(parts[0], "/") {
 			if comp == "*" {
 				matcher += "(/.*)?"
 			} else if comp != "" {

--- a/networks/p2p/simulations/http.go
+++ b/networks/p2p/simulations/http.go
@@ -501,13 +501,13 @@ func (s *Server) StreamNetworkEvents(w http.ResponseWriter, req *http.Request) {
 // A message code of '*' or '-1' is considered a wildcard and matches any code.
 func NewMsgFilters(filterParam string) (MsgFilters, error) {
 	filters := make(MsgFilters)
-	for _, filter := range strings.Split(filterParam, "-") {
+	for filter := range strings.SplitSeq(filterParam, "-") {
 		protoCodes := strings.SplitN(filter, ":", 2)
 		if len(protoCodes) != 2 || protoCodes[0] == "" || protoCodes[1] == "" {
 			return nil, fmt.Errorf("invalid message filter: %s", filter)
 		}
 		proto := protoCodes[0]
-		for _, code := range strings.Split(protoCodes[1], ",") {
+		for code := range strings.SplitSeq(protoCodes[1], ",") {
 			if code == "*" || code == "-1" {
 				filters[MsgFilter{Proto: proto, Code: -1}] = struct{}{}
 				continue

--- a/node/api_admin_network.go
+++ b/node/api_admin_network.go
@@ -149,7 +149,7 @@ func (api *AdminNetworkNodeAPI) StartHTTP(host *string, port *int, cors *string,
 	allowedOrigins := api.node.config.HTTPCors
 	if cors != nil {
 		allowedOrigins = nil
-		for _, origin := range strings.Split(*cors, ",") {
+		for origin := range strings.SplitSeq(*cors, ",") {
 			allowedOrigins = append(allowedOrigins, strings.TrimSpace(origin))
 		}
 	}
@@ -157,7 +157,7 @@ func (api *AdminNetworkNodeAPI) StartHTTP(host *string, port *int, cors *string,
 	allowedVHosts := api.node.config.HTTPVirtualHosts
 	if vhosts != nil {
 		allowedVHosts = nil
-		for _, vhost := range strings.Split(*vhosts, ",") {
+		for vhost := range strings.SplitSeq(*vhosts, ",") {
 			allowedVHosts = append(allowedVHosts, strings.TrimSpace(vhost))
 		}
 	}
@@ -165,7 +165,7 @@ func (api *AdminNetworkNodeAPI) StartHTTP(host *string, port *int, cors *string,
 	modules := api.node.httpWhitelist
 	if apis != nil {
 		modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			modules = append(modules, strings.TrimSpace(m))
 		}
 	}
@@ -228,7 +228,7 @@ func (api *AdminNetworkNodeAPI) StartWS(host *string, port *int, allowedOrigins 
 	origins := api.node.config.WSOrigins
 	if allowedOrigins != nil {
 		origins = nil
-		for _, origin := range strings.Split(*allowedOrigins, ",") {
+		for origin := range strings.SplitSeq(*allowedOrigins, ",") {
 			origins = append(origins, strings.TrimSpace(origin))
 		}
 	}
@@ -236,7 +236,7 @@ func (api *AdminNetworkNodeAPI) StartWS(host *string, port *int, allowedOrigins 
 	modules := api.node.config.WSModules
 	if apis != nil {
 		modules = nil
-		for _, m := range strings.Split(*apis, ",") {
+		for m := range strings.SplitSeq(*apis, ",") {
 			modules = append(modules, strings.TrimSpace(m))
 		}
 	}

--- a/node/cn/tracers/internal/tracers/assets.go
+++ b/node/cn/tracers/internal/tracers/assets.go
@@ -369,8 +369,8 @@ func AssetDir(name string) ([]string, error) {
 	node := _bintree
 	if len(name) != 0 {
 		cannonicalName := strings.Replace(name, "\\", "/", -1)
-		pathList := strings.Split(cannonicalName, "/")
-		for _, p := range pathList {
+		pathList := strings.SplitSeq(cannonicalName, "/")
+		for p := range pathList {
 			node = node.Children[p]
 			if node == nil {
 				return nil, fmt.Errorf("Asset %s not found", name)

--- a/rlp/internal/rlpstruct/rlpstruct.go
+++ b/rlp/internal/rlpstruct/rlpstruct.go
@@ -148,7 +148,7 @@ func parseTag(field Field, lastPublic int) (Tags, error) {
 	name := field.Name
 	tag := reflect.StructTag(field.Tag)
 	var ts Tags
-	for _, t := range strings.Split(tag.Get("rlp"), ",") {
+	for t := range strings.SplitSeq(tag.Get("rlp"), ",") {
 		switch t = strings.TrimSpace(t); t {
 		case "":
 			// empty tag is allowed for some reason

--- a/utils/build/util.go
+++ b/utils/build/util.go
@@ -192,7 +192,7 @@ func ExpandPackages(packages []string) []string {
 				log.Fatalf("package listing failed: %v\n%s", err, string(out))
 			}
 
-			for _, line := range strings.Split(string(out), "\n") {
+			for line := range strings.SplitSeq(string(out), "\n") {
 				newPkgs = append(newPkgs, strings.TrimSpace(line))
 			}
 			return newPkgs


### PR DESCRIPTION
## Proposed changes

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

More info: https://github.com/golang/go/issues/61901




## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
