### PR TITLE
crypto: Fix ECIES invalid-curve handling

### DIFF
--- a/crypto/ecies/ecies.go
+++ b/crypto/ecies/ecies.go
@@ -129,6 +129,11 @@ func (prv *PrivateKey) GenerateShared(pub *PublicKey, skLen, macLen int) (sk []b
 	if prv.PublicKey.Curve != pub.Curve {
 		return nil, ErrInvalidCurve
 	}
+
+	if pub.X == nil || pub.Y == nil || !pub.Curve.IsOnCurve(pub.X, pub.Y) {
+		return nil, ErrInvalidPublicKey
+	}
+
 	if skLen+macLen > MaxSharedKeyLength(pub) {
 		return nil, ErrSharedKeyTooBig
 	}

--- a/networks/p2p/rlpx/rlpx_oralce_poc_test.go
+++ b/networks/p2p/rlpx/rlpx_oralce_poc_test.go
@@ -1,0 +1,57 @@
+package rlpx
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/ecies"
+)
+
+func TestHandshakeECIESInvalidCurveOracle(t *testing.T) {
+	initKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	respKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	init := handshakeState{
+		initiator: true,
+		remote:    ecies.ImportECDSAPublic(&respKey.PublicKey),
+	}
+	authMsg, err := init.makeAuthMsg(initKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet, err := init.sealEIP8(authMsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var recv handshakeState
+	if _, err := recv.readMsg(new(authMsgV4), respKey, bytes.NewReader(packet)); err != nil {
+		t.Fatalf("expected valid packet to decrypt: %v", err)
+	}
+
+	tampered := append([]byte(nil), packet...)
+	if len(tampered) < 2+65 {
+		t.Fatalf("unexpected packet length %d", len(tampered))
+	}
+	tampered[2] = 0x04
+	for i := 1; i < 65; i++ {
+		tampered[2+i] = 0x00
+	}
+
+	var recv2 handshakeState
+	_, err = recv2.readMsg(new(authMsgV4), respKey, bytes.NewReader(tampered))
+	if err == nil {
+		t.Fatal("expected decryption failure for invalid curve point")
+	}
+	if !errors.Is(err, ecies.ErrInvalidPublicKey) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This PR adds ECIES invalid-curve handling to reject invalid ephemeral public keys in the early stage of RLPx handshake.
- Add curve validation in `ecies.GenerateShared` to reject invalid public keys before ECDH.
- Update RLPx PoC test to assert invalid curve points fail with `ErrInvalidPublicKey`.

ref: [geth#33669](/ethereum/go-ethereum/pull/33669)

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
