### PR TITLE
api: Add Osaka fields to kaia_ header API

### DIFF
--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -868,6 +868,10 @@ func RPCMarshalHeader(head *types.Header, rules params.Rules) map[string]interfa
 		result["randomReveal"] = hexutil.Bytes(head.RandomReveal)
 		result["mixhash"] = hexutil.Bytes(head.MixHash)
 	}
+	if rules.IsOsaka {
+		result["excessBlobGas"] = (*hexutil.Big)(new(big.Int).SetUint64(*head.ExcessBlobGas))
+		result["blobGasUsed"] = hexutil.Uint64(*head.BlobGasUsed)
+	}
 
 	return result
 }

--- a/blockchain/types/gen_header_json.go
+++ b/blockchain/types/gen_header_json.go
@@ -16,24 +16,26 @@ var _ = (*headerMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
-		ParentHash   common.Hash    `json:"parentHash"       gencodec:"required"`
-		Rewardbase   common.Address `json:"reward"           gencodec:"required"`
-		Root         common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash       common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash  common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom        Bloom          `json:"logsBloom"        gencodec:"required"`
-		BlockScore   *hexutil.Big   `json:"blockScore"       gencodec:"required"`
-		Number       *hexutil.Big   `json:"number"           gencodec:"required"`
-		GasUsed      hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time         *hexutil.Big   `json:"timestamp"        gencodec:"required"`
-		TimeFoS      hexutil.Uint   `json:"timestampFoS"              gencodec:"required"`
-		Extra        hexutil.Bytes  `json:"extraData"                 gencodec:"required"`
-		Governance   hexutil.Bytes  `json:"governanceData"            gencodec:"required"`
-		Vote         hexutil.Bytes  `json:"voteData,omitempty"`
-		BaseFee      *hexutil.Big   `json:"baseFeePerGas,omitempty" rlp:"optional"`
-		RandomReveal hexutil.Bytes  `json:"randomReveal,omitempty" rlp:"optional"`
-		MixHash      hexutil.Bytes  `json:"mixHash,omitempty" rlp:"optional"`
-		Hash         common.Hash    `json:"hash"`
+		ParentHash    common.Hash     `json:"parentHash"       gencodec:"required"`
+		Rewardbase    common.Address  `json:"reward"           gencodec:"required"`
+		Root          common.Hash     `json:"stateRoot"        gencodec:"required"`
+		TxHash        common.Hash     `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash   common.Hash     `json:"receiptsRoot"     gencodec:"required"`
+		Bloom         Bloom           `json:"logsBloom"        gencodec:"required"`
+		BlockScore    *hexutil.Big    `json:"blockScore"       gencodec:"required"`
+		Number        *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasUsed       hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
+		Time          *hexutil.Big    `json:"timestamp"        gencodec:"required"`
+		TimeFoS       hexutil.Uint    `json:"timestampFoS"              gencodec:"required"`
+		Extra         hexutil.Bytes   `json:"extraData"                 gencodec:"required"`
+		Governance    hexutil.Bytes   `json:"governanceData"            gencodec:"required"`
+		Vote          hexutil.Bytes   `json:"voteData,omitempty"`
+		BaseFee       *hexutil.Big    `json:"baseFeePerGas,omitempty" rlp:"optional"`
+		RandomReveal  hexutil.Bytes   `json:"randomReveal,omitempty" rlp:"optional"`
+		MixHash       hexutil.Bytes   `json:"mixHash,omitempty" rlp:"optional"`
+		BlobGasUsed   *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		Hash          common.Hash     `json:"hash"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -53,6 +55,8 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.BaseFee = (*hexutil.Big)(h.BaseFee)
 	enc.RandomReveal = h.RandomReveal
 	enc.MixHash = h.MixHash
+	enc.BlobGasUsed = (*hexutil.Uint64)(h.BlobGasUsed)
+	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -60,23 +64,25 @@ func (h Header) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
-		ParentHash   *common.Hash    `json:"parentHash"       gencodec:"required"`
-		Rewardbase   *common.Address `json:"reward"           gencodec:"required"`
-		Root         *common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash       *common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash  *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom        *Bloom          `json:"logsBloom"        gencodec:"required"`
-		BlockScore   *hexutil.Big    `json:"blockScore"       gencodec:"required"`
-		Number       *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasUsed      *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time         *hexutil.Big    `json:"timestamp"        gencodec:"required"`
-		TimeFoS      *hexutil.Uint   `json:"timestampFoS"              gencodec:"required"`
-		Extra        *hexutil.Bytes  `json:"extraData"                 gencodec:"required"`
-		Governance   *hexutil.Bytes  `json:"governanceData"            gencodec:"required"`
-		Vote         *hexutil.Bytes  `json:"voteData,omitempty"`
-		BaseFee      *hexutil.Big    `json:"baseFeePerGas,omitempty" rlp:"optional"`
-		RandomReveal *hexutil.Bytes  `json:"randomReveal,omitempty" rlp:"optional"`
-		MixHash      *hexutil.Bytes  `json:"mixHash,omitempty" rlp:"optional"`
+		ParentHash    *common.Hash    `json:"parentHash"       gencodec:"required"`
+		Rewardbase    *common.Address `json:"reward"           gencodec:"required"`
+		Root          *common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash        *common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash   *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom         *Bloom          `json:"logsBloom"        gencodec:"required"`
+		BlockScore    *hexutil.Big    `json:"blockScore"       gencodec:"required"`
+		Number        *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasUsed       *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time          *hexutil.Big    `json:"timestamp"        gencodec:"required"`
+		TimeFoS       *hexutil.Uint   `json:"timestampFoS"              gencodec:"required"`
+		Extra         *hexutil.Bytes  `json:"extraData"                 gencodec:"required"`
+		Governance    *hexutil.Bytes  `json:"governanceData"            gencodec:"required"`
+		Vote          *hexutil.Bytes  `json:"voteData,omitempty"`
+		BaseFee       *hexutil.Big    `json:"baseFeePerGas,omitempty" rlp:"optional"`
+		RandomReveal  *hexutil.Bytes  `json:"randomReveal,omitempty" rlp:"optional"`
+		MixHash       *hexutil.Bytes  `json:"mixHash,omitempty" rlp:"optional"`
+		BlobGasUsed   *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -145,6 +151,12 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.MixHash != nil {
 		h.MixHash = *dec.MixHash
+	}
+	if dec.BlobGasUsed != nil {
+		h.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
+	}
+	if dec.ExcessBlobGas != nil {
+		h.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
 	}
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

`kaia_getHeaderByNumber` is missing Osaka fields, so this PR fixes it.
Also, this PR regenerates `gen_header_json.go` via gencodec.

Before this PR:
```
$ cast rpc kaia_getHeaderByNumber latest | jq -c "[.blobGasUsed, .excessBlobGas]"
[null,null]
```

After this PR
```
$ cast rpc kaia_getHeaderByNumber latest | jq -c "[.blobGasUsed, .excessBlobGas]"
["0x0","0x0"]
```

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)


## Further comments

Others are unaffected by this PR.
```
$ cast rpc eth_getHeaderByNumber latest | jq -c "[.blobGasUsed, .excessBlobGas]"
["0x0","0x0"]
$ cast rpc eth_getBlockByNumber latest false | jq -c "[.blobGasUsed, .excessBlobGas]"
["0x0","0x0"]
$ cast rpc kaia_getBlockByNumber latest false | jq -c "[.blobGasUsed, .excessBlobGas]"
["0x0","0x0"]
```