### PR TITLE
p2p/discovery: Polish UDP/Discovery stack

### DIFF
--- a/networks/p2p/discover/discover_storage_simple_test.go
+++ b/networks/p2p/discover/discover_storage_simple_test.go
@@ -119,7 +119,7 @@ func (tn *simpleTestnet) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeI
 }
 
 func (*simpleTestnet) close()                                      {}
-func (*simpleTestnet) waitping(from NodeID) error                  { return nil }
+func (*simpleTestnet) waitping(from NodeID, fromIP net.IP) error   { return nil }
 func (*simpleTestnet) ping(toid NodeID, toaddr *net.UDPAddr) error { return nil }
 
 func isIn(candidate *Node, list []*Node) bool {

--- a/networks/p2p/discover/table.go
+++ b/networks/p2p/discover/table.go
@@ -140,7 +140,7 @@ type bondproc struct {
 // sockets and without generating a private key.
 type transport interface {
 	ping(toid NodeID, toaddr *net.UDPAddr) error
-	waitping(NodeID) error
+	waitping(fromID NodeID, fromIP net.IP) error
 	findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID, targetNT NodeType, max int) ([]*Node, error)
 	close()
 }
@@ -760,7 +760,7 @@ func (tab *Table) pingpong(w *bondproc, pinged bool, id NodeID, addr *net.UDPAdd
 		// sending findnode requests. If they still remember us,
 		// waitping will simply time out.
 		tab.localLogger.Trace("pingpong-waitping", "to", id)
-		tab.net.waitping(id)
+		tab.net.waitping(id, addr.IP)
 	}
 	// Bonding succeeded, update the node database.
 	w.n = NewNode(id, addr.IP, uint16(addr.Port), tcpPort, nil, nType)

--- a/networks/p2p/discover/table_test.go
+++ b/networks/p2p/discover/table_test.go
@@ -243,7 +243,7 @@ func (t *pingRecorder) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID,
 	return nil, nil
 }
 func (t *pingRecorder) close() {}
-func (t *pingRecorder) waitping(from NodeID) error {
+func (t *pingRecorder) waitping(from NodeID, fromIP net.IP) error {
 	return nil // remote always pings
 }
 
@@ -642,7 +642,7 @@ func (tn *preminedTestnet) findnode(toid NodeID, toaddr *net.UDPAddr, target Nod
 }
 
 func (*preminedTestnet) close()                                      {}
-func (*preminedTestnet) waitping(from NodeID) error                  { return nil }
+func (*preminedTestnet) waitping(from NodeID, fromIP net.IP) error   { return nil }
 func (*preminedTestnet) ping(toid NodeID, toaddr *net.UDPAddr) error { return nil }
 
 // mine generates a testnet struct literal with nodes at

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -627,8 +627,10 @@ func (t *udp) readLoop(unhandled chan<- ReadPacket) {
 			logger.Debug("Temporary UDP read error", "err", err)
 			continue
 		} else if err != nil {
-			// Shut down the loop for permanent errors.
-			logger.Warn("UDP read error", "err", err)
+			if !errors.Is(err, net.ErrClosed) { // net.ErrClosed is expected at the program shutdown.
+				// Shut down the readLoop() for unexpected permanent errors.
+				logger.Warn("UDP read error", "err", err)
+			}
 			return
 		}
 		if t.handlePacket(from, buf[:nbytes]) != nil && unhandled != nil {

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -380,9 +380,9 @@ func (t *udp) ping(toid NodeID, toaddr *net.UDPAddr) error {
 	return err
 }
 
-func (t *udp) waitping(from NodeID) error {
-	// Wait for PING from any IP address.
-	return <-t.pending(from, nil, pingPacket, NodeTypeUnknown, func(interface{}) bool { return true })
+func (t *udp) waitping(fromID NodeID, fromIP net.IP) error {
+	// Wait for PING from the given IP address.
+	return <-t.pending(fromID, fromIP, pingPacket, NodeTypeUnknown, func(interface{}) bool { return true })
 }
 
 // findnode sends a findnode request to the given node and waits until

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -346,6 +346,14 @@ func (t *udp) close() {
 	t.wg.Wait()
 }
 
+func (t *udp) isAuthorized(fromID NodeID, nType NodeType) bool {
+	return t.Discovery.IsAuthorized(fromID, nType)
+}
+
+func (t *udp) hasBond(fromID NodeID) bool {
+	return t.Discovery.HasBond(fromID)
+}
+
 // ping sends a ping message to the given node and waits for a reply.
 func (t *udp) ping(toid NodeID, toaddr *net.UDPAddr) error {
 	req := &ping{
@@ -715,7 +723,7 @@ func (req *ping) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 		mismatchNetworkCounter.Mark(1)
 		return errMismatchNetwork
 	}
-	if !t.Discovery.IsAuthorized(fromID, req.From.NType) {
+	if !t.isAuthorized(fromID, req.From.NType) {
 		logger.Trace("unauthorized node.", "nodeid", fromID, "nodetype", req.From.NType)
 		return errUnauthorized
 	}
@@ -762,7 +770,7 @@ func (req *findnode) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 	if expired(req.Expiration) {
 		return errExpired
 	}
-	if !t.HasBond(fromID) {
+	if !t.hasBond(fromID) {
 		// No bond exists, we don't process the packet. This prevents
 		// an attack vector where the discovery protocol could be used
 		// to amplify traffic in a DDOS attack. A malicious actor

--- a/networks/p2p/discover/udp_test.go
+++ b/networks/p2p/discover/udp_test.go
@@ -178,6 +178,7 @@ func TestUDP_responseTimeouts(t *testing.T) {
 		// For all other requests, a reply is scheduled to arrive
 		// within the timeout window.
 		p := &pending{
+			fromIP:   net.IPv4(127, 0, 0, 1),
 			ptype:    byte(rand.Intn(255)),
 			callback: func(interface{}) bool { return true },
 		}
@@ -190,7 +191,7 @@ func TestUDP_responseTimeouts(t *testing.T) {
 			p.errc = nilErr
 			test.udp.addpending <- p
 			time.AfterFunc(randomDuration(60*time.Millisecond), func() {
-				if !test.udp.handleReply(p.from, p.ptype, nil) {
+				if !test.udp.handleReply(p.from, p.fromIP, p.ptype, nil) {
 					t.Logf("not matched: %v", p)
 				}
 			})


### PR DESCRIPTION
## Proposed changes

- `udp.close()` waits for the infinite loop() and readLoop() shutdown https://github.com/kaiachain/kaia/commit/68069d220b74d6e6fd14e2b2f614a8050708dc4d
- Remove unnecessary log `WARN[02/09,23:24:15 +09] [34] UDP read error     err="read udp [::]:32323: use of closed network connection"` https://github.com/kaiachain/kaia/commit/176fb13abb8604333b7965a243bfb5ed1ca3692a
- In case of reply-type packets (pong, neighbors), check that the reply is coming from the IP address that I requested. Ignoring reply-type packets coming from an unwanted (not requested) IP. https://github.com/kaiachain/kaia/commit/964bf854352741fa21c92efda3a135d3c8f49ca4, cd8cf6d18
  - 1. I send a FINDNODE to 1.2.3.4.
  - 2. Enqueue {type=NEIGHBORS, from=1.2.3.4} in the pending queue
  - 3. If a NEIGHBORS comes from 1.2.3.4, handle the packet. Ignore it otherwise.
- Split `packet.preverify()` and `packet.handle()` for readability. https://github.com/kaiachain/kaia/pull/744/commits/ef64917c03bb2ab0af505bcb315154a224089c36
  - preverify(): common sanity checks
  - handle(): packet type-specific
- Wrap `t.Discovery.IsAuthorized()` and `t.Discovery.HasBond()` so we can switch underlying implementation later. https://github.com/kaiachain/kaia/pull/744/changes/a35f698e82b727a99a2c6e6efa3c2752a57f8e64

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
