### PR TITLE
github: Add write permission to CLA

### DIFF
--- a/.github/workflows/CLA.yml
+++ b/.github/workflows/CLA.yml
@@ -8,7 +8,7 @@ on:
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
   actions: write
-  contents: write # this can be 'read' if the signatures are in remote repository
+  contents: read # this can be 'read' if the signatures are in remote repository
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
## Proposed changes

Add write permission. Fixes [Resource not accessible by integration error](https://github.com/kaiachain/kaia/actions/runs/20126320122/job/58041238563).
See [issue](https://github.com/contributor-assistant/github-action/issues/130).

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [x] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)
