### PR TITLE
permless: Add VRank module

### DIFF
--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -31,6 +31,14 @@ func (v *ValsetModule) GetCouncil(num uint64) ([]common.Address, error) {
 	}
 }
 
+func (v *ValsetModule) GetCandidates(num uint64) ([]common.Address, error) {
+	// TODO-permless: implement me
+	return []common.Address{
+		common.HexToAddress("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"),
+		common.HexToAddress("0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"),
+	}, nil
+}
+
 // GetDemotedValidators are subtract of qualified from council(N)
 func (v *ValsetModule) GetDemotedValidators(num uint64) ([]common.Address, error) {
 	council, err := v.getCouncil(num)

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -50,6 +50,21 @@ func (mr *MockValsetModuleMockRecorder) APIs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockValsetModule)(nil).APIs))
 }
 
+// GetCandidates mocks base method.
+func (m *MockValsetModule) GetCandidates(arg0 uint64) ([]common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCandidates", arg0)
+	ret0, _ := ret[0].([]common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCandidates indicates an expected call of GetCandidates.
+func (mr *MockValsetModuleMockRecorder) GetCandidates(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCandidates", reflect.TypeOf((*MockValsetModule)(nil).GetCandidates), arg0)
+}
+
 // GetCommittee mocks base method.
 func (m *MockValsetModule) GetCommittee(arg0, arg1 uint64) ([]common.Address, error) {
 	m.ctrl.T.Helper()

--- a/kaiax/vrank/collector.go
+++ b/kaiax/vrank/collector.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package vrank
+
+import (
+	"sync"
+	"time"
+
+	"github.com/kaiachain/kaia/common"
+)
+
+// ViewKey identifies a (sequence, round) for collection.
+type ViewKey struct {
+	N uint64
+	R uint8
+}
+
+// Cmp returns -1 if a < b, 0 if a == b, 1 if a > b (order: Seq then Round).
+func (a ViewKey) Cmp(b ViewKey) int {
+	if a.N != b.N {
+		if a.N < b.N {
+			return -1
+		}
+		return 1
+	}
+	if a.R != b.R {
+		if a.R < b.R {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// CandidateMsg is a VRankCandidate plus when it was received. Caller uses this for verification and elapsed.
+type CandidateMsg struct {
+	ReceivedAt time.Time
+	Msg        *VRankCandidate
+}
+
+// Collector stores VRankCandidate messages per view.
+type Collector struct {
+	mu             sync.RWMutex
+	prepreparedMap map[ViewKey]time.Time
+	viewMap        map[ViewKey]map[common.Address]CandidateMsg
+}
+
+// NewCollector creates a collector. maxWindow limits how far ahead of currentView messages are accepted (0 = unbounded).
+func NewCollector() *Collector {
+	return &Collector{
+		prepreparedMap: make(map[ViewKey]time.Time),
+		viewMap:        make(map[ViewKey]map[common.Address]CandidateMsg),
+	}
+}
+
+// RemoveOldViews deletes views that are strictly behind threshold.
+func (c *Collector) RemoveOldViews(threshold ViewKey) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for vk := range c.prepreparedMap {
+		if vk.Cmp(threshold) < 0 {
+			delete(c.prepreparedMap, vk)
+		}
+	}
+	for vk := range c.viewMap {
+		if vk.Cmp(threshold) < 0 {
+			delete(c.viewMap, vk)
+		}
+	}
+}
+
+func (c *Collector) AddPrepreparedTime(vk ViewKey, prepreparedAt time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.prepreparedMap[vk] = prepreparedAt
+}
+
+// AddCandMsg stores a VRankCandidate message for the given view. No verification is done here.
+// Returns false if msg is nil or vk is too far (behind currentView or beyond currentView+maxWindow).
+func (c *Collector) AddCandMsg(vk ViewKey, sender common.Address, receivedAt time.Time, msg *VRankCandidate) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	candMap, ok := c.viewMap[vk]
+	if !ok {
+		c.viewMap[vk] = make(map[common.Address]CandidateMsg)
+		candMap = c.viewMap[vk]
+	}
+	// no duplicate messages
+	if _, ok := candMap[sender]; ok {
+		return false
+	}
+	candMap[sender] = CandidateMsg{ReceivedAt: receivedAt, Msg: msg}
+	return true
+}
+
+// GetViewData returns the raw data for the view: start time and all stored messages.
+func (c *Collector) GetViewData(vk ViewKey) (time.Time, map[common.Address]CandidateMsg) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	prepreparedAt := c.prepreparedMap[vk]
+	candMap := c.viewMap[vk]
+	return prepreparedAt, candMap
+}

--- a/kaiax/vrank/collector_test.go
+++ b/kaiax/vrank/collector_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package vrank
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollector_GetViewData_UnknownView(t *testing.T) {
+	c := NewCollector()
+	at, m := c.GetViewData(ViewKey{N: 1, R: 0})
+	assert.True(t, at.IsZero())
+	assert.Nil(t, m)
+}
+
+func TestCollector_GetViewData_NoCandMsgAdded(t *testing.T) {
+	var (
+		c   = NewCollector()
+		vk  = ViewKey{N: 1, R: 0}
+		now = time.Now()
+	)
+	c.AddPrepreparedTime(vk, now)
+	at, m := c.GetViewData(vk)
+	assert.False(t, at.IsZero())
+	assert.Equal(t, now.UnixNano(), at.UnixNano())
+	assert.Nil(t, m)
+	assert.Len(t, m, 0)
+}
+
+func TestCollector_AddCandMsg_DuplicateRejected(t *testing.T) {
+	var (
+		c    = NewCollector()
+		vk   = ViewKey{N: 1, R: 0}
+		addr = common.HexToAddress("0x01")
+		msg  = &VRankCandidate{BlockNumber: 1, Round: 0}
+		when = time.Now()
+	)
+
+	ok := c.AddCandMsg(vk, addr, when, msg)
+	assert.True(t, ok)
+	_, m := c.GetViewData(vk)
+	assert.Len(t, m, 1)
+	assert.Equal(t, msg, m[addr].Msg)
+
+	ok = c.AddCandMsg(vk, addr, when.Add(time.Second), msg)
+	assert.False(t, ok)
+	_, m = c.GetViewData(vk)
+	assert.Len(t, m, 1)
+}
+
+func TestCollector_RemoveOldViews(t *testing.T) {
+	var (
+		c         = NewCollector()
+		views     = []ViewKey{{N: 1, R: 0}, {N: 1, R: 8}, {N: 2, R: 0}, {N: 2, R: 1}, {N: 3, R: 0}}
+		threshold = ViewKey{N: 2, R: 1}
+		wantGone  = []bool{true, true, true, false, false}
+	)
+
+	for _, v := range views {
+		c.AddPrepreparedTime(v, time.Now())
+		c.AddCandMsg(v, common.HexToAddress("0x01"), time.Now(), &VRankCandidate{BlockNumber: v.N, Round: v.R})
+	}
+
+	c.RemoveOldViews(threshold)
+	for i, v := range views {
+		at, m := c.GetViewData(v)
+		if wantGone[i] {
+			assert.True(t, at.IsZero(), "view %v should be removed", v)
+			assert.Nil(t, m)
+		} else {
+			assert.False(t, at.IsZero(), "view %v should remain", v)
+			assert.NotNil(t, m)
+		}
+	}
+}
+
+func TestViewKey_Cmp(t *testing.T) {
+	a, b, c := ViewKey{N: 1, R: 0}, ViewKey{N: 2, R: 0}, ViewKey{N: 1, R: 1}
+	assert.Less(t, a.Cmp(b), 0)
+	assert.Greater(t, b.Cmp(a), 0)
+	assert.Equal(t, 0, a.Cmp(a))
+	assert.Less(t, a.Cmp(c), 0)
+	assert.Greater(t, c.Cmp(a), 0)
+}

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -19,11 +19,15 @@ package vrank
 import "errors"
 
 var (
-	ErrInitUnexpectedNil   = errors.New("unexpected nil during module init")
-	ErrVRankPreprepareNil  = errors.New("VRankPreprepare is nil")
-	ErrVRankCandidateNil   = errors.New("VRankCandidate is nil")
-	ErrGetCandidateFailed  = errors.New("valset.GetCandidates failed")
-	ErrViewMismatch        = errors.New("view mismatch")
-	ErrBlockHashMismatch   = errors.New("block hash mismatch")
-	ErrMsgFromNonCandidate = errors.New("message from non-candidate")
+	ErrInitUnexpectedNil     = errors.New("unexpected nil during module init")
+	ErrVRankPreprepareNil    = errors.New("VRankPreprepare is nil")
+	ErrVRankCandidateNil     = errors.New("VRankCandidate is nil")
+	ErrGetCandidateFailed    = errors.New("valset.GetCandidates failed")
+	ErrPrepreparedTimeNotSet = errors.New("preprepared time is not set")
+	ErrPrepreparedViewNotSet = errors.New("preprepared view is not set")
+	ErrViewMismatch          = errors.New("view mismatch")
+	ErrBlockHashMismatch     = errors.New("block hash mismatch")
+	ErrMsgFromNonCandidate   = errors.New("message from non-candidate")
+	ErrTooFar                = errors.New("too far in the future")
+	ErrRoundOutOfRange       = errors.New("round out of range")
 )

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -19,8 +19,11 @@ package vrank
 import "errors"
 
 var (
-	ErrInitUnexpectedNil  = errors.New("unexpected nil during module init")
-	ErrVRankPreprepareNil = errors.New("VRankPreprepare is nil")
-	ErrVRankCandidateNil  = errors.New("VRankCandidate is nil")
-	ErrGetCandidateFailed = errors.New("valset.GetCandidates failed")
+	ErrInitUnexpectedNil   = errors.New("unexpected nil during module init")
+	ErrVRankPreprepareNil  = errors.New("VRankPreprepare is nil")
+	ErrVRankCandidateNil   = errors.New("VRankCandidate is nil")
+	ErrGetCandidateFailed  = errors.New("valset.GetCandidates failed")
+	ErrViewMismatch        = errors.New("view mismatch")
+	ErrBlockHashMismatch   = errors.New("block hash mismatch")
+	ErrMsgFromNonCandidate = errors.New("message from non-candidate")
 )

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2026 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify
@@ -14,23 +14,13 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
-package valset
+package vrank
 
-import (
-	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/kaiax"
+import "errors"
+
+var (
+	ErrInitUnexpectedNil  = errors.New("unexpected nil during module init")
+	ErrVRankPreprepareNil = errors.New("VRankPreprepare is nil")
+	ErrVRankCandidateNil  = errors.New("VRankCandidate is nil")
+	ErrGetCandidateFailed = errors.New("valset.GetCandidates failed")
 )
-
-//go:generate mockgen -destination=./mock/module.go -package=mock github.com/kaiachain/kaia/kaiax/valset ValsetModule
-type ValsetModule interface {
-	kaiax.BaseModule
-	kaiax.JsonRpcModule
-	kaiax.ExecutionModule
-	kaiax.RewindableModule
-
-	GetCouncil(num uint64) ([]common.Address, error)
-	GetCommittee(num uint64, round uint64) ([]common.Address, error)
-	GetCandidates(num uint64) ([]common.Address, error)
-	GetDemotedValidators(num uint64) ([]common.Address, error)
-	GetProposer(num uint64, round uint64) (common.Address, error)
-}

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -197,6 +197,11 @@ func (v *VRankModule) GetCfReport(blockNum, round uint64) (vrank.CfReport, error
 		return nil, vrank.ErrRoundOutOfRange
 	}
 
+	// if I was not a validator for blockNum, I couldn't have collected cfReport for blockNum.
+	if !v.isValidator(blockNum) {
+		return vrank.CfReport{}, nil
+	}
+
 	vk := vrank.ViewKey{N: blockNum, R: uint8(round)}
 	prepreparedAt, expectedBlockHash, viewMap := v.collector.GetViewData(vk)
 	if prepreparedAt.IsZero() {

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -161,7 +161,7 @@ func (v *VRankModule) isProposer(blockNum, round uint64) bool {
 		return false
 	}
 
-	return proposer == v.nodeId
+	return proposer == v.nodeID
 }
 
 func (v *VRankModule) isCandidate(blockNum uint64) bool {
@@ -171,7 +171,7 @@ func (v *VRankModule) isCandidate(blockNum uint64) bool {
 		return false
 	}
 
-	return slices.Contains(candidates, v.nodeId)
+	return slices.Contains(candidates, v.nodeID)
 }
 
 func (v *VRankModule) isValidator(blockNum uint64) bool {
@@ -181,7 +181,7 @@ func (v *VRankModule) isValidator(blockNum uint64) bool {
 		return false
 	}
 
-	return slices.Contains(validators, v.nodeId)
+	return slices.Contains(validators, v.nodeID)
 }
 
 // for building N-th header's VRank field, caller should query N-1 with the previous block's round.

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"math/big"
+	"slices"
+	"time"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kaiax/vrank"
+)
+
+// HandleIstanbulPreprepare is executed by validators for timer start, andthe proposer for broadcast
+func (v *VRankModule) HandleIstanbulPreprepare(block *types.Block, view *istanbul.View) {
+	if !v.ChainConfig.IsPermissionlessForkEnabled(block.Number()) {
+		return
+	}
+
+	blockNum := block.NumberU64()
+	if v.isValidator(blockNum) {
+		v.candResponses.Clear()
+		v.prepreparedTime = time.Now()
+	}
+	if v.isProposer(blockNum, view.Round.Uint64()) {
+		vrankPreprepare := &vrank.VRankPreprepare{Block: block}
+		v.BroadcastVRankPreprepare(vrankPreprepare)
+	}
+}
+
+// HandleVRankPreprepare is executed by candidates
+func (v *VRankModule) HandleVRankPreprepare(preprepare *vrank.VRankPreprepare) error {
+	block := preprepare.Block
+	if !v.ChainConfig.IsPermissionlessForkEnabled(block.Number()) {
+		return nil
+	}
+	if preprepare == nil || preprepare.Block == nil {
+		logger.Error("VRankPreprepare is nil")
+		return vrank.ErrVRankPreprepareNil
+	}
+
+	if v.isCandidate(block.NumberU64()) {
+		sig, err := crypto.Sign(crypto.Keccak256(block.Hash().Bytes()), v.NodeKey)
+		if err != nil {
+			logger.Error("Sign failed", "blockNum", block.NumberU64())
+			return err
+		}
+		msg := &vrank.VRankCandidate{
+			BlockNumber: block.NumberU64(),
+			Round:       0,
+			BlockHash:   block.Hash(),
+			Sig:         sig,
+		}
+		v.BroadcastVRankCandidate(msg)
+	}
+	return nil
+}
+
+// HandleVRankCandidate is executed by validators
+func (v *VRankModule) HandleVRankCandidate(msg *vrank.VRankCandidate) error {
+	if !v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(msg.BlockNumber)) {
+		return nil
+	}
+
+	if msg == nil {
+		logger.Error("Unexpected nil")
+		return vrank.ErrVRankCandidateNil
+	}
+
+	elapsed := time.Since(v.prepreparedTime)
+	if v.isValidator(msg.BlockNumber) {
+		cand, err := istanbul.GetSignatureAddress(msg.BlockHash.Bytes(), msg.Sig)
+		if err != nil {
+			logger.Error("GetSignatureAddress failed", "blockNum", msg.BlockNumber, "blockHash", msg.BlockHash, "sig", msg.Sig)
+			return err
+		}
+		logger.Trace("HandleVRankCandidate", "cand", cand, "elapsed", elapsed, "blockHash", msg.BlockHash.Hex())
+		v.candResponses.Store(cand, elapsed)
+	}
+	return nil
+}
+
+// BroadcastVRankPreprepare is called by the proposer
+func (v *VRankModule) BroadcastVRankPreprepare(vrankPreprepare *vrank.VRankPreprepare) {
+	block := vrankPreprepare.Block
+	candidates, err := v.Valset.GetCandidates(block.NumberU64())
+	if err != nil || candidates == nil {
+		logger.Error("GetCandidates failed", "blockNum", block.NumberU64())
+		return
+	}
+	v.broadcast(candidates, VRankPreprepareMsg, vrankPreprepare)
+}
+
+// BroadcastVRankPreprepare is called by candidates
+func (v *VRankModule) BroadcastVRankCandidate(vrankCandidate *vrank.VRankCandidate) {
+	validators, err := v.Valset.GetCouncil(vrankCandidate.BlockNumber)
+	if err != nil || validators == nil {
+		logger.Error("GetCouncil failed", "blockNum", vrankCandidate.BlockNumber)
+		return
+	}
+
+	v.broadcast(validators, VRankCandidateMsg, vrankCandidate)
+}
+
+func (v *VRankModule) broadcast(targets []common.Address, code int, msg any) {
+	req := &vrank.BroadcastRequest{
+		Targets: targets,
+		Code:    code,
+		Msg:     msg,
+	}
+	v.broadcastCh <- req
+}
+
+func (v *VRankModule) isProposer(blockNum, round uint64) bool {
+	proposer, err := v.Valset.GetProposer(blockNum, round)
+	if err != nil {
+		logger.Error("GetProposer failed", "blockNum", blockNum, "round", round)
+		return false
+	}
+
+	return proposer == v.nodeId
+}
+
+func (v *VRankModule) isCandidate(blockNum uint64) bool {
+	candidates, err := v.Valset.GetCandidates(blockNum)
+	if err != nil || candidates == nil {
+		logger.Error("GetCandidates failed", "blockNum", blockNum)
+		return false
+	}
+
+	return slices.Contains(candidates, v.nodeId)
+}
+
+func (v *VRankModule) isValidator(blockNum uint64) bool {
+	validators, err := v.Valset.GetCouncil(blockNum)
+	if err != nil || validators == nil {
+		logger.Error("GetCandidates failed", "blockNum", blockNum)
+		return false
+	}
+
+	return slices.Contains(validators, v.nodeId)
+}
+
+func (v *VRankModule) GetCfReport(blockNum uint64) (vrank.CfReport, error) {
+	if blockNum == 0 {
+		return vrank.CfReport{}, nil
+	}
+
+	candidates, err := v.Valset.GetCandidates(blockNum)
+
+	if err != nil || candidates == nil {
+		logger.Error("GetCandidates failed", "blockNum", blockNum)
+		return nil, vrank.ErrGetCandidateFailed
+	}
+
+	var cfReport vrank.CfReport
+	for _, addr := range candidates {
+		elapsed, ok := v.candResponses.Load(addr)
+		if !ok || elapsed.(time.Duration) > candidatePrepareDeadlineMs {
+			cfReport = append(cfReport, addr)
+		}
+	}
+
+	return cfReport, nil
+}
+
+func (v *VRankModule) handleBroadcastLoop() {
+	for {
+		select {
+		case req, ok := <-v.broadcastCh:
+			if !ok {
+				return
+			}
+			v.broadcastFeed.Send(req)
+		}
+	}
+}

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -220,7 +220,12 @@ func (v *VRankModule) GetCfReport(blockNum uint64) (vrank.CfReport, error) {
 }
 
 func (v *VRankModule) handleBroadcastLoop() {
-	for req := range v.broadcastCh {
-		v.broadcastFeed.Send(req)
+	for {
+		select {
+		case req := <-v.broadcastCh:
+			v.broadcastFeed.Send(req)
+		case <-v.stopCh:
+			return
+		}
 	}
 }

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -155,7 +155,7 @@ func TestHandleIstanbulPreprepare(t *testing.T) {
 		proposer, validator, candidate := createCN(t, valset), createCN(t, valset), createCN(t, valset)
 
 		// proposer is not in the next council, so it should only broadcast and does not start collection.
-		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{validator.Addr}, nil).Times(2)
+		valset.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{validator.Addr}, nil).Times(2)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(2)
 		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(2)
 
@@ -174,7 +174,7 @@ func TestHandleIstanbulPreprepare(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
 		proposer, nonProposer, candidate := createCN(t, valset), createCN(t, valset), createCN(t, valset)
 
-		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
+		valset.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(3)
 		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(3)
 
@@ -215,7 +215,7 @@ func TestHandleVRankPreprepare(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
 		proposer, nonProposer, candidate := createCN(t, valset), createCN(t, valset), createCN(t, valset)
 
-		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
+		valset.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(3)
 		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(3)
 
@@ -250,7 +250,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		proposer, nonProposer, candidate := createCN(t, valset), createCN(t, valset), createCN(t, valset)
 		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: []byte{}}
 
-		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
+		valset.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(3)
 		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(3)
 
@@ -270,7 +270,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: sig}
 
 		// proposer is not in the next council, so it should only broadcast and does not start collection.
-		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{validator.Addr}, nil).Times(3)
+		valset.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{validator.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(2)
 		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(2)
 
@@ -295,7 +295,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		block2 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(2)})
 		invalidSig, _ := crypto.Sign(crypto.Keccak256(block2.Hash().Bytes()), cand.Key)
 
-		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{val.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{val.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{cand.Addr}, nil).AnyTimes()
 
@@ -343,7 +343,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		sig, _ := crypto.Sign(crypto.Keccak256(block1.Hash().Bytes()), cand.Key)
 		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: sig}
 
-		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{val.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{val.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{cand.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 
@@ -390,7 +390,7 @@ func TestGetCfReport(t *testing.T) {
 	liarCands := candAddrs[2:4]
 	lateCands := candAddrs[4:6]
 
-	valset.EXPECT().GetCouncil(uint64(2)).Return(valAddrs, nil).AnyTimes()
+	valset.EXPECT().GetCouncil(uint64(1)).Return(valAddrs, nil).AnyTimes()
 	valset.EXPECT().GetCandidates(uint64(1)).Return(candAddrs, nil).AnyTimes()
 	valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(validators[0].Addr, nil).AnyTimes()
 

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
+	"github.com/kaiachain/kaia/kaiax/vrank"
+	"github.com/kaiachain/kaia/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type CN struct {
+	Key         *ecdsa.PrivateKey
+	Addr        common.Address
+	VRankModule *VRankModule
+	sub         chan *vrank.BroadcastRequest
+}
+
+func createCN(t *testing.T, valset valset.ValsetModule) *CN {
+	key, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	sub := make(chan *vrank.BroadcastRequest)
+	module := NewVRankModule()
+	err := module.Init(&InitOpts{
+		NodeKey:     key,
+		Valset:      valset,
+		ChainConfig: params.TestKaiaConfig("permissionless"),
+	})
+	require.NoError(t, err)
+
+	module.broadcastFeed.Subscribe(sub)
+	err = module.Start()
+	require.NoError(t, err)
+	return &CN{
+		Key:         key,
+		Addr:        addr,
+		VRankModule: module,
+		sub:         sub,
+	}
+}
+
+func TestVRankModule(t *testing.T) {
+	var (
+		valset = mock_valset.NewMockValsetModule(gomock.NewController(t))
+		val    = createCN(t, valset)
+		cand   = createCN(t, valset)
+
+		block  = types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
+		sig, _ = crypto.Sign(crypto.Keccak256(block.Hash().Bytes()), cand.Key)
+
+		pppMsg  = vrank.VRankPreprepare{Block: block}
+		candMsg = vrank.VRankCandidate{BlockNumber: block.NumberU64(), Round: 0, BlockHash: block.Hash(), Sig: sig}
+	)
+
+	t.Logf("val.Addr: %s, cand.Addr: %s", val.Addr.Hex(), cand.Addr.Hex())
+
+	valset.EXPECT().GetCouncil(gomock.Any()).Return([]common.Address{val.Addr}, nil).AnyTimes()
+	valset.EXPECT().GetCandidates(gomock.Any()).Return([]common.Address{cand.Addr}, nil).AnyTimes()
+	valset.EXPECT().GetProposer(gomock.Any(), gomock.Any()).Return(val.Addr, nil).AnyTimes()
+
+	// validator correctly broadcast VRankPreprepare upon receiving IstanbulPreprepare
+	assert.Equal(t, time.Time{}, val.VRankModule.prepreparedTime)
+	val.VRankModule.HandleIstanbulPreprepare(block, &istanbul.View{Round: common.Big0})
+	assert.NotEqual(t, time.Time{}, val.VRankModule.prepreparedTime)
+	req := <-val.sub
+	assert.Equal(t, []common.Address{cand.Addr}, req.Targets)
+	assert.Equal(t, VRankPreprepareMsg, req.Code)
+	assert.Equal(t, &pppMsg, req.Msg)
+
+	// candidate correctly broadcast VRankCandidate upon receiving VRankPreprepare
+	cand.VRankModule.HandleVRankPreprepare(&vrank.VRankPreprepare{Block: block})
+	req = <-cand.sub
+	assert.Equal(t, []common.Address{val.Addr}, req.Targets)
+	assert.Equal(t, VRankCandidateMsg, req.Code)
+	assert.Equal(t, &candMsg, req.Msg)
+
+	// validator correctly collects VRankCandidate upon receiving VRankCandidate
+	err := val.VRankModule.HandleVRankCandidate(&candMsg)
+	assert.NoError(t, err)
+	d, ok := val.VRankModule.candResponses.Load(cand.Addr)
+	assert.True(t, ok)
+	assert.NotEqual(t, time.Duration(0), d.(time.Duration))
+}

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -65,6 +65,16 @@ func createCN(t *testing.T, valset valset.ValsetModule) *CN {
 	}
 }
 
+func ensurePop(t *testing.T, sub chan *vrank.BroadcastRequest) *vrank.BroadcastRequest {
+	select {
+	case req := <-sub:
+		return req
+	case <-time.After(2 * time.Second):
+		t.Fatal("should broadcast")
+	}
+	return nil
+}
+
 func TestVRankModule(t *testing.T) {
 	var (
 		valset = mock_valset.NewMockValsetModule(gomock.NewController(t))
@@ -89,14 +99,14 @@ func TestVRankModule(t *testing.T) {
 	assert.Equal(t, time.Time{}, val.VRankModule.prepreparedTime)
 	val.VRankModule.HandleIstanbulPreprepare(block, view)
 	assert.NotEqual(t, time.Time{}, val.VRankModule.prepreparedTime)
-	req := <-val.sub
+	req := ensurePop(t, val.sub)
 	assert.Equal(t, []common.Address{cand.Addr}, req.Targets)
 	assert.Equal(t, VRankPreprepareMsg, req.Code)
 	assert.Equal(t, &pppMsg, req.Msg)
 
 	// candidate correctly broadcast VRankCandidate upon receiving VRankPreprepare
 	cand.VRankModule.HandleVRankPreprepare(&pppMsg)
-	req = <-cand.sub
+	req = ensurePop(t, cand.sub)
 	assert.Equal(t, []common.Address{val.Addr}, req.Targets)
 	assert.Equal(t, VRankCandidateMsg, req.Code)
 	assert.Equal(t, &candMsg, req.Msg)
@@ -107,4 +117,58 @@ func TestVRankModule(t *testing.T) {
 	d, ok := val.VRankModule.candResponses.Load(cand.Addr)
 	assert.True(t, ok)
 	assert.NotEqual(t, time.Duration(0), d.(time.Duration))
+}
+
+func TestHandleIstanbulPreprepare(t *testing.T) {
+	var (
+		block1  = types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
+		view1_0 = &istanbul.View{Sequence: big.NewInt(1), Round: common.Big0}
+	)
+
+	t.Run("permissionless fork is disabled", func(t *testing.T) {
+		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
+		val := createCN(t, valset)
+		val.VRankModule.ChainConfig.PermissionlessCompatibleBlock = nil
+		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
+		assert.Equal(t, time.Time{}, val.VRankModule.prepreparedTime)
+		select {
+		case <-val.sub:
+			t.Fatal("under disabled permissionless fork, it should not broadcast")
+		default:
+		}
+	})
+
+	t.Run("non-proposers should not broadcast", func(t *testing.T) {
+		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
+		var vals []*CN
+		for i := 0; i < 3; i++ {
+			vals = append(vals, createCN(t, valset))
+		}
+		proposer := vals[0]
+		nonProposer := vals[1]
+		candidate := vals[2]
+
+		valset.EXPECT().GetCouncil(uint64(2)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(len(vals))
+		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(len(vals))
+		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(len(vals))
+
+		proposer.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
+		nonProposer.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
+		candidate.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
+
+		assert.NotEqual(t, time.Time{}, proposer.VRankModule.prepreparedTime)
+		assert.NotEqual(t, time.Time{}, nonProposer.VRankModule.prepreparedTime)
+		assert.Equal(t, time.Time{}, candidate.VRankModule.prepreparedTime) // candidate should not preprepare
+
+		req := ensurePop(t, proposer.sub)
+		assert.Equal(t, []common.Address{candidate.Addr}, req.Targets)
+
+		select {
+		case <-nonProposer.sub:
+			t.Fatal("non-proposer should not broadcast")
+		case <-candidate.sub:
+			t.Fatal("candidate should not broadcast")
+		default:
+		}
+	})
 }

--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -60,7 +60,7 @@ type VRankModule struct {
 	broadcastFeed event.Feed
 	stopCh        chan struct{}
 
-	nodeId common.Address
+	nodeID common.Address
 
 	// only for validators
 	prepreparedView istanbul.View // for collection window management
@@ -80,7 +80,7 @@ func (v *VRankModule) Init(opts *InitOpts) error {
 		return vrank.ErrInitUnexpectedNil
 	}
 	v.InitOpts = *opts
-	v.nodeId = crypto.PubkeyToAddress(opts.NodeKey.PublicKey)
+	v.nodeID = crypto.PubkeyToAddress(opts.NodeKey.PublicKey)
 	return nil
 }
 

--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"crypto/ecdsa"
+	"sync"
+	"time"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/event"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
+	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/params"
+)
+
+const (
+	candidatePrepareDeadlineMs = 200 * time.Millisecond
+
+	VRankPreprepareMsg = 0x17
+	VRankCandidateMsg  = 0x18
+
+	broadcastChSize = 2048
+)
+
+var (
+	_ vrank.VRankModule = &VRankModule{}
+
+	logger = log.NewModuleLogger(log.KaiaxVrank)
+)
+
+//go:generate mockgen -destination=./mock/protocol_manager_mock.go -package=impl github.com/kaiachain/kaia/kaiax/vrank/impl ProtocolManager
+type ProtocolManager interface {
+	FindCNPeers(map[common.Address]bool) map[common.Address]consensus.Peer
+}
+
+type InitOpts struct {
+	Valset      valset.ValsetModule
+	NodeKey     *ecdsa.PrivateKey
+	ChainConfig *params.ChainConfig
+}
+
+type VRankModule struct {
+	InitOpts
+
+	broadcastCh   chan *vrank.BroadcastRequest
+	broadcastFeed event.Feed
+
+	nodeId common.Address
+
+	prepreparedTime time.Time
+	candResponses   sync.Map // map[common.Address]time.Duration
+}
+
+func NewVRankModule() *VRankModule {
+	return &VRankModule{}
+}
+
+func (v *VRankModule) Init(opts *InitOpts) error {
+	if opts == nil || opts.Valset == nil || opts.NodeKey == nil || opts.ChainConfig == nil {
+		return vrank.ErrInitUnexpectedNil
+	}
+	v.InitOpts = *opts
+	v.nodeId = crypto.PubkeyToAddress(opts.NodeKey.PublicKey)
+	v.broadcastCh = make(chan *vrank.BroadcastRequest, broadcastChSize)
+	return nil
+}
+
+func (v *VRankModule) Start() error {
+	go v.handleBroadcastLoop()
+	logger.Info("VRankModule started")
+
+	return nil
+}
+
+func (v *VRankModule) Stop() {
+	logger.Info("VRankModule stopped")
+}

--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -57,6 +57,7 @@ type VRankModule struct {
 
 	broadcastCh   chan *vrank.BroadcastRequest
 	broadcastFeed event.Feed
+	stopCh        chan struct{}
 
 	nodeId common.Address
 
@@ -70,6 +71,7 @@ type VRankModule struct {
 func NewVRankModule() *VRankModule {
 	return &VRankModule{
 		broadcastCh: make(chan *vrank.BroadcastRequest, broadcastChSize),
+		stopCh:      make(chan struct{}),
 	}
 }
 
@@ -91,4 +93,5 @@ func (v *VRankModule) Start() error {
 
 func (v *VRankModule) Stop() {
 	logger.Info("VRankModule stopped")
+	close(v.stopCh)
 }

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -28,7 +28,7 @@ type VRankModule interface {
 	HandleIstanbulPreprepare(block *types.Block, view *istanbul.View)
 	HandleVRankPreprepare(msg *VRankPreprepare) error
 	HandleVRankCandidate(msg *VRankCandidate) error
-	GetCfReport(blockNum uint64) (CfReport, error)
+	GetCfReport(blockNum, round uint64) (CfReport, error)
 }
 
 type VRankModuleHost interface {

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2026 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify
@@ -14,23 +14,23 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
-package valset
+package vrank
 
 import (
-	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/kaiax"
 )
 
-//go:generate mockgen -destination=./mock/module.go -package=mock github.com/kaiachain/kaia/kaiax/valset ValsetModule
-type ValsetModule interface {
+type VRankModule interface {
 	kaiax.BaseModule
-	kaiax.JsonRpcModule
-	kaiax.ExecutionModule
-	kaiax.RewindableModule
 
-	GetCouncil(num uint64) ([]common.Address, error)
-	GetCommittee(num uint64, round uint64) ([]common.Address, error)
-	GetCandidates(num uint64) ([]common.Address, error)
-	GetDemotedValidators(num uint64) ([]common.Address, error)
-	GetProposer(num uint64, round uint64) (common.Address, error)
+	HandleIstanbulPreprepare(block *types.Block, view *istanbul.View)
+	HandleVRankPreprepare(msg *VRankPreprepare) error
+	HandleVRankCandidate(msg *VRankCandidate) error
+	GetCfReport(blockNum uint64) (CfReport, error)
+}
+
+type VRankModuleHost interface {
+	RegisterVRankModule(module VRankModule)
 }

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -19,6 +19,7 @@ package vrank
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/rlp"
 )
 
@@ -32,6 +33,7 @@ type BroadcastRequest struct {
 
 type VRankPreprepare struct {
 	Block *types.Block
+	View  *istanbul.View
 }
 
 type VRankCandidate struct {

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kaia Authors
+// Copyright 2026 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify
@@ -14,23 +14,45 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
-package valset
+package vrank
 
 import (
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/kaiax"
+	"github.com/kaiachain/kaia/rlp"
 )
 
-//go:generate mockgen -destination=./mock/module.go -package=mock github.com/kaiachain/kaia/kaiax/valset ValsetModule
-type ValsetModule interface {
-	kaiax.BaseModule
-	kaiax.JsonRpcModule
-	kaiax.ExecutionModule
-	kaiax.RewindableModule
+type CfReport []common.Address
 
-	GetCouncil(num uint64) ([]common.Address, error)
-	GetCommittee(num uint64, round uint64) ([]common.Address, error)
-	GetCandidates(num uint64) ([]common.Address, error)
-	GetDemotedValidators(num uint64) ([]common.Address, error)
-	GetProposer(num uint64, round uint64) (common.Address, error)
+type BroadcastRequest struct {
+	Targets []common.Address
+	Code    int
+	Msg     any
+}
+
+type VRankPreprepare struct {
+	Block *types.Block
+}
+
+type VRankCandidate struct {
+	BlockNumber uint64
+	Round       uint8
+	BlockHash   common.Hash
+	Sig         []byte
+}
+
+func EncodeCfReport(cfReport CfReport) ([]byte, error) {
+	if len(cfReport) == 0 {
+		return nil, nil
+	}
+
+	return rlp.EncodeToBytes(cfReport)
+}
+
+func DecodeCfReport(data []byte) (CfReport, error) {
+	var cfReport []common.Address
+	if err := rlp.DecodeBytes(data, &cfReport); err != nil {
+		return nil, err
+	}
+	return cfReport, nil
 }

--- a/kaiax/vrank/types_test.go
+++ b/kaiax/vrank/types_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package vrank
+
+import (
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeDecodeCfReport(t *testing.T) {
+	cases := []struct {
+		name   string
+		report CfReport
+	}{
+		{
+			name:   "addresses",
+			report: CfReport{common.HexToAddress("0x15d34AAf54267DB7D7cC839724318F2730aC377B"), common.HexToAddress("0x9965507D1a55bcC2695C58ba16FB37d819D0A4DC")},
+		},
+		{
+			name:   "empty",
+			report: CfReport{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := EncodeCfReport(tc.report)
+			assert.NoError(t, err)
+			if len(tc.report) == 0 {
+				assert.Nil(t, enc)
+				return
+			}
+			assert.NotEmpty(t, enc)
+			dec, err := DecodeCfReport(enc)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.report, dec)
+		})
+	}
+}

--- a/log/log_modules.go
+++ b/log/log_modules.go
@@ -139,6 +139,7 @@ const (
 	KaiaxGasless
 	Builder
 	KaiaxAuction
+	KaiaxVrank
 
 	// ModuleNameLen should be placed at the end of the list.
 	ModuleNameLen
@@ -227,4 +228,5 @@ var moduleNames = [ModuleNameLen]string{
 	"kaiax/gasless",
 	"builder",
 	"kaiax/auction",
+	"kaiax/vrank",
 }


### PR DESCRIPTION
## Proposed changes

This PR adds initial VRank module according to [KIP-227](https://github.com/kaiachain/kips/pull/27) which consists of message handlers.

The ideal process of VRank message processing:

```
proposer@N -> candidates@N: broadcast VRankPreprepare (`HandleIstanbulPreprepare()`)
candidates@N -> validators@N+1: broadcast VRankCandidate (`HandleVRankPreprepare()`)
validators@N+1: collect VRankCandidate messages (`HandleVRankCandidate()`)
proposer@N+1: fill `header.VRank` based on messages (`GetCfReport()`)
```

However, the implementation uses `validators@N` because `validators@N+1` is not finalized during `consensus@N`.

Note that this PR implements only module which does not interact with other objects; it does not yet handle actual Istanbul messages, send VRank messages, or fill `header.VRank` field.

Nil checks must be done by caller.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

