### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/networks/p2p/discover/discover_api_test.go
+++ b/networks/p2p/discover/discover_api_test.go
@@ -19,6 +19,7 @@
 package discover
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
@@ -153,14 +154,7 @@ func TestTable_GetBucketEntries(t *testing.T) {
 			t.Error("the length of actual data is different from the result of GetBucketEntries")
 		}
 		for _, node := range storage.data {
-			existed := false
-			for _, node2 := range entries {
-				if node.CompareNode(node2) {
-					existed = true
-					break
-				}
-			}
-			if !existed {
+			if !slices.ContainsFunc(entries, node.CompareNode) {
 				t.Error("node does not existed", "nodeid", node.ID)
 			}
 		}

--- a/networks/p2p/discover/discover_storage_simple_test.go
+++ b/networks/p2p/discover/discover_storage_simple_test.go
@@ -21,6 +21,7 @@ package discover
 import (
 	"crypto/rand"
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
@@ -123,12 +124,7 @@ func (*simpleTestnet) waitping(from NodeID) error                  { return nil 
 func (*simpleTestnet) ping(toid NodeID, toaddr *net.UDPAddr) error { return nil }
 
 func isIn(candidate *Node, list []*Node) bool {
-	for _, node := range list {
-		if candidate.CompareNode(node) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(list, candidate.CompareNode)
 }
 
 func TestShuffle(t *testing.T) {

--- a/networks/p2p/discover/node.go
+++ b/networks/p2p/discover/node.go
@@ -33,6 +33,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -289,10 +290,8 @@ func (n *Node) AddSubport(port uint16) {
 	if n.TCPs == nil {
 		n.TCPs = []uint16{}
 	}
-	for _, val := range n.TCPs {
-		if val == port {
-			return
-		}
+	if slices.Contains(n.TCPs, port) {
+		return
 	}
 	n.TCPs = append(n.TCPs, port)
 }

--- a/networks/p2p/peer.go
+++ b/networks/p2p/peer.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -151,10 +152,8 @@ func (p *Peer) Name() string {
 // versions is supported by both this node and the peer p.
 func (p *Peer) RunningCap(protocol string, versions []uint) bool {
 	if protos, ok := p.running[protocol]; ok {
-		for _, ver := range versions {
-			if protos[ConnDefault].Version == ver {
-				return true
-			}
+		if slices.Contains(versions, protos[ConnDefault].Version) {
+			return true
 		}
 	}
 	return false

--- a/node/cn/filters/filter.go
+++ b/node/cn/filters/filter.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"slices"
 	"strconv"
 
 	"github.com/kaiachain/kaia/blockchain"
@@ -311,16 +312,6 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) (logs [
 	return nil, nil
 }
 
-func includes(addresses []common.Address, a common.Address) bool {
-	for _, addr := range addresses {
-		if addr == a {
-			return true
-		}
-	}
-
-	return false
-}
-
 // filterLogs creates a slice of logs matching the given criteria.
 func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]common.Hash) []*types.Log {
 	var ret []*types.Log
@@ -333,7 +324,7 @@ Logs:
 			continue
 		}
 
-		if len(addresses) > 0 && !includes(addresses, log.Address) {
+		if len(addresses) > 0 && !slices.Contains(addresses, log.Address) {
 			continue
 		}
 		// If the to filtered topics is greater than the amount of topics in logs, skip.
@@ -341,14 +332,7 @@ Logs:
 			continue Logs
 		}
 		for i, topics := range topics {
-			match := len(topics) == 0 // empty rule set == wildcard
-			for _, topic := range topics {
-				if log.Topics[i] == topic {
-					match = true
-					break
-				}
-			}
-			if !match {
+			if !slices.Contains(topics, log.Topics[i]) {
 				continue Logs
 			}
 		}

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
@@ -928,9 +929,9 @@ func TestGetPeers_AddrExists(t *testing.T) {
 	foundAddrs := pm.GetPeers()
 
 	assert.Equal(t, 3, len(foundAddrs))
-	assert.True(t, contains(foundAddrs, addrs[0]))
-	assert.True(t, contains(foundAddrs, addrs[1]))
-	assert.True(t, contains(foundAddrs, addrs[2]))
+	assert.True(t, slices.Contains(foundAddrs, addrs[0]))
+	assert.True(t, slices.Contains(foundAddrs, addrs[1]))
+	assert.True(t, slices.Contains(foundAddrs, addrs[2]))
 }
 
 func TestGetPeers_AddrNotExists(t *testing.T) {
@@ -964,9 +965,9 @@ func TestGetPeers_AddrNotExists(t *testing.T) {
 	foundAddrs := pm.GetPeers()
 
 	assert.Equal(t, 3, len(foundAddrs))
-	assert.True(t, contains(foundAddrs, addrs[0]))
-	assert.True(t, contains(foundAddrs, addrs[1]))
-	assert.True(t, contains(foundAddrs, addrs[2]))
+	assert.True(t, slices.Contains(foundAddrs, addrs[0]))
+	assert.True(t, slices.Contains(foundAddrs, addrs[1]))
+	assert.True(t, slices.Contains(foundAddrs, addrs[2]))
 }
 
 func TestEnqueue(t *testing.T) {
@@ -1144,15 +1145,6 @@ func TestReBroadcastTxsSortedByTime(t *testing.T) {
 		assert.Equal(t, sortedTxs[i].Hash(), tx.Hash())
 		assert.False(t, sortedTxs[i].Time().Equal(tx.Time()))
 	}
-}
-
-func contains(addrs []common.Address, item common.Address) bool {
-	for _, a := range addrs {
-		if a == item {
-			return true
-		}
-	}
-	return false
 }
 
 func createAndRegisterPeers(mockCtrl *gomock.Controller, peers *peerSet) (*MockPeer, *MockPeer, *MockPeer) {

--- a/node/cn/peer_set_test.go
+++ b/node/cn/peer_set_test.go
@@ -20,6 +20,7 @@ package cn
 
 import (
 	"math/big"
+	"slices"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -1005,12 +1006,7 @@ func TestPeerSet_TypePeersWithoutBlock(t *testing.T) {
 }
 
 func containsPeer(target Peer, peers []Peer) bool {
-	for _, peer := range peers {
-		if target == peer {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(peers, target)
 }
 
 func countPeerType(t common.ConnType, peers []Peer) int {

--- a/work/builder/bundle.go
+++ b/work/builder/bundle.go
@@ -17,6 +17,8 @@
 package builder
 
 import (
+	"slices"
+
 	"github.com/kaiachain/kaia/common"
 )
 
@@ -82,10 +84,8 @@ func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 	}
 
 	// 2-2. Check for overlapping txs
-	for _, txOrGen := range newBundle.BundleTxs {
-		if b.Has(txOrGen) {
-			return true
-		}
+	if slices.ContainsFunc(newBundle.BundleTxs, b.Has) {
+		return true
 	}
 
 	// 2-3. Check for TargetTxHash breaking current bundle.


### PR DESCRIPTION
## Proposed changes


There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
