### PR TITLE
consensus: Rename Vrank metrics

### DIFF
--- a/consensus/istanbul/core/vrank.go
+++ b/consensus/istanbul/core/vrank.go
@@ -53,11 +53,11 @@ const (
 
 var (
 	// VRank metrics
-	vrankFirstPreprepareArrivalTimeGauge       = metrics.NewRegisteredGauge("vrank/first_preprepare", nil)
-	vrankFirstCommitArrivalTimeGauge           = metrics.NewRegisteredGauge("vrank/first_commit", nil)
-	vrankQuorumCommitArrivalTimeGauge          = metrics.NewRegisteredGauge("vrank/quorum_commit", nil)
-	vrankAvgCommitArrivalTimeWithinQuorumGauge = metrics.NewRegisteredGauge("vrank/avg_commit_within_quorum", nil)
-	vrankLastCommitArrivalTimeGauge            = metrics.NewRegisteredGauge("vrank/last_commit", nil)
+	vrankFirstPreprepareArrivalTimeGauge       = metrics.NewRegisteredGauge("vrank/preprepare/first", nil)
+	vrankFirstCommitArrivalTimeGauge           = metrics.NewRegisteredGauge("vrank/commit/first", nil)
+	vrankQuorumCommitArrivalTimeGauge          = metrics.NewRegisteredGauge("vrank/commit/quorumreached", nil)
+	vrankAvgCommitArrivalTimeWithinQuorumGauge = metrics.NewRegisteredGauge("vrank/commit/quorumaverage", nil)
+	vrankLastCommitArrivalTimeGauge            = metrics.NewRegisteredGauge("vrank/commit/last", nil)
 
 	VRankLogFrequency = DefaultVRankLogFrequency // Will be set to the value of VRankLogFrequencyFlag in SetKaiaConfig()
 


### PR DESCRIPTION
## Proposed changes

- Rename `vrank` metrics to not include underscores. Logging agent replaces the slash `/` with underscore `_`, so underscores in the metric name itself are confusing.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
