### PR TITLE
core/vrank: update default vrank log frequency

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul/core"
 	"github.com/kaiachain/kaia/datasync/chaindatafetcher"
 	"github.com/kaiachain/kaia/datasync/chaindatafetcher/kafka"
 	"github.com/kaiachain/kaia/datasync/dbsyncer"
@@ -2050,7 +2051,7 @@ var (
 	VRankLogFrequencyFlag = &cli.Uint64Flag{
 		Name:     "vrank.log-frequency",
 		Usage:    "Frequency of VRank logging in blocks (0=disabled, 1=every block, 60=every 60 blocks, ...)",
-		Value:    uint64(0),
+		Value:    core.DefaultVRankLogFrequency,
 		Category: "VRANK",
 	}
 

--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -39,6 +39,10 @@ type vrank struct {
 	commitArrivalTimeMap  map[common.Address]time.Duration
 }
 
+const (
+	DefaultVRankLogFrequency = uint64(60)
+)
+
 var (
 	// VRank metrics
 	vrankFirstPreprepareArrivalTimeGauge       = metrics.NewRegisteredGauge("vrank/first_preprepare", nil)
@@ -47,7 +51,7 @@ var (
 	vrankAvgCommitArrivalTimeWithinQuorumGauge = metrics.NewRegisteredGauge("vrank/avg_commit_within_quorum", nil)
 	vrankLastCommitArrivalTimeGauge            = metrics.NewRegisteredGauge("vrank/last_commit", nil)
 
-	VRankLogFrequency = uint64(0) // Will be set to the value of VRankLogFrequencyFlag in SetKaiaConfig()
+	VRankLogFrequency = DefaultVRankLogFrequency // Will be set to the value of VRankLogFrequencyFlag in SetKaiaConfig()
 
 	Vrank *vrank
 )


### PR DESCRIPTION
## Proposed changes

This PR changes the default vrank log frequnecy to 60 block (around 60s). To disable the log, we can set `vrank.log-frequency 0`.

```
// with default log frequency
WARN[01/16,15:31:39 +09] [25|consensus/istanbul/core/vrank.go:134]       VRank                                     seq=300 round=0 preprepareArrivalTime=2 commitArrivalTimes=[8]
```

```
// with --vrank.log-frequency 10
WARN[01/16,15:32:16 +09] [25|consensus/istanbul/core/vrank.go:134]       VRank                                     seq=310 round=0 preprepareArrivalTime=3 commitArrivalTimes=[6]
```

```
// with --vrank.log-frequency 0
15:33:25 +09] [51|work/worker.go:683]                         Commit new mining work                    number=360 hash=a50137…8f21f1 txs=0 elapsed=1.959ms    commitTime=1.806ms   finalizeTime=148.291µs
INFO[01/16,15:33:25 +09] [25|consensus/istanbul/core/prepare.go:90]      received a quorum of the messages and change state to prepared  msgType=1 prepareMsgNum=1 commitMsgNum=0 valSet=1
INFO[01/16,15:33:25 +09] [24|consensus/istanbul/backend/backend.go:296]  Committed                                 number=360 hash=2e5e0e…b0eb15 address=0x807771489e5cd2e9bCec3a95068e9e883C1F1515
INFO[01/16,15:33:25 +09] [51|work/agent.go:119]                          Successfully sealed new block             number=360 hash=2e5e0e…b0eb15
INFO[01/16,15:33:25 +09] [51|work/worker.go:487]                         Successfully wrote mined block            num=360 hash=2e5e0e…b0eb15 txs=0 elapsed=410.584µs
INFO[01/16,15:33:26 +09] [51|work/worker.go:683]                         Commit new mining work                    number=361 hash=6f5a5a…4b1fec txs=0 elapsed=2.479ms    commitTime=2.287ms   finalizeTime=186.417µs
INFO[01/16,15:33:26 +09] [25|consensus/istanbul/core/prepare.go:90]      received a quorum of the messages and change state to prepared  msgType=1 prepareMsgNum=1 commitMsgNum=0 valSet=1
INFO[01/16,15:33:26 +09] [24|consensus/istanbul/backend/backend.go:296]  Committed                                 number=361 hash=13a009…07e9a2 address=0x807771489e5cd2e9bCec3a95068e9e883C1F1515
INFO[01/16,15:33:26 +09] [51|work/agent.go:119]                          Successfully sealed new block             number=361 hash=13a009…07e9a2
INFO[01/16,15:33:26 +09] [51|work/worker.go:487]                         Successfully wrote mined block            num=361 hash=13a009…07e9a2 txs=0 elapsed=444.791µs
```

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
