### PR TITLE
revert #608 govParamSet cache

### DIFF
--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"math/big"
 	"reflect"
-	"slices"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -170,14 +169,12 @@ func prefixedRlpHash(prefix byte, x interface{}) (h common.Hash) {
 // EmptyBody returns true if there is no additional 'body' to complete the header
 // that is: no transactions.
 func (h *Header) EmptyBody() bool {
-	// Avoid derivesha.GetType() during header-only paths; compare against all known empty roots
-	return slices.Contains(EmptyRootHashes, h.TxHash)
+	return h.TxHash == GetEmptyRootHash(h.Number)
 }
 
 // EmptyReceipts returns true if there are no receipts for this header/block.
 func (h *Header) EmptyReceipts() bool {
-	// Avoid derivesha.GetType() during header-only paths; compare against all known empty roots
-	return slices.Contains(EmptyRootHashes, h.ReceiptHash)
+	return h.ReceiptHash == GetEmptyRootHash(h.Number)
 }
 
 // Body is a simple (mutable, non-safe) data container for storing and moving

--- a/blockchain/types/derive_sha.go
+++ b/blockchain/types/derive_sha.go
@@ -60,9 +60,6 @@ var (
 	// Empty TransactionRoot and ReceiptsRoot for the Concat algorithm.
 	EmptyTxRootConcat = EmptyCodeHash
 
-	// All known empty hashes to check for empty body or empty receipts.
-	EmptyRootHashes = []common.Hash{EmptyRootHash, EmptyCodeHash}
-
 	////////////////////////////////
 
 	// DeriveSha and EmptyRootHash are populated by derivesha.InitDeriveSha().

--- a/kaiax/gov/contractgov/impl/error.go
+++ b/kaiax/gov/contractgov/impl/error.go
@@ -6,9 +6,8 @@ import (
 )
 
 var (
-	ErrNotReady         = errors.New("ContractEngine is not ready")
-	ErrStorageRootEmpty = errors.New("Storage root of GovParam contract is empty")
-	ErrHeaderGovFail    = errors.New("headerGov GetParamSet() failed")
+	ErrNotReady      = errors.New("ContractEngine is not ready")
+	ErrHeaderGovFail = errors.New("headerGov GetParamSet() failed")
 )
 
 func errInitNil(msg string) error {

--- a/kaiax/gov/contractgov/impl/getter.go
+++ b/kaiax/gov/contractgov/impl/getter.go
@@ -63,44 +63,7 @@ func (c *contractGovModule) contractGetAllParamsAtFromAddr(blockNum uint64, addr
 		return nil, ErrNotReady
 	}
 
-	// Get storage root for this contract at the latest state
-	storageRoot := c.getStorageRootHash(addr)
-	if common.EmptyHash(storageRoot) {
-		return nil, ErrStorageRootEmpty
-	}
-
-	// Create composite cache key: contract address + storage root (64 bytes)
-	var cacheKey [64]byte
-	copy(cacheKey[:32], addr.Hash().Bytes())
-	copy(cacheKey[32:], storageRoot.Bytes())
-
-	// Try to get from cache first
-	c.cacheMutex.RLock()
-	if cached, exists := c.paramSetCache.Get(cacheKey); exists {
-		c.cacheMutex.RUnlock()
-		cacheHits.Inc(1) // Cache hit
-		return cached, nil
-	}
-	cacheMisses.Inc(1) // Cache miss
-	c.cacheMutex.RUnlock()
-
-	// compute the result
-	result, err := c.computeContractParams(blockNum, addr)
-	if err != nil {
-		return nil, err
-	}
-
-	// Store in cache
-	c.cacheMutex.Lock()
-	c.paramSetCache.Add(cacheKey, result)
-	c.cacheMutex.Unlock()
-
-	return result, nil
-}
-
-// computeContractParams computes the contract parameters without caching
-func (c *contractGovModule) computeContractParams(blockNum uint64, addr common.Address) (gov.PartialParamSet, error) {
-	caller := backends.NewBlockchainContractBackend(c.Chain, nil, nil)
+	caller := backends.NewBlockchainContractBackend(chain, nil, nil)
 	contract, err := govcontract.NewGovParamCaller(addr, caller)
 	if err != nil {
 		return nil, err
@@ -124,18 +87,6 @@ func (c *contractGovModule) computeContractParams(blockNum uint64, addr common.A
 func (c *contractGovModule) contractAddrAt(blockNum uint64) (common.Address, error) {
 	headerParams := c.Hgm.GetParamSet(blockNum)
 	return headerParams.GovParamContract, nil
-}
-
-// getStorageRootHash computes the storage root for the ContractGov contract at the latest state
-func (c *contractGovModule) getStorageRootHash(contractAddr common.Address) common.Hash {
-	state, err := c.Chain.State()
-	if err != nil {
-		logger.Error("Failed to get the latest state", "err", err)
-		return common.Hash{}
-	}
-
-	// Get the storage root for the specific contract
-	return state.GetStorageRoot(contractAddr)
 }
 
 func ParseContractCall(names []string, values [][]byte) gov.PartialParamSet {

--- a/kaiax/gov/contractgov/impl/init.go
+++ b/kaiax/gov/contractgov/impl/init.go
@@ -1,26 +1,17 @@
 package impl
 
 import (
-	"sync"
-
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/kaiachain/kaia/consensus"
-	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/contractgov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
-	"github.com/rcrowley/go-metrics"
 )
 
 var (
 	_ contractgov.ContractGovModule = (*contractGovModule)(nil)
 
 	logger = log.NewModuleLogger(log.KaiaxGov)
-
-	// Cache metrics
-	cacheHits   = metrics.NewRegisteredCounter("gov/contractgov/cache/hits", nil)
-	cacheMisses = metrics.NewRegisteredCounter("gov/contractgov/cache/misses", nil)
 )
 
 type chain interface {
@@ -35,17 +26,10 @@ type InitOpts struct {
 
 type contractGovModule struct {
 	InitOpts
-
-	// Cache for parameter sets by contract address + storage root
-	paramSetCache *lru.Cache[[64]byte, gov.PartialParamSet] // contract addr + storage root -> param set
-	cacheMutex    sync.RWMutex
 }
 
 func NewContractGovModule() *contractGovModule {
-	paramCache, _ := lru.New[[64]byte, gov.PartialParamSet](100) // Cache up to 100 different storage roots
-	return &contractGovModule{
-		paramSetCache: paramCache,
-	}
+	return &contractGovModule{}
 }
 
 func (c *contractGovModule) Init(opts *InitOpts) error {


### PR DESCRIPTION
## Proposed changes
This PR reverts https://github.com/kaiachain/kaia/pull/608 since there's a problem in reading contract govParam.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
