### PR TITLE
blockchain/vm: Refactor memory resize

### DIFF
--- a/blockchain/vm/memory.go
+++ b/blockchain/vm/memory.go
@@ -70,10 +70,14 @@ func (m *Memory) Increase(size uint64) {
 	m.store = append(m.store, make([]byte, size)...)
 }
 
-// Resize resizes the memory to size
+// Resize grows the memory to the requested size.
 func (m *Memory) Resize(size uint64) {
-	if uint64(m.Len()) < size {
-		m.store = append(m.store, make([]byte, size-uint64(m.Len()))...)
+	if uint64(len(m.store)) < size {
+		if uint64(cap(m.store)) >= size {
+			m.store = m.store[:size]
+		} else {
+			m.store = append(m.store, make([]byte, size-uint64(len(m.store)))...)
+		}
 	}
 }
 

--- a/blockchain/vm/memory_test.go
+++ b/blockchain/vm/memory_test.go
@@ -67,3 +67,10 @@ func TestMemoryCopy(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkResize(b *testing.B) {
+	memory := NewMemory()
+	for i := range b.N {
+		memory.Resize(uint64(i))
+	}
+}


### PR DESCRIPTION
## Proposed changes

This PR refactors memory resize to improve performance ([ref](/ethereum/go-ethereum/pull/33056))

```
goos: darwin
goarch: arm64
pkg: github.com/kaiachain/kaia/blockchain/vm
cpu: Apple M1 Max
          │ /tmp/old.txt │             /tmp/new.txt              │
          │    sec/op    │    sec/op      vs base                │
Resize-10   3.4645n ± 2%   0.7251n ± 38%  -79.07% (p=0.000 n=10)

          │ /tmp/old.txt │          /tmp/new.txt          │
          │     B/op     │    B/op     vs base            │
Resize-10     5.000 ± 0%   5.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

          │ /tmp/old.txt │          /tmp/new.txt          │
          │  allocs/op   │ allocs/op   vs base            │
Resize-10     0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
