### PR TITLE
ci: Fix linter error

### DIFF
--- a/.github/workflows/test-pr-workflow.yml
+++ b/.github/workflows/test-pr-workflow.yml
@@ -17,14 +17,8 @@ jobs:
     uses: ./.github/workflows/test-executor-template.yml
     with:
       test_command: |
-        CURRENT_BRANCH="${GITHUB_REF_NAME}"
         BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-        if [[ "$CURRENT_BRANCH" == "dev" || "$BASE_BRANCH" == "dev" ]]; then
-        git fetch origin dev
-        else
-        git fetch origin dev:dev
-        fi
-        go run build/ci.go lint -v --new-from-rev=dev
+        go run build/ci.go lint -v --new-from-rev="origin/${BASE_BRANCH}"
 
   test-networks:
     uses: ./.github/workflows/test-executor-template.yml


### PR DESCRIPTION
## Proposed changes

The GitHub Action's test-linter job failed because of the following error. Somehow the `--new-from-rev=dev` option isn't working because there is no `dev` branch in the CI environment.
```
level=warning msg="[runner] Can't process results by diff processor: can't prepare diff by revgrep: could not read git repo: error executing \"git diff --color=never --no-ext-diff --relative dev --\": exit status 128: fatal: bad revision 'dev'\n"
```

I found that following variables are injected in the GitHub Action execution environment, when we use `on pull_request` trigger. See the [test run](https://github.com/kaiachain/kaia/actions/runs/19338068826/job/55318632166?pr=635). The variables changed after #625, breaking the workflow.
```
GITHUB_REF        refs/pull/635/merge
GITHUB_REF_NAME   635/merge
GITHUB_HEAD_REF   ci-linter-test
GITHUB_BASE_REF   dev        (a.k.a. github.event.pull_request.base.ref)
```

Now, to fix the `test-linter` job, I have two solutions.

Solution 1. Use `dev` as linter's base ref. [It works](https://github.com/kaiachain/kaia/actions/runs/19338967594/job/55321863604?pr=635)
```sh
if [[ "$GITHUB_REF_NAME" == "dev" ]]; then
  # Fetch remote ref 'origin/dev' only because I'm already on 'dev'
  # This command always works
  git fetch origin dev
else
  # Fetch remote ref 'origin/dev' and create remote-tracking branch 'dev'.
  # This command fails if I'm on dev branch - "refusing to update checked out branch"
  git fetch origin dev:dev
fi
go run build/ci.go lint -v --new-from-rev=dev
```

Solution 2. Fetch `origin/dev` as linter's base ref. [It works](https://github.com/kaiachain/kaia/actions/runs/19340097192/job/55325911691?pr=635).
```sh
git fetch origin dev
go run build/ci.go lint -v --new-from-rev=origin/dev
```

This PR took the second approach. Generalized to $GITHUB_BASE_REF. 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
