### PR TITLE
test: organize EEST block tests

### DIFF
--- a/blockchain/vm/errors.go
+++ b/blockchain/vm/errors.go
@@ -44,6 +44,7 @@ var (
 	ErrMaxCodeSizeExceeded   = errors.New("evm: max code size exceeded")
 	ErrInvalidJump           = errors.New("evm: invalid jump destination")
 	ErrInvalidCode           = errors.New("invalid code: must not begin with 0xef")
+	ErrNonceUintOverflow     = errors.New("nonce uint64 overflow")
 
 	// errStopToken is an internal token indicating interpreter loop termination,
 	// never returned to outside callers.

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -521,6 +521,10 @@ func (evm *EVM) create(caller types.ContractRef, codeAndHash *codeAndHash, gas u
 	if !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
 		return nil, common.Address{}, gas, ErrInsufficientBalance // TODO-Klaytn-Issue615
 	}
+	nonce := evm.StateDB.GetNonce(caller.Address())
+	if nonce+1 < nonce {
+		return nil, common.Address{}, gas, ErrNonceUintOverflow
+	}
 
 	// Increasing nonce since a failed tx with one of following error will be loaded on a block.
 	evm.StateDB.IncNonce(caller.Address())

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -58,90 +58,121 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	}
 	bt := new(testMatcher)
 
-	// TODO-Kaia: should remove these skip
-	// executing precompiled contracts with value transferring is not permitted
-	// https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/vm/evm.go#L268-L269
-	bt.skipLoad(`^frontier/opcodes/all_opcodes/all_opcodes.json`)
-	// "to" is address_0x0000000000000000000000000000000000000001: insertion error because precompiled contract address validation in TxInternalData#Validate
-	// https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/types/tx_internal_data_legacy.go#L365
-	bt.skipLoad(`^prague/eip7702_set_code_tx/set_code_txs_2/gas_diff_pointer_vs_direct_call.json`)
-	// "to" is address_0x0000000000000000000000000000000000000005: insertion error because precompiled contract address validation in TxInternalData#Validate
-	// https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/types/tx_internal_data_legacy.go#L365
-	bt.skipLoad(`^prague/eip7702_set_code_tx/set_code_txs_2/call_to_precompile_in_pointer_context.json/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py::test_call_to_precompile_in_pointer_context\[fork_Osaka-precompile_0x0000000000000000000000000000000000000005-\]`)
-	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/modexp_thresholds/modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[fork_Osaka-blockchain_test_from_state_test-exact_gas\]`)
-	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/modexp_thresholds/modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[fork_Osaka-blockchain_test_from_state_test-extra_gas\]`)
-	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/modexp_thresholds/modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[fork_Osaka-blockchain_test_from_state_test-insufficient_gas\]`)
-	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/test_modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[.*\]`)
-	// "to" is address_0x0000000000000000000000000000000000000100: insertion error because precompiled contract address validation in TxInternalData#Validate
-	// https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/types/tx_internal_data_legacy.go#L365
-	bt.skipLoad(`^osaka/eip7951_p256verify_precompiles/p256verify/precompile_as_tx_entry_point.json`)
-	bt.skipLoad(`^osaka/eip7951_p256verify_precompiles/test_precompile_will_return_success_with_tx_value.json`)
-	bt.skipLoad(`^osaka/eip7951_p256verify_precompiles/test_precompile_as_tx_entry_point.json`)
-	// "to" is address_0x000000000000000000000000000000000000000a: insertion error because precompiled contract address validation in TxInternalData#Validate
-	// https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/types/tx_internal_data_legacy.go#L365
-	bt.skipLoad(`^cancun/eip4844_blobs/test_tx_entry_point.json`)
-	bt.skipLoad(`^cancun/eip4844_blobs/point_evaluation_precompile/tx_entry_point.json`)
-
-	// tests to skip
-	// unsupported EIPs
+	// should be skipped
+	// note: Unsupported EIPs
 	bt.skipLoad(`^shanghai/eip4895_withdrawals/`)
 	bt.skipLoad(`^cancun/eip4788_beacon_root/`)
 	bt.skipLoad(`^prague/eip7251_consolidations`)
 	bt.skipLoad(`^prague/eip7685_general_purpose_el_requests`)
 	bt.skipLoad(`^prague/eip7002_el_triggerable_withdrawals`)
 	bt.skipLoad(`^prague/eip6110_deposits`)
-	// type 3 tx (EIP-4844) is not supported before Osaka. See tests/block_test_util.go:decode()
-	bt.skipLoad(`^cancun/eip4844_blobs/.*\[fork_(Cancun|Prague)`)
+	bt.skipLoad(`^osaka/eip7825_transaction_gas_limit_cap`)
+
+	// should be skipped
+	// note: Type 3 tx (EIP-4844) is not supported before Osaka. See tests/block_test_util.go:decode().
 	bt.skipLoad(`^static/state_tests/Cancun/stEIP4844_blobtransactions/.*\[fork_(Cancun|Prague)`)
-	bt.skipLoad(`^istanbul/eip1344_chainid/.*\[fork_(Cancun|Prague).*typed_transaction_3`)
-	bt.skipLoad(`^prague/eip7623_increase_calldata_cost/.*\[fork_(Cancun|Prague).*type_3`)
-	bt.skipLoad(`^prague/eip7623_increase_calldata_cost/test_transaction_validity_type_3.json/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py::test_transaction_validity_type_3\[fork_(Cancun|Prague)`)
-	// block RLP decoding failed when expected to succeed: failed to decode transaction: rlp: expected input list for types.TxInternalDataLegacy
-	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Cancun-blockchain_test-test_program_program_BLOBBASEFEE-debug\]`)
+	bt.skipLoad(`^static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhashOutOfRange.json/tests/static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhashOutOfRangeFiller.yml::opcodeBlobhashOutOfRange\[fork_Prague-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhashOutOfRange.json/tests/static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhashOutOfRangeFiller.yml::opcodeBlobhashOutOfRange\[fork_Cancun-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhBounds.json/tests/static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhBoundsFiller.yml::opcodeBlobhBounds\[fork_Prague-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhBounds.json/tests/static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhBoundsFiller.yml::opcodeBlobhBounds\[fork_Cancun-blockchain_test_from_state_test-\]`)
 	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Prague-blockchain_test-test_program_program_BLOBBASEFEE-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Osaka-blockchain_test-test_program_program_BLOBBASEFEE-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Cancun-blockchain_test-test_program_program_BLOBBASEFEE-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Prague-blockchain_test-test_program_program_BLOBBASEFEE-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Osaka-blockchain_test-test_program_program_BLOBBASEFEE-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Cancun-blockchain_test-program_BLOBBASEFEE-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Prague-blockchain_test-program_BLOBBASEFEE-debug\]`)
-	bt.skipLoad(`^frontier/validation/test_tx_gas_limit.json/tests/frontier/validation/test_transaction.py::test_tx_gas_limit\[fork_Cancun-`)
-	bt.skipLoad(`^istanbul/eip1344_chainid/test_chainid.json/tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid\[fork_Cancun-typed_transaction_3-blockchain_test_from_state_test\]`)
+	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Cancun-blockchain_test-test_program_program_BLOBBASEFEE-debug\]`)
 	bt.skipLoad(`^istanbul/eip1344_chainid/test_chainid.json/tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid\[fork_Prague-typed_transaction_3-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^istanbul/eip1344_chainid/test_chainid.json/tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid\[fork_Osaka-typed_transaction_3-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^prague/eip7623_increase_calldata_cost/.*type_3.*`)
-	bt.skipLoad(`^prague/eip7702_set_code_tx/test_eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Prague-tx_type_3-evm_code_type_LEGACY-blockchain_test-different_block\]`)
+	bt.skipLoad(`^istanbul/eip1344_chainid/test_chainid.json/tests/istanbul/eip1344_chainid/test_chainid.py::test_chainid\[fork_Cancun-typed_transaction_3-blockchain_test_from_state_test\]`)
+	bt.skipLoad(`^istanbul/eip1344_chainid/.*\[fork_(Cancun|Prague).*typed_transaction_3`)
+	bt.skipLoad(`^cancun/eip4844_blobs/.*\[fork_(Cancun|Prague)`)
 	bt.skipLoad(`^prague/eip7702_set_code_tx/test_eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Prague-tx_type_3-evm_code_type_LEGACY-blockchain_test-same_block\]`)
-	bt.skipLoad(`^prague/eip7702_set_code_tx/test_eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Osaka-tx_type_3-evm_code_type_LEGACY-blockchain_test-different_block\]`)
-	bt.skipLoad(`^prague/eip7702_set_code_tx/test_eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Osaka-tx_type_3-evm_code_type_LEGACY-blockchain_test-same_block\]`)
-	bt.skipLoad(`^prague/eip7702_set_code_tx/set_code_txs/eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Prague-tx_type_3-evm_code_type_LEGACY-blockchain_test-different_block\]`)
-	bt.skipLoad(`^prague/eip7702_set_code_tx/set_code_txs/eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Prague-tx_type_3-evm_code_type_LEGACY-blockchain_test-same_block\]`)
-	bt.skipLoad(`^prague/eip7702_set_code_tx/set_code_txs/eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Osaka-tx_type_3-evm_code_type_LEGACY-blockchain_test-different_block\]`)
-	bt.skipLoad(`^prague/eip7702_set_code_tx/set_code_txs/eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Osaka-tx_type_3-evm_code_type_LEGACY-blockchain_test-same_block\]`)
-	bt.skipLoad(`^osaka/eip7934_block_rlp_limit/max_block_rlp_size/block_rlp_size_at_limit_with_all_typed_transactions.json/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py::test_block_rlp_size_at_limit_with_all_typed_transactions\[fork_Osaka-typed_transaction_3-blockchain_test\]`)
-	bt.skipLoad(`^osaka/eip7934_block_rlp_limit/test_block_rlp_size_at_limit_with_all_typed_transactions.json/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py::test_block_rlp_size_at_limit_with_all_typed_transactions\[fork_Osaka-typed_transaction_3-blockchain_test\]`)
-	bt.skipLoad(`^static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhashOutOfRange.json/tests/static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhashOutOfRangeFiller.yml::opcodeBlobhashOutOfRange\[.*\]`)
-	bt.skipLoad(`^static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhBounds.json/tests/static/state_tests/Cancun/stEIP4844_blobtransactions/opcodeBlobhBoundsFiller.yml::opcodeBlobhBounds\[.*\]`)
-	// Kaia cannot calculate the same block hash as Ethereum
+	bt.skipLoad(`^prague/eip7702_set_code_tx/test_eoa_tx_after_set_code.json/tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_eoa_tx_after_set_code\[fork_Prague-tx_type_3-evm_code_type_LEGACY-blockchain_test-different_block\]`)
+	bt.skipLoad(`^prague/eip7623_increase_calldata_cost/test_transaction_validity_type_3.json/tests/prague/eip7623_increase_calldata_cost/test_transaction_validity.py::test_transaction_validity_type_3\[fork_(Cancun|Prague)`)
+	bt.skipLoad(`^prague/eip7623_increase_calldata_cost/.*type_3.*\[fork_Prague`)
+	bt.skipLoad(`^prague/eip7623_increase_calldata_cost/.*\[fork_(Cancun|Prague).*type_3`)
+
+	// should be skipped
+	// note: Kaia cannot calculate the same block hash as Ethereum.
 	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Cancun-blockchain_test-test_program_program_BLOCKHASH-debug\]`)
 	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Prague-blockchain_test-test_program_program_BLOCKHASH-debug\]`)
 	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Osaka-blockchain_test-test_program_program_BLOCKHASH-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Cancun-blockchain_test-test_program_program_BLOCKHASH-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Prague-blockchain_test-test_program_program_BLOCKHASH-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Osaka-blockchain_test-test_program_program_BLOCKHASH-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Cancun-blockchain_test-program_BLOCKHASH-debug\]`)
-	bt.skipLoad(`^frontier/scenarios/scenarios/scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios\[fork_Prague-blockchain_test-program_BLOCKHASH-debug\]`)
-	// Kaia's MaxBlockSize (10 MiB) higher than Ethereum's (8 MiB), so max_plus_1 is accepted in Kaia.
-	bt.skipLoad(`^osaka/eip7934_block_rlp_limit/max_block_rlp_size/block_at_rlp_size_limit_boundary.json/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py::test_block_at_rlp_size_limit_boundary\[fork_Osaka-blockchain_test-max_rlp_size_plus_1_byte\]`)
+
+	// should be skipped
+	// note: Kaia's MaxBlockSize (10 MiB) higher than Ethereum's (8 MiB), so max_plus_1 is accepted in Kaia.
 	bt.skipLoad(`^osaka/eip7934_block_rlp_limit/test_block_at_rlp_size_limit_boundary.json/tests/osaka/eip7934_block_rlp_limit/test_max_block_rlp_size.py::test_block_at_rlp_size_limit_boundary\[fork_Osaka-blockchain_test-max_rlp_size_plus_1_byte\]`)
 
-	// TODO: Skip EIP tests that are not yet supported; expect to remove them
-	bt.skipLoad(`osaka/eip7825_transaction_gas_limit_cap`)
-	// TODO: Investigate after all Osaka EIPs are applied
-	bt.skipLoad(`^frontier/identity_precompile/identity/call_identity_precompile.json/tests/frontier/identity_precompile/test_identity.py::test_call_identity_precompile\[fork_Osaka-blockchain_test_from_state_test-identity_1_nonzerovalue-call_type_CALL\]`)
+	// should be skipped
+	// note: Withdrawal (eip4895) is not supported.
+	bt.skipLoad(`^osaka/eip7934_block_rlp_limit/test_block_at_rlp_limit_with_withdrawals.json`)
 
-	// TODO: Investigate skip or ignore these tests
-	// block insertion should have failed
+	// should be skipped
+	// note: There are two causes of failure:
+	//   - Different amount of gas is consumed because 0x0b contract is added to access list by ActivePrecompiles although Cancun doesn't have it as a precompiled contract.
+	//     - See https://github.com/kaiachain/kaia/blob/a7cb0f8aef2ce813e7ceda38e38353d63437489d/blockchain/vm/contracts.go#L242-L250.
+	//   - Executing precompiled contracts with value transferring is not permitted
+	//     - See https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/vm/evm.go#L267-L270
+	// But the failure happens in only Cancun fork, so we can skip these.
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Cancun-blockchain_test_from_state_test-all_then_yes_from_prague\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Cancun-blockchain_test_from_state_test-all_then_yes_from_prague-15\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Cancun-blockchain_test_from_state_test-all_then_yes_from_prague-8\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Cancun-blockchain_test_from_state_test-yes.*\]`)
+
+	// should be skipped
+	// note: Different amount of gas is consumed because 0x0b contract is added to access list by ActivePrecompiles although Ethereum's Cancun fork doesn't have it as a precompiled contract.
+	// See https://github.com/kaiachain/kaia/blob/a7cb0f8aef2ce813e7ceda38e38353d63437489d/blockchain/vm/contracts.go#L242-L250.
+	// but the failure happens in only Cancun fork, so we can skip these.
+	bt.skipLoad(`^static/state_tests/stSpecialTest/failed_tx_xcf416c53_Paris.json/tests/static/state_tests/stSpecialTest/failed_tx_xcf416c53_ParisFiller.json::failed_tx_xcf416c53_Paris\[fork_Cancun-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^frontier/precompiles/test_precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-blockchain_test_from_state_test-31_bytes\]`)
+	bt.skipLoad(`^frontier/precompiles/test_precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-blockchain_test_from_state_test-32_bytes\]`)
+	bt.skipLoad(`^frontier/precompiles/test_precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-blockchain_test_from_state_test-empty_calldata\]`)
+	bt.skipLoad(`^frontier/precompiles/test_precompiles.json/tests/frontier/precompiles/test_precompiles.py::test_precompiles\[fork_Cancun-address_0x000000000000000000000000000000000000000b-precompile_exists_False-blockchain_test_from_state_test\]`)
+
+	// should be skipped
+	// note: Kaia's Cancun fork allow creating SCA with 0xEF code, but Ethereum's Cancun fork does not.
+	// See https://github.com/kaiachain/kaia/blob/e89d0fece3d9ca7428e8ba541afa6394074e8f85/blockchain/vm/evm.go#L588-L591.
+	bt.skipLoad(`^static/state_tests/stCreateTest/CreateTransactionRefundEF.json/tests/static/state_tests/stCreateTest/CreateTransactionRefundEFFiller.yml::CreateTransactionRefundEF\[fork_Cancun-blockchain_test_from_state_test-refund_EF\]`)
+	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create-0xef-v0\]`)
+	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create-0xef-v1\]`)
+	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create2-0xef-v0\]`)
+	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create2-0xef-v1\]`)
+	bt.skipLoad(`^static/state_tests/stCreateTest/CREATE2_RefundEF.json/tests/static/state_tests/stCreateTest/CREATE2_RefundEFFiller.yml::CREATE2_RefundEF\[fork_Cancun-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/stCreate2/CREATE2_FirstByte_loop.json/tests/static/state_tests/stCreate2/CREATE2_FirstByte_loopFiller.yml::CREATE2_FirstByte_loop\[fork_Cancun-blockchain_test_from_state_test-invalidByte\]`)
+	bt.skipLoad(`^frontier/create/test_create_one_byte.json/tests/frontier/create/test_create_one_byte.py::test_create_one_byte\[fork_Cancun-create_opcode_CREATE-evm_code_type_LEGACY-blockchain_test_from_state_test\]`)
+	bt.skipLoad(`^frontier/create/test_create_one_byte.json/tests/frontier/create/test_create_one_byte.py::test_create_one_byte\[fork_Cancun-create_opcode_CREATE2-evm_code_type_LEGACY-blockchain_test_from_state_test\]`)
+
+	// should be skipped
+	// note: Kaia's Cancun fork recognizes 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b as a contract (AccountKeyTypeFail).
+	// Kaia's after-Prague forks recognizes 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b as EOA with code (AccountKeyTypePublic).
+	// Sender cannot be a contract in Kaia. But the failure happens in only Cancun fork, so we can skip these.
+	bt.skipLoad(`^static/state_tests/stTransactionTest/Opcodes_TransactionInit.json/tests/static/state_tests/stTransactionTest/Opcodes_TransactionInitFiller.json::Opcodes_TransactionInit\[fork_Cancun-blockchain_test_from_state_test.*\]`)
+
+	// should be skipped
+	// note: `panic: can't encode object at ...: rlp: cannot encode negative big.Int` happens.
+	// But the failure happens in only Cancun fork, so we can skip these.
+	bt.skipLoad(`^static/state_tests/stEIP1559/lowGasPriceOldTypes.json/tests/static/state_tests/stEIP1559/lowGasPriceOldTypesFiller.yml::lowGasPriceOldTypes\[fork_Cancun-blockchain_test_from_state_test-`)
+	bt.skipLoad(`^static/state_tests/stEIP1559/lowFeeCap.json/tests/static/state_tests/stEIP1559/lowFeeCapFiller.yml::lowFeeCap\[fork_Cancun-blockchain_test_from_state_test-declaredKeyWrite\]`)
+	bt.skipLoad(`^frontier/validation/test_tx_gas_limit.json/tests/frontier/validation/test_transaction.py::test_tx_gas_limit\[fork_Cancun-`)
+
+	// should be resolved
+	// note: Executing precompiled contracts with value transferring is not permitted
+	// See https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/vm/evm.go#L267-L270
+	bt.skipLoad(`^frontier/opcodes/all_opcodes/all_opcodes.json`)
+
+	// should be resolved
+	// note: "to" is not allow to be a precompiled contract address.
+	// See https://github.com/kaiachain/kaia/blob/d44ae2f4269a84bd379b4e992d8e3be46b7e5ad3/blockchain/types/tx_internal_data_legacy.go#L365
+	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest642.json/tests/static/state_tests/stRandom2/randomStatetest642Filler.json::randomStatetest642\[.*\]`)
+	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest644.json/tests/static/state_tests/stRandom2/randomStatetest644Filler.json::randomStatetest644\[.*\]`)
+	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest645.json/tests/static/state_tests/stRandom2/randomStatetest645Filler.json::randomStatetest645\[.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/modexpRandomInput.json/tests/static/state_tests/stPreCompiledContracts2/modexpRandomInputFiller.json::modexpRandomInput\[.*\]`)
+	bt.skipLoad(`^cancun/eip4844_blobs/test_tx_entry_point.json`)
+	bt.skipLoad(`^prague/eip7702_set_code_tx/test_gas_diff_pointer_vs_direct_call.json/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py::test_gas_diff_pointer_vs_direct_call\[.*-pointer_definition_PointerDefinition`)
+	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/modexp_thresholds/modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[fork_Osaka-blockchain_test_from_state_test-exact_gas\]`)
+	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/modexp_thresholds/modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[fork_Osaka-blockchain_test_from_state_test-extra_gas\]`)
+	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/modexp_thresholds/modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[fork_Osaka-blockchain_test_from_state_test-insufficient_gas\]`)
+	bt.skipLoad(`^osaka/eip7883_modexp_gas_increase/test_modexp_used_in_transaction_entry_points.json/tests/osaka/eip7883_modexp_gas_increase/test_modexp_thresholds.py::test_modexp_used_in_transaction_entry_points\[.*\]`)
+	bt.skipLoad(`^osaka/eip7951_p256verify_precompiles/p256verify/precompile_as_tx_entry_point.json`)
+	bt.skipLoad(`^osaka/eip7951_p256verify_precompiles/test_precompile_will_return_success_with_tx_value.json`)
+	bt.skipLoad(`^osaka/eip7951_p256verify_precompiles/test_precompile_as_tx_entry_point.json`)
+
+	// should be resolved
+	// note: `block insertion should have failed` happens. Current tester cannot recognize invalid block header.
 	bt.skipLoad(`^frontier/validation/test_gas_limit_below_minimum.json/tests/frontier/validation/test_header.py::test_gas_limit_below_minimum\[fork_Cancun-`)
 	bt.skipLoad(`^frontier/validation/test_gas_limit_below_minimum.json/tests/frontier/validation/test_header.py::test_gas_limit_below_minimum\[fork_Prague-`)
 	bt.skipLoad(`^frontier/validation/test_gas_limit_below_minimum.json/tests/frontier/validation/test_header.py::test_gas_limit_below_minimum\[fork_Osaka-`)
@@ -155,106 +186,41 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 	bt.skipLoad(`^static/state_tests/stEIP1559/lowGasLimit.json/tests/static/state_tests/stEIP1559/lowGasLimitFiller.yml::lowGasLimit\[fork_Prague-blockchain_test_from_state_test--g0\]`)
 	bt.skipLoad(`^static/state_tests/stEIP1559/lowGasLimit.json/tests/static/state_tests/stEIP1559/lowGasLimitFiller.yml::lowGasLimit\[fork_Osaka-blockchain_test_from_state_test--g0\]`)
 	bt.skipLoad(`^static/state_tests/stEIP1559/tipTooHigh.json/tests/static/state_tests/stEIP1559/tipTooHighFiller.yml::tipTooHigh\[fork_Cancun-blockchain_test_from_state_test-declaredKeyWrite\]`)
-	// block #1 insertion into chain failed: the address is reserved for pre-compiled contracts
-	bt.skipLoad(`^prague/eip7702_set_code_tx/test_gas_diff_pointer_vs_direct_call.json/tests/prague/eip7702_set_code_tx/test_set_code_txs_2.py::test_gas_diff_pointer_vs_direct_call\[.*-pointer_definition_PointerDefinition`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest642.json/tests/static/state_tests/stRandom2/randomStatetest642Filler.json::randomStatetest642\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest644.json/tests/static/state_tests/stRandom2/randomStatetest644Filler.json::randomStatetest644\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest645.json/tests/static/state_tests/stRandom2/randomStatetest645Filler.json::randomStatetest645\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/modexpRandomInput.json/tests/static/state_tests/stPreCompiledContracts2/modexpRandomInputFiller.json::modexpRandomInput\[.*\]`)
-	// post state validation failed: account balance mismatch for addr
-	bt.skipLoad(`^frontier/identity_precompile/test_call_identity_precompile.json/tests/frontier/identity_precompile/test_identity.py::test_call_identity_precompile\[fork_Cancun-blockchain_test_from_state_test-identity_1_nonzerovalue-call_type_CALL\]`)
-	bt.skipLoad(`^frontier/identity_precompile/test_call_identity_precompile.json/tests/frontier/identity_precompile/test_identity.py::test_call_identity_precompile\[fork_Prague-blockchain_test_from_state_test-identity_1_nonzerovalue-call_type_CALL\]`)
-	bt.skipLoad(`^frontier/identity_precompile/test_call_identity_precompile.json/tests/frontier/identity_precompile/test_identity.py::test_call_identity_precompile\[fork_Osaka-blockchain_test_from_state_test-identity_1_nonzerovalue-call_type_CALL\]`)
-	bt.skipLoad(`^frontier/opcodes/test_all_opcodes.json/tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes\[fork_Cancun-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^frontier/opcodes/test_all_opcodes.json/tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes\[fork_Prague-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^frontier/opcodes/test_all_opcodes.json/tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes\[fork_Osaka-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^frontier/precompiles/precompile_absence/precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-`)
-	bt.skipLoad(`^frontier/precompiles/precompile_absence/precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Prague-`)
-	bt.skipLoad(`^frontier/precompiles/precompile_absence/precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Osaka-`)
-	bt.skipLoad(`^frontier/precompiles/test_precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Cancun-blockchain_test_from_state_test-`)
-	bt.skipLoad(`^frontier/precompiles/test_precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Prague-blockchain_test_from_state_test-`)
-	bt.skipLoad(`^frontier/precompiles/test_precompile_absence.json/tests/frontier/precompiles/test_precompile_absence.py::test_precompile_absence\[fork_Osaka-blockchain_test_from_state_test-`)
-	bt.skipLoad(`^frontier/precompiles/precompiles/precompiles.json/tests/frontier/precompiles/test_precompiles.py::test_precompiles\[fork_Cancun-address_0xb-precompile_exists_False-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^frontier/precompiles/test_precompiles.json/tests/frontier/precompiles/test_precompiles.py::test_precompiles\[fork_Cancun-address_0x000000000000000000000000000000000000000b-precompile_exists_False-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^frontier/create/test_create_one_byte.json/tests/frontier/create/test_create_one_byte.py::test_create_one_byte\[fork_Cancun-create_opcode_CREATE-evm_code_type_LEGACY-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^frontier/create/test_create_one_byte.json/tests/frontier/create/test_create_one_byte.py::test_create_one_byte\[fork_Cancun-create_opcode_CREATE2-evm_code_type_LEGACY-blockchain_test_from_state_test\]`)
-	bt.skipLoad(`^osaka/eip7934_block_rlp_limit/test_block_at_rlp_limit_with_withdrawals.json`)
+
+	// should be resolved
+	// note: `signal: killed` happens. It may be due to OOM. A lot of opcodes are executed in one transaction.
+	bt.skipLoad(`^static/state_tests/stStaticCall/`)
+
+	// should be resolved
+	// note: Executing precompiled contracts with value transferring is not permitted.
+	// See https://github.com/kaiachain/kaia/blob/a7cb0f8aef2ce813e7ceda38e38353d63437489d/blockchain/vm/evm.go#L281-L284.
 	bt.skipLoad(`^static/state_tests/stArgsZeroOneBalance/callNonConst.json/tests/static/state_tests/stArgsZeroOneBalance/callNonConstFiller.yml::callNonConst\[fork_Cancun-blockchain_test_from_state_test--v1\]`)
-	bt.skipLoad(`^static/state_tests/stArgsZeroOneBalance/callNonConst.json/tests/static/state_tests/stArgsZeroOneBalance/callNonConstFiller.yml::callNonConst\[fork_Prague-blockchain_test_from_state_test--v1\]`)
 	bt.skipLoad(`^static/state_tests/stArgsZeroOneBalance/callNonConst.json/tests/static/state_tests/stArgsZeroOneBalance/callNonConstFiller.yml::callNonConst\[fork_Osaka-blockchain_test_from_state_test--v1\]`)
+	bt.skipLoad(`^static/state_tests/stArgsZeroOneBalance/callNonConst.json/tests/static/state_tests/stArgsZeroOneBalance/callNonConstFiller.yml::callNonConst\[fork_Prague-blockchain_test_from_state_test--v1\]`)
+	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create-high-nonce-v1\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Cancun-blockchain_test_from_state_test-new.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Osaka-blockchain_test_from_state_test-all_then_yes_from_prague.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Osaka-blockchain_test_from_state_test-new.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Osaka-blockchain_test_from_state_test-yes.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Prague-blockchain_test_from_state_test-all_then_yes_from_prague.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Prague-blockchain_test_from_state_test-new.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[fork_Prague-blockchain_test_from_state_test-yes.*\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGas.json/tests/static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGasFiller.json::CallEcrecover0_NoGas\[fork_Cancun-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGas.json/tests/static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGasFiller.json::CallEcrecover0_NoGas\[fork_Osaka-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGas.json/tests/static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGasFiller.json::CallEcrecover0_NoGas\[fork_Prague-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValue.json/tests/static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValueFiller.json::CallSha256_1_nonzeroValue\[fork_Cancun-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValue.json/tests/static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValueFiller.json::CallSha256_1_nonzeroValue\[fork_Osaka-blockchain_test_from_state_test-\]`)
+	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValue.json/tests/static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValueFiller.json::CallSha256_1_nonzeroValue\[fork_Prague-blockchain_test_from_state_test-\]`)
 	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest650.json/tests/static/state_tests/stRandom2/randomStatetest650Filler.json::randomStatetest650\[fork_Cancun-blockchain_test_from_state_test-\]`)
 	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest650.json/tests/static/state_tests/stRandom2/randomStatetest650Filler.json::randomStatetest650\[fork_Prague-blockchain_test_from_state_test-\]`)
-	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValue.json/tests/static/state_tests/stPreCompiledContracts2/CallSha256_1_nonzeroValueFiller.json::CallSha256_1_nonzeroValue\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGas.json/tests/static/state_tests/stPreCompiledContracts2/CallEcrecover0_NoGasFiller.json::CallEcrecover0_NoGas\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stPreCompiledContracts/precompsEIP2929Cancun.json/tests/static/state_tests/stPreCompiledContracts/precompsEIP2929CancunFiller.yml::precompsEIP2929Cancun\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stSpecialTest/failed_tx_xcf416c53_Paris.json/tests/static/state_tests/stSpecialTest/failed_tx_xcf416c53_ParisFiller.json::failed_tx_xcf416c53_Paris\[fork_Cancun-blockchain_test_from_state_test-\]`)
-	// ------ added after enable blob tests
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest100.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest108.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest326.json/.*\[fork_(Cancun|Prague)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest163.json/.*\[fork_(Cancun|Prague)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest368.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest365.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest336.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest153.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest151.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest146.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest143.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest632.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest627.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest618.json/.*\[fork_(Cancun|Prague)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest542.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest506.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest456.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest417.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest415.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stSystemOperationsTest/testRandomTest.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stSystemOperationsTest/createWithInvalidOpcode.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^frontier/scenarios/test_scenarios.json/tests/frontier/scenarios/test_scenarios.py::test_scenarios[fork_(Cancun|Prague|Osaka)-blockchain_test-test_program_program_TIMESTAMP-debug]`)
-
-	// post state validation failed: account balance/nonce/code/storage mismatch
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateTransactionRefundEF.json/tests/static/state_tests/stCreateTest/CreateTransactionRefundEFFiller.yml::CreateTransactionRefundEF\[fork_Cancun-blockchain_test_from_state_test-refund_EF\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create-0xef-v0\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create-0xef-v1\]`)
 	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create-high-nonce-v0\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create-high-nonce-v1\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create2-0xef-v0\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Cancun-blockchain_test_from_state_test-create2-0xef-v1\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Osaka-blockchain_test_from_state_test-create-high-nonce-v0\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Osaka-blockchain_test_from_state_test-create-high-nonce-v1\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Prague-blockchain_test_from_state_test-create-high-nonce-v0\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CreateAddressWarmAfterFail.json/tests/static/state_tests/stCreateTest/CreateAddressWarmAfterFailFiller.yml::CreateAddressWarmAfterFail\[fork_Prague-blockchain_test_from_state_test-create-high-nonce-v1\]`)
-	bt.skipLoad(`^static/state_tests/stCreate2/CREATE2_HighNonce.json/tests/static/state_tests/stCreate2/CREATE2_HighNonceFiller.yml::CREATE2_HighNonce\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stCreate2/CREATE2_FirstByte_loop.json/tests/static/state_tests/stCreate2/CREATE2_FirstByte_loopFiller.yml::CREATE2_FirstByte_loop\[fork_Cancun-blockchain_test_from_state_test-invalidByte\]`)
-	bt.skipLoad(`^static/state_tests/stCreate2/CREATE2_HighNonceDelegatecall.json/tests/static/state_tests/stCreate2/CREATE2_HighNonceDelegatecallFiller.yml::CREATE2_HighNonceDelegatecall\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CREATE_HighNonce.json/tests/static/state_tests/stCreateTest/CREATE_HighNonceFiller.yml::CREATE_HighNonce\[.*\]`)
-	bt.skipLoad(`^static/state_tests/stCreateTest/CREATE2_RefundEF.json/tests/static/state_tests/stCreateTest/CREATE2_RefundEFFiller.yml::CREATE2_RefundEF\[.*\]`)
-	// ------ added after enable blob tests
-	bt.skipLoad(`^static/state_tests/stCallCreateCallCodeTest/createJS_ExampleContract.json/tests/static/state_tests/stCallCreateCallCodeTest/createJS_ExampleContractFiller.json::createJS_ExampleContract\[fork_(Cancun|Prague|Osaka)-blockchain_test_from_state_test-\]`)
-	bt.skipLoad(`^static/state_tests/stCallCreateCallCodeTest/createJS_NoCollision.json/tests/static/state_tests/stCallCreateCallCodeTest/createJS_NoCollisionFiller.json::createJS_NoCollision\[fork_(Cancun|Prague|Osaka)-blockchain_test_from_state_test-\]`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest578.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest466.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom2/randomStatetest435.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest325.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest308.json/.*\[fork_(Cancun|Prague)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest26.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest246.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest199.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest17.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest379.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/stRandom/randomStatetest349.json/.*\[fork_(Cancun|Prague|Osaka)`)
-	bt.skipLoad(`^static/state_tests/VMTests/vmTests/blockInfo.json/.*\[fork_(Cancun|Prague|Osaka)`)
-
-	// invalid sender: a legacy transaction must be with a legacy account key
-	bt.skipLoad(`^static/state_tests/stTransactionTest/Opcodes_TransactionInit.json`)
-	// panic: can't encode object at ...: rlp: cannot encode negative big.Int
-	bt.skipLoad(`^static/state_tests/stEIP1559/lowGasPriceOldTypes.json/tests/static/state_tests/stEIP1559/lowGasPriceOldTypesFiller.yml::lowGasPriceOldTypes\[fork_Cancun-blockchain_test_from_state_test-`)
-	bt.skipLoad(`^static/state_tests/stEIP1559/lowFeeCap.json/tests/static/state_tests/stEIP1559/lowFeeCapFiller.yml::lowFeeCap\[fork_Cancun-blockchain_test_from_state_test-declaredKeyWrite\]`)
-	// panic: runtime error: invalid memory address or nil pointer dereference
-	bt.skipLoad(`^istanbul/eip152_blake2/test_blake2b_gas_limit.json`)
-	bt.skipLoad(`^static/state_tests/stReturnDataTest/clearReturnBuffer.json`)
-	// signal: killed
-	bt.skipLoad(`^static/state_tests/stStaticCall/`)
+	bt.skipLoad(`^frontier/identity_precompile/test_call_identity_precompile.json/tests/frontier/identity_precompile/test_identity.py::test_call_identity_precompile\[fork_Cancun-blockchain_test_from_state_test-identity_1_nonzerovalue-call_type_CALL\]`)
+	bt.skipLoad(`^frontier/identity_precompile/test_call_identity_precompile.json/tests/frontier/identity_precompile/test_identity.py::test_call_identity_precompile\[fork_Osaka-blockchain_test_from_state_test-identity_1_nonzerovalue-call_type_CALL\]`)
+	bt.skipLoad(`^frontier/identity_precompile/test_call_identity_precompile.json/tests/frontier/identity_precompile/test_identity.py::test_call_identity_precompile\[fork_Prague-blockchain_test_from_state_test-identity_1_nonzerovalue-call_type_CALL\]`)
+	bt.skipLoad(`^frontier/opcodes/test_all_opcodes.json/tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes\[fork_Cancun-blockchain_test_from_state_test\]`)
+	bt.skipLoad(`^frontier/opcodes/test_all_opcodes.json/tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes\[fork_Osaka-blockchain_test_from_state_test\]`)
+	bt.skipLoad(`^frontier/opcodes/test_all_opcodes.json/tests/frontier/opcodes/test_all_opcodes.py::test_all_opcodes\[fork_Prague-blockchain_test_from_state_test\]`)
+	bt.skipLoad(`^frontier/precompiles/precompiles/precompiles.json/tests/frontier/precompiles/test_precompiles.py::test_precompiles\[fork_Cancun-address_0xb-precompile_exists_False-blockchain_test_from_state_test\]`)
 
 	bt.walk(t, executionSpecBlockTestDir, func(t *testing.T, name string, test *BlockTest) {
 		skipForks := []string{

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -432,6 +432,7 @@ func (t *BlockTest) insertBlocks(bc *blockchain.BlockChain, gBlock types.Block, 
 			b.SetRewardbase(common.Address(header.Coinbase))
 			b.SetMixHash(header.MixHash)
 			b.SetBaseFee(header.BaseFee)
+			b.SetTime(big.NewInt(int64(header.Time)))
 			if bc.Config().IsOsakaForkEnabled(header.Number) {
 				if header.ExcessBlobGas != nil {
 					b.SetExcessBlobGas(*header.ExcessBlobGas)


### PR DESCRIPTION
## Proposed changes

This PR organizes EEST block tests.

This contains the following change:

- enable eip 4844 tests
- organizing eest block tests: classify test cases into "should be skipped" and "should be resolved"
  - `should be skipped`: Kaia doesn't need to execute tests because of unsupported EIP, old fork tests and etc.
  - `should be resolved`: It's better to enable tests by modifying tester because of checking Ethereum compatibility.
  - added [reasons](https://github.com/ulbqb/kaia/blob/ab7c814b996e42257a4f48dedfb22fa0615db009/tests/block_test.go#L61-L223) why they should be skipped or resolved.
- main code fix: add validation to prevent overflow of nonce value on creating contract
- eest tester fix: set correct timestamp to block header

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
