### PR TITLE
console: Add blobrelated apis to web3ext

### DIFF
--- a/api/api_eth.go
+++ b/api/api_eth.go
@@ -1677,7 +1677,7 @@ func (api *EthAPI) GetBlobSidecars(ctx context.Context, number *rpc.BlockNumber,
 	return results, nil
 }
 
-func (api *EthAPI) GetBlobSidecarsByTxHash(ctx context.Context, txHash common.Hash, fullBlob bool) (*map[string]interface{}, error) {
+func (api *EthAPI) GetBlobSidecarByTxHash(ctx context.Context, txHash common.Hash, fullBlob bool) (*map[string]interface{}, error) {
 	tx, blockHash, number, index := api.kaiaBlockChainAPI.b.GetTxAndLookupInfo(txHash)
 	if tx == nil {
 		return nil, fmt.Errorf("transaction not found: %s", txHash.String())

--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -3661,7 +3661,7 @@ func TestEthAPI_GetBlobSidecarsByTxHash(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMock()
-			result, err := api.GetBlobSidecarsByTxHash(context.Background(), tc.txHash, tc.fullBlob)
+			result, err := api.GetBlobSidecarByTxHash(context.Background(), tc.txHash, tc.fullBlob)
 
 			if tc.expectedErr != "" {
 				require.Error(t, err)

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -194,6 +194,16 @@ web3._extend({
 			call: 'eth_blobBaseFee',
 			params: 0,
 		}),
+		new web3._extend.Method({
+			name: 'getBlobSidecars',
+			call: 'eth_getBlobSidecars',
+			params: 2,
+		}),
+		new web3._extend.Method({
+			name: 'getBlobSidecarByTxHash',
+			call: 'eth_getBlobSidecarByTxHash',
+			params: 2,
+		}),
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
## Proposed changes

Add `eth_getBlobSidecars` and `eth_getBlobSidecarByTxHash` to web3ext, which were added in #672.
This is a minor point, but the method name of eth_api was getBlobSidecar`s`ByTxHash, so I changed it to getBlobSidecarByTxHash.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- #606 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
