### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -23,6 +23,8 @@
 package backend
 
 import (
+	"maps"
+
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
@@ -91,9 +93,7 @@ func (api *API) Candidates() map[common.Address]bool {
 	defer api.istanbul.candidatesLock.RUnlock()
 
 	proposals := make(map[common.Address]bool)
-	for address, auth := range api.istanbul.candidates {
-		proposals[address] = auth
-	}
+	maps.Copy(proposals, api.istanbul.candidates)
 	return proposals
 }
 

--- a/kaiax/gov/headergov/impl/api.go
+++ b/kaiax/gov/headergov/impl/api.go
@@ -1,6 +1,8 @@
 package impl
 
 import (
+	"maps"
+
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -136,21 +138,15 @@ func (api *headerGovAPI) Status() StatusResponse {
 	groupedVotes := make(map[uint64]headergov.VotesInEpoch, len(api.h.groupedVotes))
 	for epochIdx, votes := range api.h.groupedVotes {
 		copiedVotes := make(headergov.VotesInEpoch, len(votes))
-		for blockNum, vote := range votes {
-			copiedVotes[blockNum] = vote
-		}
+		maps.Copy(copiedVotes, votes)
 		groupedVotes[epochIdx] = copiedVotes
 	}
 
 	governances := make(map[uint64]headergov.GovData, len(api.h.governances))
-	for blockNum, gov := range api.h.governances {
-		governances[blockNum] = gov
-	}
+	maps.Copy(governances, api.h.governances)
 
 	govHistory := make(headergov.History, len(api.h.history))
-	for blockNum, pset := range api.h.history {
-		govHistory[blockNum] = pset
-	}
+	maps.Copy(govHistory, api.h.history)
 
 	myVotes := make([]headergov.VoteData, len(api.h.myVotes))
 	copy(myVotes, api.h.myVotes)

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -25,6 +25,7 @@ package cn
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"sort"
 	"sync"
@@ -210,9 +211,7 @@ func (ps *peerSet) Peers() map[string]Peer {
 	defer ps.lock.RUnlock()
 
 	set := make(map[string]Peer)
-	for id, p := range ps.peers {
-		set[id] = p
-	}
+	maps.Copy(set, ps.peers)
 	return set
 }
 
@@ -221,9 +220,7 @@ func (ps *peerSet) CNPeers() map[common.Address]Peer {
 	defer ps.lock.RUnlock()
 
 	set := make(map[common.Address]Peer)
-	for addr, p := range ps.cnpeers {
-		set[addr] = p
-	}
+	maps.Copy(set, ps.cnpeers)
 	return set
 }
 
@@ -232,9 +229,7 @@ func (ps *peerSet) ENPeers() map[common.Address]Peer {
 	defer ps.lock.RUnlock()
 
 	set := make(map[common.Address]Peer)
-	for addr, p := range ps.enpeers {
-		set[addr] = p
-	}
+	maps.Copy(set, ps.enpeers)
 	return set
 }
 
@@ -243,9 +238,7 @@ func (ps *peerSet) PNPeers() map[common.Address]Peer {
 	defer ps.lock.RUnlock()
 
 	set := make(map[common.Address]Peer)
-	for addr, p := range ps.pnpeers {
-		set[addr] = p
-	}
+	maps.Copy(set, ps.pnpeers)
 	return set
 }
 

--- a/node/sc/bridgepeer.go
+++ b/node/sc/bridgepeer.go
@@ -25,6 +25,7 @@ package sc
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"sync"
 	"time"
@@ -450,9 +451,7 @@ func (ps *bridgePeerSet) Peers() map[string]BridgePeer {
 	defer ps.lock.RUnlock()
 
 	set := make(map[string]BridgePeer)
-	for id, p := range ps.peers {
-		set[id] = p
-	}
+	maps.Copy(set, ps.peers)
 	return set
 }
 


### PR DESCRIPTION
## Proposed changes

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.



## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
