### PR TITLE
api: fix RpcMarshalBlobSidecar by using hexutil

### DIFF
--- a/api/api_eth.go
+++ b/api/api_eth.go
@@ -1677,7 +1677,7 @@ func (api *EthAPI) GetBlobSidecars(ctx context.Context, number *rpc.BlockNumber,
 	return results, nil
 }
 
-func (api *EthAPI) GetBlobSidecarsByTxHash(ctx context.Context, txHash common.Hash, fullBlob bool) (*map[string]interface{}, error) {
+func (api *EthAPI) GetBlobSidecarByTxHash(ctx context.Context, txHash common.Hash, fullBlob bool) (*map[string]interface{}, error) {
 	tx, blockHash, number, index := api.kaiaBlockChainAPI.b.GetTxAndLookupInfo(txHash)
 	if tx == nil {
 		return nil, fmt.Errorf("transaction not found: %s", txHash.String())
@@ -1713,9 +1713,9 @@ func (api *EthAPI) RpcMarshalBlobSidecar(sidecar *types.BlobTxSidecar, fullBlob 
 	result := make(map[string]interface{})
 	result["blobSidecar"] = sidecarMap
 	result["blockHash"] = blockHash
-	result["blockNumber"] = blockNumber
+	result["blockNumber"] = hexutil.Big(*blockNumber)
 	result["txHash"] = txHash
-	result["txIndex"] = txIndex
+	result["txIndex"] = hexutil.Uint(txIndex)
 	return &result
 }
 

--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -3338,9 +3338,9 @@ func TestEthAPI_GetBlobSidecars(t *testing.T) {
 				require.Len(t, results, 1)
 				result := *results[0]
 				assert.Equal(t, blockWithBlobTx.Hash(), result["blockHash"])
-				assert.Equal(t, big.NewInt(1), result["blockNumber"])
+				assert.Equal(t, hexutil.Big(*big.NewInt(1)), result["blockNumber"])
 				assert.Equal(t, blobTx.Hash(), result["txHash"])
-				assert.Equal(t, 0, result["txIndex"])
+				assert.Equal(t, hexutil.Uint(0), result["txIndex"])
 				sidecarResult := result["blobSidecar"].(map[string]interface{})
 				assert.Equal(t, types.BlobSidecarVersion1, byte(sidecarResult["version"].(uint8)))
 				blobs := sidecarResult["blobs"].([]kzg4844.Blob)
@@ -3402,7 +3402,7 @@ func TestEthAPI_GetBlobSidecars(t *testing.T) {
 				// First blob tx at index 0
 				result0 := *results[0]
 				assert.Equal(t, blobTx.Hash(), result0["txHash"])
-				assert.Equal(t, 0, result0["txIndex"])
+				assert.Equal(t, hexutil.Uint(0), result0["txIndex"])
 			},
 		},
 		{
@@ -3431,8 +3431,8 @@ func TestEthAPI_GetBlobSidecars(t *testing.T) {
 				require.Len(t, results, 1)
 				// Verify that only the first result is returned
 				result0 := *results[0]
-				assert.Equal(t, big.NewInt(4), result0["blockNumber"])
-				assert.Equal(t, 0, result0["txIndex"])
+				assert.Equal(t, hexutil.Big(*big.NewInt(4)), result0["blockNumber"])
+				assert.Equal(t, hexutil.Uint(0), result0["txIndex"])
 				sidecarResult := result0["blobSidecar"].(map[string]interface{})
 				assert.Equal(t, types.BlobSidecarVersion1, byte(sidecarResult["version"].(uint8)))
 			},
@@ -3471,7 +3471,7 @@ func TestEthAPI_GetBlobSidecars(t *testing.T) {
 				require.Len(t, results, 1)
 				result := *results[0]
 				assert.Equal(t, blockWithBlobTx.Hash(), result["blockHash"])
-				assert.Equal(t, big.NewInt(1), result["blockNumber"])
+				assert.Equal(t, hexutil.Big(*big.NewInt(1)), result["blockNumber"])
 				assert.Equal(t, blobTx.Hash(), result["txHash"])
 				sidecarResult := result["blobSidecar"].(map[string]interface{})
 				assert.Equal(t, types.BlobSidecarVersion1, byte(sidecarResult["version"].(uint8)))
@@ -3510,7 +3510,7 @@ func TestEthAPI_GetBlobSidecars(t *testing.T) {
 	}
 }
 
-func TestEthAPI_GetBlobSidecarsByTxHash(t *testing.T) {
+func TestEthAPI_GetBlobSidecarByTxHash(t *testing.T) {
 	mockCtrl, mockBackend, api := testInitForEthApi(t)
 	defer mockCtrl.Finish()
 
@@ -3604,9 +3604,9 @@ func TestEthAPI_GetBlobSidecarsByTxHash(t *testing.T) {
 					"proofs":      cellProofs,
 				},
 				"blockHash":   blockHash,
-				"blockNumber": blockNumber,
+				"blockNumber": hexutil.Big(*blockNumber),
 				"txHash":      blobTx.Hash(),
-				"txIndex":     txIndex,
+				"txIndex":     hexutil.Uint(txIndex),
 			},
 		},
 		{
@@ -3625,9 +3625,9 @@ func TestEthAPI_GetBlobSidecarsByTxHash(t *testing.T) {
 					"proofs":      cellProofs,
 				},
 				"blockHash":   blockHash,
-				"blockNumber": blockNumber,
+				"blockNumber": hexutil.Big(*blockNumber),
 				"txHash":      blobTx.Hash(),
-				"txIndex":     txIndex,
+				"txIndex":     hexutil.Uint(txIndex),
 			},
 		},
 		{
@@ -3661,7 +3661,7 @@ func TestEthAPI_GetBlobSidecarsByTxHash(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMock()
-			result, err := api.GetBlobSidecarsByTxHash(context.Background(), tc.txHash, tc.fullBlob)
+			result, err := api.GetBlobSidecarByTxHash(context.Background(), tc.txHash, tc.fullBlob)
 
 			if tc.expectedErr != "" {
 				require.Error(t, err)


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Bugfix the response format for `getBlobTxSidecars` API and `getBlobTxSidecarByTxHash` API
* `blockNumber` needs a hex string
* `txIndex` needs a hex string

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

- https://github.com/kaiachain/kaia/pull/672
- https://github.com/kaiachain/kaia/issues/606

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Duprecated update: https://github.com/kaiachain/kaia/pull/699 about `getBlobTxSidecarByTxHash`
