### PR TITLE
p2p: Replace server channels with mutex-protected methods

### DIFF
--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -234,15 +234,8 @@ func NewServer(config Config) Server {
 	}
 
 	if config.EnableMultiChannelServer {
-		listeners := make([]net.Listener, 0, len(config.SubListenAddr)+1)
-		listenAddrs := make([]string, 0, len(config.SubListenAddr)+1)
-		listenAddrs = append(listenAddrs, config.ListenAddr)
-		listenAddrs = append(listenAddrs, config.SubListenAddr...)
 		return &MultiChannelServer{
-			BaseServer:     bServer,
-			listeners:      listeners,
-			ListenAddrs:    listenAddrs,
-			CandidateConns: make(map[discover.NodeID][]*conn),
+			BaseServer: bServer,
 		}
 	} else {
 		return &SingleChannelServer{

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -73,16 +73,8 @@ type BaseServer struct {
 	trusted      map[discover.NodeID]bool
 	dialstate    dialer
 
-	// Request channels
-	wakeup        chan struct{} // TODO: dialsched should react to the peer changes.
-	addstatic     chan *discover.Node
-	removestatic  chan *discover.Node
-	peerOp        chan peerOpFunc
-	peerOpDone    chan struct{}
-	posthandshake chan *conn
-	addpeer       chan *conn
-	delpeer       chan peerDrop
-	discpeer      chan discover.NodeID
+	// Wake the dial loop when peer lifecycle changes affect scheduling.
+	wakeup chan struct{} // TODO: dialsched should react to the peer changes.
 }
 
 // SingleChannelServer is a server that uses a single channel.
@@ -180,14 +172,6 @@ func (srv *BaseServer) initialize() error {
 	}
 	srv.quit = make(chan struct{})
 	srv.wakeup = make(chan struct{}, 1)
-	srv.addpeer = make(chan *conn)
-	srv.delpeer = make(chan peerDrop)
-	srv.posthandshake = make(chan *conn)
-	srv.addstatic = make(chan *discover.Node)
-	srv.removestatic = make(chan *discover.Node)
-	srv.peerOp = make(chan peerOpFunc)
-	srv.peerOpDone = make(chan struct{})
-	srv.discpeer = make(chan discover.NodeID)
 
 	srv.selfID = discover.PubkeyID(&srv.PrivateKey.PublicKey)
 	srv.peers = make(map[discover.NodeID]*Peer)
@@ -506,7 +490,7 @@ func (srv *BaseServer) SetupConn(fd net.Conn, flags connFlag, dialDest *discover
 		return errors.New("shutdown")
 	}
 
-	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, cont: make(chan error), portOrder: ConnDefault}
+	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, portOrder: ConnDefault}
 
 	// if err occurs, dialPubkey is automatically set as nil
 	if dialDest != nil {
@@ -632,22 +616,6 @@ func (srv *BaseServer) handleAddPeerConn(c *conn) error {
 	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 	return nil
-}
-
-// checkpoint sends the conn to run, which performs the
-// post-handshake checks for the stage (posthandshake, addpeer).
-func (srv *BaseServer) checkpoint(c *conn, stage chan<- *conn) error {
-	select {
-	case stage <- c:
-	case <-srv.quit:
-		return errServerStopped
-	}
-	select {
-	case err := <-c.cont:
-		return err
-	case <-srv.quit:
-		return errServerStopped
-	}
 }
 
 // runPeer runs in its own goroutine for each peer.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -53,6 +53,7 @@ type BaseServer struct {
 	running bool
 	quit    chan struct{}
 	loopWG  sync.WaitGroup // loop, listenLoop
+	peerWG  sync.WaitGroup // peer goroutines
 
 	// Relying components
 	logger       log.Logger
@@ -108,6 +109,7 @@ func (srv *BaseServer) Stop() {
 	close(srv.quit)   // Ask loops to terminate
 	srv.lock.Unlock() // Unlock to allow loops to finish their remaining jobs.
 	srv.loopWG.Wait() // Wait for loops to terminate
+	srv.peerWG.Wait() // Wait for peers to terminate
 	srv.logger.Info("Stopped P2P server")
 }
 
@@ -303,7 +305,9 @@ func (srv *BaseServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
+			srv.lock.Lock()
 			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), peers, time.Now())
+			srv.lock.Unlock()
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -322,26 +326,17 @@ running:
 			// can update its state and remove it from the active
 			// tasks list.
 			srv.logger.Trace("Dial task done", "task", t)
+			srv.lock.Lock()
 			dialstate.taskDone(t, time.Now())
+			srv.lock.Unlock()
 			delTask(t)
-		case pd := <-srv.delpeer:
-			// A peer disconnected.
-			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
-			delete(peers, pd.ID())
-
-			if pd.Inbound() {
-				srv.inboundCount--
-			}
-
-			peerCountGauge.Update(int64(len(peers)))
-			peerInCountGauge.Update(int64(srv.inboundCount))
-			peerOutCountGauge.Update(int64(len(peers) - srv.inboundCount))
 		case nid := <-srv.discpeer:
+			srv.lock.Lock()
 			if p, ok := peers[nid]; ok {
 				p.Disconnect(DiscRequested)
 				p.logger.Debug("disconnect peer")
 			}
+			srv.lock.Unlock()
 		}
 	}
 
@@ -355,16 +350,14 @@ running:
 	//	srv.DiscV5.Close()
 	//}
 	// Disconnect all peers.
-	for _, p := range peers {
-		p.Disconnect(DiscQuitting)
+	srv.lock.Lock()
+	shutdownPeers := make([]*Peer, 0, len(srv.peers))
+	for _, p := range srv.peers {
+		shutdownPeers = append(shutdownPeers, p)
 	}
-	// Wait for peers to shut down. Pending connections and tasks are
-	// not handled here and will terminate soon-ish because srv.quit
-	// is closed.
-	for len(peers) > 0 {
-		p := <-srv.delpeer
-		p.logger.Trace("<-delpeer (spindown)", "remainingTasks", len(runningTasks))
-		delete(peers, p.ID())
+	srv.lock.Unlock()
+	for _, p := range shutdownPeers {
+		p.Disconnect(DiscQuitting)
 	}
 }
 
@@ -643,6 +636,7 @@ func (srv *BaseServer) handleAddPeerConn(c *conn) error {
 	peerInCountGauge.Update(int64(srv.inboundCount))
 	peerOutCountGauge.Update(int64(len(srv.peers) - srv.inboundCount))
 
+	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 	return nil
 }
@@ -667,6 +661,8 @@ func (srv *BaseServer) checkpoint(c *conn, stage chan<- *conn) error {
 // it waits until the Peer logic returns and removes
 // the peer.
 func (srv *BaseServer) runPeer(p *Peer) {
+	defer srv.peerWG.Done()
+
 	if srv.newPeerHook != nil {
 		srv.newPeerHook(p)
 	}
@@ -687,9 +683,25 @@ func (srv *BaseServer) runPeer(p *Peer) {
 		Error: err.Error(),
 	})
 
-	// Note: run waits for existing peers to be sent on srv.delpeer
-	// before returning, so this send should not select on srv.quit.
-	srv.delpeer <- peerDrop{p, err, remoteRequested}
+	srv.handleDelPeer(peerDrop{p, err, remoteRequested})
+}
+
+func (srv *BaseServer) handleDelPeer(pd peerDrop) {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(srv.peers)-1, "req", pd.requested, "err", pd.err)
+	delete(srv.peers, pd.ID())
+
+	if pd.Inbound() {
+		srv.inboundCount--
+	}
+
+	peerCountGauge.Update(int64(len(srv.peers)))
+	peerInCountGauge.Update(int64(srv.inboundCount))
+	peerOutCountGauge.Update(int64(len(srv.peers) - srv.inboundCount))
+	srv.wakeupDialer()
 }
 
 // Dial creates a TCP connection to the node.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -330,13 +330,6 @@ running:
 			dialstate.taskDone(t, time.Now())
 			srv.lock.Unlock()
 			delTask(t)
-		case nid := <-srv.discpeer:
-			srv.lock.Lock()
-			if p, ok := peers[nid]; ok {
-				p.Disconnect(DiscRequested)
-				p.logger.Debug("disconnect peer")
-			}
-			srv.lock.Unlock()
 		}
 	}
 
@@ -716,7 +709,18 @@ func (srv *BaseServer) DialMulti(dest *discover.Node) ([]net.Conn, error) {
 
 // Disconnect tries to disconnect peer.
 func (srv *BaseServer) Disconnect(destID discover.NodeID) {
-	srv.discpeer <- destID
+	srv.lock.Lock()
+	if !srv.running {
+		srv.lock.Unlock()
+		return
+	}
+	p := srv.peers[destID]
+	srv.lock.Unlock()
+
+	if p != nil {
+		p.Disconnect(DiscRequested)
+		p.logger.Debug("disconnect peer")
+	}
 }
 
 // GetProtocols returns a slice of protocols.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -273,7 +273,6 @@ func (srv *BaseServer) run(dialstate dialer) {
 	defer srv.loopWG.Done()
 	var (
 		peers        = srv.peers
-		trusted      = srv.trusted
 		taskdone     = make(chan task, maxActiveDialTasks)
 		runningTasks []task
 		queuedTasks  []task // tasks that can't run yet
@@ -325,19 +324,6 @@ running:
 			srv.logger.Trace("Dial task done", "task", t)
 			dialstate.taskDone(t, time.Now())
 			delTask(t)
-		case c := <-srv.posthandshake:
-			// A connection has passed the encryption handshake so
-			// the remote identity is known (but hasn't been verified yet).
-			if trusted[c.id] {
-				// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
-				c.flags |= trustedConn
-			}
-			// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
-			select {
-			case c.cont <- srv.encHandshakeChecks(peers, srv.inboundCount, c):
-			case <-srv.quit:
-				break running
-			}
 		case c := <-srv.addpeer:
 			// At this point the connection is past the protocol handshake.
 			// Its capabilities are known and the remote identity is verified.
@@ -446,7 +432,7 @@ func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inbou
 		return DiscTooManyPeers
 	case peers[c.id] != nil:
 		return DiscAlreadyConnected
-	case c.id == srv.Self().ID:
+	case c.id == srv.selfID:
 		return DiscSelf
 	default:
 		return nil
@@ -621,7 +607,7 @@ func (srv *BaseServer) setupConn(c *conn, flags connFlag, dialDest *discover.Nod
 		clog.Trace("Dialed identity mismatch", "want", c, dialDest.ID)
 		return DiscUnexpectedIdentity
 	}
-	err = srv.checkpoint(c, srv.posthandshake)
+	err = srv.handlePostHandshake(c)
 	if err != nil {
 		clog.Trace("Rejected peer before protocol handshake", "err", err)
 		return err
@@ -647,6 +633,19 @@ func (srv *BaseServer) setupConn(c *conn, flags connFlag, dialDest *discover.Nod
 	// launched by run.
 	clog.Trace("connection set up", "inbound", dialDest == nil)
 	return nil
+}
+
+func (srv *BaseServer) handlePostHandshake(c *conn) error {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	if !srv.running {
+		return errServerStopped
+	}
+	if srv.trusted[c.id] {
+		c.flags |= trustedConn
+	}
+	return srv.encHandshakeChecks(srv.peers, srv.inboundCount, c)
 }
 
 // checkpoint sends the conn to run, which performs the

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -318,15 +318,6 @@ running:
 			// The server was stopped. Run the cleanup logic.
 			break running
 		case <-srv.wakeup:
-		case n := <-srv.removestatic:
-			// This channel is used by RemovePeer to send a
-			// disconnect request to a peer and begin the
-			// stop keeping the node connected
-			srv.logger.Debug("Removing static node", "node", n)
-			dialstate.removeStatic(n)
-			if p, ok := peers[n.ID]; ok {
-				p.Disconnect(DiscRequested)
-			}
 		case op := <-srv.peerOp:
 			// This channel is used by Peers and PeerCount.
 			op(peers)
@@ -780,10 +771,10 @@ func (srv *BaseServer) Resolve(target discover.NodeID, nType discover.NodeType) 
 func (srv *BaseServer) AddPeer(node *discover.Node) {
 	srv.lock.Lock()
 	defer srv.lock.Unlock()
-
 	if !srv.running {
 		return
 	}
+
 	srv.logger.Debug("Adding static node", "node", node)
 	srv.dialstate.addStatic(node)
 	srv.wakeupDialer()
@@ -791,9 +782,16 @@ func (srv *BaseServer) AddPeer(node *discover.Node) {
 
 // RemovePeer disconnects from the given node.
 func (srv *BaseServer) RemovePeer(node *discover.Node) {
-	select {
-	case srv.removestatic <- node:
-	case <-srv.quit:
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+	if !srv.running {
+		return
+	}
+
+	srv.logger.Debug("Removing static node", "node", node)
+	srv.dialstate.removeStatic(node)
+	if p, ok := srv.peers[node.ID]; ok {
+		p.Disconnect(DiscRequested)
 	}
 }
 

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -324,43 +324,6 @@ running:
 			srv.logger.Trace("Dial task done", "task", t)
 			dialstate.taskDone(t, time.Now())
 			delTask(t)
-		case c := <-srv.addpeer:
-			// At this point the connection is past the protocol handshake.
-			// Its capabilities are known and the remote identity is verified.
-			var err error
-			err = srv.protoHandshakeChecks(peers, srv.inboundCount, c)
-			if err == nil {
-				// The handshakes are done and it passed all checks.
-				p, err := newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
-				if err != nil {
-					srv.logger.Error("Fail make a new peer", "err", err)
-				} else {
-					// If message events are enabled, pass the peerFeed
-					// to the peer
-					if srv.EnableMsgEvents {
-						p.events = &srv.peerFeed
-					}
-					name := truncateName(c.name)
-					srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
-					go srv.runPeer(p)
-					peers[c.id] = p
-
-					if p.Inbound() {
-						srv.inboundCount++
-					}
-					peerCountGauge.Update(int64(len(peers)))
-					peerInCountGauge.Update(int64(srv.inboundCount))
-					peerOutCountGauge.Update(int64(len(peers) - srv.inboundCount))
-				}
-			}
-			// The dialer logic relies on the assumption that
-			// dial tasks complete after the peer has been added or
-			// discarded. Unblock the task last.
-			select {
-			case c.cont <- err:
-			case <-srv.quit:
-				break running
-			}
 		case pd := <-srv.delpeer:
 			// A peer disconnected.
 			d := common.PrettyDuration(mclock.Now() - pd.created)
@@ -624,13 +587,13 @@ func (srv *BaseServer) setupConn(c *conn, flags connFlag, dialDest *discover.Nod
 	}
 	c.caps, c.name, c.multiChannel = phs.Caps, phs.Name, phs.Multichannel
 
-	err = srv.checkpoint(c, srv.addpeer)
+	err = srv.handleAddPeerConn(c)
 	if err != nil {
 		clog.Trace("Rejected peer", "err", err)
 		return err
 	}
 	// If the checks completed successfully, runPeer has now been
-	// launched by run.
+	// launched by handleAddPeerConn.
 	clog.Trace("connection set up", "inbound", dialDest == nil)
 	return nil
 }
@@ -646,6 +609,42 @@ func (srv *BaseServer) handlePostHandshake(c *conn) error {
 		c.flags |= trustedConn
 	}
 	return srv.encHandshakeChecks(srv.peers, srv.inboundCount, c)
+}
+
+func (srv *BaseServer) handleAddPeerConn(c *conn) error {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	if !srv.running {
+		return errServerStopped
+	}
+	err := srv.protoHandshakeChecks(srv.peers, srv.inboundCount, c)
+	if err != nil {
+		return err
+	}
+
+	p, err := newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
+	if err != nil {
+		srv.logger.Error("Fail make a new peer", "err", err)
+		return err
+	}
+
+	if srv.EnableMsgEvents {
+		p.events = &srv.peerFeed
+	}
+	name := truncateName(c.name)
+	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(srv.peers)+1)
+
+	srv.peers[c.id] = p
+	if p.Inbound() {
+		srv.inboundCount++
+	}
+	peerCountGauge.Update(int64(len(srv.peers)))
+	peerInCountGauge.Update(int64(srv.inboundCount))
+	peerOutCountGauge.Update(int64(len(srv.peers) - srv.inboundCount))
+
+	go srv.runPeer(p)
+	return nil
 }
 
 // checkpoint sends the conn to run, which performs the

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -85,8 +85,8 @@ type SingleChannelServer struct {
 // It blocks until all active connections are closed.
 func (srv *BaseServer) Stop() {
 	srv.lock.Lock()
-	defer srv.lock.Unlock()
 	if !srv.running {
+		srv.lock.Unlock()
 		return
 	}
 	srv.running = false
@@ -98,6 +98,7 @@ func (srv *BaseServer) Stop() {
 	}
 
 	close(srv.quit)   // Ask loops to terminate
+	srv.lock.Unlock() // Unlock to allow loops to finish their remaining jobs.
 	srv.loopWG.Wait() // Wait for loops to terminate
 	srv.logger.Info("Stopped P2P server")
 }

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -67,11 +67,12 @@ type BaseServer struct {
 	lastLookupMu sync.Mutex
 
 	// Peer lifecycle state
-	selfID       discover.NodeID // precompulted Self().ID
-	peers        map[discover.NodeID]*Peer
-	inboundCount int
-	trusted      map[discover.NodeID]bool
-	dialstate    dialer
+	selfID        discover.NodeID // precompulted Self().ID
+	peers         map[discover.NodeID]*Peer
+	inboundCount  int
+	outboundCount int
+	trusted       map[discover.NodeID]bool
+	dialstate     dialer
 
 	// Wake the dial loop when peer lifecycle changes affect scheduling.
 	wakeup chan struct{} // TODO: dialsched should react to the peer changes.
@@ -175,7 +176,6 @@ func (srv *BaseServer) initialize() error {
 
 	srv.selfID = discover.PubkeyID(&srv.PrivateKey.PublicKey)
 	srv.peers = make(map[discover.NodeID]*Peer)
-	srv.inboundCount = 0
 	srv.trusted = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
 	for _, n := range srv.TrustedNodes {
 		srv.trusted[n.ID] = true
@@ -602,16 +602,10 @@ func (srv *BaseServer) handleAddPeerConn(c *conn) error {
 	if srv.EnableMsgEvents {
 		p.events = &srv.peerFeed
 	}
-	name := truncateName(c.name)
-	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(srv.peers)+1)
-
 	srv.peers[c.id] = p
-	if p.Inbound() {
-		srv.inboundCount++
-	}
-	peerCountGauge.Update(int64(len(srv.peers)))
-	peerInCountGauge.Update(int64(srv.inboundCount))
-	peerOutCountGauge.Update(int64(len(srv.peers) - srv.inboundCount))
+	srv.incrementConnectionCounts(p)
+	srv.reportPeerMetric()
+	srv.logger.Debug("Adding p2p peer", "name", truncateName(c.name), "addr", c.fd.RemoteAddr(), "peers", len(srv.peers))
 
 	srv.peerWG.Add(1)
 	go srv.runPeer(p)
@@ -651,18 +645,34 @@ func (srv *BaseServer) handleDelPeer(pd peerDrop) {
 	srv.lock.Lock()
 	defer srv.lock.Unlock()
 
-	d := common.PrettyDuration(mclock.Now() - pd.created)
-	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(srv.peers)-1, "req", pd.requested, "err", pd.err)
 	delete(srv.peers, pd.ID())
 
-	if pd.Inbound() {
-		srv.inboundCount--
-	}
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(srv.peers), "req", pd.requested, "err", pd.err)
+	srv.decrementConnectionCounts(pd.Peer)
+	srv.reportPeerMetric()
+	srv.wakeupDialer()
+}
 
+func (srv *BaseServer) incrementConnectionCounts(p *Peer) {
+	peerInbound, peerOutbound := p.GetNumberInboundAndOutbound()
+	srv.inboundCount += peerInbound
+	srv.outboundCount += peerOutbound
+}
+
+func (srv *BaseServer) decrementConnectionCounts(p *Peer) {
+	peerInbound, peerOutbound := p.GetNumberInboundAndOutbound()
+	srv.inboundCount -= peerInbound
+	srv.outboundCount -= peerOutbound
+}
+
+func (srv *BaseServer) reportPeerMetric() {
 	peerCountGauge.Update(int64(len(srv.peers)))
 	peerInCountGauge.Update(int64(srv.inboundCount))
-	peerOutCountGauge.Update(int64(len(srv.peers) - srv.inboundCount))
-	srv.wakeupDialer()
+	peerOutCountGauge.Update(int64(srv.outboundCount))
+	connectionCountGauge.Update(int64(srv.outboundCount + srv.inboundCount))
+	connectionInCountGauge.Update(int64(srv.inboundCount))
+	connectionOutCountGauge.Update(int64(srv.outboundCount))
 }
 
 // Dial creates a TCP connection to the node.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -48,29 +48,32 @@ type BaseServer struct {
 	newTransport func(net.Conn, *ecdsa.PublicKey) transport
 	newPeerHook  func(*Peer)
 
-	lock    sync.Mutex // protects running
+	// Lifecycle
+	lock    sync.Mutex
 	running bool
+	quit    chan struct{}
+	loopWG  sync.WaitGroup // loop, listenLoop
 
-	ntab         discover.Discovery
-	listener     net.Listener
-	ourHandshake *protoHandshake
+	// Relying components
+	logger       log.Logger
+	ntab         discover.Discovery // UDP discovery
+	ourHandshake *protoHandshake    // our TCP handshake message
+	listener     net.Listener       // TCP listener
+	peerFeed     event.Feed         // Peer event feed as in peer.go:PeerEventType.
+
+	// LastLookup memory TODO: dialsched should manage it inside.
 	lastLookup   time.Time
 	lastLookupMu sync.Mutex
 
-	// These are for Peers, PeerCount (and nothing else).
-	peerOp     chan peerOpFunc
-	peerOpDone chan struct{}
-
-	quit          chan struct{}
+	// Request channels
 	addstatic     chan *discover.Node
 	removestatic  chan *discover.Node
+	peerOp        chan peerOpFunc
+	peerOpDone    chan struct{}
 	posthandshake chan *conn
 	addpeer       chan *conn
 	delpeer       chan peerDrop
 	discpeer      chan discover.NodeID
-	loopWG        sync.WaitGroup // loop, listenLoop
-	peerFeed      event.Feed
-	logger        log.Logger
 }
 
 // SingleChannelServer is a server that uses a single channel.
@@ -87,12 +90,16 @@ func (srv *BaseServer) Stop() {
 		return
 	}
 	srv.running = false
+
+	// Stop TCP listeners
 	if srv.listener != nil {
 		// this unblocks listener Accept
 		srv.listener.Close()
 	}
-	close(srv.quit)
-	srv.loopWG.Wait()
+
+	close(srv.quit)   // Ask loops to terminate
+	srv.loopWG.Wait() // Wait for loops to terminate
+	srv.logger.Info("Stopped P2P server")
 }
 
 // Start starts running the server.
@@ -104,21 +111,56 @@ func (srv *BaseServer) Start() (err error) {
 		return errors.New("server already running")
 	}
 	srv.running = true
+
+	if err := srv.initialize(); err != nil {
+		return err
+	}
+
+	if !srv.NoDiscovery {
+		if err := srv.startDiscovery(srv.ListenAddr); err != nil {
+			return err
+		}
+	}
+
+	srv.ourHandshake = srv.makeOurHandshakeMsg()
+
+	if srv.NoDial && srv.NoListen {
+		srv.logger.Error("P2P server will be useless, neither dialing nor listening")
+	}
+
+	// Start listening
+	if !srv.NoListen {
+		if srv.ListenAddr != "" {
+			if err := srv.startListening(); err != nil {
+				return err
+			}
+		} else {
+			srv.logger.Error("P2P server might be useless, listening address is missing")
+		}
+	}
+
+	// Start dialing. TODO: Only if !NoDial, start DialSched.
+	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
+	srv.loopWG.Add(1)
+	go srv.run(dialer)
+
+	srv.logger.Info("Started P2P server", "id", discover.PubkeyID(&srv.PrivateKey.PublicKey), "multichannel", false)
+	return nil
+}
+
+func (srv *BaseServer) initialize() error {
 	srv.logger = srv.Config.Logger
 	if srv.logger == nil {
 		srv.logger = logger.NewWith()
 	}
 	srv.logger.Info("Starting P2P networking")
 
-	// static fields
 	if srv.PrivateKey == nil {
 		return errors.New("Server.PrivateKey must be set to a non-nil key")
 	}
-
 	if !srv.ConnectionType.Valid() {
 		return errors.New("Invalid connection type speficied")
 	}
-
 	if srv.newTransport == nil {
 		srv.newTransport = newRLPX
 	}
@@ -135,88 +177,57 @@ func (srv *BaseServer) Start() (err error) {
 	srv.peerOpDone = make(chan struct{})
 	srv.discpeer = make(chan discover.NodeID)
 
-	var (
-		conn      *net.UDPConn
-		realaddr  *net.UDPAddr
-		unhandled chan discover.ReadPacket
-	)
-
-	if !srv.NoDiscovery {
-		addr, err := net.ResolveUDPAddr("udp", srv.ListenAddr)
-		if err != nil {
-			return err
-		}
-		conn, err = net.ListenUDP("udp", addr)
-		if err != nil {
-			return err
-		}
-		realaddr = conn.LocalAddr().(*net.UDPAddr)
-		if srv.NAT != nil {
-			if !realaddr.IP.IsLoopback() {
-				go nat.Map(srv.NAT, srv.quit, "udp", realaddr.Port, realaddr.Port, "klaytn discovery")
-			}
-			// TODO: react to external IP changes over time.
-			if ext, err := srv.NAT.ExternalIP(); err == nil {
-				realaddr = &net.UDPAddr{IP: ext, Port: realaddr.Port}
-			}
-		}
-	}
-
-	// node table
-	if !srv.NoDiscovery {
-		cfg := discover.Config{
-			PrivateKey:    srv.PrivateKey,
-			AnnounceAddr:  realaddr,
-			NodeDBPath:    srv.NodeDatabase,
-			NetRestrict:   srv.NetRestrict,
-			Bootnodes:     srv.BootstrapNodes,
-			Unhandled:     unhandled,
-			Conn:          conn,
-			Addr:          realaddr,
-			Id:            discover.PubkeyID(&srv.PrivateKey.PublicKey),
-			NodeType:      ConvertNodeType(srv.ConnectionType),
-			NetworkID:     srv.NetworkID,
-			DiscoverTypes: srv.DiscoverTypes,
-		}
-
-		cfgForLog := cfg
-		cfgForLog.PrivateKey = nil
-
-		logger.Info("Create udp", "config", cfgForLog)
-
-		ntab, err := discover.ListenUDP(&cfg)
-		if err != nil {
-			return err
-		}
-		srv.ntab = ntab
-	}
-
-	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
-
-	// handshake
-	srv.ourHandshake = &protoHandshake{Version: baseProtocolVersion, Name: srv.Name(), ID: discover.PubkeyID(&srv.PrivateKey.PublicKey), Multichannel: false}
-	for _, p := range srv.Protocols {
-		srv.ourHandshake.Caps = append(srv.ourHandshake.Caps, p.cap())
-	}
-	// listen/dial
-	if srv.NoDial && srv.NoListen {
-		srv.logger.Error("P2P server will be useless, neither dialing nor listening")
-	}
-	if !srv.NoListen {
-		if srv.ListenAddr != "" {
-			if err := srv.startListening(); err != nil {
-				return err
-			}
-		} else {
-			srv.logger.Error("P2P server might be useless, listening address is missing")
-		}
-	}
-
-	srv.loopWG.Add(1)
-	go srv.run(dialer)
-	srv.running = true
-	srv.logger.Info("Started P2P server", "id", discover.PubkeyID(&srv.PrivateKey.PublicKey), "multichannel", false)
 	return nil
+}
+
+func (srv *BaseServer) startDiscovery(listenAddr string) error {
+	addr, err := net.ResolveUDPAddr("udp", listenAddr)
+	if err != nil {
+		return err
+	}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return err
+	}
+	realaddr := conn.LocalAddr().(*net.UDPAddr)
+	if srv.NAT != nil {
+		if !realaddr.IP.IsLoopback() {
+			go nat.Map(srv.NAT, srv.quit, "udp", realaddr.Port, realaddr.Port, "klaytn discovery")
+		}
+		// TODO: react to external IP changes over time.
+		if ext, err := srv.NAT.ExternalIP(); err == nil {
+			realaddr = &net.UDPAddr{IP: ext, Port: realaddr.Port}
+		}
+	}
+	cfg := discover.Config{
+		PrivateKey:    srv.PrivateKey,
+		AnnounceAddr:  realaddr,
+		NodeDBPath:    srv.NodeDatabase,
+		NetRestrict:   srv.NetRestrict,
+		Bootnodes:     srv.BootstrapNodes,
+		Unhandled:     nil,
+		Conn:          conn,
+		Addr:          realaddr,
+		Id:            discover.PubkeyID(&srv.PrivateKey.PublicKey),
+		NodeType:      ConvertNodeType(srv.ConnectionType),
+		NetworkID:     srv.NetworkID,
+		DiscoverTypes: srv.DiscoverTypes,
+	}
+
+	ntab, err := discover.ListenUDP(&cfg)
+	if err != nil {
+		return err
+	}
+	srv.ntab = ntab
+	return nil
+}
+
+func (srv *BaseServer) makeOurHandshakeMsg() *protoHandshake {
+	hs := &protoHandshake{Version: baseProtocolVersion, Name: srv.Name(), ID: discover.PubkeyID(&srv.PrivateKey.PublicKey), Multichannel: false}
+	for _, p := range srv.Protocols {
+		hs.Caps = append(hs.Caps, p.cap())
+	}
+	return hs
 }
 
 func (srv *BaseServer) startListening() error {

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -73,6 +73,7 @@ type BaseServer struct {
 	dialstate    dialer
 
 	// Request channels
+	wakeup        chan struct{} // TODO: dialsched should react to the peer changes.
 	addstatic     chan *discover.Node
 	removestatic  chan *discover.Node
 	peerOp        chan peerOpFunc
@@ -176,6 +177,7 @@ func (srv *BaseServer) initialize() error {
 		srv.Dialer = TCPDialer{&net.Dialer{Timeout: defaultDialTimeout}}
 	}
 	srv.quit = make(chan struct{})
+	srv.wakeup = make(chan struct{}, 1)
 	srv.addpeer = make(chan *conn)
 	srv.delpeer = make(chan peerDrop)
 	srv.posthandshake = make(chan *conn)
@@ -315,12 +317,7 @@ running:
 		case <-srv.quit:
 			// The server was stopped. Run the cleanup logic.
 			break running
-		case n := <-srv.addstatic:
-			// This channel is used by AddPeer to add to the
-			// ephemeral static peer list. Add it to the dialer,
-			// it will keep the node connected.
-			srv.logger.Debug("Adding static node", "node", n)
-			dialstate.addStatic(n)
+		case <-srv.wakeup:
 		case n := <-srv.removestatic:
 			// This channel is used by RemovePeer to send a
 			// disconnect request to a peer and begin the
@@ -432,6 +429,15 @@ running:
 		p := <-srv.delpeer
 		p.logger.Trace("<-delpeer (spindown)", "remainingTasks", len(runningTasks))
 		delete(peers, p.ID())
+	}
+}
+
+// Signal the dialer loop in run() to wake up upon peer changes.
+// TODO: dialsched should react to the peer changes.
+func (srv *BaseServer) wakeupDialer() {
+	select {
+	case srv.wakeup <- struct{}{}:
+	default:
 	}
 }
 
@@ -772,10 +778,15 @@ func (srv *BaseServer) Resolve(target discover.NodeID, nType discover.NodeType) 
 // server is shut down. If the connection fails for any reason, the server will
 // attempt to reconnect the peer.
 func (srv *BaseServer) AddPeer(node *discover.Node) {
-	select {
-	case srv.addstatic <- node:
-	case <-srv.quit:
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	if !srv.running {
+		return
 	}
+	srv.logger.Debug("Adding static node", "node", node)
+	srv.dialstate.addStatic(node)
+	srv.wakeupDialer()
 }
 
 // RemovePeer disconnects from the given node.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -318,10 +318,6 @@ running:
 			// The server was stopped. Run the cleanup logic.
 			break running
 		case <-srv.wakeup:
-		case op := <-srv.peerOp:
-			// This channel is used by Peers and PeerCount.
-			op(peers)
-			srv.peerOpDone <- struct{}{}
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
@@ -824,46 +820,42 @@ func (srv *BaseServer) PeersInfo() []*PeerInfo {
 
 // PeerCount returns the number of connected peers.
 func (srv *BaseServer) PeerCount() int {
-	var count int
-	select {
-	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) { count = len(ps) }:
-		<-srv.peerOpDone
-	case <-srv.quit:
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	if !srv.running {
+		return 0
 	}
-	return count
+	return len(srv.peers)
 }
 
 func (srv *BaseServer) PeerCountByType() map[string]uint {
-	pc := make(map[string]uint)
-	pc["total"] = 0
-	select {
-	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) {
-		for _, peer := range ps {
-			key := ConvertConnTypeToString(peer.ConnType())
-			pc[key]++
-			pc["total"]++
-		}
-	}:
-		<-srv.peerOpDone
-	case <-srv.quit:
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	pc := map[string]uint{"total": 0}
+	if !srv.running {
+		return pc
+	}
+	for _, peer := range srv.peers {
+		key := ConvertConnTypeToString(peer.ConnType())
+		pc[key]++
+		pc["total"]++
 	}
 	return pc
 }
 
 // Peers returns all connected peers.
 func (srv *BaseServer) Peers() []*Peer {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
 	var ps []*Peer
-	select {
-	// Note: We'd love to put this function into a variable but
-	// that seems to cause a weird compiler error in some
-	// environments.
-	case srv.peerOp <- func(peers map[discover.NodeID]*Peer) {
-		for _, p := range peers {
-			ps = append(ps, p)
-		}
-	}:
-		<-srv.peerOpDone
-	case <-srv.quit:
+	if !srv.running {
+		return ps
+	}
+	for _, p := range srv.peers {
+		ps = append(ps, p)
 	}
 	return ps
 }

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -771,14 +771,17 @@ func (srv *BaseServer) AddPeer(node *discover.Node) {
 // RemovePeer disconnects from the given node.
 func (srv *BaseServer) RemovePeer(node *discover.Node) {
 	srv.lock.Lock()
-	defer srv.lock.Unlock()
 	if !srv.running {
+		srv.lock.Unlock()
 		return
 	}
 
 	srv.logger.Debug("Removing static node", "node", node)
 	srv.dialstate.removeStatic(node)
-	if p, ok := srv.peers[node.ID]; ok {
+	p := srv.peers[node.ID]
+	srv.lock.Unlock()
+
+	if p != nil {
 		p.Disconnect(DiscRequested)
 	}
 }

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -65,6 +65,13 @@ type BaseServer struct {
 	lastLookup   time.Time
 	lastLookupMu sync.Mutex
 
+	// Peer lifecycle state
+	selfID       discover.NodeID // precompulted Self().ID
+	peers        map[discover.NodeID]*Peer
+	inboundCount int
+	trusted      map[discover.NodeID]bool
+	dialstate    dialer
+
 	// Request channels
 	addstatic     chan *discover.Node
 	removestatic  chan *discover.Node
@@ -141,9 +148,9 @@ func (srv *BaseServer) Start() (err error) {
 	}
 
 	// Start dialing. TODO: Only if !NoDial, start DialSched.
-	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
+	srv.dialstate = newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
 	srv.loopWG.Add(1)
-	go srv.run(dialer)
+	go srv.run(srv.dialstate)
 
 	srv.logger.Info("Started P2P server", "id", discover.PubkeyID(&srv.PrivateKey.PublicKey), "multichannel", false)
 	return nil
@@ -177,6 +184,14 @@ func (srv *BaseServer) initialize() error {
 	srv.peerOp = make(chan peerOpFunc)
 	srv.peerOpDone = make(chan struct{})
 	srv.discpeer = make(chan discover.NodeID)
+
+	srv.selfID = discover.PubkeyID(&srv.PrivateKey.PublicKey)
+	srv.peers = make(map[discover.NodeID]*Peer)
+	srv.inboundCount = 0
+	srv.trusted = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
+	for _, n := range srv.TrustedNodes {
+		srv.trusted[n.ID] = true
+	}
 
 	return nil
 }
@@ -255,19 +270,12 @@ func (srv *BaseServer) startListening() error {
 func (srv *BaseServer) run(dialstate dialer) {
 	defer srv.loopWG.Done()
 	var (
-		peers        = make(map[discover.NodeID]*Peer)
-		inboundCount = 0
-		trusted      = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
+		peers        = srv.peers
+		trusted      = srv.trusted
 		taskdone     = make(chan task, maxActiveDialTasks)
 		runningTasks []task
 		queuedTasks  []task // tasks that can't run yet
 	)
-	// Put trusted nodes into a map to speed up checks.
-	// Trusted peers are loaded on startup and cannot be
-	// modified while the server is running.
-	for _, n := range srv.TrustedNodes {
-		trusted[n.ID] = true
-	}
 
 	// removes t from runningTasks
 	delTask := func(t task) {
@@ -342,7 +350,7 @@ running:
 			}
 			// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
 			select {
-			case c.cont <- srv.encHandshakeChecks(peers, inboundCount, c):
+			case c.cont <- srv.encHandshakeChecks(peers, srv.inboundCount, c):
 			case <-srv.quit:
 				break running
 			}
@@ -350,7 +358,7 @@ running:
 			// At this point the connection is past the protocol handshake.
 			// Its capabilities are known and the remote identity is verified.
 			var err error
-			err = srv.protoHandshakeChecks(peers, inboundCount, c)
+			err = srv.protoHandshakeChecks(peers, srv.inboundCount, c)
 			if err == nil {
 				// The handshakes are done and it passed all checks.
 				p, err := newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
@@ -368,11 +376,11 @@ running:
 					peers[c.id] = p
 
 					if p.Inbound() {
-						inboundCount++
+						srv.inboundCount++
 					}
 					peerCountGauge.Update(int64(len(peers)))
-					peerInCountGauge.Update(int64(inboundCount))
-					peerOutCountGauge.Update(int64(len(peers) - inboundCount))
+					peerInCountGauge.Update(int64(srv.inboundCount))
+					peerOutCountGauge.Update(int64(len(peers) - srv.inboundCount))
 				}
 			}
 			// The dialer logic relies on the assumption that
@@ -390,12 +398,12 @@ running:
 			delete(peers, pd.ID())
 
 			if pd.Inbound() {
-				inboundCount--
+				srv.inboundCount--
 			}
 
 			peerCountGauge.Update(int64(len(peers)))
-			peerInCountGauge.Update(int64(inboundCount))
-			peerOutCountGauge.Update(int64(len(peers) - inboundCount))
+			peerInCountGauge.Update(int64(srv.inboundCount))
+			peerOutCountGauge.Update(int64(len(peers) - srv.inboundCount))
 		case nid := <-srv.discpeer:
 			if p, ok := peers[nid]; ok {
 				p.Disconnect(DiscRequested)

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -577,6 +577,11 @@ func (srv *MultiChannelServer) RemovePeer(node *discover.Node) {
 	}
 }
 
+// Disconnect tries to disconnect peer.
+func (srv *MultiChannelServer) Disconnect(destID discover.NodeID) {
+	srv.discpeer <- destID
+}
+
 // PeersInfo returns an array of metadata objects describing connected peers.
 func (srv *MultiChannelServer) PeersInfo() []*PeerInfo {
 	infos := make([]*PeerInfo, 0, srv.PeerCount())

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -237,7 +237,7 @@ func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *
 		return errors.New("shutdown")
 	}
 
-	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, cont: make(chan error), portOrder: PortOrderUndefined}
+	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, portOrder: PortOrderUndefined}
 
 	if dialDest != nil {
 		// retrieve pubkey. if err occurs, dialPubkey is automatically set as nil

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -44,6 +44,7 @@ type MultiChannelServer struct {
 	listeners      []net.Listener              // Extended TCP listener
 	ListenAddrs    []string                    // Extended TCP listen addresses
 	CandidateConns map[discover.NodeID][]*conn // Subset of connections towards a premature peer
+	outboundCount  int
 }
 
 // Stop terminates the server and all active peer connections.
@@ -69,6 +70,7 @@ func (srv *MultiChannelServer) Stop() {
 	close(srv.quit)   // Ask loops to terminate
 	srv.lock.Unlock() // Unlock to allow loops to finish their remaining jobs.
 	srv.loopWG.Wait() // Wait for loops to terminate
+	srv.peerWG.Wait() // Wait for peers to terminate
 	srv.logger.Info("Stopped P2P server")
 }
 
@@ -110,9 +112,9 @@ func (srv *MultiChannelServer) Start() (err error) {
 	}
 
 	// Start dialing. TODO: Only if !NoDial, start DialSched.
-	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
+	srv.dialstate = newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
 	srv.loopWG.Add(1)
-	go srv.run(dialer)
+	go srv.run(srv.dialstate)
 
 	srv.logger.Info("Started P2P server", "id", discover.PubkeyID(&srv.PrivateKey.PublicKey), "multichannel", true)
 	return nil
@@ -128,6 +130,7 @@ func (srv *MultiChannelServer) initialize() error {
 	srv.ListenAddrs = append(srv.ListenAddrs, srv.ListenAddr)
 	srv.ListenAddrs = append(srv.ListenAddrs, srv.SubListenAddr...)
 	srv.CandidateConns = make(map[discover.NodeID][]*conn)
+	srv.outboundCount = 0
 	return nil
 }
 
@@ -261,9 +264,8 @@ func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *
 	return err
 }
 
-// setupConn runs the handshakes and attempts to add the connection
-// as a peer. It returns when the connection has been added as a peer
-// or the handshakes have failed.
+// Overrides BaseServer.setupConn() to preserve multichannel port-order handling
+// while moving the peer admission stages off the event loop.
 func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *discover.Node) error {
 	// Prevent leftover pending conns from entering the handshake.
 	srv.lock.Lock()
@@ -296,7 +298,7 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 		clog.Trace("Dialed identity mismatch", "want", c, dialDest.ID)
 		return DiscUnexpectedIdentity
 	}
-	err = srv.checkpoint(c, srv.posthandshake)
+	err = srv.handlePostHandshake(c)
 	if err != nil {
 		clog.Trace("Rejected peer before protocol handshake", "err", err)
 		return err
@@ -324,36 +326,89 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 		return errUpdateDial
 	}
 
-	err = srv.checkpoint(c, srv.addpeer)
+	err = srv.handleAddPeerConn(c)
 	if err != nil {
 		clog.Trace("Rejected peer", "err", err)
 		return err
 	}
 	// If the checks completed successfully, runPeer has now been
-	// launched by run.
+	// launched by handleAddPeerConn.
 	clog.Trace("connection set up", "inbound", dialDest == nil)
 	return nil
 }
 
-// run is the main loop that the server runs.
+// Override BaseServer.handleAddPeerConn because multichannel peer admission
+// waits for the full candidate connection set and updates outbound metrics.
+func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	if !srv.running {
+		return errServerStopped
+	}
+	err := srv.protoHandshakeChecks(srv.peers, srv.inboundCount, c)
+	if err != nil {
+		return err
+	}
+
+	var p *Peer
+	if c.multiChannel {
+		connSet := srv.CandidateConns[c.id]
+		if connSet == nil {
+			connSet = make([]*conn, len(srv.ListenAddrs))
+			srv.CandidateConns[c.id] = connSet
+		}
+
+		if int(c.portOrder) < len(connSet) {
+			connSet[c.portOrder] = c
+		}
+
+		pending := len(connSet)
+		for _, conn := range connSet {
+			if conn != nil {
+				pending--
+			}
+		}
+		if pending != 0 {
+			return nil
+		}
+
+		p, err = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
+		srv.CandidateConns[c.id] = nil
+	} else {
+		p, err = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
+	}
+	if err != nil {
+		srv.logger.Error("Fail make a new peer", "err", err)
+		return err
+	}
+
+	if srv.EnableMsgEvents {
+		p.events = &srv.peerFeed
+	}
+	name := truncateName(c.name)
+	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(srv.peers)+1)
+
+	srv.peers[c.id] = p
+	peerCountGauge.Update(int64(len(srv.peers)))
+	srv.inboundCount, srv.outboundCount = increasesConnectionMetric(srv.inboundCount, srv.outboundCount, p)
+
+	srv.peerWG.Add(1)
+	go srv.runPeer(p)
+	return nil
+}
+
+// Overrides BaseServer.run() to keep multichannel dialing while peer lifecycle
+// serialization moves to the direct handlers.
 func (srv *MultiChannelServer) run(dialstate dialer) {
 	logger.Debug("[p2p.Server] start MultiChannel p2p server")
 	defer srv.loopWG.Done()
 	var (
-		peers         = make(map[discover.NodeID]*Peer)
-		inboundCount  = 0
-		outboundCount = 0
-		trusted       = make(map[discover.NodeID]bool, len(srv.TrustedNodes))
-		taskdone      = make(chan task, maxActiveDialTasks)
-		runningTasks  []task
-		queuedTasks   []task // tasks that can't run yet
+		peers        = srv.peers
+		taskdone     = make(chan task, maxActiveDialTasks)
+		runningTasks []task
+		queuedTasks  []task // tasks that can't run yet
 	)
-	// Put trusted nodes into a map to speed up checks.
-	// Trusted peers are loaded on startup and cannot be
-	// modified while the server is running.
-	for _, n := range srv.TrustedNodes {
-		trusted[n.ID] = true
-	}
 
 	// removes t from runningTasks
 	delTask := func(t task) {
@@ -380,7 +435,9 @@ func (srv *MultiChannelServer) run(dialstate dialer) {
 		queuedTasks = append(queuedTasks[:0], startTasks(queuedTasks)...)
 		// Query dialer for new tasks and start as many as possible now.
 		if len(runningTasks) < maxActiveDialTasks {
+			srv.lock.Lock()
 			nt := dialstate.newTasks(len(runningTasks)+len(queuedTasks), peers, time.Now())
+			srv.lock.Unlock()
 			queuedTasks = append(queuedTasks, startTasks(nt)...)
 		}
 	}
@@ -393,117 +450,16 @@ running:
 		case <-srv.quit:
 			// The server was stopped. Run the cleanup logic.
 			break running
-		case n := <-srv.addstatic:
-			// This channel is used by AddPeer to add to the
-			// ephemeral static peer list. Add it to the dialer,
-			// it will keep the node connected.
-			srv.logger.Debug("Adding static node", "node", n)
-			dialstate.addStatic(n)
-		case n := <-srv.removestatic:
-			// This channel is used by RemovePeer to send a
-			// disconnect request to a peer and begin the
-			// stop keeping the node connected
-			srv.logger.Debug("Removing static node", "node", n)
-			dialstate.removeStatic(n)
-			if p, ok := peers[n.ID]; ok {
-				p.Disconnect(DiscRequested)
-			}
-		case op := <-srv.peerOp:
-			// This channel is used by Peers and PeerCount.
-			op(peers)
-			srv.peerOpDone <- struct{}{}
+		case <-srv.wakeup:
 		case t := <-taskdone:
 			// A task got done. Tell dialstate about it so it
 			// can update its state and remove it from the active
 			// tasks list.
 			srv.logger.Trace("Dial task done", "task", t)
+			srv.lock.Lock()
 			dialstate.taskDone(t, time.Now())
+			srv.lock.Unlock()
 			delTask(t)
-		case c := <-srv.posthandshake:
-			// A connection has passed the encryption handshake so
-			// the remote identity is known (but hasn't been verified yet).
-			if trusted[c.id] {
-				// Ensure that the trusted flag is set before checking against MaxPhysicalConnections.
-				c.flags |= trustedConn
-			}
-			// TODO: track in-progress inbound node IDs (pre-Peer) to avoid dialing them.
-			select {
-			case c.cont <- srv.encHandshakeChecks(peers, inboundCount, c):
-			case <-srv.quit:
-				break running
-			}
-		case c := <-srv.addpeer:
-			var p *Peer
-			var e error
-			// At this point the connection is past the protocol handshake.
-			// Its capabilities are known and the remote identity is verified.
-			err := srv.protoHandshakeChecks(peers, inboundCount, c)
-			if err == nil {
-				if c.multiChannel {
-					connSet := srv.CandidateConns[c.id]
-					if connSet == nil {
-						connSet = make([]*conn, len(srv.ListenAddrs))
-						srv.CandidateConns[c.id] = connSet
-					}
-
-					if int(c.portOrder) < len(connSet) {
-						connSet[c.portOrder] = c
-					}
-
-					count := len(connSet)
-					for _, conn := range connSet {
-						if conn != nil {
-							count--
-						}
-					}
-
-					if count == 0 {
-						p, e = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
-						srv.CandidateConns[c.id] = nil
-					}
-				} else {
-					// The handshakes are done and it passed all checks.
-					p, e = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
-				}
-
-				if e != nil {
-					srv.logger.Error("Fail make a new peer", "err", e)
-				} else if p != nil {
-					// If message events are enabled, pass the peerFeed
-					// to the peer
-					if srv.EnableMsgEvents {
-						p.events = &srv.peerFeed
-					}
-					name := truncateName(c.name)
-					srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(peers)+1)
-					go srv.runPeer(p)
-					peers[c.id] = p
-
-					peerCountGauge.Update(int64(len(peers)))
-					inboundCount, outboundCount = increasesConnectionMetric(inboundCount, outboundCount, p)
-				}
-			}
-			// The dialer logic relies on the assumption that
-			// dial tasks complete after the peer has been added or
-			// discarded. Unblock the task last.
-			select {
-			case c.cont <- err:
-			case <-srv.quit:
-				break running
-			}
-		case pd := <-srv.delpeer:
-			// A peer disconnected.
-			d := common.PrettyDuration(mclock.Now() - pd.created)
-			pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(peers)-1, "req", pd.requested, "err", pd.err)
-			delete(peers, pd.ID())
-
-			peerCountGauge.Update(int64(len(peers)))
-			inboundCount, outboundCount = decreasesConnectionMetric(inboundCount, outboundCount, pd.Peer)
-		case nid := <-srv.discpeer:
-			if p, ok := peers[nid]; ok {
-				p.Disconnect(DiscRequested)
-				p.logger.Debug("disconnect peer")
-			}
 		}
 	}
 
@@ -517,23 +473,22 @@ running:
 	//	srv.DiscV5.Close()
 	//}
 	// Disconnect all peers.
-	for _, p := range peers {
-		p.Disconnect(DiscQuitting)
+	srv.lock.Lock()
+	shutdownPeers := make([]*Peer, 0, len(srv.peers))
+	for _, p := range srv.peers {
+		shutdownPeers = append(shutdownPeers, p)
 	}
-	// Wait for peers to shut down. Pending connections and tasks are
-	// not handled here and will terminate soon-ish because srv.quit
-	// is closed.
-	for len(peers) > 0 {
-		p := <-srv.delpeer
-		p.logger.Trace("<-delpeer (spindown)", "remainingTasks", len(runningTasks))
-		delete(peers, p.ID())
+	srv.lock.Unlock()
+	for _, p := range shutdownPeers {
+		p.Disconnect(DiscQuitting)
 	}
 }
 
-// runPeer runs in its own goroutine for each peer.
-// it waits until the Peer logic returns and removes
-// the peer.
+// Overrides BaseServer.runPeer() because multichannel peers run all socket
+// read-writers and need multichannel-specific removal accounting.
 func (srv *MultiChannelServer) runPeer(p *Peer) {
+	defer srv.peerWG.Done()
+
 	if srv.newPeerHook != nil {
 		srv.newPeerHook(p)
 	}
@@ -554,93 +509,22 @@ func (srv *MultiChannelServer) runPeer(p *Peer) {
 		Error: err.Error(),
 	})
 
-	// Note: run waits for existing peers to be sent on srv.delpeer
-	// before returning, so this send should not select on srv.quit.
-	srv.delpeer <- peerDrop{p, err, remoteRequested}
+	srv.handleDelPeer(peerDrop{p, err, remoteRequested})
 }
 
-// AddPeer connects to the given node and maintains the connection until the
-// server is shut down. If the connection fails for any reason, the server will
-// attempt to reconnect the peer.
-func (srv *MultiChannelServer) AddPeer(node *discover.Node) {
-	select {
-	case srv.addstatic <- node:
-	case <-srv.quit:
-	}
-}
+// Override BaseServer.handleDelPeer because multichannel teardown updates both
+// inbound and outbound connection metrics.
+func (srv *MultiChannelServer) handleDelPeer(pd peerDrop) {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
 
-// RemovePeer disconnects from the given node.
-func (srv *MultiChannelServer) RemovePeer(node *discover.Node) {
-	select {
-	case srv.removestatic <- node:
-	case <-srv.quit:
-	}
-}
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(srv.peers)-1, "req", pd.requested, "err", pd.err)
+	delete(srv.peers, pd.ID())
 
-// Disconnect tries to disconnect peer.
-func (srv *MultiChannelServer) Disconnect(destID discover.NodeID) {
-	srv.discpeer <- destID
-}
-
-// PeersInfo returns an array of metadata objects describing connected peers.
-func (srv *MultiChannelServer) PeersInfo() []*PeerInfo {
-	infos := make([]*PeerInfo, 0, srv.PeerCount())
-	for _, peer := range srv.Peers() {
-		if peer != nil {
-			infos = append(infos, peer.Info())
-		}
-	}
-	for i := 0; i < len(infos); i++ {
-		for j := i + 1; j < len(infos); j++ {
-			if infos[i].ID > infos[j].ID {
-				infos[i], infos[j] = infos[j], infos[i]
-			}
-		}
-	}
-	return infos
-}
-
-// PeerCount returns the number of connected peers.
-func (srv *MultiChannelServer) PeerCount() int {
-	var count int
-	select {
-	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) { count = len(ps) }:
-		<-srv.peerOpDone
-	case <-srv.quit:
-	}
-	return count
-}
-
-// PeerCountByType returns the number of connected peers by type.
-func (srv *MultiChannelServer) PeerCountByType() map[string]uint {
-	pc := map[string]uint{"total": 0}
-	select {
-	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) {
-		for _, peer := range ps {
-			key := ConvertConnTypeToString(peer.ConnType())
-			pc[key]++
-			pc["total"]++
-		}
-	}:
-		<-srv.peerOpDone
-	case <-srv.quit:
-	}
-	return pc
-}
-
-// Peers returns all connected peers.
-func (srv *MultiChannelServer) Peers() []*Peer {
-	var ps []*Peer
-	select {
-	case srv.peerOp <- func(peers map[discover.NodeID]*Peer) {
-		for _, p := range peers {
-			ps = append(ps, p)
-		}
-	}:
-		<-srv.peerOpDone
-	case <-srv.quit:
-	}
-	return ps
+	peerCountGauge.Update(int64(len(srv.peers)))
+	srv.inboundCount, srv.outboundCount = decreasesConnectionMetric(srv.inboundCount, srv.outboundCount, pd.Peer)
+	srv.wakeupDialer()
 }
 
 // GetListenAddress returns the listen addresses of the server.

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -44,7 +44,6 @@ type MultiChannelServer struct {
 	listeners      []net.Listener              // Extended TCP listener
 	ListenAddrs    []string                    // Extended TCP listen addresses
 	CandidateConns map[discover.NodeID][]*conn // Subset of connections towards a premature peer
-	outboundCount  int
 }
 
 // Stop terminates the server and all active peer connections.
@@ -130,7 +129,6 @@ func (srv *MultiChannelServer) initialize() error {
 	srv.ListenAddrs = append(srv.ListenAddrs, srv.ListenAddr)
 	srv.ListenAddrs = append(srv.ListenAddrs, srv.SubListenAddr...)
 	srv.CandidateConns = make(map[discover.NodeID][]*conn)
-	srv.outboundCount = 0
 	return nil
 }
 
@@ -386,12 +384,10 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 	if srv.EnableMsgEvents {
 		p.events = &srv.peerFeed
 	}
-	name := truncateName(c.name)
-	srv.logger.Debug("Adding p2p peer", "name", name, "addr", c.fd.RemoteAddr(), "peers", len(srv.peers)+1)
-
 	srv.peers[c.id] = p
-	peerCountGauge.Update(int64(len(srv.peers)))
-	srv.inboundCount, srv.outboundCount = increasesConnectionMetric(srv.inboundCount, srv.outboundCount, p)
+	srv.incrementConnectionCounts(p)
+	srv.reportPeerMetric()
+	srv.logger.Debug("Adding p2p peer", "name", truncateName(c.name), "addr", c.fd.RemoteAddr(), "peers", len(srv.peers))
 
 	srv.peerWG.Add(1)
 	go srv.runPeer(p)
@@ -518,13 +514,24 @@ func (srv *MultiChannelServer) handleDelPeer(pd peerDrop) {
 	srv.lock.Lock()
 	defer srv.lock.Unlock()
 
-	d := common.PrettyDuration(mclock.Now() - pd.created)
-	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(srv.peers)-1, "req", pd.requested, "err", pd.err)
 	delete(srv.peers, pd.ID())
 
-	peerCountGauge.Update(int64(len(srv.peers)))
-	srv.inboundCount, srv.outboundCount = decreasesConnectionMetric(srv.inboundCount, srv.outboundCount, pd.Peer)
+	d := common.PrettyDuration(mclock.Now() - pd.created)
+	pd.logger.Debug("Removing p2p peer", "duration", d, "peers", len(srv.peers), "req", pd.requested, "err", pd.err)
+	srv.decrementConnectionCounts(pd.Peer)
+	srv.reportPeerMetric()
 	srv.wakeupDialer()
+}
+
+func (srv *MultiChannelServer) reportPeerMetric() {
+	peerCountGauge.Update(int64(len(srv.peers)))
+	// In multi-channel, one peer may contain both inbound and outbound connections,
+	// if two parties happened to dial each other at the same time. In this case,
+	// it is unclear whether the peer should be counted as inbound or outbound.
+	// Therefore, we do not report the peerIn and peerOut metrics for multi-channel.
+	connectionCountGauge.Update(int64(srv.outboundCount + srv.inboundCount))
+	connectionInCountGauge.Update(int64(srv.inboundCount))
+	connectionOutCountGauge.Update(int64(srv.outboundCount))
 }
 
 // GetListenAddress returns the listen addresses of the server.

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -569,6 +569,14 @@ func (srv *MultiChannelServer) AddPeer(node *discover.Node) {
 	}
 }
 
+// RemovePeer disconnects from the given node.
+func (srv *MultiChannelServer) RemovePeer(node *discover.Node) {
+	select {
+	case srv.removestatic <- node:
+	case <-srv.quit:
+	}
+}
+
 // GetListenAddress returns the listen addresses of the server.
 func (srv *MultiChannelServer) GetListenAddress() []string {
 	return srv.ListenAddrs

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -577,6 +577,67 @@ func (srv *MultiChannelServer) RemovePeer(node *discover.Node) {
 	}
 }
 
+// PeersInfo returns an array of metadata objects describing connected peers.
+func (srv *MultiChannelServer) PeersInfo() []*PeerInfo {
+	infos := make([]*PeerInfo, 0, srv.PeerCount())
+	for _, peer := range srv.Peers() {
+		if peer != nil {
+			infos = append(infos, peer.Info())
+		}
+	}
+	for i := 0; i < len(infos); i++ {
+		for j := i + 1; j < len(infos); j++ {
+			if infos[i].ID > infos[j].ID {
+				infos[i], infos[j] = infos[j], infos[i]
+			}
+		}
+	}
+	return infos
+}
+
+// PeerCount returns the number of connected peers.
+func (srv *MultiChannelServer) PeerCount() int {
+	var count int
+	select {
+	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) { count = len(ps) }:
+		<-srv.peerOpDone
+	case <-srv.quit:
+	}
+	return count
+}
+
+// PeerCountByType returns the number of connected peers by type.
+func (srv *MultiChannelServer) PeerCountByType() map[string]uint {
+	pc := map[string]uint{"total": 0}
+	select {
+	case srv.peerOp <- func(ps map[discover.NodeID]*Peer) {
+		for _, peer := range ps {
+			key := ConvertConnTypeToString(peer.ConnType())
+			pc[key]++
+			pc["total"]++
+		}
+	}:
+		<-srv.peerOpDone
+	case <-srv.quit:
+	}
+	return pc
+}
+
+// Peers returns all connected peers.
+func (srv *MultiChannelServer) Peers() []*Peer {
+	var ps []*Peer
+	select {
+	case srv.peerOp <- func(peers map[discover.NodeID]*Peer) {
+		for _, p := range peers {
+			ps = append(ps, p)
+		}
+	}:
+		<-srv.peerOpDone
+	case <-srv.quit:
+	}
+	return ps
+}
+
 // GetListenAddress returns the listen addresses of the server.
 func (srv *MultiChannelServer) GetListenAddress() []string {
 	return srv.ListenAddrs

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -51,8 +51,8 @@ type MultiChannelServer struct {
 // Overrides BaseServer.Stop() to close multiple TCP listeners.
 func (srv *MultiChannelServer) Stop() {
 	srv.lock.Lock()
-	defer srv.lock.Unlock()
 	if !srv.running {
+		srv.lock.Unlock()
 		return
 	}
 	srv.running = false
@@ -67,6 +67,7 @@ func (srv *MultiChannelServer) Stop() {
 	}
 
 	close(srv.quit)   // Ask loops to terminate
+	srv.lock.Unlock() // Unlock to allow loops to finish their remaining jobs.
 	srv.loopWG.Wait() // Wait for loops to terminate
 	srv.logger.Info("Stopped P2P server")
 }

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -38,15 +38,17 @@ import (
 
 // MultiChannelServer is a server that uses a multi channel.
 // It inherits BaseServer. This file only contains overriding methods.
+// There must be a reason to override BaseServer methods.
 type MultiChannelServer struct {
 	*BaseServer
-	listeners      []net.Listener
-	ListenAddrs    []string
-	CandidateConns map[discover.NodeID][]*conn
+	listeners      []net.Listener              // Extended TCP listener
+	ListenAddrs    []string                    // Extended TCP listen addresses
+	CandidateConns map[discover.NodeID][]*conn // Subset of connections towards a premature peer
 }
 
 // Stop terminates the server and all active peer connections.
 // It blocks until all active connections are closed.
+// Overrides BaseServer.Stop() to close multiple TCP listeners.
 func (srv *MultiChannelServer) Stop() {
 	srv.lock.Lock()
 	defer srv.lock.Unlock()
@@ -54,6 +56,8 @@ func (srv *MultiChannelServer) Stop() {
 		return
 	}
 	srv.running = false
+
+	// Stop TCP listeners
 	if srv.listener != nil {
 		// this unblocks listener Accept
 		srv.listener.Close()
@@ -61,8 +65,10 @@ func (srv *MultiChannelServer) Stop() {
 	for _, listener := range srv.listeners {
 		listener.Close()
 	}
-	close(srv.quit)
-	srv.loopWG.Wait()
+
+	close(srv.quit)   // Ask loops to terminate
+	srv.loopWG.Wait() // Wait for loops to terminate
+	srv.logger.Info("Stopped P2P server")
 }
 
 // Start starts running the MultiChannelServer.
@@ -74,110 +80,26 @@ func (srv *MultiChannelServer) Start() (err error) {
 		return errors.New("server already running")
 	}
 	srv.running = true
-	srv.logger = srv.Config.Logger
-	if srv.logger == nil {
-		srv.logger = logger.NewWith()
-	}
-	srv.logger.Info("Starting P2P networking")
 
-	// static fields
-	if srv.PrivateKey == nil {
-		return errors.New("Server.PrivateKey must be set to a non-nil key")
+	if err := srv.initialize(); err != nil {
+		return err
 	}
-
-	if !srv.ConnectionType.Valid() {
-		return errors.New("Invalid connection type speficied")
-	}
-
-	if srv.newTransport == nil {
-		srv.newTransport = newRLPX
-	}
-	if srv.Dialer == nil {
-		srv.Dialer = TCPDialer{&net.Dialer{Timeout: defaultDialTimeout}}
-	}
-	srv.quit = make(chan struct{})
-	srv.addpeer = make(chan *conn)
-	srv.delpeer = make(chan peerDrop)
-	srv.posthandshake = make(chan *conn)
-	srv.addstatic = make(chan *discover.Node)
-	srv.removestatic = make(chan *discover.Node)
-	srv.peerOp = make(chan peerOpFunc)
-	srv.peerOpDone = make(chan struct{})
-	srv.discpeer = make(chan discover.NodeID)
-
-	var (
-		conn      *net.UDPConn
-		realaddr  *net.UDPAddr
-		unhandled chan discover.ReadPacket
-	)
 
 	if !srv.NoDiscovery {
-		addr, err := net.ResolveUDPAddr("udp", srv.ListenAddrs[ConnDefault])
-		if err != nil {
+		if err := srv.startDiscovery(srv.ListenAddrs[ConnDefault]); err != nil {
 			return err
 		}
-		conn, err = net.ListenUDP("udp", addr)
-		if err != nil {
-			return err
-		}
-		realaddr = conn.LocalAddr().(*net.UDPAddr)
-		if srv.NAT != nil {
-			if !realaddr.IP.IsLoopback() {
-				go nat.Map(srv.NAT, srv.quit, "udp", realaddr.Port, realaddr.Port, "klaytn discovery")
-			}
-			// TODO: react to external IP changes over time.
-			if ext, err := srv.NAT.ExternalIP(); err == nil {
-				realaddr = &net.UDPAddr{IP: ext, Port: realaddr.Port}
-			}
-		}
 	}
 
-	// node table
-	if !srv.NoDiscovery {
-		cfg := discover.Config{
-			PrivateKey:    srv.PrivateKey,
-			AnnounceAddr:  realaddr,
-			NodeDBPath:    srv.NodeDatabase,
-			NetRestrict:   srv.NetRestrict,
-			Bootnodes:     srv.BootstrapNodes,
-			Unhandled:     unhandled,
-			Conn:          conn,
-			Addr:          realaddr,
-			Id:            discover.PubkeyID(&srv.PrivateKey.PublicKey),
-			NodeType:      ConvertNodeType(srv.ConnectionType),
-			NetworkID:     srv.NetworkID,
-			DiscoverTypes: srv.DiscoverTypes,
-		}
+	srv.ourHandshake = srv.makeOurHandshakeMsg()
 
-		ntab, err := discover.ListenUDP(&cfg)
-		if err != nil {
-			return err
-		}
-		srv.ntab = ntab
-	}
-
-	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
-
-	// handshake
-	srv.ourHandshake = &protoHandshake{Version: baseProtocolVersion, Name: srv.Name(), ID: discover.PubkeyID(&srv.PrivateKey.PublicKey), Multichannel: true}
-	for _, p := range srv.Protocols {
-		srv.ourHandshake.Caps = append(srv.ourHandshake.Caps, p.cap())
-	}
-	for _, l := range srv.ListenAddrs {
-		s := strings.Split(l, ":")
-		if len(s) == 2 {
-			if port, err := strconv.Atoi(s[1]); err == nil {
-				srv.ourHandshake.ListenPort = append(srv.ourHandshake.ListenPort, uint64(port))
-			}
-		}
-	}
-
-	// listen/dial
 	if srv.NoDial && srv.NoListen {
 		srv.logger.Error("P2P server will be useless, neither dialing nor listening")
 	}
+
+	// Start listening
 	if !srv.NoListen {
-		if srv.ListenAddrs != nil && len(srv.ListenAddrs) != 0 && srv.ListenAddrs[ConnDefault] != "" {
+		if len(srv.ListenAddrs) != 0 && srv.ListenAddrs[ConnDefault] != "" {
 			if err := srv.startListening(); err != nil {
 				return err
 			}
@@ -186,11 +108,43 @@ func (srv *MultiChannelServer) Start() (err error) {
 		}
 	}
 
+	// Start dialing. TODO: Only if !NoDial, start DialSched.
+	dialer := newDialState(srv.StaticNodes, srv.BootstrapNodes, srv.ntab, srv.maxDialedConns(), srv.NetRestrict, srv.PrivateKey, srv.getTypeStatics())
 	srv.loopWG.Add(1)
 	go srv.run(dialer)
-	srv.running = true
+
 	srv.logger.Info("Started P2P server", "id", discover.PubkeyID(&srv.PrivateKey.PublicKey), "multichannel", true)
 	return nil
+}
+
+// Overrides BaseServer.initialize() to add multi channel specific fields.
+func (srv *MultiChannelServer) initialize() error {
+	if err := srv.BaseServer.initialize(); err != nil {
+		return err
+	}
+	srv.listeners = make([]net.Listener, 0, len(srv.SubListenAddr)+1)
+	srv.ListenAddrs = make([]string, 0, len(srv.SubListenAddr)+1)
+	srv.ListenAddrs = append(srv.ListenAddrs, srv.ListenAddr)
+	srv.ListenAddrs = append(srv.ListenAddrs, srv.SubListenAddr...)
+	srv.CandidateConns = make(map[discover.NodeID][]*conn)
+	return nil
+}
+
+// Overrides BaseServer.makeOurHandshakeMsg() to advertise the multiple listen ports.
+func (srv *MultiChannelServer) makeOurHandshakeMsg() *protoHandshake {
+	hs := &protoHandshake{Version: baseProtocolVersion, Name: srv.Name(), ID: discover.PubkeyID(&srv.PrivateKey.PublicKey), Multichannel: true}
+	for _, p := range srv.Protocols {
+		hs.Caps = append(hs.Caps, p.cap())
+	}
+	for _, l := range srv.ListenAddrs {
+		s := strings.Split(l, ":")
+		if len(s) == 2 {
+			if port, err := strconv.Atoi(s[1]); err == nil {
+				hs.ListenPort = append(hs.ListenPort, uint64(port))
+			}
+		}
+	}
+	return hs
 }
 
 // startListening starts listening on the specified port on the server.

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -559,6 +559,16 @@ func (srv *MultiChannelServer) runPeer(p *Peer) {
 	srv.delpeer <- peerDrop{p, err, remoteRequested}
 }
 
+// AddPeer connects to the given node and maintains the connection until the
+// server is shut down. If the connection fails for any reason, the server will
+// attempt to reconnect the peer.
+func (srv *MultiChannelServer) AddPeer(node *discover.Node) {
+	select {
+	case srv.addstatic <- node:
+	case <-srv.quit:
+	}
+}
+
 // GetListenAddress returns the listen addresses of the server.
 func (srv *MultiChannelServer) GetListenAddress() []string {
 	return srv.ListenAddrs

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -372,7 +372,7 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 		}
 
 		p, err = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
-		srv.CandidateConns[c.id] = nil
+		delete(srv.CandidateConns, c.id)
 	} else {
 		p, err = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
 	}

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -437,6 +437,38 @@ func TestServerManyTasks(t *testing.T) {
 	}
 }
 
+func TestServerStopWaitsForPeerWG(t *testing.T) {
+	srv := &SingleChannelServer{
+		&BaseServer{
+			quit:    make(chan struct{}),
+			running: true,
+			logger:  logger.NewWith(),
+		},
+	}
+
+	srv.peerWG.Add(1)
+
+	stopped := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned before peer goroutines finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	srv.peerWG.Done()
+
+	select {
+	case <-stopped:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stop did not return after peer goroutines finished")
+	}
+}
+
 type taskgen struct {
 	newFunc  func(running int, peers map[discover.NodeID]*Peer) []task
 	doneFunc func(task)

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -131,13 +131,13 @@ func startTestMultiChannelServer(t *testing.T, id discover.NodeID, pf func(*Peer
 func makeconn(fd net.Conn, id discover.NodeID) *conn {
 	dialDest, _ := id.Pubkey()
 	tx := newTestTransport(id, fd, dialDest, false)
-	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id, cont: make(chan error)}
+	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id}
 }
 
 func makeMultiChannelConn(fd net.Conn, id discover.NodeID) *conn {
 	dialDest, _ := id.Pubkey()
 	tx := newTestTransport(id, fd, dialDest, true)
-	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id, cont: make(chan error), multiChannel: true}
+	return &conn{fd: fd, transport: tx, flags: staticDialedConn, conntype: common.ConnTypeUndefined, id: id, multiChannel: true}
 }
 
 func TestServerListen(t *testing.T) {
@@ -488,7 +488,7 @@ func TestServerAtCap(t *testing.T) {
 	newconn := func(id discover.NodeID) *conn {
 		fd, _ := net.Pipe()
 		tx := newTestTransport(id, fd, nil, false)
-		return &conn{fd: fd, transport: tx, flags: inboundConn, conntype: common.ConnTypeUndefined, id: id, cont: make(chan error)}
+		return &conn{fd: fd, transport: tx, flags: inboundConn, conntype: common.ConnTypeUndefined, id: id}
 	}
 
 	// Inject a few connections to fill up the peer set.

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -494,7 +494,7 @@ func TestServerAtCap(t *testing.T) {
 	// Inject a few connections to fill up the peer set.
 	for i := 0; i < 10; i++ {
 		c := newconn(randomID())
-		if err := srv.checkpoint(c, srv.addpeer); err != nil {
+		if err := srv.handleAddPeerConn(c); err != nil {
 			t.Fatalf("could not add conn %d: %v", i, err)
 		}
 	}

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -437,38 +437,6 @@ func TestServerManyTasks(t *testing.T) {
 	}
 }
 
-func TestServerStopWaitsForPeerWG(t *testing.T) {
-	srv := &SingleChannelServer{
-		&BaseServer{
-			quit:    make(chan struct{}),
-			running: true,
-			logger:  logger.NewWith(),
-		},
-	}
-
-	srv.peerWG.Add(1)
-
-	stopped := make(chan struct{})
-	go func() {
-		srv.Stop()
-		close(stopped)
-	}()
-
-	select {
-	case <-stopped:
-		t.Fatal("Stop returned before peer goroutines finished")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	srv.peerWG.Done()
-
-	select {
-	case <-stopped:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("Stop did not return after peer goroutines finished")
-	}
-}
-
 type taskgen struct {
 	newFunc  func(running int, peers map[discover.NodeID]*Peer) []task
 	doneFunc func(task)

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -500,12 +500,12 @@ func TestServerAtCap(t *testing.T) {
 	}
 	// Try inserting a non-trusted connection.
 	c := newconn(randomID())
-	if err := srv.checkpoint(c, srv.posthandshake); err != DiscTooManyPeers {
+	if err := srv.handlePostHandshake(c); err != DiscTooManyPeers {
 		t.Error("wrong error for insert:", err)
 	}
 	// Try inserting a trusted connection.
 	c = newconn(trustedID)
-	if err := srv.checkpoint(c, srv.posthandshake); err != nil {
+	if err := srv.handlePostHandshake(c); err != nil {
 		t.Error("unexpected error for trusted conn @posthandshake:", err)
 	}
 	if !c.is(trustedConn) {

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -31,33 +31,6 @@ import (
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 )
 
-// decreasesConnectionMetric decreases the metric of the number of peer connections.
-func decreasesConnectionMetric(inboundCount int, outboundCount int, p *Peer) (int, int) {
-	pInbound, pOutbound := p.GetNumberInboundAndOutbound()
-	inboundCount -= pInbound
-	outboundCount -= pOutbound
-
-	updatesConnectionMetric(inboundCount, outboundCount)
-	return inboundCount, outboundCount
-}
-
-// increasesConnectionMetric increases the metric of the number of peer connections.
-func increasesConnectionMetric(inboundCount int, outboundCount int, p *Peer) (int, int) {
-	pInbound, pOutbound := p.GetNumberInboundAndOutbound()
-	inboundCount += pInbound
-	outboundCount += pOutbound
-
-	updatesConnectionMetric(inboundCount, outboundCount)
-	return inboundCount, outboundCount
-}
-
-// updatesConnectionMetric updates the metric of the number of peer connections.
-func updatesConnectionMetric(inboundCount int, outboundCount int) {
-	connectionCountGauge.Update(int64(outboundCount + inboundCount))
-	connectionInCountGauge.Update(int64(inboundCount))
-	connectionOutCountGauge.Update(int64(outboundCount))
-}
-
 type peerDrop struct {
 	*Peer
 	err       error

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -58,8 +58,6 @@ func updatesConnectionMetric(inboundCount int, outboundCount int) {
 	connectionOutCountGauge.Update(int64(outboundCount))
 }
 
-type peerOpFunc func(map[discover.NodeID]*Peer)
-
 type peerDrop struct {
 	*Peer
 	err       error
@@ -108,7 +106,6 @@ type conn struct {
 	transport
 	flags        connFlag
 	conntype     common.ConnType // valid after the encryption handshake at the inbound connection case
-	cont         chan error      // The run loop uses cont to signal errors to SetupConn.
 	id           discover.NodeID // valid after the encryption handshake
 	caps         []Cap           // valid after the protocol handshake
 	name         string          // valid after the protocol handshake


### PR DESCRIPTION
## Proposed changes

- Refactor the huge `Start()` into smaller functions: `initialize()`, `startDiscovery()`, `makeOurHandshakeMsg()`.
- Refactor the metric reporting code snippets.
- Replaces the event-loop request channels in `p2p.Server` with `srv.lock`-serialized direct methods.
  - The `peer` and related variables reside in the `BaseServer struct`.
  - The `dialstate` task loop remains, but will be removed later by introducing `DialSched`.

Before | After
-- | --
chan addstatic | AddPeer() directly updates dialstate under srv.lock and wakes the dial loop
chan removestatic | RemovePeer() directly updates dialstate under srv.lock
chan peerOp, peerOpDone | Peers(), PeerCount(), PeerCountByType(), and PeersInfo() read state directly under srv.lock
chan posthandshake | setupConn() directly calls handlePostHandshake() 
chan addpeer | setupConn() directly calls handleAddPeerConn()
chan delpeer | runPeer() calls handleDelPeer() directly
chan discpeer | Disconnect() calls handleDiscPeer() directly
shutdown waiting via `for { <-delpeer }` | `peerWG.Wait()`

- Note that important operations are all protected by `srv.lock`:
```
[ External callers ] no server lock held

[ Internal background loops ]
- run(), listenLoop(), runPeer(), setupConn()
-> mostly lock-free orchestration

[ Internal critical sections ]
- Start(), Stop()
- AddPeer(), RemovePeer(), Disconnect(), Peers(), PeerCount(), PeerCountByType(),
- handlePostHandshake(), handleAddPeerConn(), handleDelPeer()
-> serialized by srv.lock
```

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- #751 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
