### PR TITLE
test: Fix redis cache timeout test

### DIFF
--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -219,7 +219,6 @@ func TestRedisCache_Timeout(t *testing.T) {
 			t.Error(err)
 			return
 		}
-		close(serverReady)
 
 		listen, err := net.ListenTCP("tcp", tcpAddr)
 		if err != nil {
@@ -227,6 +226,7 @@ func TestRedisCache_Timeout(t *testing.T) {
 			return
 		}
 		defer listen.Close()
+		close(serverReady)
 
 		for {
 			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {


### PR DESCRIPTION
## Proposed changes

This PR fixes `TestRedisCache_Timeout` to correctly set up the test scenario. The `serverReady` closes when the TCP server hasn't been prepared, so the TCP connection might not be established. For more robustness, we can change the code to start the Redis request after `AcceptTCP,` but it seems this patch would be enough.

Sample failure: https://app.circleci.com/pipelines/github/kaiachain/kaia/4445/workflows/c15f1426-807b-4557-992b-34debf9ef186/jobs/24879

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

_Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
