### PR TITLE
consensus: remove CalcBlockScore from Engine Interface

### DIFF
--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -187,15 +187,14 @@ func (b *BlockGen) PrevBlock(index int) *types.Block {
 	return b.chain[index]
 }
 
-// OffsetTime modifies the time instance of a block, implicitly changing its
-// associated blockscore. It's useful to test scenarios where forking is not
+// OffsetTime modifies the time instance of a block. It's useful to test scenarios where forking is not
 // tied to chain length directly.
 func (b *BlockGen) OffsetTime(seconds int64) {
 	b.header.Time.Add(b.header.Time, new(big.Int).SetInt64(seconds))
 	if b.header.Time.Cmp(b.parent.Header().Time) <= 0 {
 		panic("block time out of range")
 	}
-	b.header.BlockScore = b.engine.CalcBlockScore(b.chainReader, b.header.Time.Uint64(), b.parent.Header())
+	b.header.BlockScore = consensus.DefaultBlockScore
 }
 
 // GenerateChain creates a chain of n blocks. The first block's
@@ -230,7 +229,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		defer blockchain.Stop()
 
 		b := &BlockGen{i: i, parent: parent, chain: blocks, chainReader: blockchain, statedb: stateDB, config: config, engine: engine}
-		b.header = makeHeader(b.chainReader, parent, stateDB, b.engine)
+		b.header = makeHeader(b.chainReader, parent, stateDB)
 
 		engine.Initialize(blockchain, b.header, stateDB)
 
@@ -269,7 +268,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	return blocks, receipts
 }
 
-func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.StateDB, engine consensus.Engine) *types.Header {
+func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.StateDB) *types.Header {
 	var time *big.Int
 	if parent.Time() == nil {
 		time = big.NewInt(10)
@@ -280,13 +279,9 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 	header := &types.Header{
 		Root:       state.IntermediateRoot(true),
 		ParentHash: parent.Hash(),
-		BlockScore: engine.CalcBlockScore(chain, time.Uint64(), &types.Header{
-			Number:     parent.Number(),
-			Time:       new(big.Int).Sub(time, big.NewInt(10)),
-			BlockScore: parent.BlockScore(),
-		}),
-		Number: new(big.Int).Add(parent.Number(), common.Big1),
-		Time:   time,
+		BlockScore: consensus.DefaultBlockScore,
+		Number:     new(big.Int).Add(parent.Number(), common.Big1),
+		Time:       time,
 	}
 	if chain.Config().IsMagmaForkEnabled(header.Number) {
 		header.BaseFee = misc.NextMagmaBlockBaseFee(parent.Header(), chain.Config().Governance.KIP71)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -23,8 +23,6 @@
 package consensus
 
 import (
-	"math/big"
-
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
@@ -126,10 +124,6 @@ type Engine interface {
 	// consensus rules that happen at finalization (e.g. block rewards).
 	Finalize(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
 		receipts []*types.Receipt) (*types.Block, error)
-
-	// CalcBlockScore is the blockscore adjustment algorithm. It returns the blockscore
-	// that a new block should have.
-	CalcBlockScore(chain ChainReader, time uint64, parent *types.Header) *big.Int
 
 	// APIs returns the RPC APIs this consensus engine provides.
 	APIs(chain ChainReader) []rpc.API

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -145,8 +145,7 @@ func (f *Faker) Prepare(chain consensus.ChainReader, header *types.Header) error
 		return errors.New("header number is nil")
 	}
 
-	parent := chain.GetHeader(header.ParentHash, header.Number.Uint64()-1)
-	header.BlockScore = f.CalcBlockScore(chain, header.Time.Uint64(), parent)
+	header.BlockScore = big.NewInt(1) // Simplified difficulty for testing
 	return nil
 }
 
@@ -187,11 +186,6 @@ func (f *Faker) Seal(chain consensus.ChainReader, block *types.Block) (*types.Bl
 	}
 
 	return block, nil
-}
-
-// CalcBlockScore calculates the block score.
-func (f *Faker) CalcBlockScore(chain consensus.ChainReader, time uint64, parent *types.Header) *big.Int {
-	return big.NewInt(1)
 }
 
 // APIs returns RPC APIs (none for faker).

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -566,10 +566,6 @@ func (sb *backend) updateBlock(block *types.Block) (*types.Block, error) {
 	return block.WithSeal(header), nil
 }
 
-func (sb *backend) CalcBlockScore(chain consensus.ChainReader, time uint64, parent *types.Header) *big.Int {
-	return big.NewInt(0)
-}
-
 // APIs returns the RPC APIs this consensus engine provides.
 func (sb *backend) APIs(chain consensus.ChainReader) []rpc.API {
 	return []rpc.API{

--- a/consensus/mocks/engine_mock.go
+++ b/consensus/mocks/engine_mock.go
@@ -5,7 +5,6 @@
 package mocks
 
 import (
-	big "math/big"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -67,20 +66,6 @@ func (m *MockEngine) Author(arg0 *types.Header) (common.Address, error) {
 func (mr *MockEngineMockRecorder) Author(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Author", reflect.TypeOf((*MockEngine)(nil).Author), arg0)
-}
-
-// CalcBlockScore mocks base method.
-func (m *MockEngine) CalcBlockScore(arg0 consensus.ChainReader, arg1 uint64, arg2 *types.Header) *big.Int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CalcBlockScore", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*big.Int)
-	return ret0
-}
-
-// CalcBlockScore indicates an expected call of CalcBlockScore.
-func (mr *MockEngineMockRecorder) CalcBlockScore(arg0, arg1, arg2 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalcBlockScore", reflect.TypeOf((*MockEngine)(nil).CalcBlockScore), arg0, arg1, arg2)
 }
 
 // CanVerifyHeadersConcurrently mocks base method.
@@ -234,21 +219,6 @@ func (m *MockEngine) VerifyHeader(arg0 consensus.ChainReader, arg1 *types.Header
 func (mr *MockEngineMockRecorder) VerifyHeader(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeader", reflect.TypeOf((*MockEngine)(nil).VerifyHeader), arg0, arg1, arg2)
-}
-
-// VerifyHeaders mocks base method.
-func (m *MockEngine) VerifyHeaders(arg0 consensus.ChainReader, arg1 []*types.Header, arg2 []bool) (chan<- struct{}, <-chan error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyHeaders", arg0, arg1, arg2)
-	ret0, _ := ret[0].(chan<- struct{})
-	ret1, _ := ret[1].(<-chan error)
-	return ret0, ret1
-}
-
-// VerifyHeaders indicates an expected call of VerifyHeaders.
-func (mr *MockEngineMockRecorder) VerifyHeaders(arg0, arg1, arg2 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeaders", reflect.TypeOf((*MockEngine)(nil).VerifyHeaders), arg0, arg1, arg2)
 }
 
 // VerifySeal mocks base method.

--- a/kaiax/supply/impl/testutil_test.go
+++ b/kaiax/supply/impl/testutil_test.go
@@ -280,7 +280,6 @@ func rebalanceAlloc(t *testing.T, blockNum uint64, addr common.Address, code []b
 
 func setupMockEngine(engine *consensus_mock.MockEngine, chain *blockchain.BlockChain, mReward reward.RewardModule) {
 	engine.EXPECT().Author(gomock.Any()).Return(addrProposer, nil).AnyTimes()
-	engine.EXPECT().CalcBlockScore(gomock.Any(), gomock.Any(), gomock.Any()).Return(common.Big0).AnyTimes()
 	engine.EXPECT().CanVerifyHeadersConcurrently().Return(false).AnyTimes()
 	engine.EXPECT().Initialize(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 


### PR DESCRIPTION
## Proposed changes

This PR removes CalcBlockScore from Engine Interface.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
