### PR TITLE
params: Set version to v2.2.1 and Mainnet Osaka block number

### DIFF
--- a/blockchain/forkid/forkid_test.go
+++ b/blockchain/forkid/forkid_test.go
@@ -55,8 +55,10 @@ func TestCreation(t *testing.T) {
 				{162900479, ID{Hash: checksumToBytes(0x75771543), Next: 162900480}}, // Last Cancun+Randao block
 				{162900480, ID{Hash: checksumToBytes(0x3ab6dcda), Next: 190670000}}, // First Kaia+Kip160 block
 				{190669999, ID{Hash: checksumToBytes(0x3ab6dcda), Next: 190670000}}, // Last Kaia+Kip160 block
-				{190670000, ID{Hash: checksumToBytes(0xc00bab0e), Next: 0}},         // First Prague block
-				{198489578, ID{Hash: checksumToBytes(0xc00bab0e), Next: 0}},         // Today Prague block
+				{190670000, ID{Hash: checksumToBytes(0xc00bab0e), Next: 211090000}}, // First Prague block
+				{211089999, ID{Hash: checksumToBytes(0xc00bab0e), Next: 211090000}}, // Last Prague block
+				{211090000, ID{Hash: checksumToBytes(0x8322a580), Next: 0}},         // First Osaka block
+				{198489578, ID{Hash: checksumToBytes(0xc00bab0e), Next: 211090000}}, // Today Prague block
 			},
 		},
 		// Kairos test cases
@@ -117,14 +119,15 @@ func TestCheckForkCompatibleBlock(t *testing.T) {
 		{
 			params.MainnetChainConfig,
 			[]testcase{
-				{0, expectedNums{big.NewInt(0), big.NewInt(86816005), big.NewInt(190670000)}},                  // head is Genesis block
-				{86816005, expectedNums{big.NewInt(86816005), big.NewInt(99841497), big.NewInt(190670000)}},    // head is Istanbul+London+EthTxType block
-				{99841497, expectedNums{big.NewInt(99841497), big.NewInt(119750400), big.NewInt(190670000)}},   // head is Magma block
-				{119750400, expectedNums{big.NewInt(119750400), big.NewInt(135456000), big.NewInt(190670000)}}, // head is Kore+Kip103 block
-				{135456000, expectedNums{big.NewInt(135456000), big.NewInt(147534000), big.NewInt(190670000)}}, // head is Shanghai block
-				{147534000, expectedNums{big.NewInt(147534000), big.NewInt(162900480), big.NewInt(190670000)}}, // head is Cancun+Randao block
-				{162900480, expectedNums{big.NewInt(162900480), big.NewInt(190670000), big.NewInt(190670000)}}, // head is Kaia+Kip160 block
-				{190670000, expectedNums{big.NewInt(190670000), nil, big.NewInt(190670000)}},                   // head is Prague block
+				{0, expectedNums{big.NewInt(0), big.NewInt(86816005), big.NewInt(211090000)}},                  // head is Genesis block
+				{86816005, expectedNums{big.NewInt(86816005), big.NewInt(99841497), big.NewInt(211090000)}},    // head is Istanbul+London+EthTxType block
+				{99841497, expectedNums{big.NewInt(99841497), big.NewInt(119750400), big.NewInt(211090000)}},   // head is Magma block
+				{119750400, expectedNums{big.NewInt(119750400), big.NewInt(135456000), big.NewInt(211090000)}}, // head is Kore+Kip103 block
+				{135456000, expectedNums{big.NewInt(135456000), big.NewInt(147534000), big.NewInt(211090000)}}, // head is Shanghai block
+				{147534000, expectedNums{big.NewInt(147534000), big.NewInt(162900480), big.NewInt(211090000)}}, // head is Cancun+Randao block
+				{162900480, expectedNums{big.NewInt(162900480), big.NewInt(190670000), big.NewInt(211090000)}}, // head is Kaia+Kip160 block
+				{190670000, expectedNums{big.NewInt(190670000), big.NewInt(211090000), big.NewInt(211090000)}}, // head is Prague block
+				{211090000, expectedNums{big.NewInt(211090000), nil, big.NewInt(211090000)}},                   // head is Osaka block
 			},
 		},
 		// Kairos test cases

--- a/params/config.go
+++ b/params/config.go
@@ -61,7 +61,7 @@ var (
 		},
 		KaiaCompatibleBlock:   big.NewInt(162900480),
 		PragueCompatibleBlock: big.NewInt(190670000),
-		OsakaCompatibleBlock:  nil, // TODO-kaia-osaka: set Mainnet's OsakaCompatibleBlock
+		OsakaCompatibleBlock:  big.NewInt(211090000),
 		// Optional forks
 		Kip103CompatibleBlock: big.NewInt(119750400),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),

--- a/params/version.go
+++ b/params/version.go
@@ -28,7 +28,7 @@ const (
 	ReleaseNum   = 0
 	VersionMajor = 2 // Major version component of the current release
 	VersionMinor = 2 // Minor version component of the current release
-	VersionPatch = 0 // Patch version component of the current release
+	VersionPatch = 1 // Patch version component of the current release
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
## Proposed changes

- Mainnet hardfork: 211090000 (ETA: [2026.03.12 10:11 UTC+9](https://kaiascan.io/block/211090000?tabId=blockTransactions&page=1))

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- https://github.com/kaiachain/kaia/pull/725

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
