### PR TITLE
tests: Fix EEST memory usage

### DIFF
--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -462,10 +462,10 @@ func (st *StateTransition) preCheck() error {
 	// Check that EIP-7702 authorization list signatures are well formed.
 	if st.msg.AuthList() != nil {
 		if st.msg.To() == nil {
-			return fmt.Errorf("%w (sender %v)", ErrSetCodeTxCreate, st.msg.ValidatedSender())
+			return fmt.Errorf("%w (sender %v)", ErrSetCodeTxCreate, st.msg.ValidatedSender().Hex())
 		}
 		if len(st.msg.AuthList()) == 0 {
-			return fmt.Errorf("%w (sender %v)", ErrEmptyAuthList, st.msg.ValidatedSender())
+			return fmt.Errorf("%w (sender %v)", ErrEmptyAuthList, st.msg.ValidatedSender().Hex())
 		}
 	}
 	return st.buyGas()

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/suite"
 )
@@ -261,5 +262,6 @@ func (suite *ExecutionSpecBlockTestSuite) TestExecutionSpecBlock() {
 }
 
 func TestExecutionSpecBlockTestSuite(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
 	suite.Run(t, new(ExecutionSpecBlockTestSuite))
 }

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -350,14 +350,13 @@ func (t *BlockTest) Run() error {
 		return fmt.Errorf("genesis block state root does not match test: computed=%x, test=%x", simulatedRoot.Bytes()[:6], t.json.Genesis.Root[:6])
 	}
 
-	tracer := vm.NewStructLogger(nil)
-	chain, err := blockchain.NewBlockChain(db, nil, config, &eestEngine{Faker: faker.NewShared()}, vm.Config{Debug: true, Tracer: tracer, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
+	chain, err := blockchain.NewBlockChain(db, nil, config, &eestEngine{Faker: faker.NewShared()}, vm.Config{Debug: false, ComputationCostLimit: params.OpcodeComputationCostLimitInfinite})
 	if err != nil {
 		return err
 	}
 	defer chain.Stop()
 
-	_, err = t.insertBlocks(chain, *gblock, db, tracer)
+	_, err = t.insertBlocks(chain, *gblock, db)
 	if err != nil {
 		return err
 	}
@@ -408,7 +407,7 @@ See https://github.com/ethereum/tests/wiki/Blockchain-Tests-II
 	transaction RLP encoding, so kaia blocks are created by GenerateChain using eth
 	block RLP information.
 */
-func (t *BlockTest) insertBlocks(bc *blockchain.BlockChain, gBlock types.Block, db database.DBManager, tracer *vm.StructLogger) ([]btBlock, error) {
+func (t *BlockTest) insertBlocks(bc *blockchain.BlockChain, gBlock types.Block, db database.DBManager) ([]btBlock, error) {
 	validBlocks := make([]btBlock, 0)
 	preBlock := &gBlock
 

--- a/tests/state_test.go
+++ b/tests/state_test.go
@@ -30,12 +30,14 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/suite"
 )
 
 // TestKaiaSpecState runs the StateTests fixtures from kaia-core-tests
 func TestKaiaSpecState(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
 	t.Parallel()
 
 	st := new(testMatcher)
@@ -213,6 +215,7 @@ func (suite *ExecutionSpecStateTestSuite) TestExecutionSpecState() {
 }
 
 func TestExecutionSpecStateTestSuite(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
 	suite.Run(t, new(ExecutionSpecStateTestSuite))
 }
 


### PR DESCRIPTION
## Proposed changes

- Remove unused StructLogger logging during block_test.go:TestExecutionSpecBlockTestSuite.
- For this particular test case,
  - Reduce memory usage below the GitHub Action's standard 5GB RAM ([docs](https://docs.github.com/en/actions/reference/runners/github-hosted-runners))
  - Peak RSS 16GB -> 2.8GB
  - Elapsed time 180s -> 70s

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

Memory profile (before)
<img width="1512" height="847" alt="pprof_before" src="https://github.com/user-attachments/assets/e585d213-bba9-47b7-9c48-3f7cda5ab554" />

Memory profile (after)
<img width="1512" height="799" alt="pprof_after" src="https://github.com/user-attachments/assets/7fd60786-a73c-4d67-b624-f00a3d20e6d1" />

RSS comparison
<img width="593" height="365" alt="rss" src="https://github.com/user-attachments/assets/cafe32f0-9ea4-47da-90bc-98a381abdd05" />

