### PR TITLE
p2p/Server: Factor out channel event loop to mutex-protected methods

### DIFF
--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -1295,28 +1295,16 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 		e error
 	)
 	if c.multiChannel {
-		srv.peerMu.Lock()
-		connSet := srv.CandidateConns[c.id]
-		if connSet == nil {
-			connSet = make([]*conn, len(srv.ListenAddrs))
-			srv.CandidateConns[c.id] = connSet
+		readyConns, err := srv.collectMultiChannelConns(c)
+		if err != nil {
+			return err
 		}
-
-		if int(c.portOrder) < len(connSet) {
-			connSet[c.portOrder] = c
+		if len(readyConns) == 0 {
+			// The connections for the peer is not yet ready.
+			// Revisit after another connection is established (and handleAddPeer() is called again).
+			return nil
 		}
-
-		remaining := len(connSet)
-		for _, conn := range connSet {
-			if conn != nil {
-				remaining--
-			}
-		}
-		if remaining == 0 {
-			p, e = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
-			srv.CandidateConns[c.id] = nil
-		}
-		srv.peerMu.Unlock()
+		p, e = newPeer(readyConns, srv.Protocols, srv.Config.RWTimerConfig)
 	} else {
 		// The handshakes are done and it passed all checks.
 		p, e = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
@@ -1352,6 +1340,36 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 	srv.logger.Debug("Adding p2p peer", "name", truncateName(c.name), "addr", c.fd.RemoteAddr(), "peers", peerCount)
 	srv.reportPeerMetric()
 	return nil
+}
+
+// collectMultiChannelConns collects multi-channel connections that is required to launch a peer.
+// If the required number of connections are collected, return the list of connections for the peer.
+// If the required number of connections are not collected, return nil.
+// If the given new connection has a problem, return an error.
+func (srv *MultiChannelServer) collectMultiChannelConns(c *conn) ([]*conn, error) {
+	srv.peerMu.Lock()
+	defer srv.peerMu.Unlock()
+
+	connSet := srv.CandidateConns[c.id]
+	if connSet == nil {
+		connSet = make([]*conn, len(srv.ListenAddrs))
+		srv.CandidateConns[c.id] = connSet
+	}
+	if c.portOrder < 0 || int(c.portOrder) >= len(connSet) {
+		return nil, fmt.Errorf("invalid multi-channel port order: %d", c.portOrder)
+	}
+	connSet[c.portOrder] = c
+
+	for _, conn := range connSet {
+		if conn == nil {
+			return nil, nil
+		}
+	}
+
+	readyConns := make([]*conn, len(connSet))
+	copy(readyConns, connSet)
+	delete(srv.CandidateConns, c.id)
+	return readyConns, nil
 }
 
 func (srv *BaseServer) handlePeerDrop(pd peerDrop) {

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -1227,12 +1227,6 @@ func (srv *BaseServer) handlePostHandshake(c *conn) error {
 }
 
 func (srv *BaseServer) handleAddPeer(c *conn) error {
-	select {
-	case <-srv.quit:
-		return errServerStopped
-	default:
-	}
-
 	// At this point the connection is past the protocol handshake.
 	// Its capabilities are known and the remote identity is verified.
 	err := srv.protoHandshakeChecks(c)
@@ -1251,6 +1245,12 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 	}
 
 	srv.peerMu.Lock()
+	select {
+	case <-srv.quit:
+		srv.peerMu.Unlock()
+		return errServerStopped
+	default:
+	}
 	// Repeat the capacity check because the peer set might have changed between the handshakes.
 	if err := srv.encHandshakeChecksUnlocked(c); err != nil {
 		srv.peerMu.Unlock()
@@ -1270,12 +1270,6 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 }
 
 func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
-	select {
-	case <-srv.quit:
-		return errServerStopped
-	default:
-	}
-
 	// At this point the connection is past the protocol handshake.
 	// Its capabilities are known and the remote identity is verified.
 	if err := srv.protoHandshakeChecks(c); err != nil {
@@ -1316,6 +1310,12 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 	}
 
 	srv.peerMu.Lock()
+	select {
+	case <-srv.quit:
+		srv.peerMu.Unlock()
+		return errServerStopped
+	default:
+	}
 	// Repeat the capacity check because the peer set might have changed between the handshakes.
 	if err := srv.encHandshakeChecksUnlocked(c); err != nil {
 		srv.peerMu.Unlock()

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -697,33 +697,6 @@ func (srv *MultiChannelServer) GetListenAddress() []string {
 	return srv.ListenAddrs
 }
 
-// decreasesConnectionMetric decreases the metric of the number of peer connections.
-func decreasesConnectionMetric(inboundCount int, outboundCount int, p *Peer) (int, int) {
-	pInbound, pOutbound := p.GetNumberInboundAndOutbound()
-	inboundCount -= pInbound
-	outboundCount -= pOutbound
-
-	updatesConnectionMetric(inboundCount, outboundCount)
-	return inboundCount, outboundCount
-}
-
-// increasesConnectionMetric increases the metric of the number of peer connections.
-func increasesConnectionMetric(inboundCount int, outboundCount int, p *Peer) (int, int) {
-	pInbound, pOutbound := p.GetNumberInboundAndOutbound()
-	inboundCount += pInbound
-	outboundCount += pOutbound
-
-	updatesConnectionMetric(inboundCount, outboundCount)
-	return inboundCount, outboundCount
-}
-
-// updatesConnectionMetric updates the metric of the number of peer connections.
-func updatesConnectionMetric(inboundCount int, outboundCount int) {
-	connectionCountGauge.Update(int64(outboundCount + inboundCount))
-	connectionInCountGauge.Update(int64(inboundCount))
-	connectionOutCountGauge.Update(int64(outboundCount))
-}
-
 // runPeer runs in its own goroutine for each peer.
 // it waits until the Peer logic returns and removes
 // the peer.
@@ -1284,7 +1257,6 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 	if srv.EnableMsgEvents {
 		p.events = &srv.peerFeed
 	}
-	name := truncateName(c.name)
 
 	srv.peerMu.Lock()
 	// Repeat the capacity check because the peer set might have changed between the handshakes.
@@ -1293,22 +1265,15 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 		return err
 	}
 	srv.peers[c.id] = p
-	if p.Inbound() {
-		srv.inboundCount++
-	} else {
-		srv.outboundCount++
-	}
+	srv.incrementConnectionCounts(p)
 	peerCount := len(srv.peers)
-	inboundCount := srv.inboundCount
 	srv.peerMu.Unlock()
 
 	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 
-	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
-	peerCountGauge.Update(int64(peerCount))
-	peerInCountGauge.Update(int64(inboundCount))
-	peerOutCountGauge.Update(int64(peerCount - inboundCount))
+	srv.logger.Debug("Adding p2p peer", "name", truncateName(c.name), "addr", c.fd.RemoteAddr(), "peers", peerCount)
+	srv.reportPeerMetric()
 	return nil
 }
 
@@ -1369,7 +1334,6 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 	if srv.EnableMsgEvents {
 		p.events = &srv.peerFeed
 	}
-	name := truncateName(c.name)
 
 	srv.peerMu.Lock()
 	// Repeat the capacity check because the peer set might have changed between the handshakes.
@@ -1378,15 +1342,15 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 		return err
 	}
 	srv.peers[c.id] = p
+	srv.incrementConnectionCounts(p)
 	peerCount := len(srv.peers)
-	srv.inboundCount, srv.outboundCount = increasesConnectionMetric(srv.inboundCount, srv.outboundCount, p)
 	srv.peerMu.Unlock()
 
 	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 
-	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
-	peerCountGauge.Update(int64(peerCount))
+	srv.logger.Debug("Adding p2p peer", "name", truncateName(c.name), "addr", c.fd.RemoteAddr(), "peers", peerCount)
+	srv.reportPeerMetric()
 	return nil
 }
 
@@ -1396,19 +1360,12 @@ func (srv *BaseServer) handlePeerDrop(pd peerDrop) {
 
 	srv.peerMu.Lock()
 	delete(srv.peers, pd.ID())
-	if pd.Inbound() {
-		srv.inboundCount--
-	} else {
-		srv.outboundCount--
-	}
+	srv.decrementConnectionCounts(pd.Peer)
 	peerCount := len(srv.peers)
-	inboundCount := srv.inboundCount
 	srv.peerMu.Unlock()
 
 	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
-	peerCountGauge.Update(int64(peerCount))
-	peerInCountGauge.Update(int64(inboundCount))
-	peerOutCountGauge.Update(int64(peerCount - inboundCount))
+	srv.reportPeerMetric()
 	srv.signalSchedule()
 }
 
@@ -1418,12 +1375,12 @@ func (srv *MultiChannelServer) handlePeerDrop(pd peerDrop) {
 
 	srv.peerMu.Lock()
 	delete(srv.peers, pd.ID())
+	srv.decrementConnectionCounts(pd.Peer)
 	peerCount := len(srv.peers)
-	srv.inboundCount, srv.outboundCount = decreasesConnectionMetric(srv.inboundCount, srv.outboundCount, pd.Peer)
 	srv.peerMu.Unlock()
 
 	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
-	peerCountGauge.Update(int64(peerCount))
+	srv.reportPeerMetric()
 	srv.signalSchedule()
 }
 
@@ -1596,6 +1553,48 @@ func (srv *BaseServer) getTypeStatics() map[dialType]typedStatic {
 		logger.Crit("[p2p.Server] UnSupported Connection Type:", "ConnectionType", srv.ConnectionType)
 		return nil
 	}
+}
+
+// Caller must hold the peerMu Lock.
+func (srv *BaseServer) incrementConnectionCounts(p *Peer) {
+	peerInbound, peerOutbound := p.GetNumberInboundAndOutbound()
+	srv.inboundCount += peerInbound
+	srv.outboundCount += peerOutbound
+}
+
+// Caller must hold the peerMu Lock.
+func (srv *BaseServer) decrementConnectionCounts(p *Peer) {
+	peerInbound, peerOutbound := p.GetNumberInboundAndOutbound()
+	srv.inboundCount -= peerInbound
+	srv.outboundCount -= peerOutbound
+}
+
+func (srv *BaseServer) reportPeerMetric() {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+
+	peerCountGauge.Update(int64(len(srv.peers)))
+	peerInCountGauge.Update(int64(srv.inboundCount))
+	peerOutCountGauge.Update(int64(srv.outboundCount))
+
+	connectionCountGauge.Update(int64(srv.outboundCount + srv.inboundCount))
+	connectionInCountGauge.Update(int64(srv.inboundCount))
+	connectionOutCountGauge.Update(int64(srv.outboundCount))
+}
+
+func (srv *MultiChannelServer) reportPeerMetric() {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+
+	peerCountGauge.Update(int64(len(srv.peers)))
+	// In multi-channel, one peer may contain both inbound and outbound connections,
+	// if two parties happened to dial each other at the same time. In this case,
+	// it is unclear whether the peer should be counted as inbound or outbound.
+	// Therefore, we do not report the peerIn and peerOut metrics for multi-channel.
+
+	connectionCountGauge.Update(int64(srv.outboundCount + srv.inboundCount))
+	connectionInCountGauge.Update(int64(srv.inboundCount))
+	connectionOutCountGauge.Update(int64(srv.outboundCount))
 }
 
 type tempError interface {

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -331,6 +331,7 @@ func (srv *MultiChannelServer) Start() (err error) {
 	srv.peerOp = make(chan peerOpFunc)
 	srv.peerOpDone = make(chan struct{})
 	srv.discpeer = make(chan discover.NodeID)
+	srv.initPeerState()
 
 	var (
 		conn      *net.UDPConn
@@ -611,20 +612,10 @@ func (srv *MultiChannelServer) run(dialstate dialer) {
 	logger.Debug("[p2p.Server] start MultiChannel p2p server")
 	defer srv.loopWG.Done()
 	var (
-		peers         = make(map[discover.NodeID]*Peer)
-		inboundCount  = 0
-		outboundCount = 0
-		trusted       = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
-		taskdone      = make(chan task, maxActiveDialTasks)
-		runningTasks  []task
-		queuedTasks   []task // tasks that can't run yet
+		taskdone     = make(chan task, maxActiveDialTasks)
+		runningTasks []task
+		queuedTasks  []task // tasks that can't run yet
 	)
-	// Put trusted nodes into a map to speed up checks.
-	// Trusted peers are loaded on startup and cannot be
-	// modified while the server is running.
-	for _, n := range srv.TrustedNodes {
-		trusted[n.ID] = true
-	}
 
 	// removes t from runningTasks
 	delTask := func(t task) {
@@ -651,7 +642,7 @@ func (srv *MultiChannelServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
-			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), peers, time.Now())
+			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -665,24 +656,11 @@ running:
 			// The server was stopped. Run the cleanup logic.
 			break running
 		case n := <-srv.addstatic:
-			// This channel is used by AddPeer to add to the
-			// ephemeral static peer list. Add it to the dialer,
-			// it will keep the node connected.
-			srv.logger.Debug("Adding static node", "node", n)
-			dialstate.addStatic(n)
+			srv.handleAddStaticDialstate(dialstate, n)
 		case n := <-srv.removestatic:
-			// This channel is used by RemovePeer to send a
-			// disconnect request to a peer and begin the
-			// stop keeping the node connected
-			srv.logger.Debug("Removing static node", "node", n)
-			dialstate.removeStatic(n)
-			if p, ok := peers[n.ID]; ok {
-				p.Disconnect(DiscRequested)
-			}
+			srv.handleRemoveStaticDialstate(dialstate, n)
 		case op := <-srv.peerOp:
-			// This channel is used by Peers and PeerCount.
-			op(peers)
-			srv.peerOpDone <- struct{}{}
+			srv.handlePeerOpRequest(op)
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
@@ -691,114 +669,25 @@ running:
 			dialstate.taskDone(t, time.Now())
 			delTask(t)
 		case c := <-srv.posthandshake:
-			// A connection has passed the encryption handshake so
-			// the remote identity is known (but hasn't been verified yet).
-			if trusted[c.id] {
-				// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
-				c.flags |= trustedConn
-			}
-			// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
 			select {
-			case c.cont <- srv.encHandshakeChecks(peers, inboundCount, c):
+			case c.cont <- srv.handlePostHandshake(c):
 			case <-srv.quit:
 				break running
 			}
 		case c := <-srv.addpeer:
-			var p *Peer
-			var e error
-			// At this point the connection is past the protocol handshake.
-			// Its capabilities are known and the remote identity is verified.
-			err := srv.protoHandshakeChecks(peers, inboundCount, c)
-			if err == nil {
-				if c.multiChannel {
-					connSet := srv.CandidateConns[c.id]
-					if connSet == nil {
-						connSet = make([]*conn, len(srv.ListenAddrs))
-						srv.CandidateConns[c.id] = connSet
-					}
-
-					if int(c.portOrder) < len(connSet) {
-						connSet[c.portOrder] = c
-					}
-
-					count := len(connSet)
-					for _, conn := range connSet {
-						if conn != nil {
-							count--
-						}
-					}
-
-					if count == 0 {
-						p, e = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
-						srv.CandidateConns[c.id] = nil
-					}
-				} else {
-					// The handshakes are done and it passed all checks.
-					p, e = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
-				}
-
-				if e != nil {
-					srv.logger.Error("Fail make a new peer", "err", e)
-				} else if p != nil {
-					// If message events are enabled, pass the peerFeed
-					// to the peer
-					if srv.EnableMsgEvents {
-						p.events = &srv.peerFeed
-					}
-					name := truncateName(c.name)
-					srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
-					go srv.runPeer(p)
-					peers[c.id] = p
-
-					peerCountGauge.Update(int64(len(peers)))
-					inboundCount, outboundCount = increasesConnectionMetric(inboundCount, outboundCount, p)
-				}
-			}
-			// The dialer logic relies on the assumption that
-			// dial tasks complete after the peer has been added or
-			// discarded. Unblock the task last.
 			select {
-			case c.cont <- err:
+			case c.cont <- srv.handleAddPeer(c):
 			case <-srv.quit:
 				break running
 			}
 		case pd := <-srv.delpeer:
-			// A peer disconnected.
-			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
-			delete(peers, pd.ID())
-
-			peerCountGauge.Update(int64(len(peers)))
-			inboundCount, outboundCount = decreasesConnectionMetric(inboundCount, outboundCount, pd.Peer)
+			srv.handlePeerDrop(pd)
 		case nid := <-srv.discpeer:
-			if p, ok := peers[nid]; ok {
-				p.Disconnect(DiscRequested)
-				p.logger.Debug(fmt.Sprintf("disconnect peer"))
-			}
+			srv.handleDisconnectRequest(nid)
 		}
 	}
 
-	srv.logger.Trace("P2P networking is spinning down")
-
-	// Terminate discovery. If there is a running lookup it will terminate soon.
-	if srv.ntab != nil {
-		srv.ntab.Close()
-	}
-	//if srv.DiscV5 != nil {
-	//	srv.DiscV5.Close()
-	//}
-	// Disconnect all peers.
-	for _, p := range peers {
-		p.Disconnect(DiscQuitting)
-	}
-	// Wait for peers to shut down. Pending connections and tasks are
-	// not handled here and will terminate soon-ish because srv.quit
-	// is closed.
-	for len(peers) > 0 {
-		p := <-srv.delpeer
-		p.logger.Trace("<-delpeer (spindown)", "remainingTasks", len(runningTasks))
-		delete(peers, p.ID())
-	}
+	srv.cleanupAfterRun(len(runningTasks), srv.handlePeerDrop)
 }
 
 // Stop terminates the server and all active peer connections.
@@ -931,6 +820,12 @@ type BaseServer struct {
 	lastLookupMu sync.Mutex
 	// DiscV5       *discv5.Network
 
+	peerMu        sync.RWMutex
+	peers         map[discover.NodeID]*Peer
+	inboundCount  int
+	outboundCount int
+	trusted       map[discover.NodeID]bool
+
 	// These are for Peers, PeerCount (and nothing else).
 	peerOp     chan peerOpFunc
 	peerOpDone chan struct{}
@@ -948,6 +843,36 @@ type BaseServer struct {
 }
 
 type peerOpFunc func(map[discover.NodeID]*Peer)
+
+func (srv *BaseServer) initPeerState() {
+	srv.peerMu.Lock()
+	defer srv.peerMu.Unlock()
+
+	srv.peers = make(map[discover.NodeID]*Peer)
+	srv.inboundCount = 0
+	srv.outboundCount = 0
+	srv.trusted = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
+	for _, n := range srv.TrustedNodes {
+		srv.trusted[n.ID] = true
+	}
+}
+
+func (srv *BaseServer) allPeers() map[discover.NodeID]*Peer {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+
+	peers := make(map[discover.NodeID]*Peer, len(srv.peers))
+	for id, p := range srv.peers {
+		peers[id] = p
+	}
+	return peers
+}
+
+func (srv *BaseServer) peerLen() int {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+	return len(srv.peers)
+}
 
 type peerDrop struct {
 	*Peer
@@ -1232,6 +1157,7 @@ func (srv *BaseServer) Start() (err error) {
 	srv.peerOp = make(chan peerOpFunc)
 	srv.peerOpDone = make(chan struct{})
 	srv.discpeer = make(chan discover.NodeID)
+	srv.initPeerState()
 
 	var (
 		conn      *net.UDPConn
@@ -1344,22 +1270,235 @@ type dialer interface {
 	removeStatic(*discover.Node)
 }
 
+func (srv *BaseServer) isTrusted(id discover.NodeID) bool {
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+	return srv.trusted[id]
+}
+
+func (srv *BaseServer) handleAddStaticDialstate(dialstate dialer, n *discover.Node) {
+	// This channel is used by AddPeer to add to the
+	// ephemeral static peer list. Add it to the dialer,
+	// it will keep the node connected.
+	srv.logger.Debug("Adding static node", "node", n)
+	dialstate.addStatic(n)
+}
+
+func (srv *BaseServer) handleRemoveStaticDialstate(dialstate dialer, n *discover.Node) {
+	// This channel is used by RemovePeer to send a
+	// disconnect request to a peer and begin the
+	// stop keeping the node connected.
+	srv.logger.Debug("Removing static node", "node", n)
+	dialstate.removeStatic(n)
+
+	srv.peerMu.RLock()
+	p := srv.peers[n.ID]
+	srv.peerMu.RUnlock()
+	if p != nil {
+		p.Disconnect(DiscRequested)
+	}
+}
+
+func (srv *BaseServer) handlePeerOpRequest(op peerOpFunc) {
+	// This channel is used by Peers and PeerCount.
+	srv.peerMu.RLock()
+	op(srv.peers)
+	srv.peerMu.RUnlock()
+	srv.peerOpDone <- struct{}{}
+}
+
+func (srv *BaseServer) handlePostHandshake(c *conn) error {
+	// A connection has passed the encryption handshake so
+	// the remote identity is known (but hasn't been verified yet).
+	if srv.isTrusted(c.id) {
+		// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
+		c.flags |= trustedConn
+	}
+	// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
+	return srv.encHandshakeChecks(c)
+}
+
+func (srv *BaseServer) handleAddPeer(c *conn) error {
+	// At this point the connection is past the protocol handshake.
+	// Its capabilities are known and the remote identity is verified.
+	err := srv.protoHandshakeChecks(c)
+	if err != nil {
+		return err
+	}
+
+	p, err := newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
+	if err != nil {
+		srv.logger.Error("Fail make a new peer", "err", err)
+		return nil
+	}
+	// If message events are enabled, pass the peerFeed to the peer.
+	if srv.EnableMsgEvents {
+		p.events = &srv.peerFeed
+	}
+	name := truncateName(c.name)
+	go srv.runPeer(p)
+
+	srv.peerMu.Lock()
+	srv.peers[c.id] = p
+	if p.Inbound() {
+		srv.inboundCount++
+	} else {
+		srv.outboundCount++
+	}
+	peerCount := len(srv.peers)
+	inboundCount := srv.inboundCount
+	srv.peerMu.Unlock()
+
+	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
+	peerCountGauge.Update(int64(peerCount))
+	peerInCountGauge.Update(int64(inboundCount))
+	peerOutCountGauge.Update(int64(peerCount - inboundCount))
+	return nil
+}
+
+func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
+	// At this point the connection is past the protocol handshake.
+	// Its capabilities are known and the remote identity is verified.
+	err := srv.protoHandshakeChecks(c)
+	if err != nil {
+		return err
+	}
+
+	var (
+		p *Peer
+		e error
+	)
+	if c.multiChannel {
+		srv.peerMu.Lock()
+		connSet := srv.CandidateConns[c.id]
+		if connSet == nil {
+			connSet = make([]*conn, len(srv.ListenAddrs))
+			srv.CandidateConns[c.id] = connSet
+		}
+
+		if int(c.portOrder) < len(connSet) {
+			connSet[c.portOrder] = c
+		}
+
+		remaining := len(connSet)
+		for _, conn := range connSet {
+			if conn != nil {
+				remaining--
+			}
+		}
+		if remaining == 0 {
+			p, e = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
+			srv.CandidateConns[c.id] = nil
+		}
+		srv.peerMu.Unlock()
+	} else {
+		// The handshakes are done and it passed all checks.
+		p, e = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
+	}
+
+	if e != nil {
+		srv.logger.Error("Fail make a new peer", "err", e)
+		return nil
+	}
+	if p == nil {
+		return nil
+	}
+
+	// If message events are enabled, pass the peerFeed to the peer.
+	if srv.EnableMsgEvents {
+		p.events = &srv.peerFeed
+	}
+	name := truncateName(c.name)
+	go srv.runPeer(p)
+
+	srv.peerMu.Lock()
+	srv.peers[c.id] = p
+	peerCount := len(srv.peers)
+	srv.inboundCount, srv.outboundCount = increasesConnectionMetric(srv.inboundCount, srv.outboundCount, p)
+	srv.peerMu.Unlock()
+
+	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
+	peerCountGauge.Update(int64(peerCount))
+	return nil
+}
+
+func (srv *BaseServer) handlePeerDrop(pd peerDrop) {
+	// A peer disconnected.
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+
+	srv.peerMu.Lock()
+	delete(srv.peers, pd.ID())
+	if pd.Inbound() {
+		srv.inboundCount--
+	} else {
+		srv.outboundCount--
+	}
+	peerCount := len(srv.peers)
+	inboundCount := srv.inboundCount
+	srv.peerMu.Unlock()
+
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
+	peerCountGauge.Update(int64(peerCount))
+	peerInCountGauge.Update(int64(inboundCount))
+	peerOutCountGauge.Update(int64(peerCount - inboundCount))
+}
+
+func (srv *MultiChannelServer) handlePeerDrop(pd peerDrop) {
+	// A peer disconnected.
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+
+	srv.peerMu.Lock()
+	delete(srv.peers, pd.ID())
+	peerCount := len(srv.peers)
+	srv.inboundCount, srv.outboundCount = decreasesConnectionMetric(srv.inboundCount, srv.outboundCount, pd.Peer)
+	srv.peerMu.Unlock()
+
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
+	peerCountGauge.Update(int64(peerCount))
+}
+
+func (srv *BaseServer) handleDisconnectRequest(nid discover.NodeID) {
+	srv.peerMu.RLock()
+	p := srv.peers[nid]
+	srv.peerMu.RUnlock()
+	if p != nil {
+		p.Disconnect(DiscRequested)
+		p.logger.Debug(fmt.Sprintf("disconnect peer"))
+	}
+}
+
+func (srv *BaseServer) cleanupAfterRun(remainingTasks int, dropHandler func(peerDrop)) {
+	srv.logger.Trace("P2P networking is spinning down")
+
+	// Terminate discovery. If there is a running lookup it will terminate soon.
+	if srv.ntab != nil {
+		srv.ntab.Close()
+	}
+	//if srv.DiscV5 != nil {
+	//	srv.DiscV5.Close()
+	//}
+
+	// Disconnect all peers.
+	for _, p := range srv.allPeers() {
+		p.Disconnect(DiscQuitting)
+	}
+	// Wait for peers to shut down. Pending connections and tasks are
+	// not handled here and will terminate soon-ish because srv.quit
+	// is closed.
+	for srv.peerLen() > 0 {
+		pd := <-srv.delpeer
+		pd.logger.Trace("<-delpeer (spindown)", "remainingTasks", remainingTasks)
+		dropHandler(pd)
+	}
+}
+
 func (srv *BaseServer) run(dialstate dialer) {
 	defer srv.loopWG.Done()
 	var (
-		peers        = make(map[discover.NodeID]*Peer)
-		inboundCount = 0
-		trusted      = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
 		taskdone     = make(chan task, maxActiveDialTasks)
 		runningTasks []task
 		queuedTasks  []task // tasks that can't run yet
 	)
-	// Put trusted nodes into a map to speed up checks.
-	// Trusted peers are loaded on startup and cannot be
-	// modified while the server is running.
-	for _, n := range srv.TrustedNodes {
-		trusted[n.ID] = true
-	}
 
 	// removes t from runningTasks
 	delTask := func(t task) {
@@ -1386,7 +1525,7 @@ func (srv *BaseServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
-			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), peers, time.Now())
+			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -1400,24 +1539,11 @@ running:
 			// The server was stopped. Run the cleanup logic.
 			break running
 		case n := <-srv.addstatic:
-			// This channel is used by AddPeer to add to the
-			// ephemeral static peer list. Add it to the dialer,
-			// it will keep the node connected.
-			srv.logger.Debug("Adding static node", "node", n)
-			dialstate.addStatic(n)
+			srv.handleAddStaticDialstate(dialstate, n)
 		case n := <-srv.removestatic:
-			// This channel is used by RemovePeer to send a
-			// disconnect request to a peer and begin the
-			// stop keeping the node connected
-			srv.logger.Debug("Removing static node", "node", n)
-			dialstate.removeStatic(n)
-			if p, ok := peers[n.ID]; ok {
-				p.Disconnect(DiscRequested)
-			}
+			srv.handleRemoveStaticDialstate(dialstate, n)
 		case op := <-srv.peerOp:
-			// This channel is used by Peers and PeerCount.
-			op(peers)
-			srv.peerOpDone <- struct{}{}
+			srv.handlePeerOpRequest(op)
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
@@ -1426,116 +1552,50 @@ running:
 			dialstate.taskDone(t, time.Now())
 			delTask(t)
 		case c := <-srv.posthandshake:
-			// A connection has passed the encryption handshake so
-			// the remote identity is known (but hasn't been verified yet).
-			if trusted[c.id] {
-				// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
-				c.flags |= trustedConn
-			}
-			// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
 			select {
-			case c.cont <- srv.encHandshakeChecks(peers, inboundCount, c):
+			case c.cont <- srv.handlePostHandshake(c):
 			case <-srv.quit:
 				break running
 			}
 		case c := <-srv.addpeer:
-			// At this point the connection is past the protocol handshake.
-			// Its capabilities are known and the remote identity is verified.
-			var err error
-			err = srv.protoHandshakeChecks(peers, inboundCount, c)
-			if err == nil {
-				// The handshakes are done and it passed all checks.
-				p, err := newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
-				if err != nil {
-					srv.logger.Error("Fail make a new peer", "err", err)
-				} else {
-					// If message events are enabled, pass the peerFeed
-					// to the peer
-					if srv.EnableMsgEvents {
-						p.events = &srv.peerFeed
-					}
-					name := truncateName(c.name)
-					srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
-					go srv.runPeer(p)
-					peers[c.id] = p
-
-					if p.Inbound() {
-						inboundCount++
-					}
-					peerCountGauge.Update(int64(len(peers)))
-					peerInCountGauge.Update(int64(inboundCount))
-					peerOutCountGauge.Update(int64(len(peers) - inboundCount))
-				}
-			}
-			// The dialer logic relies on the assumption that
-			// dial tasks complete after the peer has been added or
-			// discarded. Unblock the task last.
 			select {
-			case c.cont <- err:
+			case c.cont <- srv.handleAddPeer(c):
 			case <-srv.quit:
 				break running
 			}
 		case pd := <-srv.delpeer:
-			// A peer disconnected.
-			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
-			delete(peers, pd.ID())
-
-			if pd.Inbound() {
-				inboundCount--
-			}
-
-			peerCountGauge.Update(int64(len(peers)))
-			peerInCountGauge.Update(int64(inboundCount))
-			peerOutCountGauge.Update(int64(len(peers) - inboundCount))
+			srv.handlePeerDrop(pd)
 		case nid := <-srv.discpeer:
-			if p, ok := peers[nid]; ok {
-				p.Disconnect(DiscRequested)
-				p.logger.Debug(fmt.Sprintf("disconnect peer"))
-			}
+			srv.handleDisconnectRequest(nid)
 		}
 	}
 
-	srv.logger.Trace("P2P networking is spinning down")
-
-	// Terminate discovery. If there is a running lookup it will terminate soon.
-	if srv.ntab != nil {
-		srv.ntab.Close()
-	}
-	//if srv.DiscV5 != nil {
-	//	srv.DiscV5.Close()
-	//}
-	// Disconnect all peers.
-	for _, p := range peers {
-		p.Disconnect(DiscQuitting)
-	}
-	// Wait for peers to shut down. Pending connections and tasks are
-	// not handled here and will terminate soon-ish because srv.quit
-	// is closed.
-	for len(peers) > 0 {
-		p := <-srv.delpeer
-		p.logger.Trace("<-delpeer (spindown)", "remainingTasks", len(runningTasks))
-		delete(peers, p.ID())
-	}
+	srv.cleanupAfterRun(len(runningTasks), srv.handlePeerDrop)
 }
 
-func (srv *BaseServer) protoHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCount int, c *conn) error {
+func (srv *BaseServer) protoHandshakeChecks(c *conn) error {
 	// Drop connections with no matching protocols.
 	if len(srv.Protocols) > 0 && countMatchingProtocols(srv.Protocols, c.caps) == 0 {
 		return DiscUselessPeer
 	}
 	// Repeat the encryption handshake checks because the
 	// peer set might have changed between the handshakes.
-	return srv.encHandshakeChecks(peers, inboundCount, c)
+	return srv.encHandshakeChecks(c)
 }
 
-func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCount int, c *conn) error {
+func (srv *BaseServer) encHandshakeChecks(c *conn) error {
+	srv.peerMu.RLock()
+	peerCount := len(srv.peers)
+	inboundCount := srv.inboundCount
+	_, connected := srv.peers[c.id]
+	srv.peerMu.RUnlock()
+
 	switch {
-	case !c.is(trustedConn|staticDialedConn) && len(peers) >= srv.Config.MaxPhysicalConnections:
+	case !c.is(trustedConn|staticDialedConn) && peerCount >= srv.Config.MaxPhysicalConnections:
 		return DiscTooManyPeers
 	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
 		return DiscTooManyPeers
-	case peers[c.id] != nil:
+	case connected:
 		return DiscAlreadyConnected
 	case c.id == srv.Self().ID:
 		return DiscSelf

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -323,14 +323,7 @@ func (srv *MultiChannelServer) Start() (err error) {
 		srv.Dialer = TCPDialer{&net.Dialer{Timeout: defaultDialTimeout}}
 	}
 	srv.quit = make(chan struct{})
-	srv.addpeer = make(chan *conn)
-	srv.delpeer = make(chan peerDrop)
-	srv.posthandshake = make(chan *conn)
-	srv.addstatic = make(chan *discover.Node)
-	srv.removestatic = make(chan *discover.Node)
-	srv.peerOp = make(chan peerOpFunc)
-	srv.peerOpDone = make(chan struct{})
-	srv.discpeer = make(chan discover.NodeID)
+	srv.schedWake = make(chan struct{}, 1)
 	srv.initPeerState()
 
 	var (
@@ -384,7 +377,7 @@ func (srv *MultiChannelServer) Start() (err error) {
 		srv.ntab = ntab
 	}
 
-	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
+	srv.dialstate = newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
 
 	// handshake
 	srv.ourHandshake = &protoHandshake{Version: baseProtocolVersion, Name: srv.Name(), ID: discover.PubkeyID(&srv.PrivateKey.PublicKey), Multichannel: true}
@@ -415,7 +408,7 @@ func (srv *MultiChannelServer) Start() (err error) {
 	}
 
 	srv.loopWG.Add(1)
-	go srv.run(dialer)
+	go srv.run()
 	srv.running = true
 	srv.logger.Info("Started P2P server", "id", discover.PubkeyID(&srv.PrivateKey.PublicKey), "multichannel", true)
 	return nil
@@ -506,7 +499,7 @@ func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *
 		return errors.New("shutdown")
 	}
 
-	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, cont: make(chan error), portOrder: PortOrderUndefined}
+	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, portOrder: PortOrderUndefined}
 
 	if dialDest != nil {
 		// retrieve pubkey. if err occurs, dialPubkey is automatically set as nil
@@ -568,7 +561,12 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 		clog.Trace("Dialed identity mismatch", "want", c, dialDest.ID)
 		return DiscUnexpectedIdentity
 	}
-	err = srv.checkpoint(c, srv.posthandshake)
+	select {
+	case <-srv.quit:
+		return errServerStopped
+	default:
+	}
+	err = srv.handlePostHandshake(c)
 	if err != nil {
 		clog.Trace("Rejected peer before protocol handshake", "err", err)
 		return err
@@ -596,7 +594,12 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 		return errUpdateDial
 	}
 
-	err = srv.checkpoint(c, srv.addpeer)
+	select {
+	case <-srv.quit:
+		return errServerStopped
+	default:
+	}
+	err = srv.handleAddPeer(c)
 	if err != nil {
 		clog.Trace("Rejected peer", "err", err)
 		return err
@@ -608,7 +611,7 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 }
 
 // run is the main loop that the server runs.
-func (srv *MultiChannelServer) run(dialstate dialer) {
+func (srv *MultiChannelServer) run() {
 	logger.Debug("[p2p.Server] start MultiChannel p2p server")
 	defer srv.loopWG.Done()
 	var (
@@ -642,7 +645,7 @@ func (srv *MultiChannelServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
-			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
+			nt := srv.dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -655,39 +658,18 @@ running:
 		case <-srv.quit:
 			// The server was stopped. Run the cleanup logic.
 			break running
-		case n := <-srv.addstatic:
-			srv.handleAddStaticDialstate(dialstate, n)
-		case n := <-srv.removestatic:
-			srv.handleRemoveStaticDialstate(dialstate, n)
-		case op := <-srv.peerOp:
-			srv.handlePeerOpRequest(op)
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
 			// tasks list.
 			srv.logger.Trace("Dial task done", "task", t)
-			dialstate.taskDone(t, time.Now())
+			srv.dialstate.taskDone(t, time.Now())
 			delTask(t)
-		case c := <-srv.posthandshake:
-			select {
-			case c.cont <- srv.handlePostHandshake(c):
-			case <-srv.quit:
-				break running
-			}
-		case c := <-srv.addpeer:
-			select {
-			case c.cont <- srv.handleAddPeer(c):
-			case <-srv.quit:
-				break running
-			}
-		case pd := <-srv.delpeer:
-			srv.handlePeerDrop(pd)
-		case nid := <-srv.discpeer:
-			srv.handleDisconnectRequest(nid)
+		case <-srv.schedWake:
 		}
 	}
 
-	srv.cleanupAfterRun(len(runningTasks), srv.handlePeerDrop)
+	srv.cleanupAfterRun()
 }
 
 // Stop terminates the server and all active peer connections.
@@ -746,6 +728,8 @@ func updatesConnectionMetric(inboundCount int, outboundCount int) {
 // it waits until the Peer logic returns and removes
 // the peer.
 func (srv *MultiChannelServer) runPeer(p *Peer) {
+	defer srv.peerWG.Done()
+
 	if srv.newPeerHook != nil {
 		srv.newPeerHook(p)
 	}
@@ -766,9 +750,7 @@ func (srv *MultiChannelServer) runPeer(p *Peer) {
 		Error: err.Error(),
 	})
 
-	// Note: run waits for existing peers to be sent on srv.delpeer
-	// before returning, so this send should not select on srv.quit.
-	srv.delpeer <- peerDrop{p, err, remoteRequested}
+	srv.handlePeerDrop(peerDrop{p, err, remoteRequested})
 }
 
 // SingleChannelServer is a server that uses a single channel.
@@ -825,24 +807,15 @@ type BaseServer struct {
 	inboundCount  int
 	outboundCount int
 	trusted       map[discover.NodeID]bool
+	peerWG        sync.WaitGroup
 
-	// These are for Peers, PeerCount (and nothing else).
-	peerOp     chan peerOpFunc
-	peerOpDone chan struct{}
-
-	quit          chan struct{}
-	addstatic     chan *discover.Node
-	removestatic  chan *discover.Node
-	posthandshake chan *conn
-	addpeer       chan *conn
-	delpeer       chan peerDrop
-	discpeer      chan discover.NodeID
-	loopWG        sync.WaitGroup // loop, listenLoop
-	peerFeed      event.Feed
-	logger        log.Logger
+	quit      chan struct{}
+	schedWake chan struct{}
+	dialstate dialer
+	loopWG    sync.WaitGroup // loop, listenLoop
+	peerFeed  event.Feed
+	logger    log.Logger
 }
-
-type peerOpFunc func(map[discover.NodeID]*Peer)
 
 func (srv *BaseServer) initPeerState() {
 	srv.peerMu.Lock()
@@ -868,10 +841,11 @@ func (srv *BaseServer) allPeers() map[discover.NodeID]*Peer {
 	return peers
 }
 
-func (srv *BaseServer) peerLen() int {
-	srv.peerMu.RLock()
-	defer srv.peerMu.RUnlock()
-	return len(srv.peers)
+func (srv *BaseServer) signalSchedule() {
+	select {
+	case srv.schedWake <- struct{}{}:
+	default:
+	}
 }
 
 type peerDrop struct {
@@ -902,7 +876,6 @@ type conn struct {
 	transport
 	flags        connFlag
 	conntype     common.ConnType // valid after the encryption handshake at the inbound connection case
-	cont         chan error      // The run loop uses cont to signal errors to SetupConn.
 	id           discover.NodeID // valid after the encryption handshake
 	caps         []Cap           // valid after the protocol handshake
 	name         string          // valid after the protocol handshake
@@ -975,46 +948,28 @@ func (srv *BaseServer) AddProtocols(p []Protocol) {
 
 // Peers returns all connected peers.
 func (srv *BaseServer) Peers() []*Peer {
-	var ps []*Peer
-	select {
-	// Note: We'd love to put this function into a variable but
-	// that seems to cause a weird compiler error in some
-	// environments.
-	case srv.peerOp <- func(peers map[discover.NodeID]*Peer) {
-		for _, p := range peers {
-			ps = append(ps, p)
-		}
-	}:
-		<-srv.peerOpDone
-	case <-srv.quit:
+	peers := srv.allPeers()
+	ps := make([]*Peer, 0, len(peers))
+	for _, p := range peers {
+		ps = append(ps, p)
 	}
 	return ps
 }
 
 // PeerCount returns the number of connected peers.
 func (srv *BaseServer) PeerCount() int {
-	var count int
-	select {
-	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) { count = len(ps) }:
-		<-srv.peerOpDone
-	case <-srv.quit:
-	}
-	return count
+	return len(srv.allPeers())
 }
 
 func (srv *BaseServer) PeerCountByType() map[string]uint {
-	pc := make(map[string]uint)
-	pc["total"] = 0
-	select {
-	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) {
-		for _, peer := range ps {
-			key := ConvertConnTypeToString(peer.ConnType())
-			pc[key]++
-			pc["total"]++
-		}
-	}:
-		<-srv.peerOpDone
-	case <-srv.quit:
+	peers := srv.allPeers()
+	pc := map[string]uint{
+		"total": 0,
+	}
+	for _, peer := range peers {
+		key := ConvertConnTypeToString(peer.ConnType())
+		pc[key]++
+		pc["total"]++
 	}
 	return pc
 }
@@ -1023,17 +978,40 @@ func (srv *BaseServer) PeerCountByType() map[string]uint {
 // server is shut down. If the connection fails for any reason, the server will
 // attempt to reconnect the peer.
 func (srv *BaseServer) AddPeer(node *discover.Node) {
-	select {
-	case srv.addstatic <- node:
-	case <-srv.quit:
+	if node == nil {
+		return
 	}
+	select {
+	case <-srv.quit:
+		return
+	default:
+	}
+
+	srv.dialstate.addStatic(node)
+	srv.logger.Debug("Adding static node", "node", node)
+	srv.signalSchedule()
 }
 
 // RemovePeer disconnects from the given node.
 func (srv *BaseServer) RemovePeer(node *discover.Node) {
+	if node == nil {
+		return
+	}
 	select {
-	case srv.removestatic <- node:
 	case <-srv.quit:
+		return
+	default:
+	}
+
+	srv.dialstate.removeStatic(node)
+	srv.logger.Debug("Removing static node", "node", node)
+	srv.signalSchedule()
+
+	srv.peerMu.RLock()
+	p := srv.peers[node.ID]
+	srv.peerMu.RUnlock()
+	if p != nil {
+		p.Disconnect(DiscRequested)
 	}
 }
 
@@ -1149,14 +1127,7 @@ func (srv *BaseServer) Start() (err error) {
 		srv.Dialer = TCPDialer{&net.Dialer{Timeout: defaultDialTimeout}}
 	}
 	srv.quit = make(chan struct{})
-	srv.addpeer = make(chan *conn)
-	srv.delpeer = make(chan peerDrop)
-	srv.posthandshake = make(chan *conn)
-	srv.addstatic = make(chan *discover.Node)
-	srv.removestatic = make(chan *discover.Node)
-	srv.peerOp = make(chan peerOpFunc)
-	srv.peerOpDone = make(chan struct{})
-	srv.discpeer = make(chan discover.NodeID)
+	srv.schedWake = make(chan struct{}, 1)
 	srv.initPeerState()
 
 	var (
@@ -1215,7 +1186,7 @@ func (srv *BaseServer) Start() (err error) {
 		srv.ntab = ntab
 	}
 
-	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
+	srv.dialstate = newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
 
 	// handshake
 	srv.ourHandshake = &protoHandshake{Version: baseProtocolVersion, Name: srv.Name(), ID: discover.PubkeyID(&srv.PrivateKey.PublicKey), Multichannel: false}
@@ -1237,7 +1208,7 @@ func (srv *BaseServer) Start() (err error) {
 	}
 
 	srv.loopWG.Add(1)
-	go srv.run(dialer)
+	go srv.run()
 	srv.running = true
 	srv.logger.Info("Started P2P server", "id", discover.PubkeyID(&srv.PrivateKey.PublicKey), "multichannel", false)
 	return nil
@@ -1276,37 +1247,6 @@ func (srv *BaseServer) isTrusted(id discover.NodeID) bool {
 	return srv.trusted[id]
 }
 
-func (srv *BaseServer) handleAddStaticDialstate(dialstate dialer, n *discover.Node) {
-	// This channel is used by AddPeer to add to the
-	// ephemeral static peer list. Add it to the dialer,
-	// it will keep the node connected.
-	srv.logger.Debug("Adding static node", "node", n)
-	dialstate.addStatic(n)
-}
-
-func (srv *BaseServer) handleRemoveStaticDialstate(dialstate dialer, n *discover.Node) {
-	// This channel is used by RemovePeer to send a
-	// disconnect request to a peer and begin the
-	// stop keeping the node connected.
-	srv.logger.Debug("Removing static node", "node", n)
-	dialstate.removeStatic(n)
-
-	srv.peerMu.RLock()
-	p := srv.peers[n.ID]
-	srv.peerMu.RUnlock()
-	if p != nil {
-		p.Disconnect(DiscRequested)
-	}
-}
-
-func (srv *BaseServer) handlePeerOpRequest(op peerOpFunc) {
-	// This channel is used by Peers and PeerCount.
-	srv.peerMu.RLock()
-	op(srv.peers)
-	srv.peerMu.RUnlock()
-	srv.peerOpDone <- struct{}{}
-}
-
 func (srv *BaseServer) handlePostHandshake(c *conn) error {
 	// A connection has passed the encryption handshake so
 	// the remote identity is known (but hasn't been verified yet).
@@ -1319,6 +1259,12 @@ func (srv *BaseServer) handlePostHandshake(c *conn) error {
 }
 
 func (srv *BaseServer) handleAddPeer(c *conn) error {
+	select {
+	case <-srv.quit:
+		return errServerStopped
+	default:
+	}
+
 	// At this point the connection is past the protocol handshake.
 	// Its capabilities are known and the remote identity is verified.
 	err := srv.protoHandshakeChecks(c)
@@ -1336,6 +1282,7 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 		p.events = &srv.peerFeed
 	}
 	name := truncateName(c.name)
+	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 
 	srv.peerMu.Lock()
@@ -1357,6 +1304,12 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 }
 
 func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
+	select {
+	case <-srv.quit:
+		return errServerStopped
+	default:
+	}
+
 	// At this point the connection is past the protocol handshake.
 	// Its capabilities are known and the remote identity is verified.
 	err := srv.protoHandshakeChecks(c)
@@ -1409,6 +1362,7 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 		p.events = &srv.peerFeed
 	}
 	name := truncateName(c.name)
+	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 
 	srv.peerMu.Lock()
@@ -1441,6 +1395,7 @@ func (srv *BaseServer) handlePeerDrop(pd peerDrop) {
 	peerCountGauge.Update(int64(peerCount))
 	peerInCountGauge.Update(int64(inboundCount))
 	peerOutCountGauge.Update(int64(peerCount - inboundCount))
+	srv.signalSchedule()
 }
 
 func (srv *MultiChannelServer) handlePeerDrop(pd peerDrop) {
@@ -1455,6 +1410,7 @@ func (srv *MultiChannelServer) handlePeerDrop(pd peerDrop) {
 
 	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
 	peerCountGauge.Update(int64(peerCount))
+	srv.signalSchedule()
 }
 
 func (srv *BaseServer) handleDisconnectRequest(nid discover.NodeID) {
@@ -1463,11 +1419,11 @@ func (srv *BaseServer) handleDisconnectRequest(nid discover.NodeID) {
 	srv.peerMu.RUnlock()
 	if p != nil {
 		p.Disconnect(DiscRequested)
-		p.logger.Debug(fmt.Sprintf("disconnect peer"))
+		p.logger.Debug("disconnect peer")
 	}
 }
 
-func (srv *BaseServer) cleanupAfterRun(remainingTasks int, dropHandler func(peerDrop)) {
+func (srv *BaseServer) cleanupAfterRun() {
 	srv.logger.Trace("P2P networking is spinning down")
 
 	// Terminate discovery. If there is a running lookup it will terminate soon.
@@ -1485,14 +1441,10 @@ func (srv *BaseServer) cleanupAfterRun(remainingTasks int, dropHandler func(peer
 	// Wait for peers to shut down. Pending connections and tasks are
 	// not handled here and will terminate soon-ish because srv.quit
 	// is closed.
-	for srv.peerLen() > 0 {
-		pd := <-srv.delpeer
-		pd.logger.Trace("<-delpeer (spindown)", "remainingTasks", remainingTasks)
-		dropHandler(pd)
-	}
+	srv.peerWG.Wait()
 }
 
-func (srv *BaseServer) run(dialstate dialer) {
+func (srv *BaseServer) run() {
 	defer srv.loopWG.Done()
 	var (
 		taskdone     = make(chan task, maxActiveDialTasks)
@@ -1525,7 +1477,7 @@ func (srv *BaseServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
-			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
+			nt := srv.dialstate.newTasks(len(runningTasks)+len(queuedTasks), srv.allPeers(), time.Now())
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -1538,39 +1490,18 @@ running:
 		case <-srv.quit:
 			// The server was stopped. Run the cleanup logic.
 			break running
-		case n := <-srv.addstatic:
-			srv.handleAddStaticDialstate(dialstate, n)
-		case n := <-srv.removestatic:
-			srv.handleRemoveStaticDialstate(dialstate, n)
-		case op := <-srv.peerOp:
-			srv.handlePeerOpRequest(op)
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
 			// tasks list.
 			srv.logger.Trace("Dial task done", "task", t)
-			dialstate.taskDone(t, time.Now())
+			srv.dialstate.taskDone(t, time.Now())
 			delTask(t)
-		case c := <-srv.posthandshake:
-			select {
-			case c.cont <- srv.handlePostHandshake(c):
-			case <-srv.quit:
-				break running
-			}
-		case c := <-srv.addpeer:
-			select {
-			case c.cont <- srv.handleAddPeer(c):
-			case <-srv.quit:
-				break running
-			}
-		case pd := <-srv.delpeer:
-			srv.handlePeerDrop(pd)
-		case nid := <-srv.discpeer:
-			srv.handleDisconnectRequest(nid)
+		case <-srv.schedWake:
 		}
 	}
 
-	srv.cleanupAfterRun(len(runningTasks), srv.handlePeerDrop)
+	srv.cleanupAfterRun()
 }
 
 func (srv *BaseServer) protoHandshakeChecks(c *conn) error {
@@ -1726,7 +1657,7 @@ func (srv *BaseServer) SetupConn(fd net.Conn, flags connFlag, dialDest *discover
 		return errors.New("shutdown")
 	}
 
-	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, cont: make(chan error), portOrder: ConnDefault}
+	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, portOrder: ConnDefault}
 
 	// if err occurs, dialPubkey is automatically set as nil
 	if dialDest != nil {
@@ -1776,7 +1707,12 @@ func (srv *BaseServer) setupConn(c *conn, flags connFlag, dialDest *discover.Nod
 		clog.Trace("Dialed identity mismatch", "want", c, dialDest.ID)
 		return DiscUnexpectedIdentity
 	}
-	err = srv.checkpoint(c, srv.posthandshake)
+	select {
+	case <-srv.quit:
+		return errServerStopped
+	default:
+	}
+	err = srv.handlePostHandshake(c)
 	if err != nil {
 		clog.Trace("Rejected peer before protocol handshake", "err", err)
 		return err
@@ -1793,7 +1729,12 @@ func (srv *BaseServer) setupConn(c *conn, flags connFlag, dialDest *discover.Nod
 	}
 	c.caps, c.name, c.multiChannel = phs.Caps, phs.Name, phs.Multichannel
 
-	err = srv.checkpoint(c, srv.addpeer)
+	select {
+	case <-srv.quit:
+		return errServerStopped
+	default:
+	}
+	err = srv.handleAddPeer(c)
 	if err != nil {
 		clog.Trace("Rejected peer", "err", err)
 		return err
@@ -1811,26 +1752,12 @@ func truncateName(s string) string {
 	return s
 }
 
-// checkpoint sends the conn to run, which performs the
-// post-handshake checks for the stage (posthandshake, addpeer).
-func (srv *BaseServer) checkpoint(c *conn, stage chan<- *conn) error {
-	select {
-	case stage <- c:
-	case <-srv.quit:
-		return errServerStopped
-	}
-	select {
-	case err := <-c.cont:
-		return err
-	case <-srv.quit:
-		return errServerStopped
-	}
-}
-
 // runPeer runs in its own goroutine for each peer.
 // it waits until the Peer logic returns and removes
 // the peer.
 func (srv *BaseServer) runPeer(p *Peer) {
+	defer srv.peerWG.Done()
+
 	if srv.newPeerHook != nil {
 		srv.newPeerHook(p)
 	}
@@ -1851,9 +1778,7 @@ func (srv *BaseServer) runPeer(p *Peer) {
 		Error: err.Error(),
 	})
 
-	// Note: run waits for existing peers to be sent on srv.delpeer
-	// before returning, so this send should not select on srv.quit.
-	srv.delpeer <- peerDrop{p, err, remoteRequested}
+	srv.handlePeerDrop(peerDrop{p, err, remoteRequested})
 }
 
 // NodeInfo represents a short summary of the information known about the host.
@@ -1921,7 +1846,7 @@ func (srv *BaseServer) PeersInfo() []*PeerInfo {
 
 // Disconnect tries to disconnect peer.
 func (srv *BaseServer) Disconnect(destID discover.NodeID) {
-	srv.discpeer <- destID
+	srv.handleDisconnectRequest(destID)
 }
 
 // CheckNilNetworkTable returns whether network table is nil.

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -1255,7 +1255,10 @@ func (srv *BaseServer) handlePostHandshake(c *conn) error {
 		c.flags |= trustedConn
 	}
 	// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
-	return srv.encHandshakeChecks(c)
+
+	srv.peerMu.RLock()
+	defer srv.peerMu.RUnlock()
+	return srv.encHandshakeChecksUnlocked(c)
 }
 
 func (srv *BaseServer) handleAddPeer(c *conn) error {
@@ -1282,10 +1285,13 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 		p.events = &srv.peerFeed
 	}
 	name := truncateName(c.name)
-	srv.peerWG.Add(1)
-	go srv.runPeer(p)
 
 	srv.peerMu.Lock()
+	// Repeat the capacity check because the peer set might have changed between the handshakes.
+	if err := srv.encHandshakeChecksUnlocked(c); err != nil {
+		srv.peerMu.Unlock()
+		return err
+	}
 	srv.peers[c.id] = p
 	if p.Inbound() {
 		srv.inboundCount++
@@ -1295,6 +1301,9 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 	peerCount := len(srv.peers)
 	inboundCount := srv.inboundCount
 	srv.peerMu.Unlock()
+
+	srv.peerWG.Add(1)
+	go srv.runPeer(p)
 
 	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
 	peerCountGauge.Update(int64(peerCount))
@@ -1312,8 +1321,7 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 
 	// At this point the connection is past the protocol handshake.
 	// Its capabilities are known and the remote identity is verified.
-	err := srv.protoHandshakeChecks(c)
-	if err != nil {
+	if err := srv.protoHandshakeChecks(c); err != nil {
 		return err
 	}
 
@@ -1362,14 +1370,20 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 		p.events = &srv.peerFeed
 	}
 	name := truncateName(c.name)
-	srv.peerWG.Add(1)
-	go srv.runPeer(p)
 
 	srv.peerMu.Lock()
+	// Repeat the capacity check because the peer set might have changed between the handshakes.
+	if err := srv.encHandshakeChecksUnlocked(c); err != nil {
+		srv.peerMu.Unlock()
+		return err
+	}
 	srv.peers[c.id] = p
 	peerCount := len(srv.peers)
 	srv.inboundCount, srv.outboundCount = increasesConnectionMetric(srv.inboundCount, srv.outboundCount, p)
 	srv.peerMu.Unlock()
+
+	srv.peerWG.Add(1)
+	go srv.runPeer(p)
 
 	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", peerCount)
 	peerCountGauge.Update(int64(peerCount))
@@ -1509,24 +1523,18 @@ func (srv *BaseServer) protoHandshakeChecks(c *conn) error {
 	if len(srv.Protocols) > 0 && countMatchingProtocols(srv.Protocols, c.caps) == 0 {
 		return DiscUselessPeer
 	}
-	// Repeat the encryption handshake checks because the
-	// peer set might have changed between the handshakes.
-	return srv.encHandshakeChecks(c)
+	return nil
 }
 
-func (srv *BaseServer) encHandshakeChecks(c *conn) error {
-	srv.peerMu.RLock()
-	peerCount := len(srv.peers)
-	inboundCount := srv.inboundCount
-	_, connected := srv.peers[c.id]
-	srv.peerMu.RUnlock()
-
+// This function is used to check the capacity of the peer set.
+// Caller must hold the peerMu Lock or RLock.
+func (srv *BaseServer) encHandshakeChecksUnlocked(c *conn) error {
 	switch {
-	case !c.is(trustedConn|staticDialedConn) && peerCount >= srv.Config.MaxPhysicalConnections:
+	case !c.is(trustedConn|staticDialedConn) && len(srv.peers) >= srv.Config.MaxPhysicalConnections:
 		return DiscTooManyPeers
-	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
+	case !c.is(trustedConn) && c.is(inboundConn) && srv.inboundCount >= srv.maxInboundConns():
 		return DiscTooManyPeers
-	case connected:
+	case srv.peers[c.id] != nil:
 		return DiscAlreadyConnected
 	case c.id == srv.Self().ID:
 		return DiscSelf

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -1214,23 +1214,15 @@ type dialer interface {
 	removeStatic(*discover.Node)
 }
 
-func (srv *BaseServer) isTrusted(id discover.NodeID) bool {
+func (srv *BaseServer) handlePostHandshake(c *conn) error {
 	srv.peerMu.RLock()
 	defer srv.peerMu.RUnlock()
-	return srv.trusted[id]
-}
 
-func (srv *BaseServer) handlePostHandshake(c *conn) error {
-	// A connection has passed the encryption handshake so
-	// the remote identity is known (but hasn't been verified yet).
-	if srv.isTrusted(c.id) {
+	if srv.trusted[c.id] {
 		// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
 		c.flags |= trustedConn
 	}
-	// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
 
-	srv.peerMu.RLock()
-	defer srv.peerMu.RUnlock()
 	return srv.encHandshakeChecksUnlocked(c)
 }
 
@@ -1373,21 +1365,6 @@ func (srv *MultiChannelServer) collectMultiChannelConns(c *conn) ([]*conn, error
 }
 
 func (srv *BaseServer) handlePeerDrop(pd peerDrop) {
-	// A peer disconnected.
-	d := common.PrettyDuration(mclock.Now() - pd.created)
-
-	srv.peerMu.Lock()
-	delete(srv.peers, pd.ID())
-	srv.decrementConnectionCounts(pd.Peer)
-	peerCount := len(srv.peers)
-	srv.peerMu.Unlock()
-
-	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
-	srv.reportPeerMetric()
-	srv.signalSchedule()
-}
-
-func (srv *MultiChannelServer) handlePeerDrop(pd peerDrop) {
 	// A peer disconnected.
 	d := common.PrettyDuration(mclock.Now() - pd.created)
 

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -701,8 +701,6 @@ func (srv *MultiChannelServer) GetListenAddress() []string {
 // it waits until the Peer logic returns and removes
 // the peer.
 func (srv *MultiChannelServer) runPeer(p *Peer) {
-	defer srv.peerWG.Done()
-
 	if srv.newPeerHook != nil {
 		srv.newPeerHook(p)
 	}
@@ -780,7 +778,13 @@ type BaseServer struct {
 	inboundCount  int
 	outboundCount int
 	trusted       map[discover.NodeID]bool
-	peerWG        sync.WaitGroup
+	// peerCond is broadcast whenever a peer is removed from peers.
+	// cleanupAfterRun waits on it until the peer map is empty.
+	// peerCond.L is &peerMu (write lock).
+	peerCond *sync.Cond
+	// stopping is set to true during shutdown to prevent new peers from being added.
+	// Protected by peerMu.
+	stopping bool
 
 	quit      chan struct{}
 	schedWake chan struct{}
@@ -797,10 +801,12 @@ func (srv *BaseServer) initPeerState() {
 	srv.peers = make(map[discover.NodeID]*Peer)
 	srv.inboundCount = 0
 	srv.outboundCount = 0
+	srv.stopping = false
 	srv.trusted = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
 	for _, n := range srv.TrustedNodes {
 		srv.trusted[n.ID] = true
 	}
+	srv.peerCond = sync.NewCond(&srv.peerMu)
 }
 
 func (srv *BaseServer) allPeers() map[discover.NodeID]*Peer {
@@ -1245,11 +1251,9 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 	}
 
 	srv.peerMu.Lock()
-	select {
-	case <-srv.quit:
+	if srv.stopping {
 		srv.peerMu.Unlock()
 		return errServerStopped
-	default:
 	}
 	// Repeat the capacity check because the peer set might have changed between the handshakes.
 	if err := srv.encHandshakeChecksUnlocked(c); err != nil {
@@ -1261,7 +1265,6 @@ func (srv *BaseServer) handleAddPeer(c *conn) error {
 	peerCount := len(srv.peers)
 	srv.peerMu.Unlock()
 
-	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 
 	srv.logger.Debug("Adding p2p peer", "name", truncateName(c.name), "addr", c.fd.RemoteAddr(), "peers", peerCount)
@@ -1310,11 +1313,9 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 	}
 
 	srv.peerMu.Lock()
-	select {
-	case <-srv.quit:
+	if srv.stopping {
 		srv.peerMu.Unlock()
 		return errServerStopped
-	default:
 	}
 	// Repeat the capacity check because the peer set might have changed between the handshakes.
 	if err := srv.encHandshakeChecksUnlocked(c); err != nil {
@@ -1326,7 +1327,6 @@ func (srv *MultiChannelServer) handleAddPeer(c *conn) error {
 	peerCount := len(srv.peers)
 	srv.peerMu.Unlock()
 
-	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 
 	srv.logger.Debug("Adding p2p peer", "name", truncateName(c.name), "addr", c.fd.RemoteAddr(), "peers", peerCount)
@@ -1374,6 +1374,9 @@ func (srv *BaseServer) handlePeerDrop(pd peerDrop) {
 	peerCount := len(srv.peers)
 	srv.peerMu.Unlock()
 
+	// Wake up cleanupAfterRun if it is waiting for the peer map to drain.
+	srv.peerCond.Broadcast()
+
 	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", peerCount, "req", pd.requested, "err", pd.err)
 	srv.reportPeerMetric()
 	srv.signalSchedule()
@@ -1396,18 +1399,21 @@ func (srv *BaseServer) cleanupAfterRun() {
 	if srv.ntab != nil {
 		srv.ntab.Close()
 	}
-	//if srv.DiscV5 != nil {
-	//	srv.DiscV5.Close()
-	//}
 
-	// Disconnect all peers.
-	for _, p := range srv.allPeers() {
+	// Set stopping=true under the lock so that handleAddPeer sees it atomically,
+	// then disconnect all current peers and wait for them to finish.
+	// peerCond.Wait() releases the write lock while sleeping, allowing
+	// handlePeerDrop to acquire it and delete peers from the map.
+	srv.peerMu.Lock()
+	srv.stopping = true
+	for _, p := range srv.peers {
 		p.Disconnect(DiscQuitting)
 	}
-	// Wait for peers to shut down. Pending connections and tasks are
-	// not handled here and will terminate soon-ish because srv.quit
-	// is closed.
-	srv.peerWG.Wait()
+	for len(srv.peers) > 0 {
+		logger.Warn("Waiting for peers to finish", "peers", len(srv.peers))
+		srv.peerCond.Wait() // sleep until someone calls peerCond.Broadcast()
+	}
+	srv.peerMu.Unlock()
 }
 
 func (srv *BaseServer) run() {
@@ -1758,8 +1764,6 @@ func truncateName(s string) string {
 // it waits until the Peer logic returns and removes
 // the peer.
 func (srv *BaseServer) runPeer(p *Peer) {
-	defer srv.peerWG.Done()
-
 	if srv.newPeerHook != nil {
 		srv.newPeerHook(p)
 	}

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -130,13 +130,13 @@ func startTestMultiChannelServer(t *testing.T, id discover.NodeID, pf func(*Peer
 func makeconn(fd net.Conn, id discover.NodeID) *conn {
 	dialDest, _ := id.Pubkey()
 	tx := newTestTransport(id, fd, dialDest, false)
-	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id, cont: make(chan error)}
+	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id}
 }
 
 func makeMultiChannelConn(fd net.Conn, id discover.NodeID) *conn {
 	dialDest, _ := id.Pubkey()
 	tx := newTestTransport(id, fd, dialDest, true)
-	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id, cont: make(chan error), multiChannel: true}
+	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id, multiChannel: true}
 }
 
 func TestServerListen(t *testing.T) {
@@ -345,9 +345,10 @@ func TestServerTaskScheduling(t *testing.T) {
 			logger:  logger.NewWith(),
 		},
 	}
+	srv.dialstate = tg
 	srv.loopWG.Add(1)
 	go func() {
-		srv.run(tg)
+		srv.run()
 		close(returned)
 	}()
 
@@ -395,9 +396,7 @@ func TestServerManyTasks(t *testing.T) {
 		done       = make(chan *testTask)
 		start, end = 0, 0
 	)
-	defer srv.Stop()
-	srv.loopWG.Add(1)
-	go srv.run(taskgen{
+	srv.dialstate = taskgen{
 		newFunc: func(running int, peers map[discover.NodeID]*Peer) []task {
 			start, end = end, end+maxActiveDialTasks+10
 			if end > len(alltasks) {
@@ -408,7 +407,10 @@ func TestServerManyTasks(t *testing.T) {
 		doneFunc: func(tt task) {
 			done <- tt.(*testTask)
 		},
-	})
+	}
+	defer srv.Stop()
+	srv.loopWG.Add(1)
+	go srv.run()
 
 	doneset := make(map[int]bool)
 	timeout := time.After(2 * time.Second)
@@ -483,24 +485,24 @@ func TestServerAtCap(t *testing.T) {
 	newconn := func(id discover.NodeID) *conn {
 		fd, _ := net.Pipe()
 		tx := newTestTransport(id, fd, nil, false)
-		return &conn{fd: fd, transport: tx, flags: inboundConn, conntype: common.ConnTypeUndefined, id: id, cont: make(chan error)}
+		return &conn{fd: fd, transport: tx, flags: inboundConn, conntype: common.ConnTypeUndefined, id: id}
 	}
 
 	// Inject a few connections to fill up the peer set.
 	for i := 0; i < 10; i++ {
 		c := newconn(randomID())
-		if err := srv.checkpoint(c, srv.addpeer); err != nil {
+		if err := srv.handleAddPeer(c); err != nil {
 			t.Fatalf("could not add conn %d: %v", i, err)
 		}
 	}
 	// Try inserting a non-trusted connection.
 	c := newconn(randomID())
-	if err := srv.checkpoint(c, srv.posthandshake); err != DiscTooManyPeers {
+	if err := srv.handlePostHandshake(c); err != DiscTooManyPeers {
 		t.Error("wrong error for insert:", err)
 	}
 	// Try inserting a trusted connection.
 	c = newconn(trustedID)
-	if err := srv.checkpoint(c, srv.posthandshake); err != nil {
+	if err := srv.handlePostHandshake(c); err != nil {
 		t.Error("unexpected error for trusted conn @posthandshake:", err)
 	}
 	if !c.is(trustedConn) {

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -20,6 +20,8 @@
 // Modified and improved for the klaytn development.
 // Modified and improved for the Kaia development.
 
+//go:build spec_tests
+
 package tests
 
 import (

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -20,12 +20,12 @@
 // Modified and improved for the klaytn development.
 // Modified and improved for the Kaia development.
 
+//go:build spec_tests
+
 package tests
 
 import (
-	"bytes"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/kaiachain/kaia/blockchain/vm"
@@ -232,34 +232,4 @@ func execStateTest(t *testing.T, st *testMatcher, test *StateTest, name string, 
 			})
 		})
 	}
-}
-
-// Transactions with gasLimit above this value will not get a VM trace on failure.
-const traceErrorLimit = 400000
-
-func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
-	// Set ComputationCostLimit as infinite
-	err := test(vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
-	if err == nil {
-		return
-	}
-	t.Error(err)
-	if gasLimit > traceErrorLimit {
-		t.Log("gas limit too high for EVM trace")
-		return
-	}
-	tracer := vm.NewStructLogger(nil)
-	err2 := test(vm.Config{Debug: true, Tracer: tracer, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
-	if !reflect.DeepEqual(err, err2) {
-		t.Errorf("different error for second run: %v", err2)
-	}
-	buf := new(bytes.Buffer)
-	vm.WriteTrace(buf, tracer.StructLogs())
-	if buf.Len() == 0 {
-		t.Log("no EVM operation logs generated")
-	} else {
-		t.Log("EVM operation log:\n" + buf.String())
-	}
-	t.Logf("EVM output: 0x%x", tracer.Output())
-	t.Logf("EVM error: %v", tracer.Error())
 }

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -23,9 +23,12 @@
 package tests
 
 import (
+	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/kaiachain/kaia/blockchain/vm"
+	"github.com/kaiachain/kaia/params"
 )
 
 func TestVM(t *testing.T) {
@@ -43,4 +46,34 @@ func TestVM(t *testing.T) {
 			return vmt.checkFailure(t, name, test.Run(vmconfig))
 		})
 	})
+}
+
+// Transactions with gasLimit above this value will not get a VM trace on failure.
+const traceErrorLimit = 400000
+
+func withTrace(t *testing.T, gasLimit uint64, test func(vm.Config) error) {
+	// Set ComputationCostLimit as infinite
+	err := test(vm.Config{ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
+	if err == nil {
+		return
+	}
+	t.Error(err)
+	if gasLimit > traceErrorLimit {
+		t.Log("gas limit too high for EVM trace")
+		return
+	}
+	tracer := vm.NewStructLogger(nil)
+	err2 := test(vm.Config{Debug: true, Tracer: tracer, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
+	if !reflect.DeepEqual(err, err2) {
+		t.Errorf("different error for second run: %v", err2)
+	}
+	buf := new(bytes.Buffer)
+	vm.WriteTrace(buf, tracer.StructLogs())
+	if buf.Len() == 0 {
+		t.Log("no EVM operation logs generated")
+	} else {
+		t.Log("EVM operation log:\n" + buf.String())
+	}
+	t.Logf("EVM output: 0x%x", tracer.Output())
+	t.Logf("EVM error: %v", tracer.Error())
 }


### PR DESCRIPTION
## Proposed changes

Refactor `p2p.Server` internals to remove run-loop channel harnesses and move state management to mutex-protected struct fields and respective direct handlers.

- Moved `run()`-loop local state into `BaseServer` shared struct fields:
  - Peer state `peers`, `inboundCount`, `outboundCount`, `trusted` are protected by `peersMu`.

- Replaced channel with direct helper function calls.

| before | after |
|-|-|
| `chan addstatic`, `chan removestatic` | `AddPeer()`, `RemovePeer()` |
| `chan peerOp`, `chan peerOpDone` | `Peers()`, `PeerCount()`, `PeerCountByType()` directly accessing the `peers` variable |
| `chan discpeer` | `handleDisconnectPeer()` |
| `chan delpeer` | `handlePeerDrop()` |
| `chan posthandshake`,`chan addpeer`, `chan cont` | `handlePostHandshake()`, `handleAddPeer()` directly called inside `SetupConn()` |

- Encapsulate metric updating code (peerCount, inboundCount, outboundCount)
   - incrementConnectionCounts(): increments `srv.inboundCount`, `srv.outboundCount`
   - decrementConnectionCounts(): decrements `srv.inboundCount`, `srv.outboundCount`
   - reportPeerMetric(): updates the `peer*CountGauge` and `connection*CountGauge` (depending on BaseServer vs. MultiChannelServer)

- Reduce the distance from `encHandshakeChecks()` to `srv.peers[c.id] = p` in handleAddPeer(). Prevents the same peer to be added twice if there are two dial tasks for the same peer for some reason.
  ```go
  // Before
  // internally calls encHandshakeChecks(), which internally checks `srv.peers[id] != nil`
  if err := srv.protoHandshakeChecks(); err != nil { 
      return err
  }
  
  p := newPeer(...)
  go runPeer(p)
  
  srv.peerMu.Lock()
  srv.peers[id] = p
  srv.peerMu.Unlock()
  ```
  ```go
  // After
  // don't call encHandshakeChecks() here.
  if err := srv.protoHandshakeChecks(); err != nil {
      return err
  }
  p := newPeer(...)
  
  srv.peerMu.Lock()
  if err := srv.encHandshakeChecksUnlocked(); err != nil {
      srv.peerMu.Unlock()
      return err
  }
  srv.peers[id] = p
  srv.peerMu.Unlock()
  
  p := newPeer(...)
  go runPeer(p)
  ```
- Factor out `collectMultiChannelConns`

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- See next steps in #751 

## Further comments