### PR TITLE
blockchain/vm: Implement BLOBBASEFEE opcode

### DIFF
--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/consensus"
+	"github.com/kaiachain/kaia/consensus/misc/eip4844"
 	"github.com/kaiachain/kaia/params"
 )
 
@@ -48,6 +49,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 		beneficiary common.Address
 		rewardBase  common.Address
 		baseFee     *big.Int
+		blobBaseFee *big.Int
 		random      common.Hash
 	)
 
@@ -63,6 +65,12 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 		baseFee = header.BaseFee
 	} else { // Before Magma hardfork, BASEFEE (48) returns 0
 		baseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
+	}
+
+	if header.ExcessBlobGas != nil {
+		blobBaseFee = eip4844.CalcBlobFee(chain.Config(), header)
+	} else { // Before Osaka hardfork, BLOBBASEFEE (4a) returns 0
+		blobBaseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
 	}
 
 	if header.MixHash != nil {
@@ -81,6 +89,7 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 		Time:        new(big.Int).Set(header.Time),
 		BlockScore:  new(big.Int).Set(header.BlockScore),
 		BaseFee:     baseFee,
+		BlobBaseFee: blobBaseFee,
 		Random:      random,
 	}
 }

--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -330,10 +330,13 @@ func opBlobHash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([
 }
 
 // opBlobBaseFee implements BLOBBASEFEE opcode
-// Since blob data is generated in dank sharding, opBlobBaseFee will use only the zeroBaseFee
-// as long as the blob txType is not fully supported in Kaia.
+// This works as follows:
+// - Since Cancun: Must return zero.
+// - Since Osaka: Returns BlobBaseFee calculated from ExcessBlobGas in the header.
+// Before Osaka, ExcessBlobGas was always nil, so params.ZeroBaseFee was assigned in NewEVMBlockContext in blockchain/evm.go.
+// So the logic below is applicable to before and after Osaka.
 func opBlobBaseFee(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	blobBaseFee := uint256.NewInt(params.ZeroBaseFee)
+	blobBaseFee, _ := uint256.FromBig(interpreter.evm.Context.BlobBaseFee)
 	scope.Stack.push(blobBaseFee)
 	return nil, nil
 }

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -42,6 +42,9 @@ var (
 
 	// consoleLog is a precompiled contract used for debugging purposes.
 	consoleLogContractAddress = common.HexToAddress("0x000000000000000000636F6E736F6C652E6C6F67")
+
+	// blobBaseFee is the base fee for blob transactions.
+	blobBaseFee *big.Int
 )
 
 const (
@@ -116,6 +119,7 @@ type BlockContext struct {
 	Time        *big.Int       // Provides information for TIME
 	BlockScore  *big.Int       // Provides information for DIFFICULTY
 	BaseFee     *big.Int       // Provides information for BASEFEE
+	BlobBaseFee *big.Int       // Provides information for BLOBBASEFEE
 	Random      common.Hash    // Provides information for RANDOM
 }
 

--- a/blockchain/vm/runtime/env.go
+++ b/blockchain/vm/runtime/env.go
@@ -45,6 +45,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		BlockScore:  cfg.BlockScore,
 		GasLimit:    cfg.GasLimit,
 		BaseFee:     cfg.BaseFee,
+		BlobBaseFee: cfg.BlobBaseFee,
 	}
 	return vm.NewEVM(blockContext, txContext, cfg.State, cfg.ChainConfig, &cfg.EVMConfig)
 }

--- a/blockchain/vm/runtime/runtime.go
+++ b/blockchain/vm/runtime/runtime.go
@@ -52,6 +52,7 @@ type Config struct {
 	Debug       bool
 	EVMConfig   vm.Config
 	BaseFee     *big.Int
+	BlobBaseFee *big.Int
 	BlobHashes  []common.Hash
 
 	State     *state.StateDB
@@ -96,6 +97,9 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.BaseFee == nil {
 		cfg.BaseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
+	}
+	if cfg.BlobBaseFee == nil {
+		cfg.BlobBaseFee = new(big.Int)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

This PR implements BLOBBASEFEE.

For review, the geth implementation may be useful.
ref: https://github.com/ethereum/go-ethereum/pull/28098

Changes to the following files will be implemented during integration:
- state_processor.go (If we were to add a blob field to Kaia Receipt)
- state_transition.go

## Types of changes

<!-- Please put an x in the boxes related to your change. -->

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute
- [x] Lint and unit tests pass locally with my changes (`$ make test`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- #606 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
