### PR TITLE
params: Set Kairos Osaka hardfork number

### DIFF
--- a/blockchain/forkid/forkid_test.go
+++ b/blockchain/forkid/forkid_test.go
@@ -84,8 +84,9 @@ func TestCreation(t *testing.T) {
 				{156659999, ID{Hash: checksumToBytes(0x897592ea), Next: 156660000}}, // Last Cancun+Randao block
 				{156660000, ID{Hash: checksumToBytes(0xf00fbab3), Next: 187930000}}, // First Kaia+Kip160 block
 				{187929999, ID{Hash: checksumToBytes(0xf00fbab3), Next: 187930000}}, // Last Kaia+Kip160 block
-				{187930000, ID{Hash: checksumToBytes(0x0d29cd98), Next: 0}},         // First Prague block
-				{198978293, ID{Hash: checksumToBytes(0x0d29cd98), Next: 0}},         // Last Prague block
+				{187930000, ID{Hash: checksumToBytes(0x0d29cd98), Next: 209134000}}, // First Prague block
+				{209133999, ID{Hash: checksumToBytes(0x0d29cd98), Next: 209134000}}, // Last Prague block
+				{209134000, ID{Hash: checksumToBytes(0xb028792b), Next: 0}},         // First Osaka block
 			},
 		},
 	}
@@ -130,17 +131,18 @@ func TestCheckForkCompatibleBlock(t *testing.T) {
 		{
 			params.KairosChainConfig,
 			[]testcase{
-				{0, expectedNums{big.NewInt(0), big.NewInt(75373312), big.NewInt(187930000)}},                  // head is Genesis block
-				{75373312, expectedNums{big.NewInt(75373312), big.NewInt(80295291), big.NewInt(187930000)}},    // head is Istanbul block
-				{80295291, expectedNums{big.NewInt(80295291), big.NewInt(86513895), big.NewInt(187930000)}},    // head is London block
-				{86513895, expectedNums{big.NewInt(86513895), big.NewInt(98347376), big.NewInt(187930000)}},    // head is EthTxType block
-				{98347376, expectedNums{big.NewInt(98347376), big.NewInt(111736800), big.NewInt(187930000)}},   // head is Magma block
-				{111736800, expectedNums{big.NewInt(111736800), big.NewInt(119145600), big.NewInt(187930000)}}, // head is Kore block
-				{119145600, expectedNums{big.NewInt(119145600), big.NewInt(131608000), big.NewInt(187930000)}}, // head is Kip103 block
-				{131608000, expectedNums{big.NewInt(131608000), big.NewInt(141367000), big.NewInt(187930000)}}, // head is Shanghai block
-				{141367000, expectedNums{big.NewInt(141367000), big.NewInt(156660000), big.NewInt(187930000)}}, // head is Cancun+Randao block
-				{156660000, expectedNums{big.NewInt(156660000), big.NewInt(187930000), big.NewInt(187930000)}}, // head is Kaia+Kip160 block
-				{187930000, expectedNums{big.NewInt(187930000), nil, big.NewInt(187930000)}},                   // head is Prague block
+				{0, expectedNums{big.NewInt(0), big.NewInt(75373312), big.NewInt(209134000)}},                  // head is Genesis block
+				{75373312, expectedNums{big.NewInt(75373312), big.NewInt(80295291), big.NewInt(209134000)}},    // head is Istanbul block
+				{80295291, expectedNums{big.NewInt(80295291), big.NewInt(86513895), big.NewInt(209134000)}},    // head is London block
+				{86513895, expectedNums{big.NewInt(86513895), big.NewInt(98347376), big.NewInt(209134000)}},    // head is EthTxType block
+				{98347376, expectedNums{big.NewInt(98347376), big.NewInt(111736800), big.NewInt(209134000)}},   // head is Magma block
+				{111736800, expectedNums{big.NewInt(111736800), big.NewInt(119145600), big.NewInt(209134000)}}, // head is Kore block
+				{119145600, expectedNums{big.NewInt(119145600), big.NewInt(131608000), big.NewInt(209134000)}}, // head is Kip103 block
+				{131608000, expectedNums{big.NewInt(131608000), big.NewInt(141367000), big.NewInt(209134000)}}, // head is Shanghai block
+				{141367000, expectedNums{big.NewInt(141367000), big.NewInt(156660000), big.NewInt(209134000)}}, // head is Cancun+Randao block
+				{156660000, expectedNums{big.NewInt(156660000), big.NewInt(187930000), big.NewInt(209134000)}}, // head is Kaia+Kip160 block
+				{187930000, expectedNums{big.NewInt(187930000), big.NewInt(209134000), big.NewInt(209134000)}}, // head is Prague block
+				{209134000, expectedNums{big.NewInt(209134000), nil, big.NewInt(209134000)}},                   // head is Osaka block
 			},
 		},
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -112,7 +112,7 @@ var (
 		},
 		KaiaCompatibleBlock:   big.NewInt(156660000),
 		PragueCompatibleBlock: big.NewInt(187930000),
-		OsakaCompatibleBlock:  nil, // TODO-kaia-osaka: set Kairos' OsakaCompatibleBlock
+		OsakaCompatibleBlock:  big.NewInt(209134000),
 		// Optional forks
 		Kip103CompatibleBlock: big.NewInt(119145600),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),


### PR DESCRIPTION
## Proposed changes

- Set Kairos OsakaCompatibleBlock = 209134000 ([2026.02.11 10:30 UTC+9](https://kairos.kaiascan.io/block/209134000?tabId=blockTransactions&page=1), Wednesday morning)

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
