### PR TITLE
Add clarifying provision sequence expectation in HolderVerifier

### DIFF
--- a/contracts/contracts/system_contracts/kaiabridge/HolderVerifier.sol
+++ b/contracts/contracts/system_contracts/kaiabridge/HolderVerifier.sol
@@ -117,7 +117,9 @@ contract HolderVerifier is Ownable, ReentrancyGuard, IHolderVerifier {
         require(currentBridge != address(0), "HolderVerifier: bridge not set");
 
         // NOTE: Using nextProvisionSeq + 1 may be seen counter-intuitive,
-        // but it's the operator's actual behavior.
+        // but Bridge.sol expects nextProvisionSeq + 1 in the new provision.
+        // Since HolderVerifier can execute the provision by itself,
+        // nextProvisionSeq should increment as soon as submitTransaction is finished
         uint64 bridgeSeq = IBridge(currentBridge).nextProvisionSeq();
         uint64 seq = bridgeSeq + 1;
 


### PR DESCRIPTION
## Proposed changes

- Add clarifying provision sequence expectation in HolderVerifier.sol
- Explain why nextProvisionSeq + 1 is used and that the seq advances after submitTransaction

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
