### PR TITLE
kip279: Avoid unexpected panic when nil is given to CalcBlobFee

### DIFF
--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -68,7 +68,9 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	}
 
 	if header.ExcessBlobGas != nil {
-		blobBaseFee = eip4844.CalcBlobFee(header.BaseFee)
+		// Since CalcBlobFee returns nil for a nil baseFee,
+		// use baseFee instead of header.BaseFee to at least force blobBaseFee to zero in this context.
+		blobBaseFee = eip4844.CalcBlobFee(baseFee)
 	} else { // Before Osaka hardfork, BLOBBASEFEE (4a) returns 0
 		blobBaseFee = new(big.Int).SetUint64(params.ZeroBaseFee)
 	}

--- a/consensus/misc/eip4844/eip4844.go
+++ b/consensus/misc/eip4844/eip4844.go
@@ -178,6 +178,11 @@ func calcExcessBlobGas(isOsaka bool, bcfg *BlobConfig, parent *types.Header) uin
 
 // CalcBlobFee calculates the blobfee for KIP-279 from the header's base fee field.
 func CalcBlobFee(baseFee *big.Int) *big.Int {
+	// If baseFee is nil, CalcBlobFee will return nil as it cannot be calculated.
+	// Returning nil makes the difference from 0 explicit.
+	if baseFee == nil {
+		return nil
+	}
 	return new(big.Int).Mul(baseFee, new(big.Int).SetUint64(params.BlobBaseFeeMultiplier))
 }
 


### PR DESCRIPTION
## Proposed changes

If the node is not a consensus node, `header.BaseFee == nil` may be passed to `NewEVMBlockContext` by a worker process via `IstanbulEngine.Initialize`.
In this case, `CalcBlobFee` will now panic and pn and en will not start.

### Solution

This PR makes two corrections.

- `CalcBlobFee` returns nil if it receives nil.
  - This gives the caller a chance to realize that it has given a nil `baseFee` and avoids the panic caused by `new(big.Int).Mul`.
- In `NewEVMBlockContext`, use a `baseFee` of at least 0 as the argument to `CalcBlobFee` instead of `header.BaseFee`.
  - This is to eliminate the possibility of giving a nil opcode `BLOBBASEFEE`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
