### PR TITLE
Fix typos in comments

### DIFF
--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -437,7 +437,7 @@ func bindTopicTypeGo(kind abi.Type, structs map[string]*tmplStruct) string {
 }
 
 // bindTopicTypeJava converts a Solidity topic type to a Java one. It is almost the same
-// funcionality as for simple types, but dynamic types get converted to hashes.
+// functionality as for simple types, but dynamic types get converted to hashes.
 func bindTopicTypeJava(kind abi.Type, structs map[string]*tmplStruct) string {
 	bound := bindTypeJava(kind, structs)
 

--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -1089,11 +1089,11 @@ func (stateDB *StateDB) Finalise(deleteEmptyObjects bool, setStorageRoot bool) {
 			// If state snapshotting is active, also mark the destruction there.
 			// Note, we can't do this only at the end of a block because multiple
 			// transactions within the same block might self destruct and then
-			// ressurrect an account; but the snapshotter needs both events.
+			// resurrect an account; but the snapshotter needs both events.
 			if stateDB.snap != nil {
 				stateDB.snapDestructs[so.addrHash] = struct{}{} // We need to maintain account deletions explicitly (will remain set indefinitely)
-				delete(stateDB.snapAccounts, so.addrHash)       // Clear out any previously updated account data (may be recreated via a ressurrect)
-				delete(stateDB.snapStorage, so.addrHash)        // Clear out any previously updated storage data (may be recreated via a ressurrect)
+				delete(stateDB.snapAccounts, so.addrHash)       // Clear out any previously updated account data (may be recreated via a resurrect)
+				delete(stateDB.snapStorage, so.addrHash)        // Clear out any previously updated storage data (may be recreated via a resurrect)
 			}
 		} else {
 			so.updateStorageTrie(stateDB.db)

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -578,7 +578,7 @@ func (st *StateTransition) validateAuthorization(auth *types.SetCodeAuthorizatio
 		return authority, fmt.Errorf("%w: %v", ErrAuthorizationInvalidSignature, err)
 	}
 	// Check the authority account
-	//  1) doesn't have code or has exisiting delegation
+	//  1) doesn't have code or has existing delegation
 	//  2) matches the auth's nonce
 	//
 	// Note it is added to the access list even if the authorization is invalid.

--- a/blockchain/system/rebalance.go
+++ b/blockchain/system/rebalance.go
@@ -113,7 +113,7 @@ func (caller *Kip103ContractCaller) CallContract(ctx context.Context, call kaia.
 	// call.To: the target contract address will be assigned by `BoundContract`
 	// call.Value: nil value is acceptable for `types.NewMessage`
 	// call.Data: a proper value will be assigned by `BoundContract`
-	// No need to handle acccess list here
+	// No need to handle access list here
 
 	// To fix 0x0 nonce increase, uncomment next line to generate state instance whenever it is called
 	// But for backward compatibility after hardfork, remain this code as commented
@@ -207,7 +207,7 @@ func (result *rebalanceResult) fillZeroed(contract RebalanceCaller, state *state
 			return err
 		}
 		result.Before.Zeroed[ret] = state.GetBalance(ret)
-		result.After.Zeroed[ret] = state.GetBalance(ret) // will be set as zero if rebalance suceed
+		result.After.Zeroed[ret] = state.GetBalance(ret) // will be set as zero if rebalance succeeds
 	}
 	return nil
 }

--- a/blockchain/tx_cacher.go
+++ b/blockchain/tx_cacher.go
@@ -57,7 +57,7 @@ type txSenderCacher struct {
 }
 
 // newTxSenderCacher creates a new transaction sender background cacher and starts
-// as many procesing goroutines as allowed by the GOMAXPROCS on construction.
+// as many processing goroutines as allowed by the GOMAXPROCS on construction.
 func newTxSenderCacher(threads int) *txSenderCacher {
 	cacher := &txSenderCacher{
 		tasks:   make(chan *txSenderCacherRequest, threads),


### PR DESCRIPTION
Corrects spelling errors in code comments across 5 files:
  - `funcionality` → `functionality` (bind.go)
  - `ressurrect` → `resurrect` (statedb.go, 3 instances)
  - `exisiting` → `existing` (state_transition.go)
  - `acccess` → `access` (rebalance.go)
  - `suceed` → `succeeds` (rebalance.go)
  - `procesing` → `processing` (tx_cacher.go)