### PR TITLE
cmd/account: Allow v3 flag for account import

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -550,6 +550,16 @@ func (ks *KeyStore) ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (acco
 	return ks.importKey(key, passphrase)
 }
 
+func (ks *KeyStore) ImportECDSAV3(priv *ecdsa.PrivateKey, passphrase string) (accounts.Account, error) {
+	key := newKeyV3FromECDSA(priv)
+	ks.importMu.Lock()
+	defer ks.importMu.Unlock()
+	if ks.cache.hasAddress(key.GetAddress()) {
+		return accounts.Account{}, errors.New("account already exists")
+	}
+	return ks.importKey(key, passphrase)
+}
+
 func (ks *KeyStore) importKey(key Key, passphrase string) (accounts.Account, error) {
 	a := accounts.Account{Address: key.GetAddress(), URL: accounts.URL{Scheme: KeyStoreScheme, Path: ks.storage.JoinPath(keyFileName(key.GetAddress()))}}
 	if err := ks.storage.StoreKey(a.URL.Path, key, passphrase); err != nil {

--- a/cmd/utils/nodecmd/accountcmd.go
+++ b/cmd/utils/nodecmd/accountcmd.go
@@ -139,6 +139,7 @@ changing your password is only possible interactively.
 				utils.KeyStoreDirFlag,
 				utils.PasswordFileFlag,
 				utils.LightKDFFlag,
+				utils.KeyStoreV3Flag,
 			},
 			ArgsUsage: "<keyFile>",
 			Description: `
@@ -418,7 +419,12 @@ func accountImport(ctx *cli.Context) error {
 	passphrase := getPassPhrase("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-	acct, err := ks.ImportECDSA(key, passphrase)
+	var acct accounts.Account
+	if ctx.Bool(utils.KeyStoreV3Flag.Name) {
+		acct, err = ks.ImportECDSAV3(key, passphrase)
+	} else {
+		acct, err = ks.ImportECDSA(key, passphrase)
+	}
 	if err != nil {
 		log.Fatalf("Could not create the account: %v", err)
 	}


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This PR enables the `--v3` flag for `ken account import` command so that the imported account can be stored in v3 keystore format.

```
$ ken account import --v3 test-keyfile
...
$ cat UTC--2026-01-09T03-59-58.163658000Z--60de0c1187078952bae878157ea477ccc09c06e8
{"address":"60de0c1187078952bae878157ea477ccc09c06e8","crypto":{"cipher":"aes-128-ctr","ciphertext":"81c913a952c8226f536bc83096ec19780d0fb777dae8f79d33a1369c7fa03409","cipherparams":{"iv":"fcfe245e890597f62ae933404e0395a3"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"2f21410153cf0e42a340b509f42b21b89add4983f792a8f13853a054338d0913"},"mac":"5fd744df77a50cac7f214d76875f39e349caf996710e4a74c671a1a4497cb8ec"},"id":"ac41d721-8c19-4042-9c77-37145cd7bada","version":3}
$ rm UTC--2026-01-09T03-59-58.163658000Z--60de0c1187078952bae878157ea477ccc09c06e8
$ ken account import test-keyfile 
...
$ cat UTC--2026-01-09T04-03-31.229709000Z--60de0c1187078952bae878157ea477ccc09c06e8
{"address":"60de0c1187078952bae878157ea477ccc09c06e8","keyring":[[{"cipher":"aes-128-ctr","ciphertext":"bba7e1865d2ce4234d38387af5d137b4acb593876a6308f601fd17d672b3305b","cipherparams":{"iv":"a29d0ae4fcbf8ebbbec6e0c4af92ce75"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"87d16b2871682c2d99a084e436242bd47d433ba5e6c598ca7446241b4a0847e3"},"mac":"8f87497ad9d44017a1b0828263aa316576fefca5abb529bef68e41142a242c7e"}]],"id":"049c98af-c01f-4e54-b37d-bbc1384e1dbe","version":4}
```

The v3 and v4 keystore formats differ in the `version` value and in the presence of the `keyring` field.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
