### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/networks/p2p/simulations/adapters/inproc_test.go
+++ b/networks/p2p/simulations/adapters/inproc_test.go
@@ -88,7 +88,7 @@ func TestTCPPipeBidirections(t *testing.T) {
 		msgs := 50
 		size := 7
 		for i := 0; i < msgs; i++ {
-			msg := []byte(fmt.Sprintf("ping %02d", i))
+			msg := fmt.Appendf(nil, "ping %02d", i)
 
 			_, err := c1.Write(msg)
 			if err != nil {
@@ -98,7 +98,7 @@ func TestTCPPipeBidirections(t *testing.T) {
 		}
 
 		for i := 0; i < msgs; i++ {
-			expected := []byte(fmt.Sprintf("ping %02d", i))
+			expected := fmt.Appendf(nil, "ping %02d", i)
 
 			out := make([]byte, size)
 			_, err := c2.Read(out)
@@ -111,7 +111,7 @@ func TestTCPPipeBidirections(t *testing.T) {
 				t.Errorf("expected %#v, got %#v", out, expected)
 				return
 			} else {
-				msg := []byte(fmt.Sprintf("pong %02d", i))
+				msg := fmt.Appendf(nil, "pong %02d", i)
 				_, err := c2.Write(msg)
 				if err != nil {
 					t.Error(err)
@@ -121,7 +121,7 @@ func TestTCPPipeBidirections(t *testing.T) {
 		}
 
 		for i := 0; i < msgs; i++ {
-			expected := []byte(fmt.Sprintf("pong %02d", i))
+			expected := fmt.Appendf(nil, "pong %02d", i)
 
 			out := make([]byte, size)
 			_, err := c1.Read(out)
@@ -214,7 +214,7 @@ func TestNetPipeBidirections(t *testing.T) {
 		// netPipe is blocking, so writes are emitted asynchronously
 		go func() {
 			for i := 0; i < msgs; i++ {
-				msg := []byte(fmt.Sprintf(pingTemplate, i))
+				msg := fmt.Appendf(nil, pingTemplate, i)
 
 				_, err := c1.Write(msg)
 				if err != nil {
@@ -227,7 +227,7 @@ func TestNetPipeBidirections(t *testing.T) {
 		// netPipe is blocking, so reads for pong are emitted asynchronously
 		go func() {
 			for i := 0; i < msgs; i++ {
-				expected := []byte(fmt.Sprintf(pongTemplate, i))
+				expected := fmt.Appendf(nil, pongTemplate, i)
 
 				out := make([]byte, size)
 				_, err := c1.Read(out)
@@ -247,7 +247,7 @@ func TestNetPipeBidirections(t *testing.T) {
 
 		// expect to read pings, and respond with pongs to the alternate connection
 		for i := 0; i < msgs; i++ {
-			expected := []byte(fmt.Sprintf(pingTemplate, i))
+			expected := fmt.Appendf(nil, pingTemplate, i)
 
 			out := make([]byte, size)
 			_, err := c2.Read(out)
@@ -260,7 +260,7 @@ func TestNetPipeBidirections(t *testing.T) {
 				t.Errorf("expected %#v, got %#v", expected, out)
 				return
 			} else {
-				msg := []byte(fmt.Sprintf(pongTemplate, i))
+				msg := fmt.Appendf(nil, pongTemplate, i)
 
 				_, err := c2.Write(msg)
 				if err != nil {

--- a/snapshot/generate_test.go
+++ b/snapshot/generate_test.go
@@ -708,7 +708,7 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			acc, _ := genExternallyOwnedAccount(uint64(i), big.NewInt(int64(i)))
 			val, _ := rlp.EncodeToBytes(acc)
-			key := hashData([]byte(fmt.Sprintf("acc-%d", i)))
+			key := hashData(fmt.Appendf(nil, "acc-%d", i))
 			diskdb.WriteAccountSnapshot(key, val)
 		}
 	}

--- a/snapshot/iterator_test.go
+++ b/snapshot/iterator_test.go
@@ -352,27 +352,27 @@ func TestAccountIteratorTraversalValues(t *testing.T) {
 		h = make(map[common.Hash][]byte)
 	)
 	for i := byte(2); i < 0xff; i++ {
-		a[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 0, i))
+		a[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 0, i)
 		if i > 20 && i%2 == 0 {
-			b[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 1, i))
+			b[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 1, i)
 		}
 		if i%4 == 0 {
-			c[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 2, i))
+			c[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 2, i)
 		}
 		if i%7 == 0 {
-			d[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 3, i))
+			d[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 3, i)
 		}
 		if i%8 == 0 {
-			e[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 4, i))
+			e[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 4, i)
 		}
 		if i > 50 || i < 85 {
-			f[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 5, i))
+			f[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 5, i)
 		}
 		if i%64 == 0 {
-			g[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 6, i))
+			g[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 6, i)
 		}
 		if i%128 == 0 {
-			h[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 7, i))
+			h[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 7, i)
 		}
 	}
 	// Assemble a stack of snapshots from the account layers
@@ -451,27 +451,27 @@ func TestStorageIteratorTraversalValues(t *testing.T) {
 		h = make(map[common.Hash][]byte)
 	)
 	for i := byte(2); i < 0xff; i++ {
-		a[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 0, i))
+		a[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 0, i)
 		if i > 20 && i%2 == 0 {
-			b[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 1, i))
+			b[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 1, i)
 		}
 		if i%4 == 0 {
-			c[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 2, i))
+			c[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 2, i)
 		}
 		if i%7 == 0 {
-			d[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 3, i))
+			d[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 3, i)
 		}
 		if i%8 == 0 {
-			e[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 4, i))
+			e[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 4, i)
 		}
 		if i > 50 || i < 85 {
-			f[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 5, i))
+			f[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 5, i)
 		}
 		if i%64 == 0 {
-			g[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 6, i))
+			g[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 6, i)
 		}
 		if i%128 == 0 {
-			h[common.Hash{i}] = []byte(fmt.Sprintf("layer-%d, key %d", 7, i))
+			h[common.Hash{i}] = fmt.Appendf(nil, "layer-%d, key %d", 7, i)
 		}
 	}
 	// Assemble a stack of snapshots from the account layers


### PR DESCRIPTION
## Proposed changes

I modified the return statement to utilize fmt.Appendf instead of fmt.Sprintf for creating the formatted byte slice.

The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.

More info can see https://github.com/golang/go/issues/47579


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
