### PR TITLE
gov: Verify governing node under single mode

### DIFF
--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -203,17 +203,18 @@ func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Head
 		return ErrInvalidBaseFee
 	}
 
-	// Verify the header's seal and consensus-specific fields.
-	if err := v.verifySeals(header); err != nil {
-		return err
-	}
-
 	// Verify the header with registered header modules.
 	for _, module := range v.headerModules {
 		if err := module.VerifyHeader(header, parent); err != nil {
 			return err
 		}
 	}
+
+	// Verify the header's seal and consensus-specific fields.
+	if err := v.verifySeals(header); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/kaiax/gov/headergov/impl/header.go
+++ b/kaiax/gov/headergov/impl/header.go
@@ -88,7 +88,7 @@ func (h *headerGovModule) VerifyVote(header *types.Header) error {
 		return ErrInvalidVoter
 	}
 
-	// In single mode, only the governing node can write header.Vote after Osaka.
+	// In single mode, only the governing node can write header.Vote after Permissionless.
 	params := h.GetParamSet(blockNum)
 	if h.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) &&
 		params.GovernanceMode == "single" &&

--- a/kaiax/gov/headergov/impl/header.go
+++ b/kaiax/gov/headergov/impl/header.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"maps"
+	"math/big"
 	"reflect"
 	"slices"
 
@@ -86,6 +87,15 @@ func (h *headerGovModule) VerifyVote(header *types.Header) error {
 	if author != vote.Voter() {
 		return ErrInvalidVoter
 	}
+
+	// In single mode, only the governing node can write header.Vote after Osaka.
+	params := h.GetParamSet(blockNum)
+	if h.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) &&
+		params.GovernanceMode == "single" &&
+		vote.Voter() != params.GoverningNode {
+		return ErrVotePermissionDenied
+	}
+
 	return h.checkConsistency(blockNum, vote)
 }
 

--- a/kaiax/gov/headergov/impl/header_test.go
+++ b/kaiax/gov/headergov/impl/header_test.go
@@ -123,8 +123,8 @@ func TestVerifyVote(t *testing.T) {
 func TestVerifyVote_SingleMode(t *testing.T) {
 	config := getTestChainConfig()
 	config.Governance.GoverningNode = common.Address{2} // validVoter is the proposer, but not governing node
-	t.Run("pre-osaka allows non-governing node", func(t *testing.T) {
-		config.OsakaCompatibleBlock = nil
+	t.Run("pre-permissionless allows non-governing node", func(t *testing.T) {
+		config.PermissionlessCompatibleBlock = nil
 		h := newHeaderGovModule(t, config)
 		vote := headergov.NewVoteData(validVoter, string(gov.GovernanceUnitPrice), uint64(100))
 		vb, err := vote.ToVoteBytes()
@@ -132,8 +132,8 @@ func TestVerifyVote_SingleMode(t *testing.T) {
 		err = h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra})
 		assert.NoError(t, err)
 	})
-	t.Run("post-osaka requires governing node", func(t *testing.T) {
-		config.OsakaCompatibleBlock = common.Big0
+	t.Run("post-permissionless requires governing node", func(t *testing.T) {
+		config.PermissionlessCompatibleBlock = common.Big0
 		h := newHeaderGovModule(t, config)
 		vote := headergov.NewVoteData(validVoter, string(gov.GovernanceUnitPrice), uint64(100))
 		vb, err := vote.ToVoteBytes()

--- a/kaiax/gov/headergov/impl/header_test.go
+++ b/kaiax/gov/headergov/impl/header_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	"github.com/kaiachain/kaia/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyHeader(t *testing.T) {
@@ -19,9 +20,11 @@ func TestVerifyHeader(t *testing.T) {
 		voteBytes, _       = headergov.NewVoteData(validVoter, string(gov.GovernanceUnitPrice), uint64(100)).ToVoteBytes()
 		govBytes, _        = headergov.NewGovData(gov.PartialParamSet{gov.GovernanceUnitPrice: uint64(100)}).ToGovBytes()
 		invalidGovBytes, _ = headergov.NewGovData(gov.PartialParamSet{gov.GovernanceUnitPrice: uint64(200)}).ToGovBytes()
-		h                  = newHeaderGovModule(t, getTestChainConfig())
+		config             = getTestChainConfig()
 		invalidVoteRlp     = common.FromHex("0xea9452d41ca72af615a1ac3301b0a93efa222ecc7541947265776172642e6d696e74696e67616d6f756e74")
 	)
+	config.Governance.GoverningNode = validVoter
+	h := newHeaderGovModule(t, config)
 
 	h.HandleVote(1, vote)
 
@@ -115,6 +118,29 @@ func TestVerifyVote(t *testing.T) {
 			assert.Equal(t, tc.expectedError, err)
 		})
 	}
+}
+
+func TestVerifyVote_SingleMode(t *testing.T) {
+	config := getTestChainConfig()
+	config.Governance.GoverningNode = common.Address{2} // validVoter is the proposer, but not governing node
+	t.Run("pre-osaka allows non-governing node", func(t *testing.T) {
+		config.OsakaCompatibleBlock = nil
+		h := newHeaderGovModule(t, config)
+		vote := headergov.NewVoteData(validVoter, string(gov.GovernanceUnitPrice), uint64(100))
+		vb, err := vote.ToVoteBytes()
+		require.NoError(t, err)
+		err = h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra})
+		assert.NoError(t, err)
+	})
+	t.Run("post-osaka requires governing node", func(t *testing.T) {
+		config.OsakaCompatibleBlock = common.Big0
+		h := newHeaderGovModule(t, config)
+		vote := headergov.NewVoteData(validVoter, string(gov.GovernanceUnitPrice), uint64(100))
+		vb, err := vote.ToVoteBytes()
+		require.NoError(t, err)
+		err = h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra})
+		assert.Equal(t, ErrVotePermissionDenied, err)
+	})
 }
 
 func TestGetVotesInEpoch(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

After Osaka HF, under single mode, ensure that the headerGov voter (of `header.Vote`) is the governing node.

Also, change the order of kaiax `VerifyHeader`s and `verifyCascadingFields`.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)


## Further comments

Error message
```
INFO[02/25,10:04:45 +09] [51|work/worker.go:679]                         Commit new mining work                    number=25 hash=8004de…db278f txs=0 elapsed=1.166ms    commitTime=1.030ms   finalizeTime=131.458µs
INFO[02/25,10:04:45 +09] [25|consensus/istanbul/core/prepare.go:90]      received a quorum of the messages and change state to prepared  msgType=1 prepareMsgNum=3 commitMsgNum=0 valSet=4
INFO[02/25,10:04:45 +09] [24|consensus/istanbul/backend/backend.go:296]  Committed                                 number=25 hash=1d32b1…5cdff4 address=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
ERROR[02/25,10:04:45 +09] [61|kaiax/gov/headergov/impl/consensus.go:24]   VerifyVote error                          num=25 vote="[239 148 144 247 155 246 235 44 79 135 3 101 231 133 152 46 31 16 30 147 185 6 152 107 105 112 55 49 46 98 97 115 101 102 101 101 100 101 110 111 109 105 110 97 116 111 114 25]" err="you don't have the right to vote"
```


### Changing VerifyHeader

Changing VerifyHeader does not interrupt consensus, and is backward compatible.

Only currently two modules implement kaiax `VerifyHeader`.
- reward module: `VerifyHeader` always returns nil.
- gov module: Verifies `header.Vote` and `header.Governance`

Both modules do not interrupt consensus.

In addition, it's backward compatible because `VerifyHeader` returned no error during sync test's `insertChain()`, which implies that all past blocks passed gov module's verification.