### PR TITLE
 Fix typos in comments

### DIFF
--- a/blockchain/system/rebalance.go
+++ b/blockchain/system/rebalance.go
@@ -116,7 +116,7 @@ func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call kaia.
 	// No need to handle acccess list here
 
 	// To fix 0x0 nonce increase, uncomment next line to generate state instance whenever it is called
-	// But for backward compatiblity after hardfork, remain this code as commented
+	// But for backward compatibility after hardfork, remain this code as commented
 	//state, err := caller.chain.State()
 	//if err != nil {
 	//	return nil, err

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -40,7 +40,7 @@ type (
 //
 // Some functions are named after the equivalent functions in prysm Ethereum CL.
 // (https://github.com/prysmaticlabs/prysm/blob/v4.0.2/crypto/bls/bls.go)
-// Such naming should provide compatiblity with prysm code snippets,
+// Such naming should provide compatibility with prysm code snippets,
 // in case prysm code snippets are integrated to Kaia.
 //
 // ikm -> SK:  GenerateKey

--- a/crypto/bn256/bn256_fuzz.go
+++ b/crypto/bn256/bn256_fuzz.go
@@ -123,7 +123,7 @@ func FuzzPair(data []byte) int {
 	} else if errc != nil {
 		return 0
 	}
-	// Pair the two points and ensure thet result in the same output
+	// Pair the two points and ensure they result in the same output
 	if cloudflare.PairingCheck([]*cloudflare.G1{pc}, []*cloudflare.G2{tc}) != google.PairingCheck([]*google.G1{pg}, []*google.G2{tg}) {
 		panic("pair mismatch")
 	}

--- a/datasync/chaindatafetcher/chaindata_fetcher.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher.go
@@ -238,7 +238,7 @@ func (f *ChainDataFetcher) startFetching() error {
 	f.fetchingStopCh = make(chan struct{})
 	f.fetchingWg.Add(1)
 
-	// lanuch a goroutine to handle from checkpoint to the head block.
+	// launch a goroutine to handle from checkpoint to the head block.
 	go func() {
 		defer f.fetchingWg.Done()
 		switch f.config.Mode {

--- a/storage/database/schema.go
+++ b/storage/database/schema.go
@@ -44,7 +44,7 @@ var (
 	headBlockKey       = []byte("LastBlock")
 	headBlockBackupKey = []byte("LastBlockBackup")
 
-	// headFastBlockKey tracks the latest known incomplete block's hash duirng fast sync.
+	// headFastBlockKey tracks the latest known incomplete block's hash during fast sync.
 	headFastBlockKey       = []byte("LastFast")
 	headFastBlockBackupKey = []byte("LastFastBackup")
 

--- a/storage/statedb/trie.go
+++ b/storage/statedb/trie.go
@@ -619,7 +619,7 @@ func (t *Trie) markPrunableNode(n node) {
 		t.pruningMarksCache[common.BytesToExtHash(hn)] = t.PruningBlockNumber
 	} else if hn, _ := n.cache(); hn != nil {
 		// If node.flags.hash is nonempty, it means the node is either:
-		// (1) loaded from databas - subject to pruning,
+		// (1) loaded from database - subject to pruning,
 		// (2) went through hasher by Hash or Commit - may or may not be in database, add the mark anyway.
 		t.pruningMarksCache[common.BytesToExtHash(hn)] = t.PruningBlockNumber
 	}


### PR DESCRIPTION
Fixed multiple spelling errors in code comments across the codebase:
  - `compatiblity` → `compatibility` (crypto/bls/bls.go)
  - `thet` → `they` (crypto/bn256/bn256_fuzz.go)
  - `lanuch` → `launch` (datasync/chaindatafetcher/chaindata_fetcher.go)
  - `duirng` → `during` (storage/database/schema.go)
  - `databas` → `database` (storage/statedb/trie.go)
  - `compatiblity` → `compatibility` (blockchain/system/rebalance.go)