### PR TITLE
contract: HolderVerifier checks EIP-191/KIP-97 signed message

### DIFF
--- a/contracts/contracts/testing/kaiabridge/FnsaVerifyHarness.sol
+++ b/contracts/contracts/testing/kaiabridge/FnsaVerifyHarness.sol
@@ -19,7 +19,6 @@ pragma solidity ^0.8.24;
 
 import {FnsaVerify} from "../../system_contracts/kaiabridge/FnsaVerify.sol";
 
-
 contract FnsaVerifyHarness {
     function computeFnsaAddr(bytes calldata publicKey) external pure returns (string memory) {
         return FnsaVerify.computeFnsaAddr(publicKey);

--- a/contracts/test/KAIABridge/fnsaVerify.test.ts
+++ b/contracts/test/KAIABridge/fnsaVerify.test.ts
@@ -4,7 +4,7 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { ethers } from "hardhat";
 
 const { Wallet } = ethers;
-const { arrayify, concat, sha256, ripemd160, hashMessage, hexlify } = ethers.utils;
+const { concat, hashMessage, toUtf8Bytes, keccak256 } = ethers.utils;
 
 describe("Fnsa", function () {
   const mnemonic = "arena click issue slot sleep tag access exotic opera pattern code coral"; // randomly generated test wallet
@@ -12,7 +12,6 @@ describe("Fnsa", function () {
   const wallet = Wallet.fromMnemonic(mnemonic, path);
   const signingKey = wallet._signingKey();
   const walletPub = signingKey.publicKey; // 65-byte
-  const bech32Prefix = "link";
   const expectedFnsaAddr = "link19sl2wemng3ayh3uwuw2xvj6zsypzacz0e6cahc";
   const expectedValoperAddr = "linkvaloper19sl2wemng3ayh3uwuw2xvj6zsypzacz0tw6qet";
 
@@ -51,34 +50,62 @@ describe("Fnsa", function () {
   });
 
   it("on-chain: verify", async function () {
-    const message = "Hello, world!";
-    const messageHash = hashMessage(message);
+    const message = "kaiabridge" + wallet.address.toLowerCase();
+    const ethHash = ethers.utils.hashMessage(message);
     const sig = await wallet.signMessage(message);
 
     const { fnsa } = await loadFixture(deployFnsaFixture);
-    const verifiedAddr = await fnsa.verify(walletPub, expectedFnsaAddr, messageHash, sig);
+    const verifiedAddr = await fnsa.verify(walletPub, expectedFnsaAddr, ethHash, sig);
     expect(verifiedAddr).to.equal(wallet.address);
-    const verifiedValoper = await fnsa.verify(walletPub, expectedValoperAddr, messageHash, sig);
+    const verifiedValoper = await fnsa.verify(walletPub, expectedValoperAddr, ethHash, sig);
     expect(verifiedValoper).to.equal(wallet.address);
 
     // Detects mismatches
     const otherFnsaAddr = "link1lt90gyw368jj9h547ehe8v9t4cupcsca9g9wc6";
-    await expect(fnsa.verify(walletPub, otherFnsaAddr, messageHash, sig)).to.be.revertedWith("Invalid fnsa address");
+    await expect(fnsa.verify(walletPub, otherFnsaAddr, ethHash, sig)).to.be.revertedWith("Invalid fnsa address");
     const otherValoperAddr = "linkvaloper1lt90gyw368jj9h547ehe8v9t4cupcscm9yywa";
-    await expect(
-      fnsa.verify(walletPub, otherValoperAddr, messageHash, sig),
-    ).to.be.revertedWith("Invalid fnsa address");
+    await expect(fnsa.verify(walletPub, otherValoperAddr, ethHash, sig)).to.be.revertedWith("Invalid fnsa address");
 
+    // Signature mismatch (wrong message)
     const otherMessage = "Goodbye, world!";
-    const otherMessageHash = hashMessage(otherMessage);
-    await expect(
-      fnsa.verify(walletPub, expectedFnsaAddr, otherMessageHash, sig),
-    ).to.be.revertedWith("Invalid signature");
+    const otherSig = await wallet.signMessage(otherMessage);
+    await expect(fnsa.verify(walletPub, expectedFnsaAddr, ethHash, otherSig)).to.be.revertedWith(
+      "Invalid signature",
+    );
 
+    // Signature mismatch (wrong signer)
     const otherWallet = Wallet.createRandom();
-    const otherSig = await otherWallet.signMessage(message);
-    await expect(
-      fnsa.verify(walletPub, expectedFnsaAddr, messageHash, otherSig),
-    ).to.be.revertedWith("Invalid signature");
+    const otherSig2 = await otherWallet.signMessage(message);
+    await expect(fnsa.verify(walletPub, expectedFnsaAddr, ethHash, otherSig2)).to.be.revertedWith(
+      "Invalid signature",
+    );
+  });
+
+  it("on-chain: verify (Klaytn prefix)", async function () {
+    const message = "kaiabridge" + wallet.address.toLowerCase();
+    const klayPrefix = "\x19Klaytn Signed Message:\n52";
+    const klayHash = keccak256(concat([toUtf8Bytes(klayPrefix), toUtf8Bytes(message)]));
+    const sig = wallet._signingKey().signDigest(klayHash);
+    const sigSerialized = ethers.utils.joinSignature(sig);
+
+    const { fnsa } = await loadFixture(deployFnsaFixture);
+    const verifiedAddr = await fnsa.verify(walletPub, expectedFnsaAddr, klayHash, sigSerialized);
+    expect(verifiedAddr).to.equal(wallet.address);
+    const verifiedValoper = await fnsa.verify(walletPub, expectedValoperAddr, klayHash, sigSerialized);
+    expect(verifiedValoper).to.equal(wallet.address);
+  });
+
+  it("on-chain: verify with messageHash rejects mismatch", async function () {
+    const message = "kaiabridge" + wallet.address.toLowerCase();
+    const ethHash = ethers.utils.hashMessage(message);
+    const sig = await wallet.signMessage(message);
+    const wrongHash = keccak256(toUtf8Bytes("wrong"));
+
+    const { fnsa } = await loadFixture(deployFnsaFixture);
+    await expect(fnsa.verify(walletPub, expectedFnsaAddr, wrongHash, sig)).to.be.revertedWith(
+      "messageHash mismatch",
+    );
+
+    expect(await fnsa.verify(walletPub, expectedFnsaAddr, ethHash, sig)).to.equal(wallet.address);
   });
 });


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

- FnsaVerify verifies that the provided messageHash matches the on-chain "kaiabridge"+ethAddr EIP-191/KIP-97 hashes, then recovers the signer.
- Tests updated to pass explicit eth/klay messageHash and assert mismatch reverts.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

### Test
```
$ pwd
kaia/contracts
$ npx hardhat compile
$ npx hardhat test test/KAIABridge/fnsaVerify.test.ts
$ npx hardhat test test/KAIABridge/holderVerifier.test.ts
```