### PR TITLE
p2p: Replace Discovery with Discovery2

### DIFF
--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -271,8 +271,7 @@ func (ds *DialSched) dialLoop() {
 		select { // Loop upon any of the following signals.
 		case <-ds.wakeDial: // situation changed
 		case <-dialResCh: // one dial task completed (either success or failure)
-		case <-refreshResCh: // discovery refresh completed; refill the candidate queue
-			ds.refillCandidates()
+		case <-refreshResCh: // discovery refresh completed; next getCandidates will
 		case <-idle: // done idling
 		case <-ds.closeReq:
 			return
@@ -337,16 +336,17 @@ func (ds *DialSched) getDynamicCandidates(targetType discover.NodeType, need int
 		return nil, false
 	}
 
-	// Empty queue: signal the dial loop to run a discovery refresh.
-	// We'll come back after the refresh completes and refill the queue.
-	if len(ds.candidateQueue[targetType]) == 0 {
-		return nil, true
+	// Try to refill from the table if the queue can't satisfy the demand.
+	// The table may already have nodes (e.g. from local nodeDB) without needing a refresh
+	if len(ds.candidateQueue[targetType]) < need {
+		ds.refillCandidates()
 	}
 
 	// Pop up to `need` candidates from the queue.
 	q := ds.candidateQueue[targetType]
 	end := min(need, len(q))
 	nodes, ds.candidateQueue[targetType] = q[:end], q[end:]
+	// If the queue is short even after a refill, signal the dial loop to run a discovery refresh.
 	return nodes, len(q) < need
 }
 

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -44,9 +44,8 @@ type DialBackend interface {
 
 // discovery is the minimal table API dialsched needs.
 type discovery interface {
-	GetNodes(targetType discover.NodeType, max int) []*discover.Node
-	ReadRandomNodes(buf []*discover.Node, nType discover.NodeType) int
-	Lookup(target discover.NodeID, targetType discover.NodeType) []*discover.Node
+	RandomNodes(buf []*discover.Node, nType discover.NodeType) int
+	Refresh()
 	Close()
 }
 
@@ -301,7 +300,7 @@ func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh b
 		needRefresh = needRefresh || refresh
 	}
 
-	logger.Debug("Dialing candidates", "needs", needs, "candidates", len(candidates))
+	logger.Debug("Dialing candidates", "needs", needs, "connectedOutbound", ds.connectedOutbound.len(), "dialing", ds.dialing.len(), "candidates", len(candidates))
 	return candidates, needRefresh
 }
 
@@ -310,18 +309,10 @@ func (ds *DialSched) getDynamicCandidates(targetType discover.NodeType, need int
 		return nil, false
 	}
 	oversample := need * 4 // Oversample in case some nodes are not reachable.
-	switch targetType {    // TODO: to be unified with tab.RandomNodes() and tab.Refresh()
-	case discover.NodeTypeCN, discover.NodeTypePN:
-		nodes = ds.tab.GetNodes(targetType, oversample)
-		return nodes, len(nodes) < need
-	case discover.NodeTypeEN:
-		random := make([]*discover.Node, oversample)
-		num := ds.tab.ReadRandomNodes(random, targetType)
-		nodes := random[:min(num, len(random))]
-		return nodes, len(nodes) < need
-	default:
-		return nil, false
-	}
+	buf := make([]*discover.Node, oversample)
+	num := ds.tab.RandomNodes(buf, targetType)
+	nodes = buf[:num]
+	return nodes, len(nodes) < need
 }
 
 func (ds *DialSched) launchDialTasks(candidates []*discover.Node, resCh chan struct{}) {
@@ -404,10 +395,7 @@ func (ds *DialSched) refreshOnce(resCh chan struct{}) {
 		return
 	}
 	go func() {
-		// TODO: use tab.Refresh()
-		ds.tab.Lookup(ds.selfID, discover.NodeTypeCN)
-		ds.tab.Lookup(ds.selfID, discover.NodeTypePN)
-		ds.tab.Lookup(ds.selfID, discover.NodeTypeEN)
+		ds.tab.Refresh()
 		ds.signalResult(resCh)
 	}()
 }

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -287,8 +287,8 @@ func (ds *DialSched) dialLoop() {
 // Capacity math tells us that the dialing is unlikely to be saturated, so we don't separate the candidates by node type.
 //
 // The candidates are composed of [ static | dynamic CNs | dynamic PNs | dynamic ENs ], and they are consumed from the left.
-// - The candidates are first filtered with shouldDial() and then dialed up to maxConcurrentDials (16) at once.
-// - Even if the leftmost candidates are unfortunately unreachable, they are skipped in later iterations because of the dialBackoff and connFails.
+// - The candidates are filtered with shouldDial() and then dialed up to maxConcurrentDials (16) at once.
+// - Even if some candidates are unfortunately unreachable, they are skipped in later iterations because of the dialBackoff and connFails.
 //
 // If there are too many static nodes, the dynamic candidate dialing can be delayed. But it is reasonable and expected.
 // - You don't need dynamic candidates when you have enough static nodes.
@@ -343,19 +343,11 @@ func (ds *DialSched) getDynamicCandidates(targetType discover.NodeType, need int
 		return nil, true
 	}
 
-	// Scan the queue, advancing past undialable entries, until we have collected `need` candidates.
-	// shouldDial() called here as an inaccurate screening to reject hopeless candidates.
-	// shouldDial() called later as an accurate enforcement before launching the dialOnce goroutine.
+	// Pop up to `need` candidates from the queue.
 	q := ds.candidateQueue[targetType]
-	i := 0
-	for i < len(q) && len(nodes) < need {
-		if ds.shouldDial(q[i]) {
-			nodes = append(nodes, q[i])
-		}
-		i++
-	}
-	ds.candidateQueue[targetType] = q[i:]
-	return nodes, false
+	end := min(need, len(q))
+	nodes, ds.candidateQueue[targetType] = q[:end], q[end:]
+	return nodes, len(q) < need
 }
 
 // #region dial task

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -35,6 +35,8 @@ var (
 	dialBackoff      = 30 * time.Second // Minimum interval between the dial for the same node ID.
 	refreshBackoff   = 4 * time.Second  // Minimum interval between discretionary discovery table refreshes.
 	idleDialInterval = 10 * time.Second // Spins down the dial loop when there are no ongoing dial attempts.
+
+	candidateQueueSize = 100 // Number of nodes to fetch per dynamic candidate queue refill.
 )
 
 // DialBackend is the minimal server-side API dialsched needs for outbound dial execution.
@@ -66,6 +68,12 @@ type DialConfig struct {
 	// Used only when connTarget is nil, to compute the default EN-EN target.
 	// Pass the result of Server.maxDialedConns() here.
 	maxDynDials int
+
+	// maxPeers is the total peer capacity (inbound + outbound).
+	// Dynamic dials are suppressed when connectedAll reaches this limit,
+	// mirroring the server-side check in encHandshakeChecks.
+	// Pass srv.Config.MaxPhysicalConnections here. 0 means no limit.
+	maxPeers int
 
 	// Hooks for testing.
 	dialer NodeDialer
@@ -102,12 +110,16 @@ type DialSched struct {
 	mu         sync.RWMutex
 	selfID     discover.NodeID
 	connTarget map[discover.NodeType]int // Number of outbound connections to maintain for each node type
+	maxPeers   int                       // Total peer capacity (inbound + outbound). 0 = no limit.
 	dialer     NodeDialer
 	backend    DialBackend
 
 	// Node sources
 	static typedNodeSet // The static nodes.
 	tab    discovery    // The provider of dynamic nodes.
+	// candidateQueue is a per-type queue of discovery candidates, drained sequentially across loop
+	// iterations. This avoids re-offering the same unreachable nodes before their dialBackoff expires.
+	candidateQueue map[discover.NodeType][]*discover.Node
 
 	// Controls the discretionary discovery table refresh.
 	refreshBackoff time.Time // Earliest time allowed to refresh the discovery table. Counted since the refresh started.
@@ -130,6 +142,8 @@ type DialSched struct {
 	wg       sync.WaitGroup
 }
 
+// #region public interfaces
+
 func NewDialSched(cfg DialConfig, tab discovery, backend DialBackend) *DialSched {
 	connTarget := cfg.connTarget
 	if connTarget == nil {
@@ -144,10 +158,12 @@ func NewDialSched(cfg DialConfig, tab discovery, backend DialBackend) *DialSched
 	ds := &DialSched{
 		selfID:            cfg.selfID,
 		connTarget:        connTarget,
+		maxPeers:          cfg.maxPeers,
 		dialer:            dialer,
 		backend:           backend,
 		static:            newTypedNodeSet(),
 		tab:               tab,
+		candidateQueue:    make(map[discover.NodeType][]*discover.Node),
 		dialing:           newTypedNodeSet(),
 		dialBackoff:       make(map[discover.NodeID]time.Time),
 		netrestrict:       cfg.netrestrict,
@@ -214,6 +230,8 @@ func (ds *DialSched) OnPeerDisconnected(id discover.NodeID, nType discover.NodeT
 	ds.signalDial()
 }
 
+// #region dial loop
+
 // Let the dialLoop know that the situation has changed and it should check again.
 // This operation is non-blocking. Silently skips when ds.wakeDial is full or closed.
 func (ds *DialSched) signalDial() {
@@ -233,17 +251,16 @@ func (ds *DialSched) signalResult(resCh chan struct{}) {
 	}
 }
 
-//// Dial task loop
-
 func (ds *DialSched) dialLoop() {
 	defer ds.wg.Done()
-	resCh := make(chan struct{}, maxConcurrentDials)
+	dialResCh := make(chan struct{}, maxConcurrentDials)
+	refreshResCh := make(chan struct{}, 1)
 
 	for {
 		candidates, needRefresh := ds.getCandidates()
-		ds.launchDialTasks(candidates, resCh)
+		ds.launchDialTasks(candidates, dialResCh)
 		if needRefresh && ds.shouldRefresh() {
-			ds.refreshOnce(resCh)
+			ds.refreshOnce(refreshResCh)
 		}
 
 		var idle <-chan time.Time
@@ -253,13 +270,17 @@ func (ds *DialSched) dialLoop() {
 
 		select { // Loop upon any of the following signals.
 		case <-ds.wakeDial: // situation changed
-		case <-resCh: // one dial task completed (either success or failure)
+		case <-dialResCh: // one dial task completed (either success or failure)
+		case <-refreshResCh: // discovery refresh completed; refill the candidate queue
+			ds.refillCandidates()
 		case <-idle: // done idling
 		case <-ds.closeReq:
 			return
 		}
 	}
 }
+
+// #region candidate collection
 
 // Return the candidates for dialing from the mixture of static and dynamic nodes.
 //
@@ -293,14 +314,21 @@ func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh b
 	candidates = ds.static.all()
 	ds.mu.RUnlock()
 
-	// 3. Dynamic nodes
-	for targetType, need := range needs {
-		dynamicNodes, refresh := ds.getDynamicCandidates(targetType, need)
-		candidates = append(candidates, dynamicNodes...)
-		needRefresh = needRefresh || refresh
+	// 3. Dynamic nodes — skip when already at total peer capacity.
+	// Even if we want more outbound peers (needs > 0), the total capacity might be reached (maxPeers) due to inbound peers.
+	// Static dials (added above) bypass this check, mirroring the Server's capacity check.
+	if ds.maxPeers == 0 || ds.connectedAll.len() < ds.maxPeers {
+		for targetType, need := range needs {
+			dynamicNodes, refresh := ds.getDynamicCandidates(targetType, need)
+			candidates = append(candidates, dynamicNodes...)
+			needRefresh = needRefresh || refresh
+		}
 	}
 
-	logger.Debug("Dialing candidates", "needs", needs, "connectedOutbound", ds.connectedOutbound.len(), "dialing", ds.dialing.len(), "candidates", len(candidates))
+	if len(candidates) > 0 {
+		logger.Debug("Dialing candidates", "needs", needs, "static", ds.static.len(),
+			"connectedOutbound", ds.connectedOutbound.len(), "dialing", ds.dialing.len(), "candidates", len(candidates))
+	}
 	return candidates, needRefresh
 }
 
@@ -308,12 +336,29 @@ func (ds *DialSched) getDynamicCandidates(targetType discover.NodeType, need int
 	if ds.tab == nil || need <= 0 {
 		return nil, false
 	}
-	oversample := need * 4 // Oversample in case some nodes are not reachable.
-	buf := make([]*discover.Node, oversample)
-	num := ds.tab.RandomNodes(buf, targetType)
-	nodes = buf[:num]
-	return nodes, len(nodes) < need
+
+	// Empty queue: signal the dial loop to run a discovery refresh.
+	// We'll come back after the refresh completes and refill the queue.
+	if len(ds.candidateQueue[targetType]) == 0 {
+		return nil, true
+	}
+
+	// Scan the queue, advancing past undialable entries, until we have collected `need` candidates.
+	// shouldDial() called here as an inaccurate screening to reject hopeless candidates.
+	// shouldDial() called later as an accurate enforcement before launching the dialOnce goroutine.
+	q := ds.candidateQueue[targetType]
+	i := 0
+	for i < len(q) && len(nodes) < need {
+		if ds.shouldDial(q[i]) {
+			nodes = append(nodes, q[i])
+		}
+		i++
+	}
+	ds.candidateQueue[targetType] = q[i:]
+	return nodes, false
 }
+
+// #region dial task
 
 func (ds *DialSched) launchDialTasks(candidates []*discover.Node, resCh chan struct{}) {
 	for _, n := range candidates {
@@ -388,7 +433,9 @@ func (ds *DialSched) dialMulti(dest *discover.Node, flags connFlag) error {
 	return errBackup
 }
 
-func (ds *DialSched) refreshOnce(resCh chan struct{}) {
+// #region refresh task
+
+func (ds *DialSched) refreshOnce(refreshResCh chan struct{}) {
 	ds.markRefreshStart()
 
 	if ds.tab == nil {
@@ -396,11 +443,24 @@ func (ds *DialSched) refreshOnce(resCh chan struct{}) {
 	}
 	go func() {
 		ds.tab.Refresh()
-		ds.signalResult(resCh)
+		ds.signalResult(refreshResCh)
 	}()
 }
 
-//// Internal variable accessors
+// refillCandidates refills empty per-type candidate queues from the discovery table.
+// Called by dialLoop after a refresh completes, so the table has fresh nodes.
+// Accessed only by the dialLoop goroutine; no mutex required.
+func (ds *DialSched) refillCandidates() {
+	for targetType := range ds.connTarget {
+		if len(ds.candidateQueue[targetType]) == 0 {
+			buf := make([]*discover.Node, candidateQueueSize)
+			n := ds.tab.RandomNodes(buf, targetType)
+			ds.candidateQueue[targetType] = buf[:n]
+		}
+	}
+}
+
+// #region internal variable accessors
 
 func (ds *DialSched) addStatic(n *discover.Node) {
 	if n == nil {

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -139,10 +139,9 @@ func TestDialSched_OnPeerConnected(t *testing.T) {
 		inbound   = testNode(2, "10.0.0.2", discover.NodeTypePN)
 		outbound  = testNode(3, "10.0.0.3", discover.NodeTypePN)
 		tab       = &mockTable{
-			getNodesByType: map[discover.NodeType][]*discover.Node{
+			nodesByType: map[discover.NodeType][]*discover.Node{
 				discover.NodeTypePN: {candidate},
 			},
-			randomByType: map[discover.NodeType][]*discover.Node{},
 		}
 		ds = NewDialSched(DialConfig{
 			connTarget: map[discover.NodeType]int{
@@ -169,8 +168,7 @@ func TestDialSched_OnPeerConnected(t *testing.T) {
 func TestDialSched_ShouldRefresh_RefreshBackoff(t *testing.T) {
 	var (
 		tab = &mockTable{
-			getNodesByType: map[discover.NodeType][]*discover.Node{},
-			randomByType:   map[discover.NodeType][]*discover.Node{},
+			nodesByType: map[discover.NodeType][]*discover.Node{},
 		}
 		ds = NewDialSched(DialConfig{
 			selfID: testNodeID(1),
@@ -185,7 +183,7 @@ func TestDialSched_ShouldRefresh_RefreshBackoff(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "refreshOnce did not finish in time")
 	}
-	assert.Equal(t, 3, tab.lookupCalls, "expected one refresh to perform 3 lookups (CN, PN, EN)")
+	assert.Equal(t, 1, tab.refreshCalls, "expected one Refresh call")
 
 	// Forcibly set the refresh backoff to be in the past.
 	assert.False(t, ds.shouldRefresh(), "expected refresh to be throttled immediately after refreshOnce")
@@ -198,7 +196,7 @@ func TestDialSched_ShouldRefresh_RefreshBackoff(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "second refreshOnce did not finish in time")
 	}
-	assert.Equal(t, 6, tab.lookupCalls, "expected second refresh to perform 6 lookups (CN, PN, EN)")
+	assert.Equal(t, 2, tab.refreshCalls, "expected two Refresh calls total")
 }
 
 // Static nodes are always candidates, even if connTarget is met.
@@ -223,10 +221,8 @@ func TestDialSched_GetCandidates_FromDiscovery(t *testing.T) {
 		pn  = testNode(201, "10.0.0.201", discover.NodeTypePN)
 		en  = testNode(202, "10.0.0.202", discover.NodeTypeEN)
 		tab = &mockTable{
-			getNodesByType: map[discover.NodeType][]*discover.Node{
+			nodesByType: map[discover.NodeType][]*discover.Node{
 				discover.NodeTypePN: {pn},
-			},
-			randomByType: map[discover.NodeType][]*discover.Node{
 				discover.NodeTypeEN: {en},
 			},
 		}
@@ -515,26 +511,16 @@ func TestDialSched_Close_BlockedSetupConn(t *testing.T) {
 
 // Generic mock discovery table.
 type mockTable struct {
-	getNodesByType map[discover.NodeType][]*discover.Node
-	randomByType   map[discover.NodeType][]*discover.Node
-	lookupCalls    int
+	nodesByType   map[discover.NodeType][]*discover.Node
+	refreshCalls  int
 }
 
-func (m *mockTable) Lookup(target discover.NodeID, targetType discover.NodeType) []*discover.Node {
-	m.lookupCalls++
-	return nil
+func (m *mockTable) RandomNodes(buf []*discover.Node, nType discover.NodeType) int {
+	return copy(buf, m.nodesByType[nType])
 }
 
-func (m *mockTable) GetNodes(targetType discover.NodeType, max int) []*discover.Node {
-	nodes := m.getNodesByType[targetType]
-	if max < len(nodes) {
-		return nodes[:max]
-	}
-	return nodes
-}
-
-func (m *mockTable) ReadRandomNodes(buf []*discover.Node, nType discover.NodeType) int {
-	return copy(buf, m.randomByType[nType])
+func (m *mockTable) Refresh() {
+	m.refreshCalls++
 }
 
 func (m *mockTable) Close() {

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -153,7 +153,6 @@ func TestDialSched_OnPeerConnected(t *testing.T) {
 	ds.OnPeerConnected(inbound.ID, inbound.NType, true)
 	assert.False(t, ds.connectedOutbound.contains(inbound.ID), "inbound peer should not be counted as connected outbound")
 	assert.True(t, ds.connectedAll.contains(inbound.ID), "inbound peer should be counted as connected")
-	ds.refillCandidates()
 	cands, _ := ds.getCandidates()
 	require.Len(t, cands, 1, "expected one outbound candidate for PN when only inbound PN exists")
 	assert.Equal(t, candidate.ID, cands[0].ID)
@@ -235,7 +234,6 @@ func TestDialSched_GetCandidates_FromDiscovery(t *testing.T) {
 		}, tab, nil)
 	)
 
-	ds.refillCandidates()
 	cands, needRefresh := ds.getCandidates()
 
 	assert.True(t, hasNodeID(cands, pn.ID), "PN candidates should include GetNodes result")

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -153,6 +153,7 @@ func TestDialSched_OnPeerConnected(t *testing.T) {
 	ds.OnPeerConnected(inbound.ID, inbound.NType, true)
 	assert.False(t, ds.connectedOutbound.contains(inbound.ID), "inbound peer should not be counted as connected outbound")
 	assert.True(t, ds.connectedAll.contains(inbound.ID), "inbound peer should be counted as connected")
+	ds.refillCandidates()
 	cands, _ := ds.getCandidates()
 	require.Len(t, cands, 1, "expected one outbound candidate for PN when only inbound PN exists")
 	assert.Equal(t, candidate.ID, cands[0].ID)
@@ -234,6 +235,7 @@ func TestDialSched_GetCandidates_FromDiscovery(t *testing.T) {
 		}, tab, nil)
 	)
 
+	ds.refillCandidates()
 	cands, needRefresh := ds.getCandidates()
 
 	assert.True(t, hasNodeID(cands, pn.ID), "PN candidates should include GetNodes result")
@@ -511,8 +513,8 @@ func TestDialSched_Close_BlockedSetupConn(t *testing.T) {
 
 // Generic mock discovery table.
 type mockTable struct {
-	nodesByType   map[discover.NodeType][]*discover.Node
-	refreshCalls  int
+	nodesByType  map[discover.NodeType][]*discover.Node
+	refreshCalls int
 }
 
 func (m *mockTable) RandomNodes(buf []*discover.Node, nType discover.NodeType) int {

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -152,6 +152,7 @@ func (srv *BaseServer) Start() (err error) {
 			staticNodes: srv.StaticNodes,
 			netrestrict: srv.NetRestrict,
 			maxDynDials: srv.maxDialedConns(),
+			maxPeers:    srv.MaxPeers(),
 			dialer:      srv.Dialer,
 		}, srv.ntab, srv)
 		srv.dialSched.Start()

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -222,7 +222,7 @@ func (srv *BaseServer) startDiscovery(listenAddr string) error {
 		DiscoverTypes: srv.DiscoverTypes,
 	}
 
-	ntab, err := discover.ListenUDP(&cfg)
+	ntab, err := discover.NewDiscovery2(&cfg)
 	if err != nil {
 		return err
 	}

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -126,6 +126,7 @@ func (srv *MultiChannelServer) Start() (err error) {
 			staticNodes: srv.StaticNodes,
 			netrestrict: srv.NetRestrict,
 			maxDynDials: srv.maxDialedConns(),
+			maxPeers:    srv.MaxPeers(),
 			dialer:      srv.Dialer,
 		}, srv.ntab, srv)
 		srv.dialSched.Start()


### PR DESCRIPTION
## Proposed changes

- Replace `Discovery` with `Discovery2`. Use it in p2p.Server and p2p.DialSched.
- Update DialSched's dynamic candidate selection logic.
  - Previously, the oversampling could probabilistically return the same ineligible node over and over.
  - Now the samples are first dumped onto a queue then consumed sequentially.
```
# First attempt. Empty queue. Async refill.
getDynamicCandidates():   queue empty -> return (nil, needRefresh=true)
dialLoop:                 needRefresh -> refreshOnce(refreshResCh)
dialLoop:                 case <-refreshResCh: refillCandidates()
refillCandidates():       tab.RandomNodes() → fill candidateQueue

# Second attempt. Consume queue
getDynamicCandidates():   pop from candidateQueue
```


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- #751 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
