### PR TITLE
fix: set default VRankLogFrequency to 60

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2050,7 +2050,7 @@ var (
 	VRankLogFrequencyFlag = &cli.Uint64Flag{
 		Name:     "vrank.log-frequency",
 		Usage:    "Frequency of VRank logging in blocks (0=disabled, 1=every block, 60=every 60 blocks, ...)",
-		Value:    uint64(0),
+		Value:    uint64(60),
 		Category: "VRANK",
 	}
 

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -47,7 +47,7 @@ var (
 	vrankAvgCommitArrivalTimeWithinQuorumGauge = metrics.NewRegisteredGauge("vrank/avg_commit_within_quorum", nil)
 	vrankLastCommitArrivalTimeGauge            = metrics.NewRegisteredGauge("vrank/last_commit", nil)
 
-	VRankLogFrequency = uint64(0) // Will be set to the value of VRankLogFrequencyFlag in SetKaiaConfig()
+	VRankLogFrequency = uint64(60) // Will be set to the value of VRankLogFrequencyFlag in SetKaiaConfig()
 
 	Vrank *vrank
 )


### PR DESCRIPTION
## Proposed changes

Sets the default VRank logging frequency from 0 (disabled) to 60 (every 60 blocks). This enables VRank logging by default with a reasonable frequency across both the flag definition and variable initialization.

## Types of changes

- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 🟢 Lint and unit tests pass locally with my changes