### PR TITLE
p2p/discover: Introduce alternative Table2 and Discovery2

### DIFF
--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -47,6 +47,7 @@ type discovery interface {
 	GetNodes(targetType discover.NodeType, max int) []*discover.Node
 	ReadRandomNodes(buf []*discover.Node, nType discover.NodeType) int
 	Lookup(target discover.NodeID, targetType discover.NodeType) []*discover.Node
+	Close()
 }
 
 type DialConfig struct {

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -537,6 +537,9 @@ func (m *mockTable) ReadRandomNodes(buf []*discover.Node, nType discover.NodeTyp
 	return copy(buf, m.randomByType[nType])
 }
 
+func (m *mockTable) Close() {
+}
+
 //// Dialer (Dial, DialMulti) mocks.
 
 type mockDialer struct {

--- a/networks/p2p/discover/discovery.go
+++ b/networks/p2p/discover/discovery.go
@@ -16,6 +16,13 @@
 
 package discover
 
+import (
+	"crypto/ecdsa"
+	"net"
+
+	"github.com/kaiachain/kaia/networks/p2p/netutil"
+)
+
 type Discovery2 interface {
 	// Lifecycle. Used by p2p.Server.
 	Close()
@@ -28,6 +35,33 @@ type Discovery2 interface {
 
 	// Update authorized nodes. To be used by permless.
 	PutAuthorizedNodes(nodes []*Node)
+}
+
+// Config holds Table-related settings.
+type Config struct {
+	NetworkID uint64
+	// These settings are required and configure the UDP listener:
+	PrivateKey *ecdsa.PrivateKey
+
+	// These settings are optional:
+	AnnounceAddr *net.UDPAddr     // local address announced in the DHT
+	NodeDBPath   string           // if set, the node database is stored at this filesystem location
+	NetRestrict  *netutil.Netlist // network whitelist
+	Bootnodes    []*Node          // list of bootstrap nodes
+
+	// These settings are required for create Table and UDP
+	Id       NodeID
+	Addr     *net.UDPAddr
+	udp      transport
+	Conn     conn
+	NodeType NodeType
+
+	// These settings are required for discovery packet control
+	MaxNeighborsNode uint
+	AuthorizedNodes  []*Node
+
+	// DiscoverNodetype is list of node type to enable discovery.
+	DiscoverTypes DiscoverTypesConfig
 }
 
 func NewDiscovery2(cfg *Config) (Discovery2, error) {

--- a/networks/p2p/discover/discovery.go
+++ b/networks/p2p/discover/discovery.go
@@ -65,6 +65,20 @@ type Config struct {
 }
 
 // discovery2 combines a UDP transport and a Table2 into a Discovery2 implementation.
+//
+// Lifecycle: UDP is started before Table (udp.Start -> tab.Start) and stopped after
+// (tab.Close -> udp.close), treating UDP as the transport layer and Table as the application.
+//
+// Table -> UDP calls (originating from the maintenance loops):
+//   - revalidateLoop tick -> revalidateOnce()     -> udp.ping()
+//   - refreshLoop         -> Bond() -> pingpong() -> udp.ping(), udp.waitping()
+//   - refreshLoop         -> findNodesOnce()      -> udp.findnode()
+//
+// UDP -> Table calls (originating from udp.readLoop dispatching packet handlers):
+//   - incoming PING     -> ping.preverify()     -> tab.IsAuthorized()  works even before tab.Start or after tab.Close
+//   - incoming FINDNODE -> findnode.preverify() -> tab.IsBonded()      same as above
+//   - incoming FINDNODE -> findnode.handle()    -> tab.ClosestNodes()  same as above
+//   - incoming PING     -> go t.bond(...)       -> go tab.Bond()       no-op before tab.Start or after tab.Close
 type discovery2 struct {
 	tab *Table2
 	udp *udp

--- a/networks/p2p/discover/discovery.go
+++ b/networks/p2p/discover/discovery.go
@@ -64,6 +64,36 @@ type Config struct {
 	DiscoverTypes DiscoverTypesConfig
 }
 
+// discovery2 combines a UDP transport and a Table2 into a Discovery2 implementation.
+type discovery2 struct {
+	tab *Table2
+	udp *udp
+}
+
 func NewDiscovery2(cfg *Config) (Discovery2, error) {
-	return nil, nil
+	udp := newUDPv4(cfg)
+	tab, err := newTable2(cfg, udp)
+	if err != nil {
+		return nil, err
+	}
+	udp.Start(tab)
+	tab.Start()
+	return &discovery2{tab: tab, udp: udp}, nil
+}
+
+func (d *discovery2) Close() {
+	d.tab.Close()
+	d.udp.close()
+}
+
+func (d *discovery2) Refresh() {
+	d.tab.Refresh()
+}
+
+func (d *discovery2) RandomNodes(buf []*Node, nType NodeType) int {
+	return d.tab.RandomNodes(buf, nType)
+}
+
+func (d *discovery2) PutAuthorizedNodes(nodes []*Node) {
+	d.tab.PutAuthorizedNodes(nodes)
 }

--- a/networks/p2p/discover/discovery.go
+++ b/networks/p2p/discover/discovery.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+type Discovery2 interface {
+	// Lifecycle. Used by p2p.Server.
+	Close()
+
+	// Trigger a refresh of the discovery table and wait for completion.
+	Refresh()
+
+	// Serve discovered nodes. Used by p2p.DialSched.
+	RandomNodes(buf []*Node, nType NodeType) int
+
+	// Update authorized nodes. To be used by permless.
+	PutAuthorizedNodes(nodes []*Node)
+}
+
+func NewDiscovery2(cfg *Config) (Discovery2, error) {
+	return nil, nil
+}

--- a/networks/p2p/discover/discovery_test.go
+++ b/networks/p2p/discover/discovery_test.go
@@ -1,0 +1,85 @@
+package discover
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiscovery_MainnetBootnodes is an end-to-end integration test that
+// connects to the real Kaia mainnet bootnodes and discovers peers from an EN's perspective.
+func TestDiscovery_MainnetBootnodes(t *testing.T) {
+	// Enable only if P2P_DISCOVER_E2E_TEST is set
+	if os.Getenv("P2P_DISCOVER_E2E_TEST") == "" {
+		t.Skip("skipping p2p/discover end-to-end test")
+	}
+	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
+
+	// Load mainnet bootnodes for EN users
+	urls := params.MainnetBootnodes[common.ENDPOINTNODE].Addrs
+	oldLookupIPFunc := lookupIPFunc
+	lookupIPFunc = net.LookupIP
+	defer func() {
+		lookupIPFunc = oldLookupIPFunc
+	}()
+	bootnodes := make([]*Node, 0, len(urls))
+	for _, url := range urls {
+		node, err := ParseNode(url)
+		require.NoError(t, err, "failed to parse bootnode URL: %s", url)
+		bootnodes = append(bootnodes, node)
+	}
+
+	// Generate an ephemeral key for this test node
+	key, err := crypto.GenerateKey()
+	assert.NoError(t, err)
+
+	// Listen on a random UDP port
+	udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	assert.NoError(t, err)
+	defer udpConn.Close()
+
+	addr := udpConn.LocalAddr().(*net.UDPAddr)
+	t.Logf("Listening on %v", addr)
+
+	// Start the discovery stack.
+	cfg := &Config{
+		NetworkID:  params.MainnetNetworkId,
+		PrivateKey: key,
+		Bootnodes:  bootnodes,
+		Id:         PubkeyID(&key.PublicKey),
+		Addr:       addr,
+		Conn:       udpConn,
+		NodeType:   NodeTypeEN,
+		DiscoverTypes: DiscoverTypesConfig{
+			EN: true,
+		},
+	}
+	disc, err := NewDiscovery2(cfg)
+	assert.NoError(t, err)
+	defer disc.Close()
+
+	// Refresh contacts the bootnodes and populates the table
+	disc.Refresh()
+	t.Logf("Refreshed the discovery table")
+
+	// Print nodes in the table
+	for _, ty := range []NodeType{NodeTypeCN, NodeTypePN, NodeTypeEN, NodeTypeBN} {
+		buf := make([]*Node, 100)
+		found := disc.RandomNodes(buf, ty)
+		t.Logf("Found %d %s nodes (including initial bootnodes)", found, StringNodeType(ty))
+		for i := 0; i < found && i < 10; i++ {
+			n := buf[i]
+			t.Logf("  [%d] %x@%s:%d (type=%s)", i, n.ID[:8], n.IP, n.UDP, StringNodeType(n.NType))
+		}
+		if found > 10 {
+			t.Logf("  ... and more")
+		}
+	}
+}

--- a/networks/p2p/discover/table_bond.go
+++ b/networks/p2p/discover/table_bond.go
@@ -145,41 +145,16 @@ func (tab *Table2) Bond(pinged bool, n *Node) error {
 		return nil
 	}
 
-	// Check for already ongoing bonding task.
-	tab.bondmu.Lock()
-	task := tab.bonding[n.ID]
-	if task != nil {
-		// Wait for an existing bonding task to complete.
-		tab.bondmu.Unlock()
-		<-task.done
-		return task.err
-	} else {
-		// Or register a new bonding task.
-		task = &bondtask{done: make(chan struct{})}
-		tab.bonding[n.ID] = task
-		tab.bondmu.Unlock()
-	}
-
-	// Execute the bonding task.
-	// Work outside of bondmu because pingpong might take a while.
-	tab.pingpong(task, pinged, n)
-
-	// Persist the bond result before unregistering the task.
-	// This order matters: recordBonded must be called while bonding[n.ID] is
-	// still registered so that any concurrent Bond() caller that unblocks from
-	// <-task.done and then immediately calls Bond() again will see
-	// canAssumeBonded=true and skip pingpong, avoiding a double-ping race.
-	if task.err == nil {
-		tab.addNode(n)
-		tab.recordBonded(n)
-	}
-
-	// Unregister the task after the bond result is persisted.
-	tab.bondmu.Lock()
-	delete(tab.bonding, n.ID)
-	tab.bondmu.Unlock()
-
-	return task.err
+	// Deduplicate concurrent Bond() calls for the same node.
+	_, err, _ := tab.bondGroup.Do(n.ID.String(), func() (interface{}, error) {
+		err := tab.pingpong(pinged, n)
+		if err == nil {
+			tab.addNode(n)
+			tab.recordBonded(n)
+		}
+		return nil, err
+	})
+	return err
 }
 
 // Finish the 4-way handshake:
@@ -187,14 +162,13 @@ func (tab *Table2) Bond(pinged bool, n *Node) error {
 // 2. self <-PONG-- remote udp.ping():pending(pong)
 // 3. self <-PING-- remote udp.waitping():pending(ping)  if !pinged
 // 4. self --PONG-> remote ping.handle()                 if !pinged
-func (tab *Table2) pingpong(task *bondtask, pinged bool, n *Node) {
+func (tab *Table2) pingpong(pinged bool, n *Node) error {
 	<-tab.bondslots                                // Acquire a bonding slot to limit network usage.
 	defer func() { tab.bondslots <- struct{}{} }() // Release the bonding slot.
-	defer close(task.done)
 
 	// Ping the remote side and wait for a pong.
-	if task.err = tab.udp.ping(n.ID, n.addr()); task.err != nil {
-		return
+	if err := tab.udp.ping(n.ID, n.addr()); err != nil {
+		return err
 	}
 	if !pinged {
 		// Give the remote node a chance to ping us before we start
@@ -202,6 +176,7 @@ func (tab *Table2) pingpong(task *bondtask, pinged bool, n *Node) {
 		// waitping will simply time out.
 		tab.udp.waitping(n.ID, n.IP)
 	}
+	return nil
 }
 
 // A node is assumed to be bonded if all values are recently written by recordBonded().
@@ -219,11 +194,4 @@ func (tab *Table2) recordBonded(n *Node) {
 
 	bucketEntriesGauge.Update(int64(tab.len()))
 	bucketReplacementsGauge.Update(int64(tab.numReplacements()))
-}
-
-type bondtask struct {
-	// Task caller (Bond) waits for this channel to be closed, then harvest the result (err).
-	// Task worker (pingpong) closes this channel when done.
-	done chan struct{}
-	err  error
 }

--- a/networks/p2p/discover/table_bond.go
+++ b/networks/p2p/discover/table_bond.go
@@ -25,8 +25,8 @@ import (
 var (
 	revalidateBackoff = 10 * time.Second // Do not revalidate (ping) a node within this duration.
 
-	errSelfBonding         = errors.New("cannot bond with self")
-	errTableNotInitialized = errors.New("table not yet initialized")
+	errSelfBonding   = errors.New("cannot bond with self")
+	errTableNotReady = errors.New("table not ready")
 )
 
 //// Periodic revalidation
@@ -132,8 +132,14 @@ func (tab *Table2) Bond(pinged bool, n *Node) error {
 	// Do not accept inbound (i.e. remote pinged me) bonding requests before
 	// populating from my seeds. It prevents remote nodes from filling up the table by spamming.
 	if pinged && !tab.initialized() {
-		return errTableNotInitialized
+		return errTableNotReady
 	}
+	// Do not attempt bonding if the table is closed. Could happen after tab.Close() and before udp.close()
+	// You can't write to the closed DB.
+	if tab.closed.Load() {
+		return errTableNotReady
+	}
+
 	// Skip if we're really sure that this node is reachable and completed the bonding process.
 	if tab.canAssumeBonded(n.ID) {
 		return nil

--- a/networks/p2p/discover/table_bond.go
+++ b/networks/p2p/discover/table_bond.go
@@ -1,0 +1,223 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	revalidateBackoff = 10 * time.Second // Do not revalidate (ping) a node within this duration.
+
+	errSelfBonding         = errors.New("cannot bond with self")
+	errTableNotInitialized = errors.New("table not yet initialized")
+)
+
+//// Periodic revalidation
+
+func (tab *Table2) revalidateLoop() {
+	timer := time.NewTimer(revalidateInterval)
+	defer tab.wg.Done()
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			tab.doRevalidate()
+			timer.Reset(revalidateInterval)
+		case <-tab.closeReq:
+			return
+		}
+	}
+}
+
+func (tab *Table2) doRevalidate() {
+	for _, s := range tab.storages {
+		tab.revalidateOnce(s)
+	}
+}
+
+func (tab *Table2) revalidateOnce(s tableStorage) {
+	n := s.oldest() // pick a node to revalidate.
+	if n == nil {
+		return
+	}
+
+	if tab.bondAge(n.ID) < revalidateBackoff {
+		logger.Trace("skip revalidate", "node", n.addr())
+		return
+	}
+
+	err := tab.udp.ping(n.ID, n.addr())
+	if err == nil {
+		s.add(n) // bump the node
+		tab.db.updateBondTime(n.ID, time.Now())
+		logger.Debug("Discovery revalidation passed", "node", n.addr())
+	} else {
+		s.delete(n)
+		tab.db.deleteNode(n.ID)
+		logger.Debug("Discovery revalidation failed", "node", n.addr())
+	}
+}
+
+// Returns the time since the last bond with the given node.
+// If the node is not bonded, return a very large duration.
+func (tab *Table2) bondAge(id NodeID) time.Duration {
+	return time.Since(tab.db.bondTime(id))
+}
+
+//// Bonding primitives
+
+// bondall bonds with all given nodes concurrently and returns those
+// nodes for which bonding has probably succeeded. Return the nodes
+// for which bonding succeeded.
+func (tab *Table2) bondall(nodes []*Node) []*Node {
+	rc := make(chan *Node, len(nodes))
+	wg := sync.WaitGroup{}
+	for i := range nodes {
+		wg.Add(1)
+		n := nodes[i]
+		go func(n *Node) {
+			defer wg.Done()
+			if err := tab.Bond(false, n); err == nil {
+				rc <- n
+			}
+		}(n)
+	}
+	wg.Wait()
+	close(rc)
+
+	result := make([]*Node, 0, len(nodes))
+	for n := range rc {
+		result = append(result, n)
+	}
+	return result
+}
+
+// Bond ensures the local node has a bond with the given remote node.
+// It also attempts to insert the node into the table if bonding succeeds.
+//
+// A bond is must be established before sending findnode requests.
+// Both sides must have completed a ping/pong exchange for a bond to
+// exist. The total number of active bonding processes is limited in
+// order to restrain network use.
+//
+// bond is meant to operate idempotently in that bonding with a remote
+// node which still remembers a previously established bond will work.
+// The remote node will simply not send a ping back, causing waitping
+// to time out.
+//
+// If pinged is true, the remote node has just pinged us and one half
+// of the process can be skipped.
+func (tab *Table2) Bond(pinged bool, n *Node) error {
+	if n.ID == tab.selfID {
+		return errSelfBonding
+	}
+	// Do not accept inbound (i.e. remote pinged me) bonding requests before
+	// populating from my seeds. It prevents remote nodes from filling up the table by spamming.
+	if pinged && !tab.initialized() {
+		return errTableNotInitialized
+	}
+	// Skip if we're really sure that this node is reachable and completed the bonding process.
+	if tab.canAssumeBonded(n.ID) {
+		return nil
+	}
+
+	// Check for already ongoing bonding task.
+	tab.bondmu.Lock()
+	task := tab.bonding[n.ID]
+	if task != nil {
+		// Wait for an existing bonding task to complete.
+		tab.bondmu.Unlock()
+		<-task.done
+		return task.err
+	} else {
+		// Or register a new bonding task.
+		task = &bondtask{done: make(chan struct{})}
+		tab.bonding[n.ID] = task
+		tab.bondmu.Unlock()
+	}
+
+	// Execute the bonding task.
+	// Work outside of bondmu because pingpong might take a while.
+	tab.pingpong(task, pinged, n)
+
+	// Persist the bond result before unregistering the task.
+	// This order matters: recordBonded must be called while bonding[n.ID] is
+	// still registered so that any concurrent Bond() caller that unblocks from
+	// <-task.done and then immediately calls Bond() again will see
+	// canAssumeBonded=true and skip pingpong, avoiding a double-ping race.
+	if task.err == nil {
+		tab.addNode(n)
+		tab.recordBonded(n)
+	}
+
+	// Unregister the task after the bond result is persisted.
+	tab.bondmu.Lock()
+	delete(tab.bonding, n.ID)
+	tab.bondmu.Unlock()
+
+	return task.err
+}
+
+// Finish the 4-way handshake:
+// 1. self --PING-> remote udp.ping():write(ping)
+// 2. self <-PONG-- remote udp.ping():pending(pong)
+// 3. self <-PING-- remote udp.waitping():pending(ping)  if !pinged
+// 4. self --PONG-> remote ping.handle()                 if !pinged
+func (tab *Table2) pingpong(task *bondtask, pinged bool, n *Node) {
+	<-tab.bondslots                                // Acquire a bonding slot to limit network usage.
+	defer func() { tab.bondslots <- struct{}{} }() // Release the bonding slot.
+	defer close(task.done)
+
+	// Ping the remote side and wait for a pong.
+	if task.err = tab.udp.ping(n.ID, n.addr()); task.err != nil {
+		return
+	}
+	if !pinged {
+		// Give the remote node a chance to ping us before we start
+		// sending findnode requests. If they still remember us,
+		// waitping will simply time out.
+		tab.udp.waitping(n.ID, n.IP)
+	}
+}
+
+// A node is assumed to be bonded if all values are recently written by recordBonded().
+func (tab *Table2) canAssumeBonded(id NodeID) bool {
+	recentlyBonded := tab.db.hasBond(id)
+	neverFailed := tab.db.findFails(id) == 0
+	storedInDB := tab.db.node(id) != nil
+	return recentlyBonded && neverFailed && storedInDB
+}
+
+func (tab *Table2) recordBonded(n *Node) {
+	tab.db.updateBondTime(n.ID, time.Now())
+	tab.db.updateFindFails(n.ID, 0)
+	tab.db.updateNode(n)
+
+	bucketEntriesGauge.Update(int64(tab.len()))
+	bucketReplacementsGauge.Update(int64(tab.numReplacements()))
+}
+
+type bondtask struct {
+	// Task caller (Bond) waits for this channel to be closed, then harvest the result (err).
+	// Task worker (pingpong) closes this channel when done.
+	done chan struct{}
+	err  error
+}

--- a/networks/p2p/discover/table_bond_test.go
+++ b/networks/p2p/discover/table_bond_test.go
@@ -138,7 +138,7 @@ func Test_Table_Bond_notInitialized(t *testing.T) {
 	// init is false by default; pinged=true triggers the check.
 	n := newTestNode(t, NodeTypeEN)
 	err := tab.Bond(true, n)
-	assert.ErrorIs(t, err, errTableNotInitialized)
+	assert.ErrorIs(t, err, errTableNotReady)
 }
 
 func Test_Table_Bond_happy(t *testing.T) {

--- a/networks/p2p/discover/table_bond_test.go
+++ b/networks/p2p/discover/table_bond_test.go
@@ -182,7 +182,7 @@ func Test_Table_Bond_duplicate(t *testing.T) {
 	}()
 	<-pingEntered // Wait until the first Bond has registered its task and is executing ping.
 
-	// The second Bond call should find the in-flight task and wait on task.done.
+	// The second Bond call should join the in-flight singleflight call and wait for it.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -195,12 +195,6 @@ func Test_Table_Bond_duplicate(t *testing.T) {
 		runtime.Gosched()
 	}
 
-	// Verify the bonding map still holds the task.
-	// Thread 1 is stuck at pingpong() waiting for transport.ping(), Thread 2 is stuck at Bond() waiting for task.done.
-	tab.bondmu.Lock()
-	assert.NotNil(t, tab.bonding[n.ID], "bonding task should be registered")
-	tab.bondmu.Unlock()
-
 	// If duplicate suppression is broken, a second ping enters while the first is blocked.
 	select {
 	case <-pingEntered:
@@ -210,11 +204,6 @@ func Test_Table_Bond_duplicate(t *testing.T) {
 
 	close(pingBlocker) // release the in-flight ping
 	wg.Wait()
-
-	// The bonding map must be cleared after completion.
-	tab.bondmu.Lock()
-	assert.Nil(t, tab.bonding[n.ID], "bonding task should be removed after completion")
-	tab.bondmu.Unlock()
 
 	// Both callers should receive the same (nil) error.
 	assert.NoError(t, err1)

--- a/networks/p2p/discover/table_bond_test.go
+++ b/networks/p2p/discover/table_bond_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Table_revalidateOnce_success(t *testing.T) {
+	udp := newMockTransport()
+	tab := newTestTable2(t, udp)
+
+	n := newTestNode(t, NodeTypeEN)
+	s := newFlatStorage(newSharedRand())
+	s.add(n)
+	require.Equal(t, 1, s.len())
+
+	tab.revalidateOnce(s)
+
+	// Node is still in storage (bumped to front on success).
+	assert.Equal(t, 1, s.len())
+	// Bond time is updated in the database.
+	assert.True(t, tab.db.hasBond(n.ID), "bondTime should be recent after successful revalidation")
+	assert.Equal(t, int32(1), udp.pingCnt.Load())
+}
+
+func Test_Table_revalidateOnce_failure(t *testing.T) {
+	udp := newMockTransport()
+	tab := newTestTable2(t, udp)
+
+	n := newTestNode(t, NodeTypeEN)
+	s := newFlatStorage(newSharedRand())
+	s.add(n)
+	require.Equal(t, 1, s.len())
+
+	// Pre-store the node in the DB so we can verify it gets deleted.
+	tab.db.updateNode(n)
+	require.NotNil(t, tab.db.node(n.ID))
+
+	udp.setPingErr(n.ID, errTimeout)
+	tab.revalidateOnce(s)
+
+	// Node is removed from storage on failure.
+	assert.Equal(t, 0, s.len())
+	// Node is deleted from the database.
+	assert.Nil(t, tab.db.node(n.ID), "node should be deleted from DB after failed revalidation")
+	assert.Equal(t, int32(1), udp.pingCnt.Load())
+}
+
+// Test_Table_bondall_nonBlocking verifies that bondall runs bonds concurrently:
+// even if node A's ping is blocked, node B's ping can complete simultaneously.
+// If bondall were serialising, B could never complete while A is stuck.
+func Test_Table_bondall_nonBlocking(t *testing.T) {
+	nodeA := newTestNode(t, NodeTypeEN)
+	nodeB := newTestNode(t, NodeTypeEN)
+
+	bDone := make(chan struct{})       // closed when B's ping finishes
+	aCanProceed := make(chan struct{}) // closed to unblock A's ping
+
+	udp := newMockTransport()
+	udp.pingFn = func(id NodeID, addr *net.UDPAddr) error {
+		if id == nodeA.ID {
+			<-aCanProceed // blocked until B has already finished
+			return errTimeout
+		}
+		// nodeB: succeed and signal completion
+		close(bDone)
+		return nil
+	}
+	tab := newTestTable2(t, udp)
+
+	resultCh := make(chan []*Node, 1)
+	go func() { resultCh <- tab.bondall([]*Node{nodeA, nodeB}) }()
+
+	// B's ping must complete concurrently while A is still blocked.
+	<-bDone
+	close(aCanProceed) // release A
+
+	result := <-resultCh
+	// Only B bonded successfully.
+	require.Len(t, result, 1)
+	assert.Equal(t, nodeB.ID, result[0].ID)
+}
+
+func Test_Table_bondall_filtering(t *testing.T) {
+	n1 := newTestNode(t, NodeTypeEN)
+	n2 := newTestNode(t, NodeTypeEN)
+	n3 := newTestNode(t, NodeTypeEN)
+
+	udp := newMockTransport()
+	udp.setPingErr(n2.ID, errTimeout) // n2 fails
+	tab := newTestTable2(t, udp)
+
+	result := tab.bondall([]*Node{n1, n2, n3})
+
+	// Only n1 and n3 should be returned.
+	assert.Len(t, result, 2)
+	ids := make(map[NodeID]bool)
+	for _, n := range result {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids[n1.ID], "n1 (success) should be in result")
+	assert.False(t, ids[n2.ID], "n2 (failure) should not be in result")
+	assert.True(t, ids[n3.ID], "n3 (success) should be in result")
+}
+
+func Test_Table_Bond_selfBonding(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	// tab.selfID is NodeID{} (zero); bond to self must be rejected.
+	self := NewNode(NodeID{}, net.IP{127, 0, 0, 1}, 30303, 30303, nil, NodeTypeEN)
+	err := tab.Bond(false, self)
+	assert.ErrorIs(t, err, errSelfBonding)
+}
+
+func Test_Table_Bond_notInitialized(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	// init is false by default; pinged=true triggers the check.
+	n := newTestNode(t, NodeTypeEN)
+	err := tab.Bond(true, n)
+	assert.ErrorIs(t, err, errTableNotInitialized)
+}
+
+func Test_Table_Bond_happy(t *testing.T) {
+	udp := newMockTransport()
+	tab := newTestTable2(t, udp)
+
+	n := newTestNode(t, NodeTypeEN)
+	err := tab.Bond(false, n)
+
+	require.NoError(t, err)
+	// Node should be added to the EN storage.
+	assert.Equal(t, 1, tab.storages[NodeTypeEN].len(), "node should appear in EN storage")
+	// DB should reflect successful bonding.
+	assert.True(t, tab.db.hasBond(n.ID), "DB bond time should be set")
+	assert.NotNil(t, tab.db.node(n.ID), "DB should store the node")
+	assert.Equal(t, 0, tab.db.findFails(n.ID), "DB find failures should be 0")
+	assert.Equal(t, int32(1), udp.pingCnt.Load())
+}
+
+func Test_Table_Bond_duplicate(t *testing.T) {
+	n := newTestNode(t, NodeTypeEN)
+	pingEntered := make(chan struct{}, 2)
+	pingBlocker := make(chan struct{})
+	udp := newMockTransport()
+	udp.pingFn = func(id NodeID, addr *net.UDPAddr) error {
+		pingEntered <- struct{}{}
+		<-pingBlocker
+		return nil
+	}
+	tab := newTestTable2(t, udp)
+
+	var err1, err2 error
+	var wg sync.WaitGroup
+	secondStarted := make(chan struct{})
+
+	// The first Bond call should register a task and execute ping.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err1 = tab.Bond(false, n)
+	}()
+	<-pingEntered // Wait until the first Bond has registered its task and is executing ping.
+
+	// The second Bond call should find the in-flight task and wait on task.done.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(secondStarted)
+		err2 = tab.Bond(false, n)
+	}()
+	<-secondStarted
+	for i := 0; i < 100; i++ {
+		// Give the second goroutine a scheduling chance to reach Bond().
+		runtime.Gosched()
+	}
+
+	// Verify the bonding map still holds the task.
+	// Thread 1 is stuck at pingpong() waiting for transport.ping(), Thread 2 is stuck at Bond() waiting for task.done.
+	tab.bondmu.Lock()
+	assert.NotNil(t, tab.bonding[n.ID], "bonding task should be registered")
+	tab.bondmu.Unlock()
+
+	// If duplicate suppression is broken, a second ping enters while the first is blocked.
+	select {
+	case <-pingEntered:
+		t.Fatal("duplicate Bond should not issue a second ping while first ping is blocked")
+	default:
+	}
+
+	close(pingBlocker) // release the in-flight ping
+	wg.Wait()
+
+	// The bonding map must be cleared after completion.
+	tab.bondmu.Lock()
+	assert.Nil(t, tab.bonding[n.ID], "bonding task should be removed after completion")
+	tab.bondmu.Unlock()
+
+	// Both callers should receive the same (nil) error.
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+
+	// Only one actual ping must have been issued.
+	assert.Equal(t, int32(1), udp.pingCnt.Load())
+}
+
+func Test_Table_Bond_recentlyBonded(t *testing.T) {
+	udp := newMockTransport()
+	tab := newTestTable2(t, udp)
+
+	n := newTestNode(t, NodeTypeEN)
+	// Simulate a previous successful bond: write bond time + node + findFails=0 into DB.
+	tab.recordBonded(n)
+
+	// canAssumeBonded requires node to be stored in DB too.
+	require.NotNil(t, tab.db.node(n.ID))
+	require.True(t, tab.db.hasBond(n.ID))
+	require.Equal(t, 0, tab.db.findFails(n.ID))
+
+	err := tab.Bond(false, n)
+
+	require.NoError(t, err)
+	// ping must not be called because the node is assumed to be bonded.
+	assert.Equal(t, int32(0), udp.pingCnt.Load(), "ping should be skipped for a recently bonded node")
+}
+
+// mockTransport is a transport whose ping and findnode behaviour is configurable per NodeID.
+type mockTransport struct {
+	// pingFn, if non-nil, is called instead of the per-node error map.
+	// Useful for tests that need blocking, concurrency signals, etc.
+	pingFn func(NodeID, *net.UDPAddr) error
+	// findnodeFn, if non-nil, overrides the default (return nil, nil).
+	findnodeFn func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error)
+
+	mu      sync.Mutex
+	pingErr map[NodeID]error // nil by default, indicating success
+
+	pingCnt atomic.Int32 // total ping() invocations
+}
+
+func newMockTransport() *mockTransport {
+	return &mockTransport{pingErr: make(map[NodeID]error)}
+}
+
+// setPingErr configures the error returned by ping() for the given node.
+func (m *mockTransport) setPingErr(id NodeID, err error) {
+	m.mu.Lock()
+	m.pingErr[id] = err
+	m.mu.Unlock()
+}
+
+func (m *mockTransport) ping(toid NodeID, toaddr *net.UDPAddr) error {
+	m.pingCnt.Add(1)
+	if m.pingFn != nil {
+		return m.pingFn(toid, toaddr)
+	}
+	m.mu.Lock()
+	err := m.pingErr[toid]
+	m.mu.Unlock()
+	return err
+}
+
+func (m *mockTransport) waitping(from NodeID, fromIP net.IP) error { return nil }
+func (m *mockTransport) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID, nType NodeType, max int) ([]*Node, error) {
+	if m.findnodeFn != nil {
+		return m.findnodeFn(toid, toaddr, target, nType, max)
+	}
+	return nil, nil
+}
+func (m *mockTransport) close() {}

--- a/networks/p2p/discover/table_data.go
+++ b/networks/p2p/discover/table_data.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"github.com/kaiachain/kaia/crypto"
+)
+
+func (tab *Table2) RandomNodes(buf []*Node, targetType NodeType) int {
+	if s := tab.storages[targetType]; s == nil {
+		return 0
+	} else {
+		return s.random(buf)
+	}
+}
+
+func (tab *Table2) ClosestNodes(targetID NodeID, targetType NodeType, max int) []*Node {
+	if s := tab.storages[targetType]; s == nil {
+		return nil
+	} else {
+		return s.closest(crypto.Keccak256Hash(targetID[:]), max).entries
+	}
+}
+
+func (tab *Table2) PutAuthorizedNodes(nodes []*Node) {
+	// TODO: implement
+}
+
+func (tab *Table2) IsAuthorized(id NodeID, nType NodeType) bool {
+	return true // TODO: read or mem
+}
+
+func (tab *Table2) IsBonded(id NodeID) bool {
+	return tab.bondAge(id) < nodeDBNodeExpiration
+}
+
+//// Wrappers for underlying storages.
+
+// Note that Bootnodes are counted multiple times because they are added to all storages.
+func (tab *Table2) len() int {
+	n := 0
+	for _, s := range tab.storages {
+		n += s.len()
+	}
+	return n
+}
+
+func (tab *Table2) numReplacements() int {
+	n := 0
+	for _, s := range tab.storages {
+		n += s.numReplacements()
+	}
+	return n
+}
+
+// For logging
+func (tab *Table2) lenByNodeTypes() map[string]int {
+	r := make(map[string]int)
+	for ty, s := range tab.storages {
+		r[nodeTypeName(ty)] = s.len()
+	}
+	return r
+}
+
+// Adds a node to one of the storages of the node's type.
+// If the node is a bootstrap node, it is added to all storages.
+func (tab *Table2) addNode(n *Node) {
+	if n.NType == NodeTypeBN {
+		for _, s := range tab.storages {
+			s.add(n)
+		}
+		return
+	} else {
+		if s := tab.storages[n.NType]; s != nil {
+			s.add(n)
+		}
+	}
+}
+
+func (tab *Table2) deleteNode(n *Node) {
+	if n.NType == NodeTypeBN {
+		for _, s := range tab.storages {
+			s.delete(n)
+		}
+		return
+	} else {
+		if s := tab.storages[n.NType]; s != nil {
+			s.delete(n)
+		}
+	}
+}

--- a/networks/p2p/discover/table_data_test.go
+++ b/networks/p2p/discover/table_data_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Table_addNode_typed(t *testing.T) {
+	tab := newTestTable2(t, nil)
+
+	en := newTestNode(t, NodeTypeEN)
+	tab.addNode(en)
+	assert.Equal(t, 1, tab.storages[NodeTypeEN].len(), "EN node should land in EN storage")
+	assert.Equal(t, 0, tab.storages[NodeTypeCN].len())
+	assert.Equal(t, 0, tab.storages[NodeTypePN].len())
+	assert.Equal(t, 0, tab.storages[NodeTypeBN].len())
+
+	cn := newTestNode(t, NodeTypeCN)
+	tab.addNode(cn)
+	assert.Equal(t, 1, tab.storages[NodeTypeCN].len(), "CN node should land in CN storage")
+}
+
+func Test_Table_addNode_BN(t *testing.T) {
+	tab := newTestTable2(t, nil)
+
+	bn := newTestBootnode(t, []byte{127, 0, 0, 1})
+	tab.addNode(bn)
+
+	// BN is added to every storage simultaneously.
+	assert.Equal(t, 1, tab.storages[NodeTypeCN].len())
+	assert.Equal(t, 1, tab.storages[NodeTypePN].len())
+	assert.Equal(t, 1, tab.storages[NodeTypeEN].len())
+	assert.Equal(t, 1, tab.storages[NodeTypeBN].len())
+	assert.Equal(t, 4, tab.len())
+}
+
+func Test_Table_deleteNode_typed(t *testing.T) {
+	tab := newTestTable2(t, nil)
+
+	n := newTestNode(t, NodeTypePN)
+	tab.addNode(n)
+	require.Equal(t, 1, tab.storages[NodeTypePN].len())
+
+	tab.deleteNode(n)
+	assert.Equal(t, 0, tab.storages[NodeTypePN].len())
+	// Other storages unaffected.
+	assert.Equal(t, 0, tab.storages[NodeTypeEN].len())
+}
+
+func Test_Table_deleteNode_BN(t *testing.T) {
+	tab := newTestTable2(t, nil)
+
+	bn := newTestBootnode(t, []byte{127, 0, 0, 1})
+	tab.addNode(bn)
+	require.Equal(t, 4, tab.len())
+
+	tab.deleteNode(bn)
+	assert.Equal(t, 0, tab.len(), "BN should be removed from all storages")
+}
+
+func Test_Table_RandomNodes_unknownType(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	buf := make([]*Node, 10)
+	n := tab.RandomNodes(buf, NodeTypeUnknown)
+	assert.Equal(t, 0, n, "nil storage should return 0")
+}
+
+func Test_Table_RandomNodes_happy(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	for i := 0; i < 5; i++ {
+		tab.addNode(newTestNode(t, NodeTypeEN))
+	}
+
+	buf := make([]*Node, 10)
+	n := tab.RandomNodes(buf, NodeTypeEN)
+	assert.Equal(t, 5, n)
+	assert.Nil(t, buf[5], "buffer beyond returned count should be untouched")
+}
+
+func Test_Table_ClosestNodes_unknownType(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	result := tab.ClosestNodes(NodeID{}, NodeTypeUnknown, 10)
+	assert.Nil(t, result, "nil storage should return nil")
+}
+
+func Test_Table_ClosestNodes_happy(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	for i := 0; i < 5; i++ {
+		tab.addNode(newTestNode(t, NodeTypeEN))
+	}
+
+	result := tab.ClosestNodes(NodeID{}, NodeTypeEN, 3)
+	assert.Len(t, result, 3, "should honour the max cap")
+
+	result = tab.ClosestNodes(NodeID{}, NodeTypeEN, 100)
+	assert.Len(t, result, 5, "should return all nodes when max > count")
+}
+
+func Test_Table_IsBonded_false(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	n := newTestNode(t, NodeTypeEN)
+	assert.False(t, tab.IsBonded(n.ID), "brand-new node should not be bonded")
+}
+
+func Test_Table_IsBonded_true(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	n := newTestNode(t, NodeTypeEN)
+	tab.recordBonded(n)
+	assert.True(t, tab.IsBonded(n.ID), "node with recent bond time should be bonded")
+}

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -130,6 +130,8 @@ func (tab *Table2) Close() {
 
 	close(tab.closeReq) // Ask the loops to terminate.
 	tab.wg.Wait()       // Wait for the loops to terminate.
+	tab.udp.close()
+	tab.db.close()
 	logger.Info("Discovery table closed")
 }
 

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+)
+
+var errBadBootnode = errors.New("bad bootstrap node")
+
+// Table is a self-maintained directory of nodes. Its key features are:
+// - Bond: Establishes a UDP bond with a node by sending PING and PONG packets.
+// - Refresh: Periodically or manually re-fills the table by looking up new nodes through FINDNODE requests.
+// - Revalidate: Periodically checks the health of the nodes in the table by sending PING packets.
+// - RandomNodes & ClosestNodes: Serves as an API to retrieve nodes from the table.
+type Table2 struct {
+	// Relying components
+	rand *sharedRand
+	db   *nodeDB
+	udp  transport
+
+	// Lifecycle
+	wg       sync.WaitGroup
+	init     atomic.Bool
+	closed   atomic.Bool
+	closeReq chan struct{}
+
+	// Node addresses
+	selfID   NodeID
+	nursery  []*Node
+	storages map[NodeType]tableStorage
+
+	// target number of nodes to obtain for each node type.
+	// set discoverTargets[T] = 0 to disable discovery of node type T (i.e. only accept inbound connections).
+	// see also: p2p.DialSched.connTargets.
+	discoverTargets map[NodeType]int
+
+	// UDP bonding
+	bondmu    sync.Mutex
+	bonding   map[NodeID]*bondtask // prevents concurrent bonding of the same node
+	bondslots chan struct{}        // semaphore to limit total number of active bonding processes
+
+	// UDP refresh
+	refreshmu   sync.Mutex
+	refreshDone chan struct{} // prevents concurrent refresh. refreshDone is nil when no refresh is running.
+}
+
+func newTable2(cfg *Config, udp transport) (*Table2, error) {
+	var (
+		self     = NewNode(cfg.Id, cfg.Addr.IP, uint16(cfg.Addr.Port), uint16(cfg.Addr.Port), nil, cfg.NodeType)
+		rand     = newSharedRand()
+		storages = map[NodeType]tableStorage{
+			NodeTypeCN: newFlatStorage(rand),
+			NodeTypePN: newFlatStorage(rand),
+			NodeTypeEN: newKademliaStorage(self, rand),
+			NodeTypeBN: newFlatStorage(rand),
+		}
+		discoverTargets = getDiscoverTargets(cfg)
+		bondslots       = make(chan struct{}, maxBondingPingPongs)
+
+		err error
+	)
+
+	rand.Seed()
+	db, err := newNodeDB(cfg.NodeDBPath, Version, cfg.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	nursery, err := getBootnodes(cfg)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < cap(bondslots); i++ {
+		bondslots <- struct{}{}
+	}
+
+	tab := &Table2{
+		rand:            rand,
+		db:              db,
+		udp:             udp,
+		closeReq:        make(chan struct{}),
+		nursery:         nursery,
+		storages:        storages,
+		discoverTargets: discoverTargets,
+		bonding:         make(map[NodeID]*bondtask),
+		bondslots:       bondslots,
+	}
+
+	// Insert the initial seeds into storages.
+	for _, n := range tab.nursery {
+		tab.addNode(n)
+	}
+	for _, n := range removeBn(tab.db.querySeeds(seedCount, seedMaxAge)) {
+		tab.addNode(n)
+	}
+
+	return tab, nil
+}
+
+func (tab *Table2) Start() {
+	tab.wg.Add(2)
+	go tab.refreshLoop()
+	go tab.revalidateLoop()
+	tab.db.ensureExpirer()
+}
+
+func (tab *Table2) Close() {
+	if tab.closed.Swap(true) {
+		return
+	}
+
+	close(tab.closeReq) // Ask the loops to terminate.
+	tab.wg.Wait()       // Wait for the loops to terminate.
+	logger.Info("Discovery table closed")
+}
+
+// Returns whether the table's initial seeding procedure has completed.
+func (tab *Table2) initialized() bool {
+	return tab.init.Load()
+}
+
+// Returns the number of nodes to actively discover depending of self node type.
+// Note that this number is NOT the number of connections to maintain.
+// The connection counts (or peer counts) are regulated by the p2p.Server and p2p.DialSched.
+func getDiscoverTargets(cfg *Config) map[NodeType]int {
+	switch cfg.NodeType {
+	case NodeTypeCN:
+		// CN discovers each other in a mesh structure. Assuming up to 100 validators.
+		return map[NodeType]int{
+			NodeTypeCN: 100,
+			NodeTypeBN: 3,
+		}
+	case NodeTypePN:
+		// PN discovers at least one neighboring PN. However, in production, PN connections are usually specified via static nodes
+		// to make up a certain network structure, in which case this number is irrelevant.
+		return map[NodeType]int{
+			NodeTypePN: 1,
+			NodeTypeBN: 3,
+		}
+	case NodeTypeEN:
+		// EN discovers to up to 2 PNs for high availability.
+		// EN try to learn as many ENs as possible via Kademlia algorithm.
+		return map[NodeType]int{
+			NodeTypeEN: math.MaxInt32,
+			NodeTypePN: 2,
+			NodeTypeBN: 3,
+		}
+	case NodeTypeBN:
+		// BN has to learn every CN and PN.
+		return map[NodeType]int{
+			NodeTypeCN: 100,
+			NodeTypePN: 100,
+			NodeTypeBN: 3,
+		}
+	default:
+		logger.Error("Unsupported node type", "NodeType", cfg.NodeType)
+		return map[NodeType]int{}
+	}
+}
+
+// Filter bootnodes to be used as initial seeds.
+func getBootnodes(cfg *Config) ([]*Node, error) {
+	nursery := make([]*Node, 0, len(cfg.Bootnodes))
+	for _, n := range cfg.Bootnodes {
+		if err := n.validateComplete(); err != nil {
+			return nil, fmt.Errorf("%w: %v", errBadBootnode, err)
+		}
+		if cfg.NetRestrict != nil && !cfg.NetRestrict.Contains(n.IP) {
+			logger.Warn("bootstrap node filtered by netrestrict", "node", n.String())
+			continue
+		}
+		nursery = append(nursery, n)
+	}
+	return nursery, nil
+}

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -130,7 +130,6 @@ func (tab *Table2) Close() {
 
 	close(tab.closeReq) // Ask the loops to terminate.
 	tab.wg.Wait()       // Wait for the loops to terminate.
-	tab.udp.close()
 	tab.db.close()
 	logger.Info("Discovery table closed")
 }

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -22,6 +22,8 @@ import (
 	"math"
 	"sync"
 	"sync/atomic"
+
+	"golang.org/x/sync/singleflight"
 )
 
 var errBadBootnode = errors.New("bad bootstrap node")
@@ -54,13 +56,11 @@ type Table2 struct {
 	discoverTargets map[NodeType]int
 
 	// UDP bonding
-	bondmu    sync.Mutex
-	bonding   map[NodeID]*bondtask // prevents concurrent bonding of the same node
-	bondslots chan struct{}        // semaphore to limit total number of active bonding processes
+	bondGroup singleflight.Group // deduplicates concurrent Bond() calls for the same node.
+	bondslots chan struct{}      // semaphore to limit total number of active bonding processes
 
 	// UDP refresh
-	refreshmu   sync.Mutex
-	refreshDone chan struct{} // prevents concurrent refresh. refreshDone is nil when no refresh is running.
+	refreshGroup singleflight.Group // deduplicates concurrent Refresh() calls.
 }
 
 func newTable2(cfg *Config, udp transport) (*Table2, error) {
@@ -102,7 +102,6 @@ func newTable2(cfg *Config, udp transport) (*Table2, error) {
 		nursery:         nursery,
 		storages:        storages,
 		discoverTargets: discoverTargets,
-		bonding:         make(map[NodeID]*bondtask),
 		bondslots:       bondslots,
 	}
 

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -80,12 +80,12 @@ func newTable2(cfg *Config, udp transport) (*Table2, error) {
 	)
 
 	rand.Seed()
-	db, err := newNodeDB(cfg.NodeDBPath, Version, cfg.Id)
+	nursery, err := getBootnodes(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	nursery, err := getBootnodes(cfg)
+	db, err := newNodeDB(cfg.NodeDBPath, Version, cfg.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +98,7 @@ func newTable2(cfg *Config, udp transport) (*Table2, error) {
 		db:              db,
 		udp:             udp,
 		closeReq:        make(chan struct{}),
+		selfID:          cfg.Id,
 		nursery:         nursery,
 		storages:        storages,
 		discoverTargets: discoverTargets,

--- a/networks/p2p/discover/table_init_test.go
+++ b/networks/p2p/discover/table_init_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"testing"
+
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/networks/p2p/netutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Table_getBootnodes_valid(t *testing.T) {
+	n1 := newTestBootnode(t, net.IP{10, 0, 0, 1})
+	n2 := newTestBootnode(t, net.IP{10, 0, 0, 2})
+	cfg := &Config{Bootnodes: []*Node{n1, n2}}
+
+	nursery, err := getBootnodes(cfg)
+	require.NoError(t, err)
+	require.Len(t, nursery, 2)
+	assert.Equal(t, n1.ID, nursery[0].ID)
+	assert.Equal(t, n2.ID, nursery[1].ID)
+}
+
+func Test_Table_getBootnodes_invalid(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	// UDP port 0 fails validateComplete ("missing UDP port").
+	bad := NewNode(PubkeyID(&key.PublicKey), net.IP{127, 0, 0, 1}, 0, 0, nil, NodeTypeBN)
+
+	_, err = getBootnodes(&Config{Bootnodes: []*Node{bad}})
+	assert.ErrorIs(t, err, errBadBootnode)
+}
+
+func Test_Table_getBootnodes_netRestrict(t *testing.T) {
+	restrict, err := netutil.ParseNetlist("10.0.0.0/8")
+	require.NoError(t, err)
+
+	inside := newTestBootnode(t, net.IP{10, 0, 0, 1})
+	outside := newTestBootnode(t, net.IP{192, 168, 0, 1})
+	cfg := &Config{
+		Bootnodes:   []*Node{inside, outside},
+		NetRestrict: restrict,
+	}
+
+	nursery, err := getBootnodes(cfg)
+	require.NoError(t, err)
+	require.Len(t, nursery, 1, "node outside netrestrict subnet should be filtered")
+	assert.Equal(t, inside.ID, nursery[0].ID)
+}
+
+func Test_Table_StartClose(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	tab.Start()
+	tab.Close()
+	tab.Close() // idempotent
+}
+
+//// Test helpers
+
+// newTestNode generates a cryptographically valid Node with a loopback IP.
+// The loopback IP is treated as LAN and bypasses the kademliaStorage IP limit.
+func newTestNode(t *testing.T, nType NodeType) *Node {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	return NewNode(PubkeyID(&key.PublicKey), net.IP{127, 0, 0, 1}, 30303, 30303, nil, nType)
+}
+
+// newTestTable2 constructs a Table2 backed by an in-memory node database and
+// a no-op UDP transport. tab.Close is registered as a test cleanup, so callers
+// do not have to call it explicitly (though doing so a second time is safe).
+func newTestTable2(t *testing.T, transport transport) *Table2 {
+	t.Helper()
+	cfg := &Config{
+		Id:         NodeID{},
+		Addr:       &net.UDPAddr{IP: net.IP{127, 0, 0, 1}, Port: 30303},
+		NodeType:   NodeTypeEN,
+		NodeDBPath: "", // In-memory temporary database
+	}
+	if transport == nil {
+		transport = &noopTransport{}
+	}
+	tab, err := newTable2(cfg, transport)
+	require.NoError(t, err)
+	t.Cleanup(tab.Close)
+	return tab
+}
+
+// newTestBootnode generates a cryptographically valid Node at the given IP,
+// suitable for use as a bootstrap node.
+func newTestBootnode(t *testing.T, ip net.IP) *Node {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	return NewNode(PubkeyID(&key.PublicKey), ip, 30303, 30303, nil, NodeTypeBN)
+}
+
+//// Mock UDP transports
+
+// noopTransport is a minimal no-op transport for Table2 unit tests.
+type noopTransport struct{}
+
+func (m *noopTransport) ping(toid NodeID, toaddr *net.UDPAddr) error { return nil }
+func (m *noopTransport) waitping(from NodeID, fromIP net.IP) error   { return nil }
+func (m *noopTransport) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID, nType NodeType, max int) ([]*Node, error) {
+	return nil, nil
+}
+func (m *noopTransport) close() {}

--- a/networks/p2p/discover/table_lookup.go
+++ b/networks/p2p/discover/table_lookup.go
@@ -75,7 +75,7 @@ func (tab *Table2) doRefreshOnce() {
 }
 
 func (tab *Table2) doRefresh() {
-	logger.Info("Discovery table refreshing", "counts", tab.lenByNodeTypes())
+	logger.Debug("Discovery table refreshing", "counts", tab.lenByNodeTypes())
 	tab.kademliaRefresh(NodeTypeEN)
 	tab.simpleRefresh(NodeTypeCN)
 	tab.simpleRefresh(NodeTypePN)
@@ -150,12 +150,12 @@ func (tab *Table2) findNodes(seeds []*Node, targetID NodeID, targetType NodeType
 
 	// Launch the first round of findnode requests.
 	for running < alpha {
-		target := pool.popUnasked()
-		if target == nil {
+		seed := pool.popUnasked()
+		if seed == nil {
 			break
 		}
 		running++
-		go func() { resCh <- tab.findNodesOnce(target, targetID, targetType, max) }()
+		go func() { resCh <- tab.findNodesOnce(seed, targetID, targetType, max) }()
 		logger.Trace("Discovery request sent", "targetType", targetType, "have", pool.count(excludeBn), "max", max)
 	}
 
@@ -170,9 +170,9 @@ func (tab *Table2) findNodes(seeds []*Node, targetID NodeID, targetType NodeType
 
 		// If we don't have enough nodes and willing to recursively ask, launch a new findnode request.
 		if recurse && pool.count(excludeBn) < max {
-			if target := pool.popUnasked(); target != nil {
+			if seed := pool.popUnasked(); seed != nil {
 				running++
-				go func() { resCh <- tab.findNodesOnce(target, targetID, targetType, max) }()
+				go func() { resCh <- tab.findNodesOnce(seed, targetID, targetType, max) }()
 				logger.Trace("Discovery recursive request sent", "targetType", targetType, "have", pool.count(excludeBn), "max", max)
 			}
 		}

--- a/networks/p2p/discover/table_lookup.go
+++ b/networks/p2p/discover/table_lookup.go
@@ -1,0 +1,269 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"time"
+
+	"github.com/kaiachain/kaia/crypto"
+)
+
+func (tab *Table2) refreshLoop() {
+	refreshTicker := time.NewTicker(refreshInterval)
+	defer tab.wg.Done()
+	defer refreshTicker.Stop()
+
+	// Initial refresh.
+	tab.Refresh()
+	tab.init.Store(true)
+
+	for {
+		select {
+		case <-refreshTicker.C:
+			tab.rand.Seed() // reseed the randomness before consuming it during refresh.
+			tab.doRefreshOnce()
+		case <-tab.closeReq:
+			return
+		}
+	}
+}
+
+func (tab *Table2) Refresh() {
+	if tab.closed.Load() {
+		return
+	}
+	tab.doRefreshOnce()
+}
+
+// Wraps the doRefresh() to ensure only one refresh is running at a time. Deduplicates the request.
+func (tab *Table2) doRefreshOnce() {
+	// Check for already running refresh
+	tab.refreshmu.Lock()
+	if tab.refreshDone != nil {
+		// Wait for already running refresh to complete
+		done := tab.refreshDone // capture the channel before unlocking (otherwise tab.refreshDone may become nil)
+		tab.refreshmu.Unlock()
+		<-done
+		return
+	}
+
+	// Register a new refresh completion channel
+	refreshDone := make(chan struct{})
+	tab.refreshDone = refreshDone
+	tab.refreshmu.Unlock()
+
+	tab.doRefresh()
+	close(refreshDone)
+
+	tab.refreshmu.Lock()
+	tab.refreshDone = nil
+	tab.refreshmu.Unlock()
+}
+
+func (tab *Table2) doRefresh() {
+	logger.Info("Discovery table refreshing", "counts", tab.lenByNodeTypes())
+	tab.kademliaRefresh(NodeTypeEN)
+	tab.simpleRefresh(NodeTypeCN)
+	tab.simpleRefresh(NodeTypePN)
+	tab.simpleRefresh(NodeTypeBN)
+	logger.Info("Discovery table refreshed", "counts", tab.lenByNodeTypes())
+}
+
+func (tab *Table2) kademliaRefresh(targetType NodeType) {
+	if tab.discoverTargets[targetType] <= 0 {
+		return
+	}
+
+	// Run self lookup to discover new neighbor nodes.
+	tab.lookup(tab.selfID, targetType, true, bucketSize)
+
+	// The Kademlia paper specifies that the bucket refresh should
+	// perform a lookup in the least recently used bucket. We cannot
+	// adhere to this because the findnode target is a 512bit value
+	// (not hash-sized) and it is not easily possible to generate a
+	// sha3 preimage that falls into a chosen bucket.
+	// We perform a few lookups with a random target instead.
+	for i := 0; i < 3; i++ {
+		var target NodeID
+		tab.rand.Read(target[:])
+		tab.lookup(target, targetType, true, bucketSize)
+	}
+}
+
+func (tab *Table2) simpleRefresh(targetType NodeType) {
+	if tab.discoverTargets[targetType] <= 0 {
+		return
+	}
+	tab.lookup(tab.selfID, targetType, false, tab.discoverTargets[targetType])
+}
+
+// Query more nodes from the network by sending FINDNODE requests.
+// Upon receiving a NEIGHBORS response, the nodes are first bonded, then added to the table.
+func (tab *Table2) lookup(targetID NodeID, targetType NodeType, recurse bool, max int) []*Node {
+	s := tab.storages[targetType]
+	if s == nil {
+		return nil
+	}
+	if max <= 0 {
+		return nil
+	}
+
+	// Start from the closest nodes to the target Or bootnodes.
+	targetHash := crypto.Keccak256Hash(targetID[:])
+	seeds := s.closest(targetHash, max).entries
+	if len(seeds) == 0 {
+		for _, n := range tab.nursery {
+			seeds = append(seeds, n)
+		}
+	}
+
+	// Make sure to bond the seed nodes before sending FINDNODE requests.
+	seeds = tab.bondall(seeds)
+
+	// Find new nodes by querying to the seed nodes.
+	return tab.findNodes(seeds, targetID, targetType, recurse, max)
+}
+
+// findNodes finds new nodes by querying to the seed nodes.
+func (tab *Table2) findNodes(seeds []*Node, targetID NodeID, targetType NodeType, recurse bool, max int) []*Node {
+	var (
+		// Bootnodes could be in the seeds but they are not usually the result we want.
+		excludeBn = targetType != NodeTypeBN
+		pool      = newFindNodesPool(seeds)
+		resCh     = make(chan []*Node, alpha)
+		running   = 0
+	)
+
+	// Launch the first round of findnode requests.
+	for running < alpha {
+		target := pool.popUnasked()
+		if target == nil {
+			break
+		}
+		running++
+		go func() { resCh <- tab.findNodesOnce(target, targetID, targetType, max) }()
+		logger.Trace("Discovery request sent", "targetType", targetType, "have", pool.count(excludeBn), "max", max)
+	}
+
+	// Wait for all running requests to finish.
+	for running > 0 {
+		// Wait for one request to finish.
+		res := <-resCh
+		running--
+		fresh := pool.push(res)
+		logger.Trace("Discovery response received", "targetType", targetType, "response", len(res), "fresh", fresh,
+			"pool", len(pool.all), "bootnodes", pool.numBootnodes, "unasked", len(pool.unasked))
+
+		// If we don't have enough nodes and willing to recursively ask, launch a new findnode request.
+		if recurse && pool.count(excludeBn) < max {
+			if target := pool.popUnasked(); target != nil {
+				running++
+				go func() { resCh <- tab.findNodesOnce(target, targetID, targetType, max) }()
+				logger.Trace("Discovery recursive request sent", "targetType", targetType, "have", pool.count(excludeBn), "max", max)
+			}
+		}
+	}
+
+	result := pool.harvest(targetID, excludeBn, max)
+	logger.Debug("Discovery result", "self", targetID == tab.selfID, "targetType", targetType, "recurse", recurse, "count", len(result))
+	return result
+}
+
+func (tab *Table2) findNodesOnce(seed *Node, targetID NodeID, targetType NodeType, max int) []*Node {
+	r, err := tab.udp.findnode(seed.ID, seed.addr(), targetID, targetType, max)
+	if err != nil {
+		tab.recordFindFailure(seed)
+		return nil
+	}
+	// Out of the find results, return only reachable (bonded) nodes.
+	return tab.bondall(r)
+}
+
+// Records a findnode failure.
+func (tab *Table2) recordFindFailure(seed *Node) {
+	fails := tab.db.findFails(seed.ID) + 1
+	tab.db.updateFindFails(seed.ID, fails)
+	logger.Trace("Findnode failure", "id", seed.ID, "failcount", fails)
+
+	if fails >= maxFindnodeFailures {
+		tab.deleteNode(seed)
+		tab.db.deleteNode(seed.ID)
+		logger.Trace("Too many findnode failures, dropping", "id", seed.ID, "failcount", fails)
+	}
+}
+
+// findNodesPool remembers the seed nodes and fresh nodes being processed in findNodes().
+type findNodesPool struct {
+	all          map[NodeID]*Node    // Cumulative list of nodes being processed in findNodes(). Append only and never removed.
+	unasked      map[NodeID]struct{} // Nodes in the pool that we did not ask findnode yet.
+	numBootnodes int                 // Number of bootnodes in the pool.
+}
+
+func newFindNodesPool(seeds []*Node) *findNodesPool {
+	p := &findNodesPool{
+		all:     make(map[NodeID]*Node),
+		unasked: make(map[NodeID]struct{}),
+	}
+	p.push(seeds)
+	return p
+}
+
+func (p *findNodesPool) count(excludeBn bool) int {
+	if excludeBn {
+		return len(p.all) - p.numBootnodes
+	} else {
+		return len(p.all)
+	}
+}
+
+// Pushes new nodes to the pool. Returns the number of new nodes added.
+func (p *findNodesPool) push(nodes []*Node) int {
+	added := 0
+	for _, n := range nodes {
+		if _, ok := p.all[n.ID]; ok {
+			continue
+		}
+		p.all[n.ID] = n
+		p.unasked[n.ID] = struct{}{}
+		if n.NType == NodeTypeBN {
+			p.numBootnodes++
+		}
+		added++
+	}
+	return added
+}
+
+// Pops a random unasked node.
+func (p *findNodesPool) popUnasked() *Node {
+	for id := range p.unasked {
+		delete(p.unasked, id)
+		return p.all[id]
+	}
+	return nil
+}
+
+// Returns up to max nodes ordered by distance to the target.
+func (p *findNodesPool) harvest(targetID NodeID, excludeBn bool, max int) []*Node {
+	ordered := &nodesByDistance{target: crypto.Keccak256Hash(targetID[:])}
+	for _, n := range p.all {
+		if excludeBn && n.NType == NodeTypeBN {
+			continue
+		}
+		ordered.push(n, max)
+	}
+	return ordered.entries
+}

--- a/networks/p2p/discover/table_lookup.go
+++ b/networks/p2p/discover/table_lookup.go
@@ -35,7 +35,7 @@ func (tab *Table2) refreshLoop() {
 		select {
 		case <-refreshTicker.C:
 			tab.rand.Seed() // reseed the randomness before consuming it during refresh.
-			tab.doRefreshOnce()
+			tab.doRefresh()
 		case <-tab.closeReq:
 			return
 		}
@@ -46,41 +46,20 @@ func (tab *Table2) Refresh() {
 	if tab.closed.Load() {
 		return
 	}
-	tab.doRefreshOnce()
-}
-
-// Wraps the doRefresh() to ensure only one refresh is running at a time. Deduplicates the request.
-func (tab *Table2) doRefreshOnce() {
-	// Check for already running refresh
-	tab.refreshmu.Lock()
-	if tab.refreshDone != nil {
-		// Wait for already running refresh to complete
-		done := tab.refreshDone // capture the channel before unlocking (otherwise tab.refreshDone may become nil)
-		tab.refreshmu.Unlock()
-		<-done
-		return
-	}
-
-	// Register a new refresh completion channel
-	refreshDone := make(chan struct{})
-	tab.refreshDone = refreshDone
-	tab.refreshmu.Unlock()
-
 	tab.doRefresh()
-	close(refreshDone)
-
-	tab.refreshmu.Lock()
-	tab.refreshDone = nil
-	tab.refreshmu.Unlock()
 }
 
+// doRefresh performs a full table refresh. Concurrent calls are deduplicated and wait for the single in-flight refresh.
 func (tab *Table2) doRefresh() {
-	logger.Debug("Discovery table refreshing", "counts", tab.lenByNodeTypes())
-	tab.kademliaRefresh(NodeTypeEN)
-	tab.simpleRefresh(NodeTypeCN)
-	tab.simpleRefresh(NodeTypePN)
-	tab.simpleRefresh(NodeTypeBN)
-	logger.Info("Discovery table refreshed", "counts", tab.lenByNodeTypes())
+	tab.refreshGroup.Do("refresh", func() (interface{}, error) {
+		logger.Debug("Discovery table refreshing", "counts", tab.lenByNodeTypes())
+		tab.kademliaRefresh(NodeTypeEN)
+		tab.simpleRefresh(NodeTypeCN)
+		tab.simpleRefresh(NodeTypePN)
+		tab.simpleRefresh(NodeTypeBN)
+		logger.Info("Discovery table refreshed", "counts", tab.lenByNodeTypes())
+		return nil, nil
+	})
 }
 
 func (tab *Table2) kademliaRefresh(targetType NodeType) {

--- a/networks/p2p/discover/table_lookup_test.go
+++ b/networks/p2p/discover/table_lookup_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_findNodesPool_push_dedup(t *testing.T) {
+	n := newTestNode(t, NodeTypeEN)
+	p := newFindNodesPool([]*Node{n})
+	added := p.push([]*Node{n}) // same node again
+	assert.Equal(t, 0, added, "duplicate node should not be added")
+	assert.Len(t, p.all, 1)
+}
+
+func Test_findNodesPool_count(t *testing.T) {
+	en := newTestNode(t, NodeTypeEN)
+	bn := newTestBootnode(t, net.IP{127, 0, 0, 1})
+	p := newFindNodesPool([]*Node{en, bn})
+	assert.Equal(t, 2, p.count(false), "total count including bootnodes")
+	assert.Equal(t, 1, p.count(true), "count excluding bootnodes")
+}
+
+func Test_findNodesPool_popUnasked(t *testing.T) {
+	n := newTestNode(t, NodeTypeEN)
+	p := newFindNodesPool([]*Node{n})
+	got := p.popUnasked()
+	assert.Equal(t, n.ID, got.ID)
+	assert.Nil(t, p.popUnasked(), "pool is exhausted after one pop")
+}
+
+func Test_findNodesPool_harvest(t *testing.T) {
+	en1 := newTestNode(t, NodeTypeEN)
+	en2 := newTestNode(t, NodeTypeEN)
+	bn := newTestBootnode(t, net.IP{127, 0, 0, 1})
+	p := newFindNodesPool([]*Node{en1, en2, bn})
+
+	// excludeBn=true: the bootnode should be absent from results.
+	result := p.harvest(NodeID{}, true, 10)
+	assert.Len(t, result, 2)
+	for _, n := range result {
+		assert.NotEqual(t, NodeTypeBN, n.NType)
+	}
+
+	// max=1 caps the output regardless of pool size.
+	result = p.harvest(NodeID{}, true, 1)
+	assert.Len(t, result, 1)
+}
+
+func Test_Table_recordFindFailure_increments(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	n := newTestNode(t, NodeTypeEN)
+	tab.addNode(n)
+
+	require.Equal(t, 0, tab.db.findFails(n.ID))
+	tab.recordFindFailure(n)
+	assert.Equal(t, 1, tab.db.findFails(n.ID))
+	// Node still in the table (1 < maxFindnodeFailures).
+	assert.Equal(t, 1, tab.storages[NodeTypeEN].len())
+}
+
+func Test_Table_recordFindFailure_drops(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	n := newTestNode(t, NodeTypeEN)
+	tab.addNode(n)
+	tab.db.updateNode(n)
+
+	for i := 0; i < maxFindnodeFailures; i++ {
+		tab.recordFindFailure(n)
+	}
+	// Node must be evicted from storage and database.
+	assert.Equal(t, 0, tab.storages[NodeTypeEN].len())
+	assert.Nil(t, tab.db.node(n.ID))
+}
+
+func Test_Table_findNodesOnce_error(t *testing.T) {
+	udp := newMockTransport()
+	udp.findnodeFn = func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error) {
+		return nil, errTimeout
+	}
+	tab := newTestTable2(t, udp)
+	seed := newTestNode(t, NodeTypeEN)
+	tab.addNode(seed)
+	tab.db.updateNode(seed)
+
+	result := tab.findNodesOnce(seed, NodeID{}, NodeTypeEN, 10)
+	assert.Nil(t, result)
+	assert.Equal(t, 1, tab.db.findFails(seed.ID), "failure should be recorded in DB")
+}
+
+func Test_Table_findNodesOnce_success(t *testing.T) {
+	peer := newTestNode(t, NodeTypeEN)
+	udp := newMockTransport()
+	udp.findnodeFn = func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error) {
+		return []*Node{peer}, nil
+	}
+	tab := newTestTable2(t, udp)
+	seed := newTestNode(t, NodeTypeEN)
+
+	result := tab.findNodesOnce(seed, NodeID{}, NodeTypeEN, 10)
+	// Peer is bonded (ping returns nil by default) so it appears in results.
+	require.Len(t, result, 1)
+	assert.Equal(t, peer.ID, result[0].ID)
+}
+
+func Test_Table_lookup_emptyTable(t *testing.T) {
+	var findCalled int32
+	udp := newMockTransport()
+	udp.findnodeFn = func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error) {
+		atomic.AddInt32(&findCalled, 1)
+		return nil, nil
+	}
+	tab := newTestTable2(t, udp)
+
+	// Neither seeds nor nursery → lookup terminates immediately.
+	result := tab.lookup(NodeID{}, NodeTypeEN, false, 10)
+	assert.Nil(t, result)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&findCalled), "no findnode calls expected on an empty table")
+}
+
+func Test_Table_lookup_withNursery(t *testing.T) {
+	var findCalled int32
+	udp := newMockTransport()
+	udp.findnodeFn = func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error) {
+		atomic.AddInt32(&findCalled, 1)
+		return nil, nil
+	}
+	tab := newTestTable2(t, udp)
+	tab.nursery = []*Node{newTestBootnode(t, net.IP{127, 0, 0, 1})}
+
+	tab.lookup(NodeID{}, NodeTypeEN, false, 10)
+	assert.Greater(t, atomic.LoadInt32(&findCalled), int32(0), "nursery BN should trigger at least one findnode call")
+}
+
+func Test_Table_lookup_returnsSeedResults(t *testing.T) {
+	discovered := newTestNode(t, NodeTypeEN)
+	udp := newMockTransport()
+	// First findnode call returns a new node; further calls return nothing.
+	var once sync.Once
+	udp.findnodeFn = func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error) {
+		var res []*Node
+		once.Do(func() { res = []*Node{discovered} })
+		return res, nil
+	}
+	tab := newTestTable2(t, udp)
+	tab.nursery = []*Node{newTestBootnode(t, net.IP{127, 0, 0, 1})}
+
+	result := tab.lookup(NodeID{}, NodeTypeEN, false, 10)
+	ids := make(map[NodeID]bool)
+	for _, n := range result {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids[discovered.ID], "newly discovered node should appear in lookup results")
+}
+
+func Test_Table_lookup_singleRound(t *testing.T) {
+	tab := newTestTable2(t, lookupTestnet)
+
+	// Seed with dists[256][0].  Its UDP port (256) tells the adapter which
+	// distance bucket to serve when Table2 issues the first findnode request.
+	seed := NewNode(lookupTestnet.dists[256][0], net.ParseIP("127.0.0.1"), 256, 0, nil, NodeTypeEN)
+	tab.storages[NodeTypeEN].add(seed)
+
+	results := tab.lookup(lookupTestnet.target, NodeTypeEN, false, bucketSize)
+
+	t.Logf("results (%d):", len(results))
+	for _, n := range results {
+		t.Logf("  ld=%d  %x", logdist(lookupTestnet.targetSha, n.sha), n.sha[:8])
+	}
+	assert.Equal(t, bucketSize, len(results), "should return exactly bucketSize results")
+	assert.False(t, hasDuplicates(results), "result set contains duplicate entries")
+	assert.True(t, sortedByDistanceTo(lookupTestnet.targetSha, results), "result set not sorted by distance to target")
+}
+
+func Test_Table_lookup_recursive(t *testing.T) {
+	tab := newTestTable2(t, lookupTestnet)
+
+	seed := NewNode(lookupTestnet.dists[256][0], net.ParseIP("127.0.0.1"), 256, 0, nil, NodeTypeEN)
+	tab.storages[NodeTypeEN].add(seed)
+
+	// lookupTestnet.findnode would return at most bucketSize results.
+	// lookup()-findNodes() would call 3 findOnce() calls, yielding only at most 3*bucketSize results.
+	// The recursive lookup would call findOnce() more times, fulfilling the max results.
+	results := tab.lookup(lookupTestnet.target, NodeTypeEN, true, bucketSize*4)
+
+	t.Logf("results (%d):", len(results))
+	for _, n := range results {
+		t.Logf("  ld=%d  %x", logdist(lookupTestnet.targetSha, n.sha), n.sha[:8])
+	}
+	assert.Equal(t, bucketSize*4, len(results), "should return exactly 2×bucketSize results")
+	assert.False(t, hasDuplicates(results), "result set contains duplicate entries")
+	assert.True(t, sortedByDistanceTo(lookupTestnet.targetSha, results), "result set not sorted by distance to target")
+}
+
+// Test_Table_doRefreshOnce_dedup verifies that a second concurrent call to
+// doRefreshOnce() waits for the in-flight refresh to finish rather than
+// starting its own.
+func Test_Table_doRefreshOnce_dedup(t *testing.T) {
+	var once sync.Once
+	firstFindnode := make(chan struct{})
+	blockFindnode := make(chan struct{})
+
+	udp := newMockTransport()
+	udp.findnodeFn = func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error) {
+		// Block only the very first call; all subsequent ones pass through.
+		once.Do(func() {
+			close(firstFindnode)
+			<-blockFindnode
+		})
+		return nil, nil
+	}
+	tab := newTestTable2(t, udp)
+	tab.nursery = []*Node{newTestBootnode(t, net.IP{127, 0, 0, 1})}
+
+	// g1 starts a refresh and gets blocked inside the first findnode call.
+	var g1 sync.WaitGroup
+	g1.Add(1)
+	go func() {
+		defer g1.Done()
+		tab.doRefreshOnce()
+	}()
+	<-firstFindnode // g1 is now blocking; refreshDone is registered
+
+	// The in-progress refresh channel must exist.
+	tab.refreshmu.Lock()
+	assert.NotNil(t, tab.refreshDone, "refresh should be in progress")
+	tab.refreshmu.Unlock()
+
+	// g2 should join g1's refresh and not start a new one.
+	g2done := make(chan struct{})
+	go func() {
+		tab.doRefreshOnce()
+		close(g2done)
+	}()
+
+	// Give g2 time to call doRefreshOnce and block on refreshDone.
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case <-g2done:
+		t.Error("g2 completed before g1 was released — dedup did not work")
+	default:
+		// expected: g2 is waiting on the refresh channel
+	}
+
+	// Release g1; both goroutines should now complete.
+	close(blockFindnode)
+	g1.Wait()
+	select {
+	case <-g2done:
+		// expected
+	case <-time.After(time.Second):
+		t.Error("g2 did not complete within 1 s after g1 finished")
+	}
+
+	// refreshDone must be cleared after completion.
+	tab.refreshmu.Lock()
+	assert.Nil(t, tab.refreshDone)
+	tab.refreshmu.Unlock()
+}

--- a/networks/p2p/discover/table_lookup_test.go
+++ b/networks/p2p/discover/table_lookup_test.go
@@ -239,19 +239,14 @@ func Test_Table_doRefreshOnce_dedup(t *testing.T) {
 	g1.Add(1)
 	go func() {
 		defer g1.Done()
-		tab.doRefreshOnce()
+		tab.doRefresh()
 	}()
-	<-firstFindnode // g1 is now blocking; refreshDone is registered
-
-	// The in-progress refresh channel must exist.
-	tab.refreshmu.Lock()
-	assert.NotNil(t, tab.refreshDone, "refresh should be in progress")
-	tab.refreshmu.Unlock()
+	<-firstFindnode // g1 is now blocking inside the refresh
 
 	// g2 should join g1's refresh and not start a new one.
 	g2done := make(chan struct{})
 	go func() {
-		tab.doRefreshOnce()
+		tab.doRefresh()
 		close(g2done)
 	}()
 
@@ -273,9 +268,4 @@ func Test_Table_doRefreshOnce_dedup(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Error("g2 did not complete within 1 s after g1 finished")
 	}
-
-	// refreshDone must be cleared after completion.
-	tab.refreshmu.Lock()
-	assert.Nil(t, tab.refreshDone)
-	tab.refreshmu.Unlock()
 }

--- a/networks/p2p/discover/table_storage.go
+++ b/networks/p2p/discover/table_storage.go
@@ -309,7 +309,10 @@ func (s *flatStorage) random(buf []*Node) int {
 	defer s.mu.RUnlock()
 
 	count := min(len(buf), len(s.nodes))
-	indices := s.rand.Perm(count)
+	if count == 0 {
+		return 0
+	}
+	indices := s.rand.Perm(len(s.nodes))
 	for i := 0; i < count; i++ {
 		buf[i] = s.nodes[indices[i]]
 	}

--- a/networks/p2p/discover/table_storage.go
+++ b/networks/p2p/discover/table_storage.go
@@ -1,0 +1,348 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/math"
+	"github.com/kaiachain/kaia/networks/p2p/netutil"
+)
+
+var (
+	_ tableStorage = (*kademliaStorage)(nil)
+	_ tableStorage = (*flatStorage)(nil)
+)
+
+type tableStorage interface {
+	// add adds a node to the table.
+	add(n *Node)
+	// delete deletes a node from the table.
+	delete(n *Node)
+	// random fills the given slice with random nodes from the table. Returns the number of nodes added to the buffer.
+	random(buf []*Node) int
+	// closest returns the n nodes in the table that are closest to the given id.
+	closest(target common.Hash, max int) *nodesByDistance
+	// oldest returns the oldest node, subject to revalidation.
+	oldest() *Node
+	// len returns the number of nodes in the table.
+	len() int
+	// numReplacements returns the number of replacements in the KademliaStorage. 0 for FlatStorage.
+	numReplacements() int
+}
+
+type kademliaStorage struct {
+	mu      sync.RWMutex
+	buckets [nBuckets]*bucket
+	ips     netutil.DistinctNetSet
+
+	rand    *sharedRand
+	selfID  NodeID
+	selfSha common.Hash
+}
+
+func newKademliaStorage(self *Node, rand *sharedRand) *kademliaStorage {
+	buckets := [nBuckets]*bucket{}
+	for i := range buckets {
+		buckets[i] = &bucket{
+			ips: netutil.DistinctNetSet{Subnet: bucketSubnet, Limit: bucketIPLimit},
+		}
+	}
+	return &kademliaStorage{
+		buckets: buckets,
+		ips:     netutil.DistinctNetSet{Subnet: tableSubnet, Limit: tableIPLimit},
+		rand:    rand,
+		selfID:  self.ID,
+		selfSha: self.sha,
+	}
+}
+
+func (s *kademliaStorage) add(n *Node) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b := s.bucket(n.sha)
+	if b.bump(n) {
+		// n was already in the bucket.
+		return
+	}
+	if len(b.entries) >= bucketSize {
+		// Bucket full, maybe add as replacement.
+		s.addReplacement(b, n)
+		return
+	}
+	if !s.addIP(b, n.IP) {
+		// IP limit reached.
+		return
+	}
+
+	// We have the space. Safe to add.
+	b.entries, _ = pushNode(b.entries, n, bucketSize) // Add to front
+	b.replacements = deleteNode(b.replacements, n)    // Remove from replacements (if present)
+	n.addedAt = time.Now()
+}
+
+func (s *kademliaStorage) delete(n *Node) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b := s.bucket(n.sha)
+
+	// Remove the node if exists.
+	if !hasNode(b.entries, n) {
+		return
+	}
+	b.entries = deleteNode(b.entries, n)
+	s.removeIP(b, n.IP)
+
+	// Insert a random replacement instead, if available.
+	r := s.popReplacement(b)
+	if r != nil {
+		b.entries = append(b.entries, r)
+	}
+}
+
+func (s *kademliaStorage) random(buf []*Node) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Collect all non-empty buckets.
+	var buckets [][]*Node
+	for _, b := range s.buckets {
+		if len(b.entries) > 0 {
+			buckets = append(buckets, b.entries[:])
+		}
+	}
+	if len(buckets) == 0 {
+		return 0
+	}
+	// Shuffle the buckets.
+	s.rand.Shuffle(len(buckets), func(i, j int) {
+		buckets[i], buckets[j] = buckets[j], buckets[i]
+	})
+
+	// Revolve through the buckets, pick the first entry of each bucket.
+	outIdx := 0
+	bucketIdx := 0
+	for outIdx < len(buf) {
+		buf[outIdx] = buckets[bucketIdx][0] // yield the first entry of the bucket
+		outIdx++
+
+		if len(buckets[bucketIdx]) == 1 {
+			// it was the last entry of the bucket. remove the bucket itself.
+			buckets = append(buckets[:bucketIdx], buckets[bucketIdx+1:]...)
+		} else {
+			// remove the first entry of the bucket.
+			buckets[bucketIdx] = buckets[bucketIdx][1:]
+		}
+		if len(buckets) == 0 {
+			// no more buckets left.
+			break
+		}
+
+		bucketIdx = (bucketIdx + 1) % len(buckets)
+	}
+
+	return outIdx
+}
+
+func (s *kademliaStorage) closest(target common.Hash, max int) *nodesByDistance {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := &nodesByDistance{target: target}
+	for _, b := range &s.buckets {
+		for _, n := range b.entries {
+			out.push(n, max)
+		}
+	}
+	return out
+}
+
+func (s *kademliaStorage) oldest() *Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// The last node in a random bucket.
+	for _, bucketIdx := range s.rand.Perm(len(s.buckets)) {
+		b := s.buckets[bucketIdx]
+		if len(b.entries) > 0 {
+			return b.entries[len(b.entries)-1]
+		}
+	}
+	return nil
+}
+
+func (s *kademliaStorage) len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	n := 0
+	for _, b := range s.buckets {
+		n += len(b.entries)
+	}
+	return n
+}
+
+func (s *kademliaStorage) numReplacements() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	n := 0
+	for _, b := range s.buckets {
+		n += len(b.replacements)
+	}
+	return n
+}
+
+// Choose the bucket for the given node based on the distance from the self.
+func (s *kademliaStorage) bucket(sha common.Hash) *bucket {
+	d := logdist(s.selfSha, sha)
+	if d <= bucketMinDistance {
+		return s.buckets[0]
+	}
+	return s.buckets[d-bucketMinDistance-1]
+}
+
+func (s *kademliaStorage) addReplacement(b *bucket, n *Node) {
+	for _, e := range b.replacements {
+		if e.ID == n.ID {
+			return // already in list
+		}
+	}
+	if !s.addIP(b, n.IP) {
+		return
+	}
+	var removed *Node
+	b.replacements, removed = pushNode(b.replacements, n, maxReplacements)
+	if removed != nil {
+		s.removeIP(b, removed.IP)
+	}
+}
+
+func (s *kademliaStorage) popReplacement(b *bucket) *Node {
+	if len(b.replacements) == 0 {
+		return nil
+	}
+	idx := s.rand.Intn(len(b.replacements))
+	r := b.replacements[idx]
+	b.replacements = deleteNode(b.replacements, r)
+	return r
+}
+
+// addIP adds the given IP to both the table-level and bucket-level IP sets.
+func (s *kademliaStorage) addIP(b *bucket, ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() {
+		return false
+	}
+	if netutil.IsLAN(ip) {
+		return true
+	}
+	if !s.ips.Add(ip) {
+		return false
+	}
+	if !b.ips.Add(ip) {
+		s.ips.Remove(ip)
+		return false
+	}
+	return true
+}
+
+// removeIP removes the given IP from both the table-level and bucket-level IP sets.
+func (s *kademliaStorage) removeIP(b *bucket, ip net.IP) {
+	if netutil.IsLAN(ip) {
+		return
+	}
+	s.ips.Remove(ip)
+	b.ips.Remove(ip)
+}
+
+type flatStorage struct {
+	mu    sync.RWMutex
+	nodes []*Node // A flat list of nodes. Similar to Kademlia buckets, recent nodes are at the front.
+	rand  *sharedRand
+}
+
+func newFlatStorage(rand *sharedRand) *flatStorage {
+	return &flatStorage{
+		nodes: []*Node{},
+		rand:  rand,
+	}
+}
+
+func (s *flatStorage) add(n *Node) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if bumpNode(s.nodes, n) {
+		return
+	}
+	s.nodes, _ = pushNode(s.nodes, n, math.MaxInt64)
+	n.addedAt = time.Now()
+}
+
+func (s *flatStorage) delete(n *Node) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodes = deleteNode(s.nodes, n)
+}
+
+func (s *flatStorage) random(buf []*Node) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	count := min(len(buf), len(s.nodes))
+	indices := s.rand.Perm(count)
+	for i := 0; i < count; i++ {
+		buf[i] = s.nodes[indices[i]]
+	}
+	return count
+}
+
+func (s *flatStorage) closest(target common.Hash, max int) *nodesByDistance {
+	// There is no concept of distance in the FlatStorage.
+	// Return random nodes instead.
+	buf := make([]*Node, max)
+	n := s.random(buf)
+
+	out := &nodesByDistance{target: target}
+	out.entries = buf[:n]
+	return out
+}
+
+func (s *flatStorage) oldest() *Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.nodes) == 0 {
+		return nil
+	} else {
+		return s.nodes[len(s.nodes)-1]
+	}
+}
+
+func (s *flatStorage) len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.nodes)
+}
+
+func (s *flatStorage) numReplacements() int {
+	return 0
+}

--- a/networks/p2p/discover/table_storage_test.go
+++ b/networks/p2p/discover/table_storage_test.go
@@ -1,0 +1,320 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testSelf = NewNode(NodeID{}, net.IP{127, 0, 0, 1}, 30303, 30303, nil, NodeTypeUnknown)
+
+	nodeDistCounter uint32
+)
+
+func newTestKademliaStorage() *kademliaStorage {
+	return newKademliaStorage(testSelf, newSharedRand())
+}
+
+// Create a unique node at the given distance.
+func nodeAtDist(ld int) *Node {
+	n := new(Node)
+	n.sha = hashAtDistance(testSelf.sha, ld)
+	// hashAtDistance randomizes bytes after position (len(hash)-ld/8-1), so for
+	// any ld > 1 the last byte is in the randomized zone. Stamp it with a counter
+	// to guarantee unique IDs; without this, small distances (e.g. ld=10) only
+	// randomize 1 byte (255 values) and collisions cause intermittent test failures.
+	n.sha[31] = byte(atomic.AddUint32(&nodeDistCounter, 1))
+	n.IP = net.IP{172, byte(ld), 1, 0}
+	n.NType = NodeTypeUnknown
+	copy(n.ID[:], n.sha[:])
+	return n
+}
+
+// Note that this function bypasses the IP limit, makes it easier to test.
+func fillBucket2(b *bucket, ld int) {
+	for len(b.entries) < bucketSize {
+		b.entries = append(b.entries, nodeAtDist(ld))
+	}
+}
+
+func TestKademliaStorage_AddBump(t *testing.T) {
+	s := newTestKademliaStorage()
+	n1 := nodeAtDist(10)
+
+	// Add node first time
+	s.add(n1)
+	b := s.bucket(n1.sha)
+	require.Equal(t, 1, len(b.entries), "expected 1 entry after first add")
+
+	// Add second node to same bucket
+	n2 := nodeAtDist(10)
+	s.add(n2)
+	require.Equal(t, 2, len(b.entries), "expected 2 entries after second add")
+
+	// Bump first node - it should move to front
+	s.add(n1)
+	assert.Equal(t, 2, len(b.entries), "expected 2 entries after bump")
+	assert.Equal(t, n1.ID, b.entries[0].ID, "bumped node should be at front")
+}
+
+func TestKademliaStorage_AddBucketFull(t *testing.T) {
+	s := newTestKademliaStorage()
+	targetHash := hashAtDistance(s.selfSha, 10)
+
+	// Fill the bucket.
+	b := s.bucket(targetHash)
+	fillBucket2(b, 10)
+	require.Equal(t, bucketSize, len(b.entries), "expected bucket to be full")
+
+	// Add one more - should go to replacements since bucket is full
+	n := nodeAtDist(10)
+	s.add(n)
+	assert.Equal(t, bucketSize, len(b.entries), "expected bucket to be full")
+	assert.Equal(t, 1, len(b.replacements), "expected at least 1 replacement when bucket is full")
+
+	// Manually drop a node to make room for the new node.
+	b.entries = b.entries[1:]
+
+	// Add the new node again - should go to the bucket, and removed from the replacements list.
+	s.add(n)
+	assert.Equal(t, bucketSize, len(b.entries), "expected bucket to be full")
+	assert.Equal(t, 0, len(b.replacements), "expected no replacements when bucket is full")
+}
+
+func TestKademliaStorage_AddTableIPLimit(t *testing.T) {
+	s := newTestKademliaStorage()
+
+	// Add nodes from same /24 subnet until table limit is reached
+	for i := 0; i < tableIPLimit+5; i++ {
+		n := nodeAtDist(i)
+		n.IP = net.IP{172, 0, 1, byte(i + 1)}
+		s.add(n)
+	}
+
+	assert.LessOrEqual(t, s.len(), tableIPLimit, "table IP limit exceeded")
+}
+
+func TestKademliaStorage_AddBucketIPLimit(t *testing.T) {
+	s := newTestKademliaStorage()
+	b := s.bucket(hashAtDistance(s.selfSha, 10))
+
+	// Add nodes from same /24 subnet to same bucket
+	for i := 0; i < bucketIPLimit+5; i++ {
+		n := nodeAtDist(10)
+		n.IP = net.IP{172, 0, 1, byte(i + 1)}
+		s.add(n)
+	}
+
+	assert.LessOrEqual(t, len(b.entries), bucketIPLimit, "bucket IP limit exceeded")
+}
+
+func TestKademliaStorage_Delete(t *testing.T) {
+	s := newTestKademliaStorage()
+	n := nodeAtDist(10)
+	n.IP = net.IP{172, 0, 1, 1}
+
+	// Add node
+	s.add(n)
+	require.Equal(t, 1, s.len(), "expected 1 node after add")
+
+	// Delete node
+	s.delete(n)
+	assert.Equal(t, 0, s.len(), "expected 0 nodes after delete")
+
+	// Delete again - nothing to delete.
+	s.delete(n)
+	assert.Equal(t, 0, s.len(), "expected 0 nodes after delete")
+}
+
+func TestKademliaStorage_DeletePromoteReplacements(t *testing.T) {
+	s := newTestKademliaStorage()
+	targetHash := hashAtDistance(s.selfSha, 10)
+
+	// Fill bucket.
+	b := s.bucket(targetHash)
+	fillBucket2(b, 10)
+	require.Equal(t, bucketSize, len(b.entries), "expected bucket to be full")
+
+	// Add one more - should go to replacements since bucket is full
+	n := nodeAtDist(10)
+	s.add(n)
+	assert.Equal(t, bucketSize, len(b.entries), "expected bucket to be full")
+	assert.Equal(t, 1, len(b.replacements), "expected at least 1 replacement when bucket is full")
+
+	// Delete a node from the bucket - refilled from replacements.
+	x := b.entries[0]
+	s.delete(x)
+	assert.Equal(t, 0, len(b.replacements), "popped a replacement")
+	assert.Equal(t, bucketSize, len(b.entries), "entries refilled from replacements")
+
+	// Delete another node from the bucket - nothing to refill because replacements are empty.
+	y := b.entries[0]
+	s.delete(y)
+	assert.Equal(t, bucketSize-1, len(b.entries), "entries decreased")
+}
+
+func TestKademliaStorage_Random(t *testing.T) {
+	s := newTestKademliaStorage()
+
+	// 3 different buckets. Note: bucketMinDistance is 239.
+	fillBucket2(s.bucket(hashAtDistance(s.selfSha, 235)), 235)
+	fillBucket2(s.bucket(hashAtDistance(s.selfSha, 245)), 245)
+	fillBucket2(s.bucket(hashAtDistance(s.selfSha, 255)), 255)
+	assert.Equal(t, 3*bucketSize, s.len(), "added all nodes over 3 different distance buckets")
+
+	buf := make([]*Node, 100)
+	n := s.random(buf)
+	assert.Equal(t, 3*bucketSize, n, "returned all nodes")
+
+	buf = make([]*Node, 7)
+	n = s.random(buf)
+	assert.Equal(t, 7, n, "return size capped at output buf size")
+
+	// First 3 entrires should be from the distinct buckets.
+	d1 := logdist(s.selfSha, buf[0].sha)
+	d2 := logdist(s.selfSha, buf[1].sha)
+	d3 := logdist(s.selfSha, buf[2].sha)
+	assert.NotEqual(t, d1, d2)
+	assert.NotEqual(t, d1, d3)
+	assert.NotEqual(t, d2, d3)
+}
+
+func TestKademliaStorage_Closest(t *testing.T) {
+	s := newTestKademliaStorage()
+	targetHash := hashAtDistance(s.selfSha, 10)
+
+	// Only two nodes in the table.
+	s.add(nodeAtDist(235))
+	s.add(nodeAtDist(245))
+	s.add(nodeAtDist(255))
+	require.Equal(t, 3, s.len())
+
+	// Request 7 nodes, should return 3 nodes, which is all we have.
+	out := s.closest(targetHash, 7)
+	assert.Equal(t, 3, len(out.entries))
+
+	// Add enough nodes to the table.
+	fillBucket2(s.bucket(hashAtDistance(s.selfSha, 235)), 235)
+	fillBucket2(s.bucket(hashAtDistance(s.selfSha, 245)), 245)
+	fillBucket2(s.bucket(hashAtDistance(s.selfSha, 255)), 255)
+	require.Equal(t, 3*bucketSize, s.len())
+
+	// Return as many nodes as requested.
+	out = s.closest(targetHash, 7)
+	assert.Equal(t, 7, len(out.entries))
+}
+
+func TestKademliaStorage_Oldest(t *testing.T) {
+	s := newTestKademliaStorage()
+
+	// Returns nothing when empty.
+	oldest := s.oldest()
+	assert.Nil(t, oldest)
+
+	s.add(nodeAtDist(10))
+	oldest = s.oldest()
+	assert.NotNil(t, oldest)
+}
+
+func TestFlatStorage_AddDelete(t *testing.T) {
+	s := newFlatStorage(newSharedRand())
+	n1 := nodeAtDist(10)
+	n2 := nodeAtDist(10)
+
+	// Add node first time
+	s.add(n1)
+	require.Equal(t, 1, len(s.nodes))
+
+	// Add second node to same bucket
+	s.add(n2)
+	require.Equal(t, 2, len(s.nodes))
+
+	// Bump first node - it should move to front
+	s.add(n1)
+	require.Equal(t, 2, len(s.nodes))
+	assert.Equal(t, n1.ID, s.nodes[0].ID)
+
+	// Delete a node
+	s.delete(n2)
+	require.Equal(t, 1, len(s.nodes))
+
+	// Delete the same node again - nothing to delete.
+	s.delete(n2)
+	assert.Equal(t, 1, len(s.nodes))
+}
+
+func TestFlatStorage_Random(t *testing.T) {
+	s := newFlatStorage(newSharedRand())
+	n1 := nodeAtDist(10)
+	n2 := nodeAtDist(10)
+	n3 := nodeAtDist(10)
+
+	// Add nodes
+	s.add(n1)
+	s.add(n2)
+	s.add(n3)
+	require.Equal(t, 3, len(s.nodes))
+
+	buf := make([]*Node, 100)
+	n := s.random(buf)
+	assert.Equal(t, 3, n, "returned all nodes")
+
+	buf = make([]*Node, 2)
+	n = s.random(buf)
+	assert.Equal(t, 2, n, "return size capped at output buf size")
+}
+
+func TestFlatStorage_Closest(t *testing.T) {
+	s := newFlatStorage(newSharedRand())
+	targetHash := common.Hash{} // irrelevant for FlatStorage
+	n1 := nodeAtDist(10)
+	n2 := nodeAtDist(10)
+	n3 := nodeAtDist(10)
+
+	// Add nodes
+	s.add(n1)
+	s.add(n2)
+	s.add(n3)
+	require.Equal(t, 3, len(s.nodes))
+
+	out := s.closest(targetHash, 100)
+	assert.Equal(t, 3, len(out.entries), "returned all nodes")
+
+	out = s.closest(targetHash, 2)
+	assert.Equal(t, 2, len(out.entries), "return size capped at max requested nodes")
+}
+
+func TestFlatStorage_Oldest(t *testing.T) {
+	s := newFlatStorage(newSharedRand())
+
+	// Returns nothing when empty.
+	oldest := s.oldest()
+	assert.Nil(t, oldest)
+
+	s.add(nodeAtDist(10))
+	oldest = s.oldest()
+	assert.NotNil(t, oldest)
+}

--- a/networks/p2p/discover/table_util.go
+++ b/networks/p2p/discover/table_util.go
@@ -1,0 +1,101 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Modifications Copyright 2018 The klaytn Authors
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// TODO: salvage pushNode and deleteNode to this file.
+
+func hasNode(list []*Node, n *Node) bool {
+	for _, e := range list {
+		if e.ID == n.ID {
+			return true
+		}
+	}
+	return false
+}
+
+func bumpNode(list []*Node, n *Node) bool {
+	for i := range list {
+		if list[i].ID == n.ID {
+			// move it to the front
+			copy(list[1:], list[:i])
+			list[0] = n
+			return true
+		}
+	}
+	return false
+}
+
+// A shared pseudorandom source that can be shared by multiple storages.
+// This RNG is shared so that the main table loop can seed it periodically.
+type sharedRand struct {
+	mu   sync.Mutex
+	rand *rand.Rand
+}
+
+func newSharedRand() *sharedRand {
+	return &sharedRand{
+		rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (s *sharedRand) Seed() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var b [8]byte
+	crand.Read(b[:])
+	s.rand.Seed(int64(binary.BigEndian.Uint64(b[:])))
+}
+
+func (s *sharedRand) Intn(n int) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rand.Intn(n)
+}
+
+func (s *sharedRand) Int63n(n int64) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rand.Int63n(n)
+}
+
+func (s *sharedRand) Perm(n int) []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rand.Perm(n)
+}
+
+func (s *sharedRand) Shuffle(n int, swap func(i, j int)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rand.Shuffle(n, swap)
+}
+
+func (s *sharedRand) Read(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rand.Read(p)
+}

--- a/networks/p2p/discover/table_util.go
+++ b/networks/p2p/discover/table_util.go
@@ -66,7 +66,11 @@ func (s *sharedRand) Seed() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var b [8]byte
-	crand.Read(b[:])
+	if _, err := crand.Read(b[:]); err != nil {
+		// If crypto/rand seed fails, fall back to time seed
+		s.rand.Seed(time.Now().UnixNano())
+		return
+	}
 	s.rand.Seed(int64(binary.BigEndian.Uint64(b[:])))
 }
 

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -298,7 +298,8 @@ type udp struct {
 	closing chan struct{}
 	wg      sync.WaitGroup
 
-	Discovery
+	Discovery         // old path (used by ListenUDP -> newUDP)
+	tab       *Table2 // new path (used by NewDiscovery2)
 }
 
 // ListenUDP returns a new table that listens for UDP packets on laddr.
@@ -342,6 +343,31 @@ func newUDP(cfg *Config) (Discovery, *udp, error) {
 	return udp.Discovery, udp, nil
 }
 
+func newUDPv4(cfg *Config) *udp {
+	u := &udp{
+		networkID:   cfg.NetworkID,
+		conn:        cfg.Conn,
+		priv:        cfg.PrivateKey,
+		netrestrict: cfg.NetRestrict,
+		closing:     make(chan struct{}),
+		gotreply:    make(chan reply),
+		addpending:  make(chan *pending),
+	}
+	realaddr := cfg.Addr
+	if cfg.AnnounceAddr != nil {
+		realaddr = cfg.AnnounceAddr
+	}
+	u.ourEndpoint = makeEndpoint(realaddr, uint16(realaddr.Port), cfg.NodeType)
+	return u
+}
+
+func (t *udp) Start(tab *Table2) {
+	t.tab = tab
+	t.wg.Add(2)
+	go t.loop()
+	go t.readLoop(nil)
+}
+
 func (t *udp) close() {
 	close(t.closing) // shuts down the loop()
 	t.conn.Close()   // shuts down the readLoop()
@@ -349,11 +375,33 @@ func (t *udp) close() {
 }
 
 func (t *udp) isAuthorized(fromID NodeID, nType NodeType) bool {
+	if t.tab != nil {
+		return t.tab.IsAuthorized(fromID, nType)
+	}
 	return t.Discovery.IsAuthorized(fromID, nType)
 }
 
 func (t *udp) hasBond(fromID NodeID) bool {
+	if t.tab != nil {
+		return t.tab.IsBonded(fromID)
+	}
 	return t.Discovery.HasBond(fromID)
+}
+
+func (t *udp) bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16, nType NodeType) {
+	if t.tab != nil {
+		n := NewNode(id, addr.IP, uint16(addr.Port), tcpPort, nil, nType)
+		t.tab.Bond(pinged, n)
+		return
+	}
+	t.Discovery.Bond(pinged, id, addr, tcpPort, nType)
+}
+
+func (t *udp) closestNodes(target NodeID, targetType NodeType, max int) []*Node {
+	if t.tab != nil {
+		return t.tab.ClosestNodes(target, targetType, max)
+	}
+	return t.Discovery.RetrieveNodes(crypto.Keccak256Hash(target[:]), targetType, max)
 }
 
 // #region High-level APIs
@@ -744,7 +792,7 @@ func (req *ping) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) er
 	})
 	if !t.handleReply(fromID, from.IP, pingPacket, req) {
 		// Note: we're ignoring the provided IP address right now
-		go t.Bond(true, fromID, from, req.From.TCP, req.From.NType)
+		go t.bond(true, fromID, from, req.From.TCP, req.From.NType)
 	}
 	return nil
 }
@@ -786,9 +834,8 @@ func (req *findnode) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 
 func (req *findnode) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) error {
 	// Determine "closest" nodes. The result will be the closest nodes for KademliaStorage, but random nodes for SimpleStorage.
-	target := crypto.Keccak256Hash(req.Target[:])
 	retrieveSize := findnodeRetrieveSize(req.TargetType)
-	closest := t.RetrieveNodes(target, req.TargetType, retrieveSize)
+	closest := t.closestNodes(req.Target, req.TargetType, retrieveSize)
 
 	// Send neighbors in chunks with at most maxNeighbors per packet
 	// to stay below the 1280 byte limit.

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -776,7 +776,7 @@ func (req *ping) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 		logger.Trace("unauthorized node.", "nodeid", fromID, "nodetype", req.From.NType)
 		return errUnauthorized
 	}
-	logger.Debug("authorized node.", "nodeid", fromID, "nodetype", req.From.NType)
+	logger.Trace("authorized node.", "nodeid", fromID, "nodetype", req.From.NType)
 	return nil
 }
 

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	"github.com/kaiachain/kaia/crypto"
-	"github.com/kaiachain/kaia/networks/p2p/nat"
 	"github.com/kaiachain/kaia/networks/p2p/netutil"
 	"github.com/kaiachain/kaia/rlp"
 )
@@ -203,7 +202,6 @@ type udp struct {
 	gotreply   chan reply
 
 	closing chan struct{}
-	nat     nat.Interface
 	wg      sync.WaitGroup
 
 	Discovery
@@ -279,11 +277,10 @@ type Config struct {
 	PrivateKey *ecdsa.PrivateKey
 
 	// These settings are optional:
-	AnnounceAddr *net.UDPAddr      // local address announced in the DHT
-	NodeDBPath   string            // if set, the node database is stored at this filesystem location
-	NetRestrict  *netutil.Netlist  // network whitelist
-	Bootnodes    []*Node           // list of bootstrap nodes
-	Unhandled    chan<- ReadPacket // unhandled packets are sent on this channel
+	AnnounceAddr *net.UDPAddr     // local address announced in the DHT
+	NodeDBPath   string           // if set, the node database is stored at this filesystem location
+	NetRestrict  *netutil.Netlist // network whitelist
+	Bootnodes    []*Node          // list of bootstrap nodes
 
 	// These settings are required for create Table and UDP
 	Id       NodeID
@@ -336,7 +333,7 @@ func newUDP(cfg *Config) (Discovery, *udp, error) {
 	go udp.Discovery.(*Table).loop() // TODO-Kaia-Node There is only one concrete type(Table) for Discovery. Refactor Discovery interface for their proper objective.
 	udp.wg.Add(2)
 	go udp.loop()
-	go udp.readLoop(cfg.Unhandled)
+	go udp.readLoop(nil)
 	return udp.Discovery, udp, nil
 }
 

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -306,7 +306,7 @@ func ListenUDP(cfg *Config) (Discovery, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger.Info("UDP listener up", "self", discv.Self())
+	logger.Info("UDP listener up", "id", cfg.Id, "addr", cfg.Addr, "type", cfg.NodeType)
 	return discv, nil
 }
 

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -37,6 +37,8 @@ import (
 	"github.com/kaiachain/kaia/rlp"
 )
 
+// #region Constants
+
 const Version = 4
 
 // Errors
@@ -80,8 +82,50 @@ const (
 	NodeTypeBN
 )
 
-// RPC request structures
+const (
+	macSize  = 256 / 8
+	sigSize  = 520 / 8
+	headSize = macSize + sigSize // space of packet frame data
+)
+
+var (
+	headSpace = make([]byte, headSize)
+
+	// Neighbors replies are sent across multiple packets to
+	// stay below the 1280 byte limit. We compute the maximum number
+	// of entries by stuffing a packet until it grows too large.
+	maxNeighbors int
+)
+
+func init() {
+	p := neighbors{Expiration: ^uint64(0)}
+	maxSizeNode := rpcNode{IP: make(net.IP, 16), UDP: ^uint16(0), TCP: ^uint16(0)}
+	for n := 0; ; n++ {
+		p.Nodes = append(p.Nodes, maxSizeNode)
+		size, _, err := rlp.EncodeToReader(p)
+		if err != nil {
+			// If this ever happens, it will be caught by the unit tests.
+			panic("cannot encode: " + err.Error())
+		}
+		if headSize+size+1 >= 1280 {
+			maxNeighbors = n
+			break
+		}
+	}
+}
+
+// #region Packet types
+
 type (
+	packet interface {
+		// preverify checks whether the packet is valid and should be handled at all.
+		preverify(t *udp, from *net.UDPAddr, fromID NodeID) error
+		// handle handles the packet.
+		handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) error
+		// name returns the name of the packet for logging purposes.
+		name() string
+	}
+
 	ping struct {
 		NetworkID  uint64
 		Version    uint
@@ -147,41 +191,7 @@ type (
 	}
 )
 
-func makeEndpoint(addr *net.UDPAddr, tcpPort uint16, nType NodeType) rpcEndpoint {
-	ip := addr.IP.To4()
-	if ip == nil {
-		ip = addr.IP.To16()
-	}
-	return rpcEndpoint{IP: ip, UDP: uint16(addr.Port), TCP: tcpPort, NType: nType}
-}
-
-func (t *udp) nodeFromRPC(sender *net.UDPAddr, rn rpcNode) (*Node, error) {
-	if rn.UDP <= 1024 {
-		return nil, errors.New("low port")
-	}
-	if err := netutil.CheckRelayIP(sender.IP, rn.IP); err != nil {
-		return nil, err
-	}
-	if t.netrestrict != nil && !t.netrestrict.Contains(rn.IP) {
-		return nil, errors.New("not contained in netrestrict whitelist")
-	}
-	n := NewNode(rn.ID, rn.IP, rn.UDP, rn.TCP, nil, rn.NType)
-	err := n.validateComplete()
-	return n, err
-}
-
-func nodeToRPC(n *Node) rpcNode {
-	return rpcNode{ID: n.ID, IP: n.IP, UDP: n.UDP, TCP: n.TCP, NType: n.NType}
-}
-
-type packet interface {
-	// preverify checks whether the packet is valid and should be handled at all.
-	preverify(t *udp, from *net.UDPAddr, fromID NodeID) error
-	// handle handles the packet.
-	handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byte) error
-	// name returns the name of the packet for logging purposes.
-	name() string
-}
+// #region Helper types
 
 type conn interface {
 	ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error)
@@ -190,21 +200,12 @@ type conn interface {
 	LocalAddr() net.Addr
 }
 
-// udp implements the RPC protocol.
-type udp struct {
-	networkID   uint64
-	conn        conn
-	netrestrict *netutil.Netlist
-	priv        *ecdsa.PrivateKey
-	ourEndpoint rpcEndpoint
-
-	addpending chan *pending
-	gotreply   chan reply
-
-	closing chan struct{}
-	wg      sync.WaitGroup
-
-	Discovery
+func makeEndpoint(addr *net.UDPAddr, tcpPort uint16, nType NodeType) rpcEndpoint {
+	ip := addr.IP.To4()
+	if ip == nil {
+		ip = addr.IP.To16()
+	}
+	return rpcEndpoint{IP: ip, UDP: uint16(addr.Port), TCP: tcpPort, NType: nType}
 }
 
 // pending represents a pending reply.
@@ -270,31 +271,34 @@ type ReadPacket struct {
 	Addr *net.UDPAddr
 }
 
-// Config holds Table-related settings.
-type Config struct {
-	NetworkID uint64
-	// These settings are required and configure the UDP listener:
-	PrivateKey *ecdsa.PrivateKey
+// #region Main UDP struct
 
-	// These settings are optional:
-	AnnounceAddr *net.UDPAddr     // local address announced in the DHT
-	NodeDBPath   string           // if set, the node database is stored at this filesystem location
-	NetRestrict  *netutil.Netlist // network whitelist
-	Bootnodes    []*Node          // list of bootstrap nodes
+// udp implements the RPC protocol.
+// It launches two goroutines:
+//   - loop() to manage pending replies (PONG, NEIGHBORS) related to the requests sent (PING, FINDNODE).
+//     Here, pending() registers a callback function, and handleReply() calls the callback when a reply arrives.
+//   - readLoop() to catch incoming packets (PING, PONG, FINDNODE, NEIGHBORS) and dispatch to type-specific handlers.
+//     sometimes the packet handler calls handleReply(), notifying loop() to call the callback function.
+//
+// While there are four packet types (PING, PONG, FINDNODE, NEIGHBORS), only these methods are exposed:
+//   - ping() actively sends a PING packet, and wait for PONG.
+//   - waitping() passively waits for a PING packet
+//   - findnode() actively sends a FINDNODE packet, and wait for NEIGHBORS.
+//   - You do not actively send a PONG or NEIGHBORS packets. They are send only in response to incoming requests.
+type udp struct {
+	networkID   uint64
+	conn        conn
+	netrestrict *netutil.Netlist
+	priv        *ecdsa.PrivateKey
+	ourEndpoint rpcEndpoint
 
-	// These settings are required for create Table and UDP
-	Id       NodeID
-	Addr     *net.UDPAddr
-	udp      transport
-	Conn     conn
-	NodeType NodeType
+	addpending chan *pending
+	gotreply   chan reply
 
-	// These settings are required for discovery packet control
-	MaxNeighborsNode uint
-	AuthorizedNodes  []*Node
+	closing chan struct{}
+	wg      sync.WaitGroup
 
-	// DiscoverNodetype is list of node type to enable discovery.
-	DiscoverTypes DiscoverTypesConfig
+	Discovery
 }
 
 // ListenUDP returns a new table that listens for UDP packets on laddr.
@@ -307,6 +311,7 @@ func ListenUDP(cfg *Config) (Discovery, error) {
 	return discv, nil
 }
 
+// #region UDP Init
 func newUDP(cfg *Config) (Discovery, *udp, error) {
 	udp := &udp{
 		networkID:   cfg.NetworkID,
@@ -350,6 +355,9 @@ func (t *udp) isAuthorized(fromID NodeID, nType NodeType) bool {
 func (t *udp) hasBond(fromID NodeID) bool {
 	return t.Discovery.HasBond(fromID)
 }
+
+// #region High-level APIs
+// Sends requests and waits for replies.
 
 // ping sends a ping message to the given node and waits for a reply.
 func (t *udp) ping(toid NodeID, toaddr *net.UDPAddr) error {
@@ -420,6 +428,66 @@ func (t *udp) findnode(toid NodeID, toaddr *net.UDPAddr, target NodeID, targetNT
 		target, "targetNodeType", targetNT)
 	return nodes, err
 }
+
+func (t *udp) nodeFromRPC(sender *net.UDPAddr, rn rpcNode) (*Node, error) {
+	if rn.UDP <= 1024 {
+		return nil, errors.New("low port")
+	}
+	if err := netutil.CheckRelayIP(sender.IP, rn.IP); err != nil {
+		return nil, err
+	}
+	if t.netrestrict != nil && !t.netrestrict.Contains(rn.IP) {
+		return nil, errors.New("not contained in netrestrict whitelist")
+	}
+	n := NewNode(rn.ID, rn.IP, rn.UDP, rn.TCP, nil, rn.NType)
+	err := n.validateComplete()
+	return n, err
+}
+
+func nodeToRPC(n *Node) rpcNode {
+	return rpcNode{ID: n.ID, IP: n.IP, UDP: n.UDP, TCP: n.TCP, NType: n.NType}
+}
+
+// #region Send requests
+
+func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) ([]byte, error) {
+	packet, hash, err := encodePacket(t.priv, ptype, req)
+	if err != nil {
+		return hash, err
+	}
+	return hash, t.write(toaddr, req.name(), packet)
+}
+
+func (t *udp) write(toaddr *net.UDPAddr, what string, packet []byte) error {
+	_, err := t.conn.WriteToUDP(packet, toaddr)
+	logger.Trace(">> "+what, "addr", toaddr, "err", err)
+	return err
+}
+
+func encodePacket(priv *ecdsa.PrivateKey, ptype byte, req interface{}) (packet, hash []byte, err error) {
+	b := new(bytes.Buffer)
+	b.Write(headSpace)
+	b.WriteByte(ptype)
+	if err := rlp.Encode(b, req); err != nil {
+		logger.Error("Can't encode discv4 packet", "err", err)
+		return nil, nil, err
+	}
+	packet = b.Bytes()
+	sig, err := crypto.Sign(crypto.Keccak256(packet[headSize:]), priv)
+	if err != nil {
+		logger.Error("Can't sign discv4 packet", "err", err)
+		return nil, nil, err
+	}
+	copy(packet[macSize:], sig)
+	// add the hash to the front. Note: this doesn't protect the
+	// packet in any way. Our public key will be part of this hash in
+	// The future.
+	hash = crypto.Keccak256(packet[macSize:])
+	copy(packet, hash)
+	return packet, hash, nil
+}
+
+// #region Wait for replies
 
 // pending adds a reply callback to the pending reply queue.
 // see the documentation of type pending for a detailed explanation.
@@ -497,9 +565,10 @@ func (t *udp) loop() {
 		case p := <-t.addpending:
 			p.deadline = time.Now().Add(respTimeout)
 			plist.PushBack(p)
-			if p.ptype == pongPacket {
+			switch p.ptype {
+			case pongPacket:
 				pendingPongCounter.Inc(1)
-			} else if p.ptype == neighborsPacket {
+			case neighborsPacket:
 				pendingNeighborsCounter.Inc(1)
 			}
 
@@ -559,74 +628,7 @@ func (t *udp) loop() {
 	}
 }
 
-const (
-	macSize  = 256 / 8
-	sigSize  = 520 / 8
-	headSize = macSize + sigSize // space of packet frame data
-)
-
-var (
-	headSpace = make([]byte, headSize)
-
-	// Neighbors replies are sent across multiple packets to
-	// stay below the 1280 byte limit. We compute the maximum number
-	// of entries by stuffing a packet until it grows too large.
-	maxNeighbors int
-)
-
-func init() {
-	p := neighbors{Expiration: ^uint64(0)}
-	maxSizeNode := rpcNode{IP: make(net.IP, 16), UDP: ^uint16(0), TCP: ^uint16(0)}
-	for n := 0; ; n++ {
-		p.Nodes = append(p.Nodes, maxSizeNode)
-		size, _, err := rlp.EncodeToReader(p)
-		if err != nil {
-			// If this ever happens, it will be caught by the unit tests.
-			panic("cannot encode: " + err.Error())
-		}
-		if headSize+size+1 >= 1280 {
-			maxNeighbors = n
-			break
-		}
-	}
-}
-
-func (t *udp) send(toaddr *net.UDPAddr, ptype byte, req packet) ([]byte, error) {
-	packet, hash, err := encodePacket(t.priv, ptype, req)
-	if err != nil {
-		return hash, err
-	}
-	return hash, t.write(toaddr, req.name(), packet)
-}
-
-func (t *udp) write(toaddr *net.UDPAddr, what string, packet []byte) error {
-	_, err := t.conn.WriteToUDP(packet, toaddr)
-	logger.Trace(">> "+what, "addr", toaddr, "err", err)
-	return err
-}
-
-func encodePacket(priv *ecdsa.PrivateKey, ptype byte, req interface{}) (packet, hash []byte, err error) {
-	b := new(bytes.Buffer)
-	b.Write(headSpace)
-	b.WriteByte(ptype)
-	if err := rlp.Encode(b, req); err != nil {
-		logger.Error("Can't encode discv4 packet", "err", err)
-		return nil, nil, err
-	}
-	packet = b.Bytes()
-	sig, err := crypto.Sign(crypto.Keccak256(packet[headSize:]), priv)
-	if err != nil {
-		logger.Error("Can't sign discv4 packet", "err", err)
-		return nil, nil, err
-	}
-	copy(packet[macSize:], sig)
-	// add the hash to the front. Note: this doesn't protect the
-	// packet in any way. Our public key will be part of this hash in
-	// The future.
-	hash = crypto.Keccak256(packet[macSize:])
-	copy(packet, hash)
-	return packet, hash, nil
-}
+// #region Packet dispatcher
 
 // readLoop runs in its own goroutine. it handles incoming UDP packets.
 func (t *udp) readLoop(unhandled chan<- ReadPacket) {
@@ -710,6 +712,8 @@ func decodePacket(buf []byte) (packet, NodeID, []byte, error) {
 	err = s.Decode(req)
 	return req, fromID, hash, err
 }
+
+// #region Packet handlers
 
 func (req *ping) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 	if expired(req.Expiration) {

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -56,10 +56,10 @@ type BaseServer struct {
 
 	// Relying components
 	logger       log.Logger
-	ntab         discover.Discovery // UDP discovery
-	ourHandshake *protoHandshake    // our TCP handshake message
-	listener     net.Listener       // TCP listener
-	peerFeed     event.Feed         // Peer event feed as in peer.go:PeerEventType.
+	ntab         discovery       // UDP discovery
+	ourHandshake *protoHandshake // our TCP handshake message
+	listener     net.Listener    // TCP listener
+	peerFeed     event.Feed      // Peer event feed as in peer.go:PeerEventType.
 
 	// Peer lifecycle state
 	selfID        discover.NodeID // precompulted Self().ID

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -214,7 +214,6 @@ func (srv *BaseServer) startDiscovery(listenAddr string) error {
 		NodeDBPath:    srv.NodeDatabase,
 		NetRestrict:   srv.NetRestrict,
 		Bootnodes:     srv.BootstrapNodes,
-		Unhandled:     nil,
 		Conn:          conn,
 		Addr:          realaddr,
 		Id:            discover.PubkeyID(&srv.PrivateKey.PublicKey),

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -316,7 +316,7 @@ func (srv *BaseServer) maxDialedConns() int {
 // inbound connections.
 func (srv *BaseServer) listenLoop() {
 	defer srv.loopWG.Done()
-	srv.logger.Info("RLPx listener up", "self", srv.makeSelf(srv.listener, srv.ntab))
+	srv.logger.Info("RLPx listener up", "self", srv.makeSelf(srv.listener))
 
 	tokens := defaultMaxPendingPeers
 	if srv.MaxPendingPeers > 0 {
@@ -370,11 +370,6 @@ func (srv *BaseServer) listenLoop() {
 // as a peer. It returns when the connection has been added as a peer
 // or the handshakes have failed.
 func (srv *BaseServer) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Node) error {
-	self := srv.Self()
-	if self == nil {
-		return errors.New("shutdown")
-	}
-
 	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, portOrder: ConnDefault}
 
 	// if err occurs, dialPubkey is automatically set as nil
@@ -721,27 +716,20 @@ func (srv *BaseServer) Self() *discover.Node {
 	if !srv.running {
 		return &discover.Node{IP: net.ParseIP("0.0.0.0")}
 	}
-	return srv.makeSelf(srv.listener, srv.ntab)
+	return srv.makeSelf(srv.listener)
 }
 
-func (srv *BaseServer) makeSelf(listener net.Listener, discovery discover.Discovery) *discover.Node {
-	// If the server's not running, return an empty node.
-	// If the node is running but discovery is off, manually assemble the node infos.
-	if discovery == nil {
-		// Inbound connections disabled, use zero address.
-		if listener == nil {
-			return &discover.Node{IP: net.ParseIP("0.0.0.0"), ID: discover.PubkeyID(&srv.PrivateKey.PublicKey)}
-		}
-		// Otherwise inject the listener address too
+// makeSelf returns the local node's TCP endpoint information.
+// The `listener` shall be the single listener (srv.listener) for BaseServer,
+// and one of the listeners (srv.listeners[*]) for MultiChannelServer.
+func (srv *BaseServer) makeSelf(listener net.Listener) *discover.Node {
+	id := discover.PubkeyID(&srv.PrivateKey.PublicKey)
+	if listener == nil {
+		return &discover.Node{IP: net.ParseIP("0.0.0.0"), ID: id}
+	} else {
 		addr := listener.Addr().(*net.TCPAddr)
-		return &discover.Node{
-			ID:  discover.PubkeyID(&srv.PrivateKey.PublicKey),
-			IP:  addr.IP,
-			TCP: uint16(addr.Port),
-		}
+		return discover.NewNode(id, addr.IP, uint16(addr.Port), uint16(addr.Port), nil, ConvertNodeType(srv.ConnectionType))
 	}
-	// Otherwise return the discovery node.
-	return discovery.Self()
 }
 
 // NodeInfo represents a short summary of the information known about the host.

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -192,7 +192,7 @@ func (srv *MultiChannelServer) startListening() error {
 // listenLoop waits for an external connection and connects it.
 func (srv *MultiChannelServer) listenLoop(listener net.Listener) {
 	defer srv.loopWG.Done()
-	srv.logger.Info("RLPx listener up", "self", srv.makeSelf(listener, srv.ntab))
+	srv.logger.Info("RLPx listener up", "self", srv.makeSelf(listener))
 
 	tokens := defaultMaxPendingPeers
 	if srv.MaxPendingPeers > 0 {
@@ -246,11 +246,6 @@ func (srv *MultiChannelServer) listenLoop(listener net.Listener) {
 // as a peer. It returns when the connection has been added as a peer
 // or the handshakes have failed.
 func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Node) error {
-	self := srv.Self()
-	if self == nil {
-		return errors.New("shutdown")
-	}
-
 	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, portOrder: PortOrderUndefined}
 
 	if dialDest != nil {


### PR DESCRIPTION
## Proposed changes

Add `p2p/discover.Table2`, a new discovery table implementation alongside the existing `Table`.

### Split into focused files

New | Existing
-|-
**table_init.go**: constructor | table.go:newTable
**table_bond.go**: revalidate, bond<br>(PING, PONG packets) | table.go: revalidate, bond<br>discover_storage_kademlia.go:revalidate<br>discover_storage_simple.go:revalidate
**table_lookup.go**: refresh, lookup<br>(FINDNODE, NEIGHBORS packets) | table.go: refresh, lookup<br>discover_storage_kademlia.go:lookup<br>discover_storage_simple.go:lookup
**table_storage.go**: tableStorage<br>table_storage.go: kademliaStorage<br>table_storage.go: flatStorage | discover_storage.go:discoverStorage<br>discover_storage_kademlia.go:KademliaStorage<br>discover_storage_simple.go:simpleStorage
**table_data.go**: wrappers to in-memory fields (storages) and local database (nodeDB) | (none)
**table_util.go**: misc helpers to Table2 | (none)

### Reduce interfaces

- tableStorage has a reduced interface so that the storage layers focus on the "structured list of nodes". Network-inducing mechanisms are lifted to table_bond.go and table_lookup.go.

New | Existing | Note
-|-|-
newKademliaStorage<br>newFlatStorage | name<br>setTable<br>setTargetNodeType<br>init | Destroy the mutual reference between table <-> storage
add<br>delete | add<br>delete<br>stuff | Delete the unused test helper
random<br>closest | readRandomNodes<br>closest | Rename
oldest | lookup<br>getNodes<br>doRevalidate<br>doRefresh<br>copyBondedNodes | Functionality taken by Table2
(none) | isAuthorized<br>putAuthorizedNode<br>deleteAuthorizedNode<br>getAuthorizedNodes | Functionality taken by Table2
len<br>numReplacements | len<br>nodeAll<br>getBucketEntries<br>getReplacements | Simplified helpers

- Discovery2 has a minimal interface in accordance with the reduced reliance of p2p.DialSched and p2p.Server.

New | Existing | Note
-|-|-
Close | Self<br>Close | Delete unused
Refresh<br>RandomNodes | Resolve<br>Lookup<br>GetNodes<br>ReadRandomNodes<br>RetrieveNodes | Unify similar methods
(none) | HasBond<br>Bond<br>IsAuthorized | No need to export. Only used within current package
(none) | Name<br>CreateUpdateNodeOnDB<br>CreateUpdateNodeOnTable<br>GetNodeFromDB<br>DeleteNodeFromDB<br>DeleteNodeFromTable<br>GetBucketEntries<br>GetReplacements | No need to export. A separate APIs() will expose the features.
PutAuthorizedNodes | GetAuthorizedNodes<br>PutAuthorizedNodes<br>DeleteAuthorizedNodes | Simplify accessors. The getter is exposed through APIs()

### p2p.Server simplifications

- `makeSelf()` (returns TCP listener address) no longer depends on the `discover.Table.Self()` (returns UDP listener address). They were unrelated after all.
- Removed unnecessary `Self() == nil` checks in SetupConn.

### udp.go reorganization

- no behavioral change. Symbols reordered into logical sections `#region` comments with more documentations.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- #751 

## Further comments

End-to-end discovery test

```
$ P2P_DISCOVER_E2E_TEST=1 go test -v -run=TestDiscovery_MainnetBootnodes
=== RUN   TestDiscovery_MainnetBootnodes
    discovery_test.go:49: Listening on 0.0.0.0:52685
INFO[03/11,14:45:51 +09] [34|networks/p2p/discover/table_lookup.go:78]  Discovery table refreshing                counts="map[BN:3 CN:3 EN:3 PN:3]"
DEBUG[03/11,14:45:58 +09] [34|networks/p2p/discover/table_lookup.go:182]  Discovery result                          self=true targetType=3 recurse=true count=14
DEBUG[03/11,14:46:00 +09] [34|networks/p2p/discover/table_lookup.go:182]  Discovery result                          self=false targetType=3 recurse=true count=16
DEBUG[03/11,14:46:02 +09] [34|networks/p2p/discover/table_bond.go:75]     Discovery revalidation failed             node=34.22.96.213:32323
DEBUG[03/11,14:46:02 +09] [34|networks/p2p/discover/table_lookup.go:182]  Discovery result                          self=false targetType=3 recurse=true count=16
DEBUG[03/11,14:46:02 +09] [34|networks/p2p/discover/table_bond.go:75]     Discovery revalidation failed             node=34.22.96.213:32323
DEBUG[03/11,14:46:03 +09] [34|networks/p2p/discover/table_bond.go:75]     Discovery revalidation failed             node=34.22.96.213:32323
DEBUG[03/11,14:46:03 +09] [34|networks/p2p/discover/table_bond.go:75]     Discovery revalidation failed             node=34.22.96.213:32323
DEBUG[03/11,14:46:04 +09] [34|networks/p2p/discover/table_lookup.go:182]  Discovery result                          self=false targetType=3 recurse=true count=16
DEBUG[03/11,14:46:04 +09] [34|networks/p2p/discover/table_lookup.go:182]  Discovery result                          self=true  targetType=2 recurse=false count=2
DEBUG[03/11,14:46:05 +09] [34|networks/p2p/discover/table_lookup.go:182]  Discovery result                          self=true  targetType=4 recurse=false count=2
INFO[03/11,14:46:05 +09] [34|networks/p2p/discover/table_lookup.go:83]   Discovery table refreshed                 counts="map[BN:2 CN:2 EN:42 PN:5]"
    discovery_test.go:70: Refreshed the discovery table
    discovery_test.go:76: Found 2 cn nodes (including initial bootnodes)
    discovery_test.go:79:   [0] 63f1c96874da8514@*.*.*.*:32323 (type=bn)
    discovery_test.go:79:   [1] 94cc15e2014b8658@*.*.*.*:32323 (type=bn)
    discovery_test.go:76: Found 5 pn nodes (including initial bootnodes)
    discovery_test.go:79:   [0] 77f313bc7c0628d2@*.*.*.*:32323 (type=pn)
    discovery_test.go:79:   [1] 63f1c96874da8514@*.*.*.*:32323 (type=bn)
    discovery_test.go:79:   [2] 0c7a2179b458c396@*.*.*.*:32323 (type=pn)
    discovery_test.go:79:   [3] 4828e2e75f1aae5a@*.*.*.*:32323 (type=pn)
    discovery_test.go:79:   [4] 94cc15e2014b8658@*.*.*.*:32323 (type=bn)
    discovery_test.go:76: Found 42 en nodes (including initial bootnodes)
    discovery_test.go:79:   [0] ffe7602e3f33f411@*.*.*.*:32323 (type=en)
    discovery_test.go:79:   [1] 7fd8845759c4e796@*.*.*.*:32323 (type=en)
    discovery_test.go:79:   [2] da7b2ff7eecebc1b@*.*.*.*:32323 (type=en)
    discovery_test.go:79:   [3] 41f6c5e852dbce35@*.*.*.*:32323 (type=en)
    discovery_test.go:79:   [4] b63cd62ceff67c25@*.*.*.*:32323 (type=en)
    discovery_test.go:79:   [5] c4defe69d34618bc@*.*.*.*:30048 (type=en)
    discovery_test.go:79:   [6] ead2dc732eb6be1f@*.*.*.*:32323 (type=en)
    discovery_test.go:79:   [7] 4802e9ebc8952b44@*.*.*.*:30303 (type=en)
    discovery_test.go:79:   [8] 87aa6c94a88b9563@*.*.*.*:32323 (type=en)
    discovery_test.go:79:   [9] 49fdbda2cd84fc2e@*.*.*.*:30303 (type=en)
    discovery_test.go:82:   ... and more
    discovery_test.go:76: Found 2 bn nodes (including initial bootnodes)
    discovery_test.go:79:   [0] 94cc15e2014b8658@*.*.*.*:32323 (type=bn)
    discovery_test.go:79:   [1] 63f1c96874da8514@*.*.*.*:32323 (type=bn)
INFO[03/11,14:46:05 +09] [34|networks/p2p/discover/table_init.go:134]    Discovery table closed                   
--- PASS: TestDiscovery_MainnetBootnodes (13.35s)
PASS
ok      github.com/kaiachain/kaia/networks/p2p/discover 13.881s
```
