### PR TITLE
kaiax/gov: Add lock to GetPartialParamSet

### DIFF
--- a/kaiax/gov/headergov/impl/getter.go
+++ b/kaiax/gov/headergov/impl/getter.go
@@ -23,11 +23,11 @@ func (h *headerGovModule) GetParamSet(blockNum uint64) gov.ParamSet {
 }
 
 func (h *headerGovModule) GetPartialParamSet(blockNum uint64) gov.PartialParamSet {
-	prevEpochStart := PrevEpochStart(blockNum, h.epoch, h.isKoreHF(blockNum))
-	ret := make(gov.PartialParamSet)
-
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+
+	prevEpochStart := PrevEpochStart(blockNum, h.epoch, h.isKoreHF(blockNum))
+	ret := make(gov.PartialParamSet)
 
 	blockNums := maps.Keys(h.governances)
 	slices.Sort(blockNums)

--- a/kaiax/gov/headergov/impl/getter.go
+++ b/kaiax/gov/headergov/impl/getter.go
@@ -26,12 +26,17 @@ func (h *headerGovModule) GetPartialParamSet(blockNum uint64) gov.PartialParamSe
 	prevEpochStart := PrevEpochStart(blockNum, h.epoch, h.isKoreHF(blockNum))
 	ret := make(gov.PartialParamSet)
 
-	// merge all governance sets before num's prevEpochStart.
-	for _, num := range h.GovBlockNums() {
-		if num <= prevEpochStart {
-			for name, value := range h.governances[num].Items() {
-				ret.Add(string(name), value)
-			}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	blockNums := maps.Keys(h.governances)
+	slices.Sort(blockNums)
+	for _, num := range blockNums {
+		if num > prevEpochStart {
+			break
+		}
+		for name, value := range h.governances[num].Items() {
+			ret.Add(string(name), value)
 		}
 	}
 

--- a/kaiax/gov/headergov/impl/getter_test.go
+++ b/kaiax/gov/headergov/impl/getter_test.go
@@ -3,6 +3,8 @@ package impl
 import (
 	"fmt"
 	"math/big"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/kaiachain/kaia/kaiax/gov"
@@ -126,4 +128,49 @@ func TestPrevEpochStart(t *testing.T) {
 			assert.Equal(t, tc.expectedGov, result, "Incorrect governance data block for block %d", tc.blockNum)
 		})
 	}
+}
+
+func TestGetPartialParamSet_ConcurrentAccess(t *testing.T) {
+	config := getTestChainConfigKore()
+	h := newHeaderGovModule(t, config)
+
+	// Seed initial governance so readers have data from the start.
+	h.AddGov(0, headergov.NewGovData(gov.PartialParamSet{gov.GovernanceUnitPrice: uint64(0)}))
+
+	var (
+		wgReader sync.WaitGroup
+		wgWriter sync.WaitGroup
+		stopSig atomic.Bool
+	)
+
+	// Writer goroutine continuously mutates h.governances under write lock.
+	wgWriter.Add(1)
+	go func() {
+		defer wgWriter.Done()
+		var i uint64 = 1
+		for !stopSig.Load() {
+			h.AddGov(i*100, headergov.NewGovData(gov.PartialParamSet{gov.GovernanceUnitPrice: i}))
+			i++
+			if i > 1000 {
+				i = 1
+			}
+		}
+	}()
+
+	// Reader goroutines continuously call GetPartialParamSet.
+	const readers = 8
+	for r := 0; r < readers; r++ {
+		wgReader.Add(1)
+		go func() {
+			defer wgReader.Done()
+			for i := 0; i < 5000; i++ {
+				ps := h.GetPartialParamSet(1000)
+				_ = ps[gov.GovernanceUnitPrice]
+			}
+		}()
+	}
+
+	wgReader.Wait()
+	stopSig.Store(true)
+	wgWriter.Wait()
 }

--- a/kaiax/gov/headergov/impl/getter_test.go
+++ b/kaiax/gov/headergov/impl/getter_test.go
@@ -140,7 +140,7 @@ func TestGetPartialParamSet_ConcurrentAccess(t *testing.T) {
 	var (
 		wgReader sync.WaitGroup
 		wgWriter sync.WaitGroup
-		stopSig atomic.Bool
+		stopSig  atomic.Bool
 	)
 
 	// Writer goroutine continuously mutates h.governances under write lock.


### PR DESCRIPTION
## Proposed changes

Add lock to `GetPartialParamSet()`

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)
