### PR TITLE
blockchain/types: alleviate sig cache check

### DIFF
--- a/client/signer.go
+++ b/client/signer.go
@@ -51,6 +51,10 @@ func (s *senderFromServer) Equal(other types.Signer) bool {
 	return ok && os.blockhash == s.blockhash
 }
 
+func (s *senderFromServer) IsCompatibleWith(cached types.Signer, tx *types.Transaction) bool {
+	return s.Equal(cached)
+}
+
 func (s *senderFromServer) Sender(tx *types.Transaction) (common.Address, error) {
 	if s.blockhash == (common.Hash{}) {
 		return common.Address{}, errNotCached


### PR DESCRIPTION
## Proposed changes

sigCache stores a recovered public key so it can be reused instead of performing the expensive recovery again. In the past, multiple Signer types existed, so the cache was frequently invalidated. 

With modernSigner, the rules(signer struct) are unified. modernSigner works under **the assumption that a given txType always uses the same signature algorithm and the same signing rules**. Because of this assumption, sigCache only needs to check `IsSupported(txType)` to safely reuse the cached result, while the stricter checks—such as whether the full set of supported txTypes matches—are handled separately by Equal.

## Types of changes

<!-- Please put an x in the boxes related to your change. -->

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [ ] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
