### PR TITLE
permless: Add new VRank P2P message types

### DIFF
--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -36,12 +36,13 @@ const (
 	Kaia65 = 65
 	Kaia66 = 66
 	Kaia67 = 67
+	Kaia68 = 68
 )
 
 var KaiaProtocol = Protocol{
 	Name:     "kaia",
-	Versions: []uint{Kaia67, Kaia66, Kaia65, Kaia64, Kaia63, Kaia62},
-	Lengths:  []uint64{24, 22, 21, 19, 17, 8},
+	Versions: []uint{Kaia68, Kaia67, Kaia66, Kaia65, Kaia64, Kaia63, Kaia62},
+	Lengths:  []uint64{26, 24, 22, 21, 19, 17, 8},
 }
 
 // Protocol defines the protocol of the consensus

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -134,7 +134,7 @@ func (v *VRankModule) BroadcastVRankPreprepare(vrankPreprepare *vrank.VRankPrepr
 		logger.Error("GetCandidates failed", "blockNum", block.NumberU64())
 		return
 	}
-	v.broadcast(candidates, VRankPreprepareMsg, vrankPreprepare)
+	v.broadcast(candidates, vrank.VRankPreprepareMsg, vrankPreprepare)
 }
 
 // BroadcastVRankCandidate is called by candidates.
@@ -146,11 +146,11 @@ func (v *VRankModule) BroadcastVRankCandidate(vrankCandidate *vrank.VRankCandida
 		return
 	}
 
-	v.broadcast(validators, VRankCandidateMsg, vrankCandidate)
+	v.broadcast(validators, vrank.VRankCandidateMsg, vrankCandidate)
 }
 
 func (v *VRankModule) broadcast(targets []common.Address, code int, msg any) {
-	req := &vrank.BroadcastRequest{
+	req := &vrank.VRankBroadcastEvent{
 		Targets: targets,
 		Code:    code,
 		Msg:     msg,

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -40,13 +40,13 @@ type CN struct {
 	Key         *ecdsa.PrivateKey
 	Addr        common.Address
 	VRankModule *VRankModule
-	sub         chan *vrank.BroadcastRequest
+	sub         chan *vrank.VRankBroadcastEvent
 }
 
 func createCN(t *testing.T, valset valset.ValsetModule) *CN {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
-	sub := make(chan *vrank.BroadcastRequest)
+	sub := make(chan *vrank.VRankBroadcastEvent)
 	module := NewVRankModule()
 	err := module.Init(&InitOpts{
 		NodeKey:     key,
@@ -66,7 +66,7 @@ func createCN(t *testing.T, valset valset.ValsetModule) *CN {
 	}
 }
 
-func mustPop(t *testing.T, sub chan *vrank.BroadcastRequest) *vrank.BroadcastRequest {
+func mustPop(t *testing.T, sub chan *vrank.VRankBroadcastEvent) *vrank.VRankBroadcastEvent {
 	select {
 	case req := <-sub:
 		return req
@@ -76,7 +76,7 @@ func mustPop(t *testing.T, sub chan *vrank.BroadcastRequest) *vrank.BroadcastReq
 	return nil
 }
 
-func mustNotPop(t *testing.T, sub chan *vrank.BroadcastRequest) *vrank.BroadcastRequest {
+func mustNotPop(t *testing.T, sub chan *vrank.VRankBroadcastEvent) *vrank.VRankBroadcastEvent {
 	select {
 	case <-sub:
 		t.Fatal("should not broadcast")

--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -91,6 +91,7 @@ func (v *VRankModule) Start() error {
 func (v *VRankModule) Stop() {
 	logger.Info("VRankModule stopped")
 	close(v.stopCh)
+	close(v.broadcastCh)
 }
 
 func (v *VRankModule) SubscribeVRank(sink chan<- *vrank.VRankBroadcastEvent) event.Subscription {

--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -32,9 +32,6 @@ import (
 const (
 	candidatePrepareDeadlineMs = 200
 
-	VRankPreprepareMsg = 0x17
-	VRankCandidateMsg  = 0x18
-
 	broadcastChSize    = 2048
 	vrankEpoch         = 86400
 	maxRound           = 10 // round range [0, 10]
@@ -56,7 +53,7 @@ type InitOpts struct {
 type VRankModule struct {
 	InitOpts
 
-	broadcastCh   chan *vrank.BroadcastRequest
+	broadcastCh   chan *vrank.VRankBroadcastEvent
 	broadcastFeed event.Feed
 	stopCh        chan struct{}
 
@@ -69,7 +66,7 @@ type VRankModule struct {
 
 func NewVRankModule() *VRankModule {
 	return &VRankModule{
-		broadcastCh: make(chan *vrank.BroadcastRequest, broadcastChSize),
+		broadcastCh: make(chan *vrank.VRankBroadcastEvent, broadcastChSize),
 		stopCh:      make(chan struct{}),
 		collector:   vrank.NewCollector(),
 	}
@@ -94,4 +91,8 @@ func (v *VRankModule) Start() error {
 func (v *VRankModule) Stop() {
 	logger.Info("VRankModule stopped")
 	close(v.stopCh)
+}
+
+func (v *VRankModule) SubscribeVRank(sink chan<- *vrank.VRankBroadcastEvent) event.Subscription {
+	return v.broadcastFeed.Subscribe(sink)
 }

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -19,6 +19,7 @@ package vrank
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax"
 )
 
@@ -29,6 +30,8 @@ type VRankModule interface {
 	HandleVRankPreprepare(msg *VRankPreprepare) error
 	HandleVRankCandidate(msg *VRankCandidate) error
 	GetCfReport(blockNum, round uint64) (CfReport, error)
+
+	SubscribeVRank(sink chan<- *VRankBroadcastEvent) event.Subscription
 }
 
 type VRankModuleHost interface {

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -25,10 +25,15 @@ import (
 
 type CfReport []common.Address
 
-type BroadcastRequest struct {
+const (
+	VRankPreprepareMsg = 0x17
+	VRankCandidateMsg  = 0x18
+)
+
+type VRankBroadcastEvent struct {
 	Targets []common.Address
-	Code    int
-	Msg     any
+	Code    int // VRankPreprepareMsg or VRankCandidateMsg
+	Msg     any // VRankPreprepare or VRankCandidate
 }
 
 type VRankPreprepare struct {

--- a/node/cn/channel_manager.go
+++ b/node/cn/channel_manager.go
@@ -76,6 +76,9 @@ func NewChannelManager(channelSize int) *ChannelManager {
 	channelMgr.RegisterMsgCode(MiscChannel, BlobSidecarsRequestMsg)
 	channelMgr.RegisterMsgCode(MiscChannel, BlobSidecarsMsg)
 
+	channelMgr.RegisterMsgCode(MiscChannel, VRankPreprepareMsg)
+	channelMgr.RegisterMsgCode(MiscChannel, VRankCandidateMsg)
+
 	return channelMgr
 }
 

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1621,30 +1621,39 @@ func (pm *ProtocolManager) BroadcastVRank(ev *vrank.VRankBroadcastEvent) {
 		return
 	}
 
-	preprepare, preprepareOK := ev.Msg.(*vrank.VRankPreprepare)
-	candidate, candidateOK := ev.Msg.(*vrank.VRankCandidate)
-
 	targets := make(map[common.Address]bool, len(ev.Targets))
 	for _, target := range ev.Targets {
 		targets[target] = true
+	}
+
+	var asyncSendMsg func(peer Peer)
+
+	switch ev.Code {
+	case VRankPreprepareMsg:
+		preprepare, preprepareOK := ev.Msg.(*vrank.VRankPreprepare)
+		if !preprepareOK {
+			return
+		}
+		asyncSendMsg = func(peer Peer) {
+			peer.AsyncSendVRankPreprepare(preprepare)
+		}
+	case VRankCandidateMsg:
+		candidate, candidateOK := ev.Msg.(*vrank.VRankCandidate)
+		if !candidateOK {
+			return
+		}
+		asyncSendMsg = func(peer Peer) {
+			peer.AsyncSendVRankCandidate(candidate)
+		}
+	default:
+		return
 	}
 
 	for addr, peer := range pm.peers.CNPeers() {
 		if !targets[addr] || peer.GetVersion() < kaia68 {
 			continue
 		}
-		switch ev.Code {
-		case VRankPreprepareMsg:
-			if !preprepareOK {
-				return
-			}
-			peer.AsyncSendVRankPreprepare(preprepare)
-		case VRankCandidateMsg:
-			if !candidateOK {
-				return
-			}
-			peer.AsyncSendVRankCandidate(candidate)
-		}
+		asyncSendMsg(peer)
 	}
 }
 

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -442,7 +442,7 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 	}
 
 	if !pm.IsVRankModuleDisabled() {
-		// broadcast vrank preprepares
+		// broadcast vrank messages
 		pm.vrankCh = make(chan *vrank.VRankBroadcastEvent, vrankChanSize)
 		pm.vrankSub = pm.vrankModule.SubscribeVRank(pm.vrankCh)
 		go pm.vrankBroadcastLoop()
@@ -464,6 +464,9 @@ func (pm *ProtocolManager) Stop() {
 	pm.minedBlockSub.Unsubscribe() // quits blockBroadcastLoop
 	if !pm.IsAuctionModuleDisabled() {
 		pm.bidSub.Unsubscribe() // quits bidBroadcastLoop
+	}
+	if !pm.IsVRankModuleDisabled() {
+		pm.vrankSub.Unsubscribe() // quits vrankBroadcastLoop
 	}
 
 	// Quit the sync loop.
@@ -1631,12 +1634,12 @@ func (pm *ProtocolManager) BroadcastVRank(ev *vrank.VRankBroadcastEvent) {
 			continue
 		}
 		switch ev.Code {
-		case vrank.VRankPreprepareMsg:
+		case VRankPreprepareMsg:
 			if !preprepareOK {
 				return
 			}
 			peer.AsyncSendVRankPreprepare(preprepare)
-		case vrank.VRankCandidateMsg:
+		case VRankCandidateMsg:
 			if !candidateOK {
 				return
 			}

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1352,7 +1352,7 @@ func handleVRankPreprepareMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 	if err := pm.vrankModule.HandleVRankPreprepare(vrankPreprepare); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+		logger.Debug("Ignored VRankPreprepare handler error", "peer", p.GetID(), "err", err)
 	}
 	return nil
 }
@@ -1367,7 +1367,7 @@ func handleVRankCandidateMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 	if err := pm.vrankModule.HandleVRankCandidate(vrankCandidate); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+		logger.Debug("Ignored VRankCandidate handler error", "peer", p.GetID(), "err", err)
 	}
 	return nil
 }

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/auction"
 	"github.com/kaiachain/kaia/kaiax/staking"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/node/cn/snap"
@@ -67,7 +68,8 @@ const (
 
 	// bidChanSize is the size of channel listening to NewBidEvent.
 	// The number is referenced from the size of bid pool.
-	bidChanSize = 2048
+	bidChanSize   = 2048
+	vrankChanSize = 256
 
 	concurrentPerPeer  = 3
 	channelSizePerPeer = 20
@@ -122,6 +124,8 @@ type ProtocolManager struct {
 	minedBlockSub *event.TypeMuxSubscription
 	bidCh         chan *auction.Bid
 	bidSub        event.Subscription
+	vrankCh       chan *vrank.VRankBroadcastEvent
+	vrankSub      event.Subscription
 
 	// channels for fetcher, syncer, txsyncLoop
 	newPeerCh   chan Peer
@@ -147,6 +151,7 @@ type ProtocolManager struct {
 
 	stakingModule staking.StakingModule
 	auctionModule auction.AuctionModule
+	vrankModule   vrank.VRankModule
 
 	missingBlobSidecarCh  <-chan *kaia_blockchain.MissingBlobSidecar
 	blobSidecarReqManager *sidecarReqManager
@@ -378,6 +383,14 @@ func (pm *ProtocolManager) IsAuctionModuleDisabled() bool {
 	return pm.auctionModule == nil
 }
 
+func (pm *ProtocolManager) RegisterVRankModule(vrankModule vrank.VRankModule) {
+	pm.vrankModule = vrankModule
+}
+
+func (pm *ProtocolManager) IsVRankModuleDisabled() bool {
+	return pm.vrankModule == nil
+}
+
 func (pm *ProtocolManager) getWSEndPoint() string {
 	return pm.wsendpoint
 }
@@ -426,6 +439,13 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 		pm.bidCh = make(chan *auction.Bid, bidChanSize)
 		pm.bidSub = pm.auctionModule.SubscribeNewBid(pm.bidCh)
 		go pm.bidBroadcastLoop()
+	}
+
+	if !pm.IsVRankModuleDisabled() {
+		// broadcast vrank preprepares
+		pm.vrankCh = make(chan *vrank.VRankBroadcastEvent, vrankChanSize)
+		pm.vrankSub = pm.vrankModule.SubscribeVRank(pm.vrankCh)
+		go pm.vrankBroadcastLoop()
 	}
 
 	// sync missing blob sidecars
@@ -776,6 +796,16 @@ func (pm *ProtocolManager) handleMsg(p Peer, addr common.Address, msg p2p.Msg) e
 
 	case p.GetVersion() >= kaia67 && msg.Code == BlobSidecarsMsg:
 		if err := handleBlobSidecarsMsg(pm, p, msg); err != nil {
+			return err
+		}
+
+	case p.GetVersion() >= kaia68 && msg.Code == VRankPreprepareMsg:
+		if err := handleVRankPreprepareMsg(pm, p, msg); err != nil {
+			return err
+		}
+
+	case p.GetVersion() >= kaia68 && msg.Code == VRankCandidateMsg:
+		if err := handleVRankCandidateMsg(pm, p, msg); err != nil {
 			return err
 		}
 
@@ -1312,6 +1342,36 @@ func (pm *ProtocolManager) blobSidecarSyncLoop() {
 	}
 }
 
+func handleVRankPreprepareMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
+	if pm.IsVRankModuleDisabled() {
+		return nil
+	}
+
+	var vrankPreprepare *vrank.VRankPreprepare
+	if err := msg.Decode(&vrankPreprepare); err != nil {
+		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	}
+	if err := pm.vrankModule.HandleVRankPreprepare(vrankPreprepare); err != nil {
+		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	}
+	return nil
+}
+
+func handleVRankCandidateMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
+	if pm.IsVRankModuleDisabled() {
+		return nil
+	}
+
+	var vrankCandidate *vrank.VRankCandidate
+	if err := msg.Decode(&vrankCandidate); err != nil {
+		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	}
+	if err := pm.vrankModule.HandleVRankCandidate(vrankCandidate); err != nil {
+		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	}
+	return nil
+}
+
 // handleNewBlockHashesMsg handles new block hashes message.
 func handleNewBlockHashesMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	var (
@@ -1553,6 +1613,38 @@ func (pm *ProtocolManager) BroadcastBid(bid *auction.Bid) {
 	}
 }
 
+func (pm *ProtocolManager) BroadcastVRank(ev *vrank.VRankBroadcastEvent) {
+	if pm.nodetype != common.CONSENSUSNODE {
+		return
+	}
+
+	preprepare, preprepareOK := ev.Msg.(*vrank.VRankPreprepare)
+	candidate, candidateOK := ev.Msg.(*vrank.VRankCandidate)
+
+	targets := make(map[common.Address]bool, len(ev.Targets))
+	for _, target := range ev.Targets {
+		targets[target] = true
+	}
+
+	for addr, peer := range pm.peers.CNPeers() {
+		if !targets[addr] || peer.GetVersion() < kaia68 {
+			continue
+		}
+		switch ev.Code {
+		case vrank.VRankPreprepareMsg:
+			if !preprepareOK {
+				return
+			}
+			peer.AsyncSendVRankPreprepare(preprepare)
+		case vrank.VRankCandidateMsg:
+			if !candidateOK {
+				return
+			}
+			peer.AsyncSendVRankCandidate(candidate)
+		}
+	}
+}
+
 // BroadcastTxs propagates a batch of transactions to its peers which are not known to
 // already have the given transaction.
 func (pm *ProtocolManager) BroadcastTxs(txs types.Transactions) {
@@ -1708,6 +1800,17 @@ func (pm *ProtocolManager) bidBroadcastLoop() {
 		case bid := <-pm.bidCh:
 			pm.BroadcastBid(bid)
 		case <-pm.bidSub.Err():
+			return
+		}
+	}
+}
+
+func (pm *ProtocolManager) vrankBroadcastLoop() {
+	for {
+		select {
+		case vrankRequest := <-pm.vrankCh:
+			pm.BroadcastVRank(vrankRequest)
+		case <-pm.vrankSub.Err():
 			return
 		}
 	}

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -475,7 +475,6 @@ func (p *basePeer) Broadcast() {
 			if err := p.SendVRankPreprepare(vrankPreprepare); err != nil {
 				logger.Error("fail to SendVRankPreprepare", "peer", p.id, "err", err)
 				continue
-				// return
 			}
 			p.Log().Trace("Broadcast vrank preprepare", "peer", p.id, "block", vrankPreprepare.Block.Hash())
 
@@ -483,7 +482,6 @@ func (p *basePeer) Broadcast() {
 			if err := p.SendVRankCandidate(vrankCandidate); err != nil {
 				logger.Error("fail to SendVRankCandidate", "peer", p.id, "err", err)
 				continue
-				// return
 			}
 			p.Log().Trace("Broadcast vrank candidate", "peer", p.id, "block", vrankCandidate.BlockHash)
 
@@ -646,6 +644,9 @@ func (p *basePeer) AsyncSendVRankPreprepare(msg *vrank.VRankPreprepare) {
 	select {
 	case p.queuedVRankPreprepare <- msg:
 	default:
+		if msg == nil || msg.Block == nil {
+			return
+		}
 		p.Log().Debug("Dropping vrank preprepare propagation", "block", msg.Block.Hash())
 	}
 }
@@ -654,6 +655,9 @@ func (p *basePeer) AsyncSendVRankCandidate(msg *vrank.VRankCandidate) {
 	select {
 	case p.queuedVRankCandidate <- msg:
 	default:
+		if msg == nil {
+			return
+		}
 		p.Log().Debug("Dropping vrank candidate propagation", "hash", msg.BlockHash)
 	}
 }

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/kaiax/auction"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/node/cn/snap"
@@ -75,6 +76,10 @@ const (
 	// maxQueuedBids is the maximum number of bid lists to queue up before
 	// dropping broadcasts.
 	maxQueuedBids = 128
+
+	// maxQueuedVRanks is the maximum number of vrank messages to queue up before
+	// dropping broadcasts.
+	maxQueuedVRanks = 256
 
 	handshakeTimeout = 5 * time.Second
 )
@@ -146,6 +151,20 @@ type Peer interface {
 	// AsyncSendBid queues the availability of a bid for propagation to a remote peer.
 	// If the peer's broadcast queue is full, the event is silently dropped.
 	AsyncSendBid(bid *auction.Bid)
+
+	// SendVRankPreprepare sends a vrank preprepare message to a remote peer.
+	SendVRankPreprepare(msg *vrank.VRankPreprepare) error
+
+	// SendVRankCandidate sends a vrank candidate message to a remote peer.
+	SendVRankCandidate(msg *vrank.VRankCandidate) error
+
+	// AsyncSendVRankPreprepare queues a vrank preprepare message for propagation to a remote peer.
+	// If the peer's broadcast queue is full, the event is silently dropped.
+	AsyncSendVRankPreprepare(msg *vrank.VRankPreprepare)
+
+	// AsyncSendVRankCandidate queues a vrank candidate message for propagation to a remote peer.
+	// If the peer's broadcast queue is full, the event is silently dropped.
+	AsyncSendVRankCandidate(msg *vrank.VRankCandidate)
 
 	// SendNewBlock propagates an entire block to a remote peer.
 	SendNewBlock(block *types.Block, td *big.Int) error
@@ -283,14 +302,16 @@ type basePeer struct {
 	td   *big.Int
 	lock sync.RWMutex
 
-	knownTxsCache    common.Cache              // FIFO cache of transaction hashes known to be known by this peer
-	knownBlocksCache common.Cache              // FIFO cache of block hashes known to be known by this peer
-	knownBidsCache   common.Cache              // FIFO cache of bid hashes known to be known by this peer
-	queuedTxs        chan []*types.Transaction // Queue of transactions to broadcast to the peer
-	queuedProps      chan *propEvent           // Queue of blocks to broadcast to the peer
-	queuedAnns       chan *types.Block         // Queue of blocks to announce to the peer
-	queuedBids       chan *auction.Bid         // Queue of bids to broadcast to the peer
-	term             chan struct{}             // Termination channel to stop the broadcaster
+	knownTxsCache         common.Cache                // FIFO cache of transaction hashes known to be known by this peer
+	knownBlocksCache      common.Cache                // FIFO cache of block hashes known to be known by this peer
+	knownBidsCache        common.Cache                // FIFO cache of bid hashes known to be known by this peer
+	queuedTxs             chan []*types.Transaction   // Queue of transactions to broadcast to the peer
+	queuedProps           chan *propEvent             // Queue of blocks to broadcast to the peer
+	queuedAnns            chan *types.Block           // Queue of blocks to announce to the peer
+	queuedBids            chan *auction.Bid           // Queue of bids to broadcast to the peer
+	queuedVRankPreprepare chan *vrank.VRankPreprepare // Queue of vrank preprepare messages to broadcast to the peer
+	queuedVRankCandidate  chan *vrank.VRankCandidate  // Queue of vrank candidate messages to broadcast to the peer
+	term                  chan struct{}               // Termination channel to stop the broadcaster
 
 	chainID *big.Int // ChainID to sign a transaction
 
@@ -318,18 +339,20 @@ func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) Peer {
 
 	return &singleChannelPeer{
 		basePeer: &basePeer{
-			Peer:             p,
-			rw:               rw,
-			version:          version,
-			id:               fmt.Sprintf("%x", id[:8]),
-			knownTxsCache:    newKnownTxCache(),
-			knownBlocksCache: newKnownBlockCache(),
-			knownBidsCache:   newKnownBidCache(),
-			queuedTxs:        make(chan []*types.Transaction, maxQueuedTxs),
-			queuedProps:      make(chan *propEvent, maxQueuedProps),
-			queuedAnns:       make(chan *types.Block, maxQueuedAnns),
-			queuedBids:       make(chan *auction.Bid, maxQueuedBids),
-			term:             make(chan struct{}),
+			Peer:                  p,
+			rw:                    rw,
+			version:               version,
+			id:                    fmt.Sprintf("%x", id[:8]),
+			knownTxsCache:         newKnownTxCache(),
+			knownBlocksCache:      newKnownBlockCache(),
+			knownBidsCache:        newKnownBidCache(),
+			queuedTxs:             make(chan []*types.Transaction, maxQueuedTxs),
+			queuedProps:           make(chan *propEvent, maxQueuedProps),
+			queuedAnns:            make(chan *types.Block, maxQueuedAnns),
+			queuedBids:            make(chan *auction.Bid, maxQueuedBids),
+			queuedVRankPreprepare: make(chan *vrank.VRankPreprepare, maxQueuedVRanks),
+			queuedVRankCandidate:  make(chan *vrank.VRankCandidate, maxQueuedVRanks),
+			term:                  make(chan struct{}),
 		},
 	}
 }
@@ -365,6 +388,10 @@ var ChannelOfMessage = map[uint64]int{
 	// Protocol messages belonging to kaia/67
 	BlobSidecarsRequestMsg: p2p.ConnDefault,
 	BlobSidecarsMsg:        p2p.ConnDefault,
+
+	// Protocol messages belonging to kaia/68
+	VRankPreprepareMsg: p2p.ConnDefault,
+	VRankCandidateMsg:  p2p.ConnDefault,
 }
 
 var ConcurrentOfChannel = []int{
@@ -381,18 +408,20 @@ func newPeerWithRWs(version int, p *p2p.Peer, rws []p2p.MsgReadWriter) (Peer, er
 		return newPeer(version, p, rws[p2p.ConnDefault]), nil
 	} else if lenRWs > 1 {
 		bPeer := &basePeer{
-			Peer:             p,
-			rw:               rws[p2p.ConnDefault],
-			version:          version,
-			id:               fmt.Sprintf("%x", id[:8]),
-			knownTxsCache:    newKnownTxCache(),
-			knownBlocksCache: newKnownBlockCache(),
-			knownBidsCache:   newKnownBidCache(),
-			queuedTxs:        make(chan []*types.Transaction, maxQueuedTxs),
-			queuedProps:      make(chan *propEvent, maxQueuedProps),
-			queuedAnns:       make(chan *types.Block, maxQueuedAnns),
-			queuedBids:       make(chan *auction.Bid, maxQueuedBids),
-			term:             make(chan struct{}),
+			Peer:                  p,
+			rw:                    rws[p2p.ConnDefault],
+			version:               version,
+			id:                    fmt.Sprintf("%x", id[:8]),
+			knownTxsCache:         newKnownTxCache(),
+			knownBlocksCache:      newKnownBlockCache(),
+			knownBidsCache:        newKnownBidCache(),
+			queuedTxs:             make(chan []*types.Transaction, maxQueuedTxs),
+			queuedProps:           make(chan *propEvent, maxQueuedProps),
+			queuedAnns:            make(chan *types.Block, maxQueuedAnns),
+			queuedBids:            make(chan *auction.Bid, maxQueuedBids),
+			queuedVRankPreprepare: make(chan *vrank.VRankPreprepare, maxQueuedVRanks),
+			queuedVRankCandidate:  make(chan *vrank.VRankCandidate, maxQueuedVRanks),
+			term:                  make(chan struct{}),
 		}
 		return &multiChannelPeer{
 			basePeer: bPeer,
@@ -441,6 +470,22 @@ func (p *basePeer) Broadcast() {
 				// return
 			}
 			p.Log().Trace("Broadcast bid", "peer", p.id, "hash", bid.Hash())
+
+		case vrankPreprepare := <-p.queuedVRankPreprepare:
+			if err := p.SendVRankPreprepare(vrankPreprepare); err != nil {
+				logger.Error("fail to SendVRankPreprepare", "peer", p.id, "err", err)
+				continue
+				// return
+			}
+			p.Log().Trace("Broadcast vrank preprepare", "peer", p.id, "block", vrankPreprepare.Block.Hash())
+
+		case vrankCandidate := <-p.queuedVRankCandidate:
+			if err := p.SendVRankCandidate(vrankCandidate); err != nil {
+				logger.Error("fail to SendVRankCandidate", "peer", p.id, "err", err)
+				continue
+				// return
+			}
+			p.Log().Trace("Broadcast vrank candidate", "peer", p.id, "block", vrankCandidate.BlockHash)
 
 		case <-p.term:
 			p.Log().Debug("Peer broadcast loop end", "peer", p.id)
@@ -586,6 +631,30 @@ func (p *basePeer) AsyncSendBid(bid *auction.Bid) {
 		p.AddToKnownBids(bid.Hash())
 	default:
 		p.Log().Debug("Dropping bid propagation", "hash", bid.Hash())
+	}
+}
+
+func (p *basePeer) SendVRankPreprepare(msg *vrank.VRankPreprepare) error {
+	return p2p.Send(p.rw, VRankPreprepareMsg, msg)
+}
+
+func (p *basePeer) SendVRankCandidate(msg *vrank.VRankCandidate) error {
+	return p2p.Send(p.rw, VRankCandidateMsg, msg)
+}
+
+func (p *basePeer) AsyncSendVRankPreprepare(msg *vrank.VRankPreprepare) {
+	select {
+	case p.queuedVRankPreprepare <- msg:
+	default:
+		p.Log().Debug("Dropping vrank preprepare propagation", "block", msg.Block.Hash())
+	}
+}
+
+func (p *basePeer) AsyncSendVRankCandidate(msg *vrank.VRankCandidate) {
+	select {
+	case p.queuedVRankCandidate <- msg:
+	default:
+		p.Log().Debug("Dropping vrank candidate propagation", "hash", msg.BlockHash)
 	}
 }
 
@@ -935,6 +1004,22 @@ func (p *multiChannelPeer) Broadcast() {
 				// return
 			}
 			p.Log().Trace("Broadcast bid", "peer", p.id, "hash", bid.Hash())
+
+		case vrankPreprepare := <-p.queuedVRankPreprepare:
+			if err := p.SendVRankPreprepare(vrankPreprepare); err != nil {
+				logger.Error("fail to SendVRankPreprepare", "peer", p.id, "err", err)
+				continue
+				// return
+			}
+			p.Log().Trace("Broadcast vrank preprepare", "peer", p.id, "block", vrankPreprepare.Block.Hash())
+
+		case vrankCandidate := <-p.queuedVRankCandidate:
+			if err := p.SendVRankCandidate(vrankCandidate); err != nil {
+				logger.Error("fail to SendVRankCandidate", "peer", p.id, "err", err)
+				continue
+				// return
+			}
+			p.Log().Trace("Broadcast vrank candidate", "peer", p.id, "block", vrankCandidate.BlockHash)
 
 		case <-p.term:
 			p.Log().Debug("Peer broadcast loop end", "peer", p.id)

--- a/node/cn/peer_mock_test.go
+++ b/node/cn/peer_mock_test.go
@@ -12,6 +12,7 @@ import (
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
 	auction "github.com/kaiachain/kaia/kaiax/auction"
+	vrank "github.com/kaiachain/kaia/kaiax/vrank"
 	p2p "github.com/kaiachain/kaia/networks/p2p"
 	discover "github.com/kaiachain/kaia/networks/p2p/discover"
 	snap "github.com/kaiachain/kaia/node/cn/snap"
@@ -87,6 +88,30 @@ func (m *MockPeer) AsyncSendBid(arg0 *auction.Bid) {
 func (mr *MockPeerMockRecorder) AsyncSendBid(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendBid", reflect.TypeOf((*MockPeer)(nil).AsyncSendBid), arg0)
+}
+
+// AsyncSendVRankCandidate mocks base method.
+func (m *MockPeer) AsyncSendVRankCandidate(arg0 *vrank.VRankCandidate) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AsyncSendVRankCandidate", arg0)
+}
+
+// AsyncSendVRankCandidate indicates an expected call of AsyncSendVRankCandidate.
+func (mr *MockPeerMockRecorder) AsyncSendVRankCandidate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendVRankCandidate", reflect.TypeOf((*MockPeer)(nil).AsyncSendVRankCandidate), arg0)
+}
+
+// AsyncSendVRankPreprepare mocks base method.
+func (m *MockPeer) AsyncSendVRankPreprepare(arg0 *vrank.VRankPreprepare) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AsyncSendVRankPreprepare", arg0)
+}
+
+// AsyncSendVRankPreprepare indicates an expected call of AsyncSendVRankPreprepare.
+func (mr *MockPeerMockRecorder) AsyncSendVRankPreprepare(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendVRankPreprepare", reflect.TypeOf((*MockPeer)(nil).AsyncSendVRankPreprepare), arg0)
 }
 
 // AsyncSendNewBlock mocks base method.
@@ -580,6 +605,34 @@ func (m *MockPeer) SendBid(arg0 *auction.Bid) error {
 func (mr *MockPeerMockRecorder) SendBid(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBid", reflect.TypeOf((*MockPeer)(nil).SendBid), arg0)
+}
+
+// SendVRankCandidate mocks base method.
+func (m *MockPeer) SendVRankCandidate(arg0 *vrank.VRankCandidate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendVRankCandidate", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendVRankCandidate indicates an expected call of SendVRankCandidate.
+func (mr *MockPeerMockRecorder) SendVRankCandidate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendVRankCandidate", reflect.TypeOf((*MockPeer)(nil).SendVRankCandidate), arg0)
+}
+
+// SendVRankPreprepare mocks base method.
+func (m *MockPeer) SendVRankPreprepare(arg0 *vrank.VRankPreprepare) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendVRankPreprepare", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendVRankPreprepare indicates an expected call of SendVRankPreprepare.
+func (mr *MockPeerMockRecorder) SendVRankPreprepare(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendVRankPreprepare", reflect.TypeOf((*MockPeer)(nil).SendVRankPreprepare), arg0)
 }
 
 // SendBlobSidecarsRLP mocks base method.

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -46,6 +46,7 @@ const (
 	kaia65 = 65
 	kaia66 = 66
 	kaia67 = 67
+	kaia68 = 68
 )
 
 const ProtocolMaxMsgSize = 12 * 1024 * 1024 // Maximum cap on the size of a protocol message
@@ -88,7 +89,11 @@ const (
 	BlobSidecarsRequestMsg = 0x15
 	BlobSidecarsMsg        = 0x16
 
-	MsgCodeEnd = 0x17
+	// Protocol messages belonging to kaia/68
+	VRankPreprepareMsg = 0x17
+	VRankCandidateMsg  = 0x18
+
+	MsgCodeEnd = 0x19
 )
 
 type errCode int


### PR DESCRIPTION
## Proposed changes

Add new P2P message types: `VRankPreprepareMsg`, `VRankCandidateMsg` under Kaia68.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

#743