### PR TITLE
kaiax/auction: Prevent ECDSA malleability in bid signatures

### DIFF
--- a/kaiax/auction/bid.go
+++ b/kaiax/auction/bid.go
@@ -148,7 +148,7 @@ func getSigner(sig, digest []byte) (common.Address, error) {
 	v := copiedSig[crypto.RecoveryIDOffset]
 	r := new(big.Int).SetBytes(copiedSig[0:32])
 	s := new(big.Int).SetBytes(copiedSig[32:64])
-	if !crypto.ValidateSignatureValues(v, r, s, false) {
+	if !crypto.ValidateSignatureValues(v, r, s, true) {
 		return common.Address{}, ErrInvalidSignature
 	}
 


### PR DESCRIPTION
## Proposed changes

Do not allow upper range of ECDSA signature in Auction module. Please note that this has been already applied in auctioneer before and this PR is for consistency.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
