### PR TITLE
ci: add SLACK_WEBHOOK_URL env to update-repo-metadata job

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -274,6 +274,8 @@ jobs:
       id-token: write
     container:
       image: kaiachain/circleci-rpmbuild:1.23.7-gcc11
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Get AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
The Slack notification steps referenced $SLACK_WEBHOOK_URL as a shell variable but it was never mapped from secrets, causing curl to fail with "URL using bad/illegal format or missing URL".

## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
- Added `env: SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}` at the job level

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
