### PR TITLE
crypto/kzg4844: Add BenchmarkVerifyCellProofs

### DIFF
--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -260,12 +260,6 @@ func benchmarkComputeCellProofs(b *testing.B, ckzg bool) {
 	}
 }
 
-// goos: darwin
-// goarch: arm64
-// pkg: github.com/ethereum/go-ethereum/crypto/kzg4844
-// cpu: Apple M1 Max
-// BenchmarkCKZGVerifyCellProofs
-// BenchmarkCKZGVerifyCellProofs-10               8          19569214 ns/op
 func BenchmarkCKZGVerifyCellProofs(b *testing.B)  { benchmarkVerifyCellProofs(b, true) }
 func BenchmarkGoKZGVerifyCellProofs(b *testing.B) { benchmarkVerifyCellProofs(b, false) }
 func benchmarkVerifyCellProofs(b *testing.B, ckzg bool) {
@@ -282,7 +276,7 @@ func benchmarkVerifyCellProofs(b *testing.B, ckzg bool) {
 	)
 
 	b.ResetTimer()
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		VerifyCellProofs([]Blob{*blob}, []Commitment{commitment}, proofs)
 	}
 }


### PR DESCRIPTION
## Proposed changes

- Add `benchmarkVerifyCellProofs` that measures `kzg4844.VerifyCellProofs()`. This function is used to verify the BlobTxWithBlobsV1 as defined in [EIP-4844](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md) and [EIP-7594](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7594.md).

Sample result:

```
$ go test -v -tags=ckzg -run=^$ -bench=Verify
goos: darwin
goarch: arm64
pkg: github.com/kaiachain/kaia/crypto/kzg4844
cpu: Apple M1 Max
BenchmarkCKZGVerifyProof
BenchmarkCKZGVerifyProof-10                  909           1113136 ns/op
BenchmarkGoKZGVerifyProof
BenchmarkGoKZGVerifyProof-10                 805           1468284 ns/op
BenchmarkCKZGVerifyBlobProof
BenchmarkCKZGVerifyBlobProof-10              698           1759849 ns/op
BenchmarkGoKZGVerifyBlobProof
BenchmarkGoKZGVerifyBlobProof-10             574           2097208 ns/op
BenchmarkCKZGVerifyCellProofs
BenchmarkCKZGVerifyCellProofs-10              62          19649052 ns/op
BenchmarkGoKZGVerifyCellProofs
BenchmarkGoKZGVerifyCellProofs-10             55          22200559 ns/op
```

Result summary

| Operation | CKZG | GoKZG | Usage |
|-|-|-|-|
| VerifyProof | 1.1ms | 1.5ms | KZG_POINT_EVALUATION (0x0a) precompile |
| VerifyBlobProof | 1.8ms | 2.1ms | Verify BlobTxWithBlobsV0 before Osaka |
| VerifyCellProofs | 19.6ms | 22.2ms | Verify BlobTxWithBlobsV1 since Osaka |

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
