### PR TITLE
chore: fix inconsistent comment in TestLRUShardCacheAddressKeyFromFront

### DIFF
--- a/storage/database/leveldb_bench_common_test.go
+++ b/storage/database/leveldb_bench_common_test.go
@@ -229,7 +229,7 @@ func TestLRUShardCacheAddressKey(t *testing.T) {
 	}
 }
 
-// TestLRUShardCacheHashKey is a test to check whether the add and get commands are working
+// TestLRUShardCacheAddressKeyFromFront is a test to check whether the add and get commands are working
 // when the Address created by SetBytesFromFront is used as key. Cache hit for all data.
 func TestLRUShardCacheAddressKeyFromFront(t *testing.T) {
 	cache := common.NewCache(common.LRUShardConfig{CacheSize: 40960, NumShards: 4096})


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The comment for TestLRUShardCacheAddressKeyFromFront was incorrectly labeled as TestLRUShardCacheHashKey. This has been corrected to accurately reflect the test's purpose, which is to verify LRU shard cache operations using Address keys created by SetBytesFromFront.



## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->




