### PR TITLE
api: Return blobTx fields in `kaia.getHeader*` APIs after Osaka

### DIFF
--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -873,6 +873,11 @@ func RPCMarshalHeader(head *types.Header, rules params.Rules) map[string]interfa
 		result["blobGasUsed"] = hexutil.Uint64(*head.BlobGasUsed)
 	}
 
+	if rules.IsOsaka {
+		result["excessBlobGas"] = (*hexutil.Big)(new(big.Int).SetUint64(*head.ExcessBlobGas))
+		result["blobGasUsed"] = hexutil.Uint64(*head.BlobGasUsed)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This PR adds blobTx related fields in the `{kaia,klay}_getHeader*` APIs after Osaka.

ref: #707

as-is:
```
> kaia.getHeaderByNumber(1)
{
  baseFeePerGas: "0x5d21dba00",
  blockScore: "0x1",
  extraData: "0xd883020200846b6c617988676f312e32352e33856c696e757800000000000000f89ed594cf25570192fab393a8afd0cef7a11b9f72e139e5b841991d050dd6022ee270821f702a2c510c0027f00eb7e2e2393786bad70188bddd324782b48783109d84dca3dd1cacb660c2ead58460bfac3693fc8bb9617a843a01f843b841824da8c4037ac308019da1ea0c197e4e0cc70442216fd2ff39139d6e2fb9ff397f5413fdd823d695dfce42da52ce666606b32511396c863decac8c90b5cb8be700",
  gasUsed: "0x0",
  governanceData: "0x",
  hash: "0x85c768ea1d72847065dd9147932b6404cb5ed17a86665850b28129b2073d0e5b",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  mixhash: "0x385d926001b90a95e4ab45e23870903240c90b82df889ec876905bcbfb82bb32",
  number: "0x1",
  parentHash: "0x5974f9fdf4184ed94f1ad3191eb5316488cd4f6378bf2e5e50c26e0015ce2f7a",
  randomReveal: "0x93420068edaf4558c04335c492edeffcee251087f3e8ed03483ca477a6a4dd63d641d18c97596b8d444fa2f43d186b730f4eaca686455c8d8fed274cec58c754c248f99553754886ba82f3eadbec6137ae7ae120892d0a382cf47517ecfd053f",
  receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  reward: "0xcf25570192fab393a8afd0cef7a11b9f72e139e5",
  stateRoot: "0xc965e6764efee922d4fbe4e180913683bf09724583cdeca248af5d25c1d777d7",
  timestamp: "0x6998a0df",
  timestampFoS: "0x59",
  transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  voteData: "0x"
}
```

to-be:
```
> kaia.getHeaderByNumber(1)
{
  baseFeePerGas: "0x5d21dba00",
  blobGasUsed: "0x0",
  blockScore: "0x1",
  excessBlobGas: "0x0",
  extraData: "0xd883020200846b6c617988676f312e32352e33856c696e757800000000000000f89ed594cf25570192fab393a8afd0cef7a11b9f72e139e5b84100b9db6926eb8ed1305ec6f992b69b6cdc3f33dd74dc4e607acf87ace50641c600d384de795fa9fcec1300b3482429b10c6ab8242f2ea1f6442b91646bae70f500f843b841dd3f788545051d4f957ff465287b57588b20dc7b2ec2a13af3fe3f2eff1b2bac7ba0082cf37476b3a6fa3f8c018db68d41e8546bb845b46cd28eaa235667553100",
  gasUsed: "0x0",
  governanceData: "0x",
  hash: "0xfb3b49cd8595ade37f6c50cc106883d29d9123971495c2c3a66da9925825ebee",
  logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
  mixhash: "0x385d926001b90a95e4ab45e23870903240c90b82df889ec876905bcbfb82bb32",
  number: "0x1",
  parentHash: "0x5974f9fdf4184ed94f1ad3191eb5316488cd4f6378bf2e5e50c26e0015ce2f7a",
  randomReveal: "0x93420068edaf4558c04335c492edeffcee251087f3e8ed03483ca477a6a4dd63d641d18c97596b8d444fa2f43d186b730f4eaca686455c8d8fed274cec58c754c248f99553754886ba82f3eadbec6137ae7ae120892d0a382cf47517ecfd053f",
  receiptsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  reward: "0xcf25570192fab393a8afd0cef7a11b9f72e139e5",
  stateRoot: "0xc965e6764efee922d4fbe4e180913683bf09724583cdeca248af5d25c1d777d7",
  timestamp: "0x699b313e",
  timestampFoS: "0x1a",
  transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
  voteData: "0xf094cf25570192fab393a8afd0cef7a11b9f72e139e594676f7665726e616e63652e756e697470726963658562c6d1a9b2"
}
```

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
