### PR TITLE
p2p/Server: Factor out channel event loop to mutex-protected methods

### DIFF
--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -1,0 +1,479 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/kaiachain/kaia/networks/p2p/discover"
+	"github.com/kaiachain/kaia/networks/p2p/netutil"
+)
+
+var (
+	maxConcurrentDials = 16 // Maximum number of concurrent dial attempts.
+	dialMaxRetries     = 3  // Maximum number of retries to dial the same node.
+
+	dialBackoff      = 30 * time.Second // Minimum interval between the dial for the same node ID.
+	refreshBackoff   = 4 * time.Second  // Minimum interval between discretionary discovery table refreshes.
+	idleDialInterval = 10 * time.Second // Spins down the dial loop when there are no ongoing dial attempts.
+)
+
+// DialBackend is the minimal server-side API dialsched needs for outbound dial execution.
+type DialBackend interface {
+	SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Node) error
+}
+
+// discovery is the minimal table API dialsched needs.
+type discovery interface {
+	GetNodes(targetType discover.NodeType, max int) []*discover.Node
+	ReadRandomNodes(buf []*discover.Node, nType discover.NodeType) int
+	Lookup(target discover.NodeID, targetType discover.NodeType) []*discover.Node
+}
+
+type DialConfig struct {
+	selfID   discover.NodeID
+	selfType discover.NodeType
+
+	staticNodes []*discover.Node // initial set of static nodes.
+	netrestrict *netutil.Netlist
+
+	// target number of outbound connections for each node type.
+	// Set connTargets[T] = 0 to disable dynamic dial of node type T (i.e. only accept inbound connections).
+	// Set connTargets = nil to use the default value based on the selfType.
+	// See also: discover.table.discoverTargets.
+	connTarget map[discover.NodeType]int
+}
+
+// DialSched schedules outbound dial attempts to fulfill the desired amount of connections for each node type.
+//
+// The target nodes are either dynamic or static.
+//   - Static nodes: Manually set by static-nodes.json or admin_addPeer.
+//     Connections to the static nodes are always established, regardless of the connTargets or p2p.Server's peer quota.
+//     Since we always attempt to dial static nodes, we have to limit infinite retries towards a dead static node.
+//     If a static node fails many times, the node is removed from the `static` list.
+//   - Dynamic nodes: Fetched from the discovery table. Learned from bootnodes and other peers over UDP discovery.
+//     Discovery nodes are considered if static nodes are not enough to fulfill the connTargets.
+//
+// Note that NodeTypeUnknown is also a valid static node here. NodeTypeUnknown occurs when user-supplied KNI is missing the `?ntype=` parameter.
+// In this case, the node's type is determined after the dialing and connection handshake.
+type DialSched struct {
+	mu         sync.RWMutex
+	selfID     discover.NodeID
+	connTarget map[discover.NodeType]int // Number of outbound connections to maintain for each node type
+	dialer     NodeDialer
+	backend    DialBackend
+
+	// Node sources
+	static typedNodeSet // The static nodes.
+	tab    discovery    // The provider of dynamic nodes.
+
+	// Controls the discretionary discovery table refresh.
+	refreshBackoff time.Time // Earliest time allowed to refresh the discovery table.
+
+	// Dialing nodes
+	dialing     typedNodeSet
+	dialBackoff map[discover.NodeID]time.Time // Earliest times allowed to retry dialing.
+	netrestrict *netutil.Netlist
+
+	// Connected nodes
+	connectedAll      typedNodeSet            // All connected peers, inbound + outbound.
+	connectedOutbound typedNodeSet            // Outbound connected peers only.
+	connFails         map[discover.NodeID]int // For static nodes, count the consecutive connection failures to limit retries.
+
+	// Coordination
+	started  atomic.Bool
+	closed   atomic.Bool
+	closeReq chan struct{}
+	wakeDial chan struct{}
+	wg       sync.WaitGroup
+}
+
+func NewDialSched(cfg DialConfig, tab discovery, backend DialBackend) *DialSched {
+	connTarget := cfg.connTarget
+	if connTarget == nil {
+		connTarget = defaultConnTarget(cfg.selfType)
+	}
+
+	ds := &DialSched{
+		selfID:            cfg.selfID,
+		connTarget:        connTarget,
+		dialer:            TCPDialer{Dialer: &net.Dialer{Timeout: defaultDialTimeout}},
+		backend:           backend,
+		static:            newTypedNodeSet(),
+		tab:               tab,
+		dialing:           newTypedNodeSet(),
+		dialBackoff:       make(map[discover.NodeID]time.Time),
+		netrestrict:       cfg.netrestrict,
+		connectedAll:      newTypedNodeSet(),
+		connectedOutbound: newTypedNodeSet(),
+		connFails:         make(map[discover.NodeID]int),
+		closeReq:          make(chan struct{}),
+		wakeDial:          make(chan struct{}, 1),
+	}
+	for _, n := range cfg.staticNodes {
+		ds.addStatic(n)
+	}
+
+	return ds
+}
+
+func (ds *DialSched) Start() {
+	if ds.closed.Load() || ds.started.Swap(true) {
+		return
+	}
+	ds.wg.Add(1)
+	go ds.dialLoop()
+}
+
+func (ds *DialSched) Close() {
+	if ds.closed.Swap(true) {
+		return
+	}
+	close(ds.closeReq)
+	ds.wg.Wait()
+}
+
+func (ds *DialSched) AddStatic(n *discover.Node) {
+	ds.addStatic(n)
+	ds.signalDial()
+}
+
+func (ds *DialSched) RemoveStatic(id discover.NodeID) {
+	ds.removeStatic(id)
+	ds.signalDial()
+}
+
+// OnPeerConnected updates connected bookkeeping using the actual peer type observed at handshake.
+// Inbound peers count for deduplication but not for outbound connTarget accounting.
+func (ds *DialSched) OnPeerConnected(n *discover.Node, inbound bool) {
+	ds.markConnSuccess(n, inbound)
+	ds.signalDial()
+}
+
+func (ds *DialSched) OnPeerDisconnected(id discover.NodeID, nType discover.NodeType) {
+	ds.markConnDisconnect(id)
+	ds.signalDial()
+}
+
+// Let the dialLoop know that the situation has changed and it should check again.
+func (ds *DialSched) signalDial() {
+	select {
+	case ds.wakeDial <- struct{}{}:
+	default:
+	}
+}
+
+//// Dial task loop
+
+func (ds *DialSched) dialLoop() {
+	defer ds.wg.Done()
+	resCh := make(chan struct{}, maxConcurrentDials)
+
+	for {
+		candidates, needRefresh := ds.getCandidates()
+		ds.launchDialTasks(candidates, resCh)
+		if needRefresh && ds.shouldRefresh() {
+			ds.refreshOnce(resCh)
+		}
+
+		var idle <-chan time.Time
+		if ds.dialing.len() == 0 {
+			idle = time.After(idleDialInterval)
+		}
+
+		select { // Loop upon any of the following signals.
+		case <-ds.wakeDial: // situation changed
+		case <-resCh: // one dial task completed (either success or failure)
+		case <-idle: // done idling
+		case <-ds.closeReq:
+			return
+		}
+	}
+}
+
+// Return the candidates for dialing from the mixture of static and dynamic nodes.
+func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh bool) {
+	ds.mu.RLock()
+
+	// 1. Determine the demand
+	needs := make(map[discover.NodeType]int)
+	for targetType := range ds.connTarget {
+		needs[targetType] = ds.connTarget[targetType] - ds.connectedOutbound.count(targetType) - ds.dialing.count(targetType)
+	}
+
+	// 2. Add all static nodes, even if they are already connected or in the dialing list. Those will be filtered out later.
+	// Since static nodes are exempt from the connTargets nor peer limits, all static nodes are going to be dialed.
+	candidates = ds.static.all()
+	ds.mu.RUnlock()
+
+	// 3. Dynamic nodes
+	for targetType, need := range needs {
+		dynamicNodes, refresh := ds.getDynamicCandidates(targetType, need)
+		candidates = append(candidates, dynamicNodes...)
+		needRefresh = needRefresh || refresh
+	}
+
+	logger.Warn("Dialing candidates", "needs", needs, "candidates", len(candidates))
+	return candidates, needRefresh
+}
+
+func (ds *DialSched) getDynamicCandidates(targetType discover.NodeType, need int) (nodes []*discover.Node, needRefresh bool) {
+	if ds.tab == nil || need <= 0 {
+		return nil, false
+	}
+	oversample := need * 4 // Oversample in case some nodes are not reachable.
+	switch targetType {    // TODO: to be unified with tab.RandomNodes() and tab.Refresh()
+	case discover.NodeTypeCN, discover.NodeTypePN:
+		nodes = ds.tab.GetNodes(targetType, oversample)
+		return nodes, len(nodes) < need
+	case discover.NodeTypeEN:
+		random := make([]*discover.Node, oversample)
+		num := ds.tab.ReadRandomNodes(random, targetType)
+		nodes := random[:min(num, len(random))]
+		return nodes, len(nodes) < need
+	default:
+		return nil, false
+	}
+}
+
+func (ds *DialSched) launchDialTasks(candidates []*discover.Node, resCh chan struct{}) {
+	for _, n := range candidates {
+		if !ds.shouldDial(n) {
+			continue
+		}
+		ds.markDialingStart(n)
+		nn := cloneNode(n)
+		go func() {
+			ds.dialOnce(nn)
+			resCh <- struct{}{}
+		}()
+	}
+}
+
+func (ds *DialSched) dialOnce(n *discover.Node) {
+	defer ds.markDialingEnd(n.ID)
+
+	if ds.dialer == nil || ds.backend == nil {
+		ds.markConnFailure(n.ID)
+		return
+	}
+
+	flags := dynDialedConn
+	if ds.static.contains(n.ID) {
+		flags = staticDialedConn
+	}
+
+	logger.Warn("Dialing node", "id", n.ID, "type", n.NType, "addresses", n.TCPs)
+	var err error
+	if len(n.TCPs) > 1 {
+		err = ds.dialMulti(n, flags)
+	} else {
+		err = ds.dial(n, flags)
+	}
+	logger.Warn("Dialed node", "id", n.ID, "type", n.NType, "addresses", n.TCPs, "err", err)
+
+	if err != nil {
+		ds.markConnFailure(n.ID)
+	} else {
+		ds.markConnSuccess(n, false)
+	}
+}
+
+func (ds *DialSched) dial(dest *discover.Node, flags connFlag) error {
+	fd, err := ds.dialer.Dial(dest)
+	if err != nil {
+		return err
+	}
+	mfd := newMeteredConn(fd, false)
+	return ds.backend.SetupConn(mfd, flags, dest)
+}
+
+func (ds *DialSched) dialMulti(dest *discover.Node, flags connFlag) error {
+	fds, err := ds.dialer.DialMulti(dest)
+	if err != nil {
+		return err
+	}
+
+	var errBackup error
+	for portOrder, fd := range fds {
+		mfd := newMeteredConn(fd, false)
+		destByPort := cloneNode(dest)
+		destByPort.PortOrder = uint16(portOrder)
+		if err := ds.backend.SetupConn(mfd, flags, destByPort); err != nil {
+			errBackup = err
+		}
+	}
+	if errBackup != nil {
+		for _, fd := range fds {
+			fd.Close()
+		}
+	}
+	return errBackup
+}
+
+func (ds *DialSched) refreshOnce(resCh chan struct{}) {
+	ds.mu.Lock()
+	ds.refreshBackoff = time.Now().Add(refreshBackoff)
+	ds.mu.Unlock()
+
+	if ds.tab == nil {
+		return
+	}
+	go func() {
+		ds.tab.Lookup(ds.selfID, discover.NodeTypeCN)
+		ds.tab.Lookup(ds.selfID, discover.NodeTypePN)
+		ds.tab.Lookup(ds.selfID, discover.NodeTypeEN)
+		resCh <- struct{}{}
+	}()
+}
+
+//// Internal variable accessors
+
+func (ds *DialSched) addStatic(n *discover.Node) {
+	if n == nil {
+		return
+	}
+	if n.Incomplete() {
+		logger.Warn("Rejecting incomplete static node", "id", n.ID, "type", n.NType)
+		return
+	}
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	ds.static.add(cloneNode(n))
+}
+
+func (ds *DialSched) removeStatic(id discover.NodeID) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	ds.static.remove(id)
+
+	// Additionally cleanup the dial speed bumps.
+	// This allows admin_removePeer -> admin_addPeer combo to force an immediate reconnect.
+	delete(ds.dialBackoff, id)
+	delete(ds.connFails, id)
+}
+
+func (ds *DialSched) shouldRefresh() bool {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+
+	return ds.refreshBackoff.Before(time.Now())
+}
+
+func (ds *DialSched) shouldDial(n *discover.Node) bool {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+
+	if n == nil {
+		return false
+	}
+	if n.Incomplete() {
+		logger.Warn("Rejecting incomplete dial candidate", "id", n.ID, "type", n.NType)
+		return false
+	}
+	if ds.dialing.len() >= maxConcurrentDials {
+		return false
+	}
+	if n.ID == ds.selfID {
+		return false
+	}
+	if ds.netrestrict != nil && !ds.netrestrict.Contains(n.IP) {
+		return false
+	}
+	if ds.connectedAll.contains(n.ID) {
+		return false
+	}
+	if ds.dialing.contains(n.ID) {
+		return false
+	}
+	if until, ok := ds.dialBackoff[n.ID]; ok && time.Now().Before(until) {
+		return false
+	}
+	return true
+}
+
+func (ds *DialSched) markDialingStart(n *discover.Node) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	ds.dialing.add(n)
+	ds.dialBackoff[n.ID] = time.Now().Add(dialBackoff)
+}
+
+func (ds *DialSched) markDialingEnd(id discover.NodeID) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	ds.dialing.remove(id)
+}
+
+func (ds *DialSched) markConnSuccess(n *discover.Node, inbound bool) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	if n == nil {
+		return
+	}
+	// Retype existing entry (if any) to fix the source type vs. connected type discrepancy.
+	ds.connectedAll.remove(n.ID)
+	ds.connectedAll.add(n)
+
+	ds.connectedOutbound.remove(n.ID)
+	if !inbound {
+		ds.connectedOutbound.add(n)
+	}
+
+	delete(ds.connFails, n.ID)
+	delete(ds.dialBackoff, n.ID)
+}
+
+func (ds *DialSched) markConnFailure(id discover.NodeID) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	ds.connectedAll.remove(id)
+	ds.connectedOutbound.remove(id)
+	if ds.static.contains(id) {
+		ds.connFails[id]++
+		if ds.connFails[id] > dialMaxRetries {
+			ds.static.remove(id)
+		}
+	}
+}
+
+func (ds *DialSched) markConnDisconnect(id discover.NodeID) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	ds.connectedAll.remove(id)
+	ds.connectedOutbound.remove(id)
+}
+
+func cloneNode(n *discover.Node) *discover.Node {
+	if n == nil {
+		return nil
+	}
+	nn := *n
+	nn.TCPs = append([]uint16(nil), n.TCPs...)
+	return &nn
+}

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -1,0 +1,505 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kaiachain/kaia/networks/p2p/discover"
+	"github.com/kaiachain/kaia/networks/p2p/netutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTable struct {
+	getNodesByType map[discover.NodeType][]*discover.Node
+	randomByType   map[discover.NodeType][]*discover.Node
+	lookupCalls    int
+}
+
+func (m *mockTable) Lookup(target discover.NodeID, targetType discover.NodeType) []*discover.Node {
+	m.lookupCalls++
+	return nil
+}
+
+func (m *mockTable) GetNodes(targetType discover.NodeType, max int) []*discover.Node {
+	nodes := m.getNodesByType[targetType]
+	if max < len(nodes) {
+		return nodes[:max]
+	}
+	return nodes
+}
+
+func (m *mockTable) ReadRandomNodes(buf []*discover.Node, nType discover.NodeType) int {
+	return copy(buf, m.randomByType[nType])
+}
+
+type mockDialer struct {
+	mu      sync.Mutex
+	dialErr map[discover.NodeID]error // injected errors, discriminated by NodeID.
+}
+
+func (m *mockDialer) Dial(dest *discover.Node) (net.Conn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.dialErr[dest.ID]; err != nil {
+		return nil, err
+	}
+	c1, c2 := net.Pipe()
+	_ = c2.Close()
+	return c1, nil
+}
+
+func (m *mockDialer) DialMulti(dest *discover.Node) ([]net.Conn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.dialErr[dest.ID]; err != nil {
+		return nil, err
+	}
+	conns := make([]net.Conn, 0, len(dest.TCPs))
+	for range dest.TCPs {
+		c1, c2 := net.Pipe()
+		_ = c2.Close()
+		conns = append(conns, c1)
+	}
+	return conns, nil
+}
+
+type setupConnArg struct {
+	id    discover.NodeID
+	flags connFlag
+	port  uint16
+}
+
+type mockSetupBackend struct {
+	mu       sync.Mutex
+	setupErr map[discover.NodeID]error // injected errors, discriminated by NodeID.
+	calls    []setupConnArg            // recorded SetupConn calls.
+}
+
+func (m *mockSetupBackend) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Node) error {
+	if fd != nil {
+		_ = fd.Close()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	call := setupConnArg{flags: flags}
+	if dialDest != nil {
+		call.id = dialDest.ID
+		call.port = dialDest.PortOrder
+		if err := m.setupErr[dialDest.ID]; err != nil {
+			m.calls = append(m.calls, call)
+			return err
+		}
+	}
+	m.calls = append(m.calls, call)
+	return nil
+}
+
+func testNodeID(i uint32) discover.NodeID {
+	var id discover.NodeID
+	binary.BigEndian.PutUint32(id[:], i)
+	return id
+}
+
+func testNode(i uint32, ip string, nType discover.NodeType) *discover.Node {
+	return discover.NewNode(testNodeID(i), net.ParseIP(ip), 30303, 30303, nil, nType)
+}
+
+func hasNodeID(nodes []*discover.Node, id discover.NodeID) bool {
+	return slices.ContainsFunc(nodes, func(n *discover.Node) bool {
+		return n.ID == id
+	})
+}
+
+func TestDialSched_Lifecycle_StartCloseTwice(t *testing.T) {
+	var (
+		ds = NewDialSched(DialConfig{
+			selfID: testNodeID(100),
+		}, nil, nil)
+		done = make(chan struct{})
+	)
+
+	ds.Start()
+	ds.Start() // second Start() is no-op
+	assert.True(t, ds.started.Load(), "started should remain true after Start")
+
+	go func() {
+		ds.Close()
+		ds.Close() // second Close() is no-op
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "close should return quickly even when called twice")
+	}
+
+	assert.True(t, ds.closed.Load(), "closed should be true after Close")
+}
+
+func TestDialSched_StaticNode_RejectIncomplete(t *testing.T) {
+	var (
+		incomplete = &discover.Node{ID: testNodeID(1), NType: discover.NodeTypePN}
+		complete   = testNode(2, "10.0.0.2", discover.NodeTypePN)
+
+		ds = NewDialSched(DialConfig{
+			staticNodes: []*discover.Node{incomplete, complete},
+		}, nil, nil)
+	)
+
+	assert.False(t, ds.static.contains(incomplete.ID), "incomplete static node should not be added")
+	assert.True(t, ds.static.contains(complete.ID), "complete static node should be added")
+}
+
+func TestDialSched_StaticNode_Retry(t *testing.T) {
+	staticNode := testNode(1, "10.0.0.1", discover.NodeTypeEN)
+	ds := NewDialSched(DialConfig{
+		staticNodes: []*discover.Node{staticNode},
+	}, nil, nil)
+
+	// Disconnect does not remove the static node.
+	for i := 0; i < dialMaxRetries+2; i++ {
+		ds.OnPeerDisconnected(staticNode.ID, staticNode.NType)
+	}
+	assert.True(t, ds.static.contains(staticNode.ID), "static node must not be removed by disconnection events only")
+
+	// But Failure does remove the static node.
+	for i := 0; i < dialMaxRetries+2; i++ {
+		ds.markConnFailure(staticNode.ID)
+	}
+	assert.False(t, ds.static.contains(staticNode.ID), "static node must be removed by failure events")
+}
+
+func TestDialSched_StaticNode_RedialImmediatelyAfterReAdd(t *testing.T) {
+	node := testNode(51, "10.0.0.51", discover.NodeTypePN)
+	ds := NewDialSched(DialConfig{
+		staticNodes: []*discover.Node{node},
+	}, nil, nil)
+
+	ds.dialBackoff[node.ID] = time.Now().Add(time.Minute)
+	ds.connFails[node.ID] = 2
+
+	ds.RemoveStatic(node.ID)
+	ds.AddStatic(node)
+
+	_, hasBackoff := ds.dialBackoff[node.ID]
+	_, hasConnFail := ds.connFails[node.ID]
+	assert.False(t, hasBackoff, "removeStatic should clear dialBackoff")
+	assert.False(t, hasConnFail, "removeStatic should clear connFails")
+	assert.True(t, ds.shouldDial(node), "re-added static node should be dialable immediately")
+}
+
+func TestDialSched_OnPeerConnected(t *testing.T) {
+	var (
+		candidate = testNode(1, "10.0.0.1", discover.NodeTypePN)
+		inbound   = testNode(2, "10.0.0.2", discover.NodeTypePN)
+		outbound  = testNode(3, "10.0.0.3", discover.NodeTypePN)
+		tab       = &mockTable{
+			getNodesByType: map[discover.NodeType][]*discover.Node{
+				discover.NodeTypePN: {candidate},
+			},
+			randomByType: map[discover.NodeType][]*discover.Node{},
+		}
+		ds = NewDialSched(DialConfig{
+			connTarget: map[discover.NodeType]int{
+				discover.NodeTypePN: 1,
+			},
+		}, tab, nil)
+	)
+
+	ds.OnPeerConnected(inbound, true)
+	assert.False(t, ds.connectedOutbound.contains(inbound.ID), "inbound peer should not be counted as connected outbound")
+	assert.True(t, ds.connectedAll.contains(inbound.ID), "inbound peer should be counted as connected")
+	cands, _ := ds.getCandidates()
+	require.Len(t, cands, 1, "expected one outbound candidate for PN when only inbound PN exists")
+	assert.Equal(t, candidate.ID, cands[0].ID)
+
+	ds.OnPeerConnected(outbound, false)
+	assert.True(t, ds.connectedOutbound.contains(outbound.ID), "outbound peer should be counted as connected outbound")
+	assert.True(t, ds.connectedAll.contains(outbound.ID), "outbound peer should be counted as connected")
+	cands, _ = ds.getCandidates()
+	assert.Len(t, cands, 0, "expected no outbound candidate when outbound PN target is already met")
+}
+
+func TestDialSched_ShouldRefresh_RefreshBackoff(t *testing.T) {
+	var (
+		tab = &mockTable{
+			getNodesByType: map[discover.NodeType][]*discover.Node{},
+			randomByType:   map[discover.NodeType][]*discover.Node{},
+		}
+		ds = NewDialSched(DialConfig{
+			selfID: testNodeID(1),
+		}, tab, nil)
+		resCh = make(chan struct{}, 1)
+	)
+
+	assert.True(t, ds.shouldRefresh(), "expected initial refresh to be allowed")
+	ds.refreshOnce(resCh)
+	select {
+	case <-resCh:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "refreshOnce did not finish in time")
+	}
+	assert.Equal(t, 3, tab.lookupCalls, "expected one refresh to perform 3 lookups (CN, PN, EN)")
+
+	// Forcibly set the refresh backoff to be in the past.
+	assert.False(t, ds.shouldRefresh(), "expected refresh to be throttled immediately after refreshOnce")
+	ds.refreshBackoff = time.Now().Add(-refreshBackoff)
+
+	assert.True(t, ds.shouldRefresh(), "expected refresh to be allowed after backoff expiry")
+	ds.refreshOnce(resCh)
+	select {
+	case <-resCh:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "second refreshOnce did not finish in time")
+	}
+	assert.Equal(t, 6, tab.lookupCalls, "expected second refresh to perform 6 lookups (CN, PN, EN)")
+}
+
+func TestDialSched_Candidates_StaticNodes(t *testing.T) {
+	var (
+		staticNode = testNode(61, "10.0.0.61", discover.NodeTypePN)
+		ds         = NewDialSched(DialConfig{
+			staticNodes: []*discover.Node{staticNode},
+			connTarget: map[discover.NodeType]int{
+				discover.NodeTypePN: 0, // Even if connTarget is zero, always attempt to connect to static nodes.
+			},
+		}, nil, nil)
+	)
+
+	cands, _ := ds.getCandidates()
+	assert.Equal(t, staticNode.ID, cands[0].ID, "static node should be the only candidate")
+}
+
+func TestDialSched_GetCandidates_FromDiscovery(t *testing.T) {
+	var (
+		pn  = testNode(201, "10.0.0.201", discover.NodeTypePN)
+		en  = testNode(202, "10.0.0.202", discover.NodeTypeEN)
+		tab = &mockTable{
+			getNodesByType: map[discover.NodeType][]*discover.Node{
+				discover.NodeTypePN: {pn},
+			},
+			randomByType: map[discover.NodeType][]*discover.Node{
+				discover.NodeTypeEN: {en},
+			},
+		}
+		ds = NewDialSched(DialConfig{
+			connTarget: map[discover.NodeType]int{
+				discover.NodeTypePN: 1,
+				discover.NodeTypeEN: 1,
+			},
+		}, tab, nil)
+	)
+
+	cands, needRefresh := ds.getCandidates()
+
+	assert.True(t, hasNodeID(cands, pn.ID), "PN candidates should include GetNodes result")
+	assert.True(t, hasNodeID(cands, en.ID), "EN candidates should include ReadRandomNodes result")
+	assert.False(t, needRefresh, "No need to refresh when candidates are enough")
+}
+
+func TestDialSched_GetCandidates_SkipDiscovery(t *testing.T) {
+	var (
+		pn  = testNode(211, "10.0.0.211", discover.NodeTypePN)
+		en  = testNode(212, "10.0.0.212", discover.NodeTypeEN)
+		tab = &mockTable{}
+		ds  = NewDialSched(DialConfig{
+			connTarget: map[discover.NodeType]int{
+				discover.NodeTypePN: 1,
+				discover.NodeTypeEN: 1,
+			},
+		}, tab, nil)
+	)
+
+	// Already fulfilled the connTarget demand.
+	ds.connectedOutbound.add(pn)
+	ds.connectedOutbound.add(en)
+
+	cands, needRefresh := ds.getCandidates()
+
+	assert.Len(t, cands, 0) // Don't fetch dynamic nodes.
+	assert.False(t, needRefresh, "needRefresh should remain false when demand is already satisfied")
+}
+
+func TestDialSched_ShouldDial(t *testing.T) {
+	var (
+		ds = NewDialSched(DialConfig{
+			selfID:      testNodeID(900),
+			netrestrict: mustParseNetlist(t, "10.0.0.0/8"),
+		}, nil, nil)
+
+		nodeSelf       = testNode(900, "10.0.0.9", discover.NodeTypeEN)
+		nodeRestricted = testNode(901, "11.0.0.1", discover.NodeTypeEN)
+		nodeConnected  = testNode(902, "10.0.0.2", discover.NodeTypeEN)
+		nodeDialing    = testNode(903, "10.0.0.3", discover.NodeTypeEN)
+		nodeBackoff    = testNode(904, "10.0.0.4", discover.NodeTypeEN)
+		nodeAllowed    = testNode(905, "10.0.0.5", discover.NodeTypeEN)
+
+		cases = []struct {
+			name string
+			node *discover.Node
+			want bool
+		}{
+			{name: "nil", node: nil, want: false},
+			{name: "incomplete", node: &discover.Node{ID: testNodeID(906), NType: discover.NodeTypeEN}, want: false},
+			{name: "self", node: nodeSelf, want: false},
+			{name: "netrestrict", node: nodeRestricted, want: false},
+			{name: "connected", node: nodeConnected, want: false},
+			{name: "dialing", node: nodeDialing, want: false},
+			{name: "backoff", node: nodeBackoff, want: false},
+			{name: "allowed", node: nodeAllowed, want: true},
+		}
+	)
+
+	ds.connectedAll.add(nodeConnected)
+	ds.dialing.add(nodeDialing)
+	ds.dialBackoff[nodeBackoff.ID] = time.Now().Add(time.Minute)
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, ds.shouldDial(tc.node), tc.name)
+	}
+}
+
+func TestDialSched_LaunchDialTasks(t *testing.T) {
+	var (
+		staticNode = testNode(11, "10.0.0.11", discover.NodeTypeEN)
+		dynNode    = testNode(21, "10.0.0.21", discover.NodeTypeEN)
+		md         = &mockDialer{dialErr: make(map[discover.NodeID]error)}
+		mb         = &mockSetupBackend{setupErr: make(map[discover.NodeID]error)}
+		ds         = NewDialSched(DialConfig{
+			staticNodes: []*discover.Node{staticNode},
+		}, nil, mb)
+		resCh = make(chan struct{}, 2)
+	)
+	ds.dialer = md
+
+	// Launch and wait for both dial tasks to complete.
+	ds.launchDialTasks([]*discover.Node{staticNode, dynNode}, resCh)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-resCh:
+		case <-time.After(2 * time.Second):
+			require.Fail(t, "launchDialTasks did not finish in time")
+		}
+	}
+
+	// Inspect the SetupConn() arguments (could be in different order due to concurrent execution)
+	require.Len(t, mb.calls, 2)
+	if mb.calls[0].id == staticNode.ID {
+		assert.Equal(t, setupConnArg{id: staticNode.ID, flags: staticDialedConn, port: 0}, mb.calls[0])
+		assert.Equal(t, setupConnArg{id: dynNode.ID, flags: dynDialedConn, port: 0}, mb.calls[1])
+	} else {
+		assert.Equal(t, setupConnArg{id: dynNode.ID, flags: dynDialedConn, port: 0}, mb.calls[0])
+		assert.Equal(t, setupConnArg{id: staticNode.ID, flags: staticDialedConn, port: 0}, mb.calls[1])
+	}
+
+	// Inspect the internal states
+	assert.Zero(t, ds.dialing.len(), "expected no nodes to be in the dialing state")
+	assert.True(t, ds.connectedAll.contains(staticNode.ID))
+	assert.True(t, ds.connectedAll.contains(dynNode.ID))
+	assert.True(t, ds.connectedOutbound.contains(staticNode.ID))
+	assert.True(t, ds.connectedOutbound.contains(dynNode.ID))
+}
+
+func TestDialSched_SetupConn(t *testing.T) {
+	var (
+		staticNode = testNode(11, "10.0.0.11", discover.NodeTypeEN)
+		dynNode    = testNode(21, "10.0.0.21", discover.NodeTypeEN)
+		md         = &mockDialer{dialErr: make(map[discover.NodeID]error)}
+		mb         = &mockSetupBackend{setupErr: make(map[discover.NodeID]error)}
+		ds         = NewDialSched(DialConfig{
+			staticNodes: []*discover.Node{staticNode},
+		}, nil, mb)
+	)
+	ds.dialer = md
+
+	ds.dialOnce(staticNode)
+	ds.dialOnce(dynNode)
+
+	// Inspect the SetupConn() arguments
+	require.Len(t, mb.calls, 2)
+	assert.Equal(t, setupConnArg{id: staticNode.ID, flags: staticDialedConn, port: 0}, mb.calls[0])
+	assert.Equal(t, setupConnArg{id: dynNode.ID, flags: dynDialedConn, port: 0}, mb.calls[1])
+
+	// Inspect the internal states
+	assert.True(t, ds.connectedAll.contains(staticNode.ID))
+	assert.True(t, ds.connectedAll.contains(dynNode.ID))
+	assert.True(t, ds.connectedOutbound.contains(staticNode.ID))
+	assert.True(t, ds.connectedOutbound.contains(dynNode.ID))
+}
+
+func TestDialSched_Dial_DialFailure(t *testing.T) {
+	var (
+		staticNode = testNode(301, "10.0.1.31", discover.NodeTypePN)
+		md         = &mockDialer{dialErr: make(map[discover.NodeID]error)}
+		mb         = &mockSetupBackend{
+			setupErr: map[discover.NodeID]error{
+				staticNode.ID: errors.New("mock setup failure"),
+			},
+		}
+		ds = NewDialSched(DialConfig{
+			staticNodes: []*discover.Node{staticNode},
+		}, nil, mb)
+	)
+	ds.dialer = md
+
+	ds.dialOnce(staticNode)
+
+	require.Len(t, mb.calls, 1)
+	assert.Equal(t, staticNode.ID, mb.calls[0].id)
+	assert.Equal(t, staticDialedConn, mb.calls[0].flags)
+	assert.Equal(t, 1, ds.connFails[staticNode.ID], "static dial failure should increment connFails")
+	assert.False(t, ds.connectedAll.contains(staticNode.ID), "static node should not be counted as connected")
+	assert.False(t, ds.connectedOutbound.contains(staticNode.ID), "static node should not be counted as connected")
+}
+
+func TestDialSched_DialMulti(t *testing.T) {
+	var (
+		multiNode = discover.NewNode(testNodeID(401), net.ParseIP("10.0.0.41"), 30303, 30303, []uint16{30304, 30305}, discover.NodeTypeEN)
+		md        = &mockDialer{dialErr: make(map[discover.NodeID]error)}
+		mb        = &mockSetupBackend{setupErr: make(map[discover.NodeID]error)}
+		ds        = NewDialSched(DialConfig{}, nil, mb)
+	)
+	ds.dialer = md
+
+	ds.dialOnce(multiNode)
+
+	require.Len(t, mb.calls, len(multiNode.TCPs), "SetupConn should be called for each dialed connection")
+	for i := range mb.calls {
+		assert.Equal(t, multiNode.ID, mb.calls[i].id)
+		assert.Equal(t, dynDialedConn, mb.calls[i].flags)
+		assert.Equal(t, uint16(i), mb.calls[i].port, "PortOrder should increment per connection")
+	}
+}
+
+func mustParseNetlist(t *testing.T, s string) *netutil.Netlist {
+	t.Helper()
+	nl, err := netutil.ParseNetlist(s)
+	require.NoError(t, err)
+	return nl
+}

--- a/networks/p2p/dialsched_util.go
+++ b/networks/p2p/dialsched_util.go
@@ -1,0 +1,114 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"sync"
+
+	"github.com/kaiachain/kaia/networks/p2p/discover"
+)
+
+func defaultConnTarget(selfType discover.NodeType) map[discover.NodeType]int {
+	switch selfType {
+	case discover.NodeTypeCN:
+		return map[discover.NodeType]int{
+			discover.NodeTypeCN: 100,
+		}
+	case discover.NodeTypePN:
+		return map[discover.NodeType]int{
+			discover.NodeTypePN: 1,
+		}
+	case discover.NodeTypeEN:
+		return map[discover.NodeType]int{
+			discover.NodeTypePN: 2,
+			discover.NodeTypeEN: 3,
+		}
+	default:
+		return map[discover.NodeType]int{}
+	}
+}
+
+type typedNodeSet struct {
+	mu    sync.RWMutex
+	nodes map[discover.NodeType]map[discover.NodeID]*discover.Node
+}
+
+func newTypedNodeSet() typedNodeSet {
+	ns := make(map[discover.NodeType]map[discover.NodeID]*discover.Node)
+	for _, nType := range []discover.NodeType{discover.NodeTypeCN, discover.NodeTypePN, discover.NodeTypeEN, discover.NodeTypeBN, discover.NodeTypeUnknown} {
+		ns[nType] = make(map[discover.NodeID]*discover.Node)
+	}
+	return typedNodeSet{
+		mu:    sync.RWMutex{},
+		nodes: ns,
+	}
+}
+
+func (t *typedNodeSet) add(n *discover.Node) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.nodes[n.NType][n.ID] = n
+}
+
+func (t *typedNodeSet) remove(id discover.NodeID) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for nType := range t.nodes {
+		delete(t.nodes[nType], id)
+	}
+}
+
+func (t *typedNodeSet) len() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	count := 0
+	for nType := range t.nodes {
+		count += len(t.nodes[nType])
+	}
+	return count
+}
+
+func (t *typedNodeSet) all() []*discover.Node {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	nodes := make([]*discover.Node, 0, len(t.nodes))
+	for nType := range t.nodes {
+		for _, n := range t.nodes[nType] {
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
+}
+
+func (t *typedNodeSet) contains(id discover.NodeID) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	for nType := range t.nodes {
+		if _, ok := t.nodes[nType][id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *typedNodeSet) count(nType discover.NodeType) int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.nodes[nType])
+}

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -331,6 +331,7 @@ func (srv *MultiChannelServer) Start() (err error) {
 	srv.peerOp = make(chan peerOpFunc)
 	srv.peerOpDone = make(chan struct{})
 	srv.discpeer = make(chan discover.NodeID)
+	srv.initPeerState()
 
 	var (
 		conn      *net.UDPConn
@@ -611,20 +612,10 @@ func (srv *MultiChannelServer) run(dialstate dialer) {
 	logger.Debug("[p2p.Server] start MultiChannel p2p server")
 	defer srv.loopWG.Done()
 	var (
-		peers         = make(map[discover.NodeID]*Peer)
-		inboundCount  = 0
-		outboundCount = 0
-		trusted       = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
-		taskdone      = make(chan task, maxActiveDialTasks)
-		runningTasks  []task
-		queuedTasks   []task // tasks that can't run yet
+		taskdone     = make(chan task, maxActiveDialTasks)
+		runningTasks []task
+		queuedTasks  []task // tasks that can't run yet
 	)
-	// Put trusted nodes into a map to speed up checks.
-	// Trusted peers are loaded on startup and cannot be
-	// modified while the server is running.
-	for _, n := range srv.TrustedNodes {
-		trusted[n.ID] = true
-	}
 
 	// removes t from runningTasks
 	delTask := func(t task) {
@@ -651,7 +642,7 @@ func (srv *MultiChannelServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
-			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), peers, time.Now())
+			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -665,24 +656,11 @@ running:
 			// The server was stopped. Run the cleanup logic.
 			break running
 		case n := <-srv.addstatic:
-			// This channel is used by AddPeer to add to the
-			// ephemeral static peer list. Add it to the dialer,
-			// it will keep the node connected.
-			srv.logger.Debug("Adding static node", "node", n)
-			dialstate.addStatic(n)
+			srv.handleAddStaticDialstate(dialstate, n)
 		case n := <-srv.removestatic:
-			// This channel is used by RemovePeer to send a
-			// disconnect request to a peer and begin the
-			// stop keeping the node connected
-			srv.logger.Debug("Removing static node", "node", n)
-			dialstate.removeStatic(n)
-			if p, ok := peers[n.ID]; ok {
-				p.Disconnect(DiscRequested)
-			}
+			srv.handleRemoveStaticDialstate(dialstate, n)
 		case op := <-srv.peerOp:
-			// This channel is used by Peers and PeerCount.
-			op(peers)
-			srv.peerOpDone <- struct{}{}
+			srv.handlePeerOpRequest(op)
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
@@ -691,114 +669,25 @@ running:
 			dialstate.taskDone(t, time.Now())
 			delTask(t)
 		case c := <-srv.posthandshake:
-			// A connection has passed the encryption handshake so
-			// the remote identity is known (but hasn't been verified yet).
-			if trusted[c.id] {
-				// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
-				c.flags |= trustedConn
-			}
-			// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
 			select {
-			case c.cont <- srv.encHandshakeChecks(peers, inboundCount, c):
+			case c.cont <- srv.handlePostHandshake(c):
 			case <-srv.quit:
 				break running
 			}
 		case c := <-srv.addpeer:
-			var p *Peer
-			var e error
-			// At this point the connection is past the protocol handshake.
-			// Its capabilities are known and the remote identity is verified.
-			err := srv.protoHandshakeChecks(peers, inboundCount, c)
-			if err == nil {
-				if c.multiChannel {
-					connSet := srv.CandidateConns[c.id]
-					if connSet == nil {
-						connSet = make([]*conn, len(srv.ListenAddrs))
-						srv.CandidateConns[c.id] = connSet
-					}
-
-					if int(c.portOrder) < len(connSet) {
-						connSet[c.portOrder] = c
-					}
-
-					count := len(connSet)
-					for _, conn := range connSet {
-						if conn != nil {
-							count--
-						}
-					}
-
-					if count == 0 {
-						p, e = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
-						srv.CandidateConns[c.id] = nil
-					}
-				} else {
-					// The handshakes are done and it passed all checks.
-					p, e = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
-				}
-
-				if e != nil {
-					srv.logger.Error("Fail make a new peer", "err", e)
-				} else if p != nil {
-					// If message events are enabled, pass the peerFeed
-					// to the peer
-					if srv.EnableMsgEvents {
-						p.events = &srv.peerFeed
-					}
-					name := truncateName(c.name)
-					srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
-					go srv.runPeer(p)
-					peers[c.id] = p
-
-					peerCountGauge.Update(int64(len(peers)))
-					inboundCount, outboundCount = increasesConnectionMetric(inboundCount, outboundCount, p)
-				}
-			}
-			// The dialer logic relies on the assumption that
-			// dial tasks complete after the peer has been added or
-			// discarded. Unblock the task last.
 			select {
-			case c.cont <- err:
+			case c.cont <- srv.handleAddPeer(c):
 			case <-srv.quit:
 				break running
 			}
 		case pd := <-srv.delpeer:
-			// A peer disconnected.
-			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
-			delete(peers, pd.ID())
-
-			peerCountGauge.Update(int64(len(peers)))
-			inboundCount, outboundCount = decreasesConnectionMetric(inboundCount, outboundCount, pd.Peer)
+			srv.handlePeerDrop(pd)
 		case nid := <-srv.discpeer:
-			if p, ok := peers[nid]; ok {
-				p.Disconnect(DiscRequested)
-				p.logger.Debug(fmt.Sprintf("disconnect peer"))
-			}
+			srv.handleDisconnectRequest(nid)
 		}
 	}
 
-	srv.logger.Trace("P2P networking is spinning down")
-
-	// Terminate discovery. If there is a running lookup it will terminate soon.
-	if srv.ntab != nil {
-		srv.ntab.Close()
-	}
-	//if srv.DiscV5 != nil {
-	//	srv.DiscV5.Close()
-	//}
-	// Disconnect all peers.
-	for _, p := range peers {
-		p.Disconnect(DiscQuitting)
-	}
-	// Wait for peers to shut down. Pending connections and tasks are
-	// not handled here and will terminate soon-ish because srv.quit
-	// is closed.
-	for len(peers) > 0 {
-		p := <-srv.delpeer
-		p.logger.Trace("<-delpeer (spindown)", "remainingTasks", len(runningTasks))
-		delete(peers, p.ID())
-	}
+	srv.cleanupAfterRun(len(runningTasks), srv.handlePeerDrop)
 }
 
 // Stop terminates the server and all active peer connections.
@@ -931,6 +820,12 @@ type BaseServer struct {
 	lastLookupMu sync.Mutex
 	// DiscV5       *discv5.Network
 
+	peerMu        sync.RWMutex
+	peers         map[discover.NodeID]*Peer
+	inboundCount  int
+	outboundCount int
+	trusted       map[discover.NodeID]bool
+
 	// These are for Peers, PeerCount (and nothing else).
 	peerOp     chan peerOpFunc
 	peerOpDone chan struct{}
@@ -948,6 +843,36 @@ type BaseServer struct {
 }
 
 type peerOpFunc func(map[discover.NodeID]*Peer)
+
+func (srv *BaseServer) initPeerState() {
+	srv.peerMu.Lock()
+	defer srv.peerMu.Unlock()
+
+	srv.peers = make(map[discover.NodeID]*Peer)
+	srv.inboundCount = 0
+	srv.outboundCount = 0
+	srv.trusted = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
+	for _, n := range srv.TrustedNodes {
+		srv.trusted[n.ID] = true
+	}
+}
+
+func (srv *BaseServer) allPeers() map[discover.NodeID]*Peer {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+
+	peers := make(map[discover.NodeID]*Peer, len(srv.peers))
+	for id, p := range srv.peers {
+		peers[id] = p
+	}
+	return peers
+}
+
+func (srv *BaseServer) peerLen() int {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+	return len(srv.peers)
+}
 
 type peerDrop struct {
 	*Peer
@@ -1232,6 +1157,7 @@ func (srv *BaseServer) Start() (err error) {
 	srv.peerOp = make(chan peerOpFunc)
 	srv.peerOpDone = make(chan struct{})
 	srv.discpeer = make(chan discover.NodeID)
+	srv.initPeerState()
 
 	var (
 		conn      *net.UDPConn
@@ -1344,22 +1270,235 @@ type dialer interface {
 	removeStatic(*discover.Node)
 }
 
+func (srv *BaseServer) isTrusted(id discover.NodeID) bool {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+	return srv.trusted[id]
+}
+
+func (srv *BaseServer) handleAddStaticDialstate(dialstate dialer, n *discover.Node) {
+	// This channel is used by AddPeer to add to the
+	// ephemeral static peer list. Add it to the dialer,
+	// it will keep the node connected.
+	srv.logger.Debug("Adding static node", "node", n)
+	dialstate.addStatic(n)
+}
+
+func (srv *BaseServer) handleRemoveStaticDialstate(dialstate dialer, n *discover.Node) {
+	// This channel is used by RemovePeer to send a
+	// disconnect request to a peer and begin the
+	// stop keeping the node connected.
+	srv.logger.Debug("Removing static node", "node", n)
+	dialstate.removeStatic(n)
+
+	srv.peerMu.RLock()
+	p := srv.peers[n.ID]
+	srv.peerMu.RUnlock()
+	if p != nil {
+		p.Disconnect(DiscRequested)
+	}
+}
+
+func (srv *BaseServer) handlePeerOpRequest(op peerOpFunc) {
+	// This channel is used by Peers and PeerCount.
+	srv.peerMu.RLock()
+	op(srv.peers)
+	srv.peerMu.RUnlock()
+	srv.peerOpDone <- struct{}{}
+}
+
+func (srv *BaseServer) handlePostHandshake(c *conn) error {
+	// A connection has passed the encryption handshake so
+	// the remote identity is known (but hasn't been verified yet).
+	if srv.isTrusted(c.id) {
+		// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
+		c.flags |= trustedConn
+	}
+	// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
+	return srv.encHandshakeChecks(c)
+}
+
+func (srv *BaseServer) handleAddPeer(c *conn) error {
+	// At this point the connection is past the protocol handshake.
+	// Its capabilities are known and the remote identity is verified.
+	err := srv.protoHandshakeChecks(c)
+	if err != nil {
+		return err
+	}
+
+	p, err := newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
+	if err != nil {
+		srv.logger.Error("Fail make a new peer", "err", err)
+		return nil
+	}
+	// If message events are enabled, pass the peerFeed to the peer.
+	if srv.EnableMsgEvents {
+		p.events = &srv.peerFeed
+	}
+	name := truncateName(c.name)
+	go srv.runPeer(p)
+
+	srv.peerMu.Lock()
+	srv.peers[c.id] = p
+	if p.Inbound() {
+		srv.inboundCount++
+	} else {
+		srv.outboundCount++
+	}
+	peerCount := len(srv.peers)
+	inboundCount := srv.inboundCount
+	srv.peerMu.Unlock()
+
+	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
+	peerCountGauge.Update(int64(peerCount))
+	peerInCountGauge.Update(int64(inboundCount))
+	peerOutCountGauge.Update(int64(peerCount - inboundCount))
+	return nil
+}
+
+func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
+	// At this point the connection is past the protocol handshake.
+	// Its capabilities are known and the remote identity is verified.
+	err := srv.protoHandshakeChecks(c)
+	if err != nil {
+		return err
+	}
+
+	var (
+		p *Peer
+		e error
+	)
+	if c.multiChannel {
+		srv.peerMu.Lock()
+		connSet := srv.CandidateConns[c.id]
+		if connSet == nil {
+			connSet = make([]*conn, len(srv.ListenAddrs))
+			srv.CandidateConns[c.id] = connSet
+		}
+
+		if int(c.portOrder) < len(connSet) {
+			connSet[c.portOrder] = c
+		}
+
+		remaining := len(connSet)
+		for _, conn := range connSet {
+			if conn != nil {
+				remaining--
+			}
+		}
+		if remaining == 0 {
+			p, e = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
+			srv.CandidateConns[c.id] = nil
+		}
+		srv.peerMu.Unlock()
+	} else {
+		// The handshakes are done and it passed all checks.
+		p, e = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
+	}
+
+	if e != nil {
+		srv.logger.Error("Fail make a new peer", "err", e)
+		return nil
+	}
+	if p == nil {
+		return nil
+	}
+
+	// If message events are enabled, pass the peerFeed to the peer.
+	if srv.EnableMsgEvents {
+		p.events = &srv.peerFeed
+	}
+	name := truncateName(c.name)
+	go srv.runPeer(p)
+
+	srv.peerMu.Lock()
+	srv.peers[c.id] = p
+	peerCount := len(srv.peers)
+	srv.inboundCount, srv.outboundCount = increasesConnectionMetric(srv.inboundCount, srv.outboundCount, p)
+	srv.peerMu.Unlock()
+
+	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
+	peerCountGauge.Update(int64(peerCount))
+	return nil
+}
+
+func (srv *BaseServer) handlePeerDrop(pd peerDrop) {
+	// A peer disconnected.
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+
+	srv.peerMu.Lock()
+	delete(srv.peers, pd.ID())
+	if pd.Inbound() {
+		srv.inboundCount--
+	} else {
+		srv.outboundCount--
+	}
+	peerCount := len(srv.peers)
+	inboundCount := srv.inboundCount
+	srv.peerMu.Unlock()
+
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
+	peerCountGauge.Update(int64(peerCount))
+	peerInCountGauge.Update(int64(inboundCount))
+	peerOutCountGauge.Update(int64(peerCount - inboundCount))
+}
+
+func (srv *MultiChannelServer) handlePeerDrop(pd peerDrop) {
+	// A peer disconnected.
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+
+	srv.peerMu.Lock()
+	delete(srv.peers, pd.ID())
+	peerCount := len(srv.peers)
+	srv.inboundCount, srv.outboundCount = decreasesConnectionMetric(srv.inboundCount, srv.outboundCount, pd.Peer)
+	srv.peerMu.Unlock()
+
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
+	peerCountGauge.Update(int64(peerCount))
+}
+
+func (srv *BaseServer) handleDisconnectRequest(nid discover.NodeID) {
+	srv.peerMu.RLock()
+	p := srv.peers[nid]
+	srv.peerMu.RUnlock()
+	if p != nil {
+		p.Disconnect(DiscRequested)
+		p.logger.Debug(fmt.Sprintf("disconnect peer"))
+	}
+}
+
+func (srv *BaseServer) cleanupAfterRun(remainingTasks int, dropHandler func(peerDrop)) {
+	srv.logger.Trace("P2P networking is spinning down")
+
+	// Terminate discovery. If there is a running lookup it will terminate soon.
+	if srv.ntab != nil {
+		srv.ntab.Close()
+	}
+	//if srv.DiscV5 != nil {
+	//	srv.DiscV5.Close()
+	//}
+
+	// Disconnect all peers.
+	for _, p := range srv.allPeers() {
+		p.Disconnect(DiscQuitting)
+	}
+	// Wait for peers to shut down. Pending connections and tasks are
+	// not handled here and will terminate soon-ish because srv.quit
+	// is closed.
+	for srv.peerLen() > 0 {
+		pd := <-srv.delpeer
+		pd.logger.Trace("<-delpeer (spindown)", "remainingTasks", remainingTasks)
+		dropHandler(pd)
+	}
+}
+
 func (srv *BaseServer) run(dialstate dialer) {
 	defer srv.loopWG.Done()
 	var (
-		peers        = make(map[discover.NodeID]*Peer)
-		inboundCount = 0
-		trusted      = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
 		taskdone     = make(chan task, maxActiveDialTasks)
 		runningTasks []task
 		queuedTasks  []task // tasks that can't run yet
 	)
-	// Put trusted nodes into a map to speed up checks.
-	// Trusted peers are loaded on startup and cannot be
-	// modified while the server is running.
-	for _, n := range srv.TrustedNodes {
-		trusted[n.ID] = true
-	}
 
 	// removes t from runningTasks
 	delTask := func(t task) {
@@ -1386,7 +1525,7 @@ func (srv *BaseServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
-			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), peers, time.Now())
+			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -1400,24 +1539,11 @@ running:
 			// The server was stopped. Run the cleanup logic.
 			break running
 		case n := <-srv.addstatic:
-			// This channel is used by AddPeer to add to the
-			// ephemeral static peer list. Add it to the dialer,
-			// it will keep the node connected.
-			srv.logger.Debug("Adding static node", "node", n)
-			dialstate.addStatic(n)
+			srv.handleAddStaticDialstate(dialstate, n)
 		case n := <-srv.removestatic:
-			// This channel is used by RemovePeer to send a
-			// disconnect request to a peer and begin the
-			// stop keeping the node connected
-			srv.logger.Debug("Removing static node", "node", n)
-			dialstate.removeStatic(n)
-			if p, ok := peers[n.ID]; ok {
-				p.Disconnect(DiscRequested)
-			}
+			srv.handleRemoveStaticDialstate(dialstate, n)
 		case op := <-srv.peerOp:
-			// This channel is used by Peers and PeerCount.
-			op(peers)
-			srv.peerOpDone <- struct{}{}
+			srv.handlePeerOpRequest(op)
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
@@ -1426,116 +1552,50 @@ running:
 			dialstate.taskDone(t, time.Now())
 			delTask(t)
 		case c := <-srv.posthandshake:
-			// A connection has passed the encryption handshake so
-			// the remote identity is known (but hasn't been verified yet).
-			if trusted[c.id] {
-				// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
-				c.flags |= trustedConn
-			}
-			// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
 			select {
-			case c.cont <- srv.encHandshakeChecks(peers, inboundCount, c):
+			case c.cont <- srv.handlePostHandshake(c):
 			case <-srv.quit:
 				break running
 			}
 		case c := <-srv.addpeer:
-			// At this point the connection is past the protocol handshake.
-			// Its capabilities are known and the remote identity is verified.
-			var err error
-			err = srv.protoHandshakeChecks(peers, inboundCount, c)
-			if err == nil {
-				// The handshakes are done and it passed all checks.
-				p, err := newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
-				if err != nil {
-					srv.logger.Error("Fail make a new peer", "err", err)
-				} else {
-					// If message events are enabled, pass the peerFeed
-					// to the peer
-					if srv.EnableMsgEvents {
-						p.events = &srv.peerFeed
-					}
-					name := truncateName(c.name)
-					srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
-					go srv.runPeer(p)
-					peers[c.id] = p
-
-					if p.Inbound() {
-						inboundCount++
-					}
-					peerCountGauge.Update(int64(len(peers)))
-					peerInCountGauge.Update(int64(inboundCount))
-					peerOutCountGauge.Update(int64(len(peers) - inboundCount))
-				}
-			}
-			// The dialer logic relies on the assumption that
-			// dial tasks complete after the peer has been added or
-			// discarded. Unblock the task last.
 			select {
-			case c.cont <- err:
+			case c.cont <- srv.handleAddPeer(c):
 			case <-srv.quit:
 				break running
 			}
 		case pd := <-srv.delpeer:
-			// A peer disconnected.
-			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
-			delete(peers, pd.ID())
-
-			if pd.Inbound() {
-				inboundCount--
-			}
-
-			peerCountGauge.Update(int64(len(peers)))
-			peerInCountGauge.Update(int64(inboundCount))
-			peerOutCountGauge.Update(int64(len(peers) - inboundCount))
+			srv.handlePeerDrop(pd)
 		case nid := <-srv.discpeer:
-			if p, ok := peers[nid]; ok {
-				p.Disconnect(DiscRequested)
-				p.logger.Debug(fmt.Sprintf("disconnect peer"))
-			}
+			srv.handleDisconnectRequest(nid)
 		}
 	}
 
-	srv.logger.Trace("P2P networking is spinning down")
-
-	// Terminate discovery. If there is a running lookup it will terminate soon.
-	if srv.ntab != nil {
-		srv.ntab.Close()
-	}
-	//if srv.DiscV5 != nil {
-	//	srv.DiscV5.Close()
-	//}
-	// Disconnect all peers.
-	for _, p := range peers {
-		p.Disconnect(DiscQuitting)
-	}
-	// Wait for peers to shut down. Pending connections and tasks are
-	// not handled here and will terminate soon-ish because srv.quit
-	// is closed.
-	for len(peers) > 0 {
-		p := <-srv.delpeer
-		p.logger.Trace("<-delpeer (spindown)", "remainingTasks", len(runningTasks))
-		delete(peers, p.ID())
-	}
+	srv.cleanupAfterRun(len(runningTasks), srv.handlePeerDrop)
 }
 
-func (srv *BaseServer) protoHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCount int, c *conn) error {
+func (srv *BaseServer) protoHandshakeChecks(c *conn) error {
 	// Drop connections with no matching protocols.
 	if len(srv.Protocols) > 0 && countMatchingProtocols(srv.Protocols, c.caps) == 0 {
 		return DiscUselessPeer
 	}
 	// Repeat the encryption handshake checks because the
 	// peer set might have changed between the handshakes.
-	return srv.encHandshakeChecks(peers, inboundCount, c)
+	return srv.encHandshakeChecks(c)
 }
 
-func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCount int, c *conn) error {
+func (srv *BaseServer) encHandshakeChecks(c *conn) error {
+	srv.peerMu.RLock()
+	peerCount := len(srv.peers)
+	inboundCount := srv.inboundCount
+	_, connected := srv.peers[c.id]
+	srv.peerMu.RUnlock()
+
 	switch {
-	case !c.is(trustedConn|staticDialedConn) && len(peers) >= srv.Config.MaxPhysicalConnections:
+	case !c.is(trustedConn|staticDialedConn) && peerCount >= srv.Config.MaxPhysicalConnections:
 		return DiscTooManyPeers
 	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
 		return DiscTooManyPeers
-	case peers[c.id] != nil:
+	case connected:
 		return DiscAlreadyConnected
 	case c.id == srv.Self().ID:
 		return DiscSelf


### PR DESCRIPTION
## Proposed changes

Refactor `p2p.Server` internals to remove run-loop channel harnesses and move state management to mutex-protected struct fields and respective direct handlers.

- Moved `run()`-loop local state into `BaseServer` shared struct fields:
  - Peer state `peers`, `inboundCount`, `outboundCount`, `trusted`, `peersChanged` are protected by `peersMu`.

- Replaced channel with direct helper function calls.

| before | after |
|-|-|
| `chan addstatic`, `chan removestatic` | `handleAddStatic()`, `handleRemoveStatic()` |
| `chan peerOp`, `chan peerOpDone` | `Peers()`, `PeerCount()`, `PeerCountByType()` directly accessing the peers variable |
| `chan discpeer` | `handleDisconnectPeer()` |
| `chan delpeer` | `handlePeerDrop()` |
| `checkpoint(chan posthandshake)`,`checkpoint(chan addpeer)` | `handlePostHandshake()`, `handleAddPeer()` directly called inside `SetupConn()` |

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- #751 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
