### PR TITLE
api: Make eth_config's response public

### DIFF
--- a/api/api_eth.go
+++ b/api/api_eth.go
@@ -1585,7 +1585,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 	}
 }
 
-type config struct {
+type Kip276Config struct {
 	// As mentioned in KIP-276, Kaia doesn't include ActivationTime as a field.
 	// ActivationTime  uint64                    `json:"activationTime"`
 	BlobSchedule    *params.BlobConfig        `json:"blobSchedule"`
@@ -1595,20 +1595,20 @@ type config struct {
 	SystemContracts map[string]common.Address `json:"systemContracts"`
 }
 
-type configResponse struct {
-	Current *config `json:"current"`
-	Next    *config `json:"next"`
-	Last    *config `json:"last"`
+type ConfigResponse struct {
+	Current *Kip276Config `json:"current"`
+	Next    *Kip276Config `json:"next"`
+	Last    *Kip276Config `json:"last"`
 }
 
 // Config implements the KIP-276(EIP-7910) eth_config method.
-func (api *EthAPI) Config(ctx context.Context) (*configResponse, error) {
+func (api *EthAPI) Config(ctx context.Context) (*ConfigResponse, error) {
 	b := api.kaiaBlockChainAPI.b
 	genesis, err := b.HeaderByNumber(ctx, 0)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load genesis: %w", err)
 	}
-	assemble := func(c *params.ChainConfig, head *big.Int) *config {
+	assemble := func(c *params.ChainConfig, head *big.Int) *Kip276Config {
 		if head == nil {
 			return nil
 		}
@@ -1622,7 +1622,7 @@ func (api *EthAPI) Config(ctx context.Context) (*configResponse, error) {
 		}
 
 		id := forkid.NewID(c, genesis.Hash(), head.Uint64()).Hash
-		return &config{
+		return &Kip276Config{
 			BlobSchedule:    c.BlobConfig(head),
 			ChainId:         (*hexutil.Big)(c.ChainID),
 			ForkId:          id[:],
@@ -1637,7 +1637,7 @@ func (api *EthAPI) Config(ctx context.Context) (*configResponse, error) {
 	currentForkCompatibleBlock := forkid.LatestForkCompatibleBlock(c, bn)
 	nextForkCompatibleBlock := forkid.NextForkCompatibleBlock(c, bn)
 	lastForkCompatibleBlock := forkid.LastForkCompatibleBlock(c)
-	resp := configResponse{
+	resp := ConfigResponse{
 		Next:    assemble(c, nextForkCompatibleBlock),
 		Current: assemble(c, currentForkCompatibleBlock),
 		Last:    assemble(c, lastForkCompatibleBlock),

--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -3091,28 +3091,28 @@ func TestEthAPI_Config(t *testing.T) {
 	tests := []struct {
 		name            string
 		blockNumber     uint64
-		expectedCurrent *config
-		expectedNext    *config
-		expectedLast    *config
+		expectedCurrent *Kip276Config
+		expectedNext    *Kip276Config
+		expectedLast    *Kip276Config
 	}{
 		{
 			name:        "Genesis block",
 			blockNumber: 0,
-			expectedCurrent: &config{
+			expectedCurrent: &Kip276Config{
 				BlobSchedule:    nil,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          genesisForkID[:],
 				Precompiles:     genesisPrecompiles,
 				SystemContracts: nil,
 			},
-			expectedNext: &config{
+			expectedNext: &Kip276Config{
 				BlobSchedule:    nil,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          istanbulForkID[:],
 				Precompiles:     istanbulPrecompiles,
 				SystemContracts: nil,
 			},
-			expectedLast: &config{
+			expectedLast: &Kip276Config{
 				BlobSchedule:    params.DefaultOsakaBlobConfig,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          osakaForkID[:],
@@ -3123,21 +3123,21 @@ func TestEthAPI_Config(t *testing.T) {
 		{
 			name:        "Istanbul block",
 			blockNumber: 75373312,
-			expectedCurrent: &config{
+			expectedCurrent: &Kip276Config{
 				BlobSchedule:    nil,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          istanbulForkID[:],
 				Precompiles:     istanbulPrecompiles,
 				SystemContracts: nil,
 			},
-			expectedNext: &config{
+			expectedNext: &Kip276Config{
 				BlobSchedule:    nil,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          lonondonForkID[:],
 				Precompiles:     lonondonPrecompiles,
 				SystemContracts: nil,
 			},
-			expectedLast: &config{
+			expectedLast: &Kip276Config{
 				BlobSchedule:    params.DefaultOsakaBlobConfig,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          osakaForkID[:],
@@ -3148,21 +3148,21 @@ func TestEthAPI_Config(t *testing.T) {
 		{
 			name:        "Prague fork block",
 			blockNumber: 187930000,
-			expectedCurrent: &config{
+			expectedCurrent: &Kip276Config{
 				BlobSchedule:    nil,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          pragueForkID[:],
 				Precompiles:     praguePrecompiles,
 				SystemContracts: nil,
 			},
-			expectedNext: &config{
+			expectedNext: &Kip276Config{
 				BlobSchedule:    params.DefaultOsakaBlobConfig,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          osakaForkID[:],
 				Precompiles:     osakaPrecompiles,
 				SystemContracts: nil,
 			},
-			expectedLast: &config{
+			expectedLast: &Kip276Config{
 				BlobSchedule:    params.DefaultOsakaBlobConfig,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          osakaForkID[:],
@@ -3173,7 +3173,7 @@ func TestEthAPI_Config(t *testing.T) {
 		{
 			name:        "Latest fork block (Osaka)",
 			blockNumber: 195000000,
-			expectedCurrent: &config{
+			expectedCurrent: &Kip276Config{
 				BlobSchedule:    params.DefaultOsakaBlobConfig,
 				ChainId:         (*hexutil.Big)(expectedChainConfig.ChainID),
 				ForkId:          osakaForkID[:],


### PR DESCRIPTION
## Proposed changes

eth_config is not currently registered in the APIs.

Each RPC is returned as a callback via `newCallback` by `suitableCallbacks`, but if `allExportedOrBuiltin` is false, it will be nil.
Therefore, the RPC will not be registered. To avoid this, make the return value of `EthAPI.Config` public.

https://github.com/kaiachain/kaia/blob/754e17e40d9ea420e35433faccffd5299e7c270b/networks/rpc/service.go#L136-L187

https://github.com/kaiachain/kaia/blob/754e17e40d9ea420e35433faccffd5299e7c270b/networks/rpc/service.go#L243-L262

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
