### PR TITLE
genesis: fix --override-osaka flag for private networks

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -256,14 +256,14 @@ func SetupGenesisBlockWithOverride(db database.DBManager, genesis *Genesis, over
 		if hash != ghash {
 			return nil, common.Hash{}, &GenesisMismatchError{ghash, hash}
 		}
-	}
 
-	// The genesis block is present in the database but the corresponding state might not.
-	// Because the trie can be partially corrupted, we always commit the trie.
-	// It can happen in a state migrated database or live pruned database.
-	if db.GetDomainsManager() == nil { // FlatTrie disallows re-commiting the block lower than the head block.
-		if err := commitGenesisState(genesis, db, overrides); err != nil {
-			return nil, common.Hash{}, err
+		// The genesis block is present in the database but the corresponding state might not.
+		// Because the trie can be partially corrupted, we always commit the trie.
+		// It can happen in a state migrated database or live pruned database.
+		if db.GetDomainsManager() == nil { // FlatTrie disallows re-commiting the block lower than the head block.
+			if err := commitGenesisState(genesis, db, overrides); err != nil {
+				return nil, common.Hash{}, err
+			}
 		}
 	}
 
@@ -522,9 +522,6 @@ func decodePrealloc(data string) GenesisAlloc {
 }
 
 func commitGenesisState(genesis *Genesis, db database.DBManager, overrides *ChainOverrides) error {
-	if genesis == nil {
-		genesis = DefaultGenesisBlock()
-	}
 	if err := overrides.apply(genesis.Config); err != nil {
 		return err
 	}

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -729,9 +729,10 @@ func TestSetupGenesis(t *testing.T) {
 // Test that SetupGenesisBlock writes the genesis state trie if not present.
 func TestGenesisRestoreState(t *testing.T) {
 	db := database.NewMemoryDBManager()
+	genesis := DefaultGenesisBlock()
 
 	// Setup first to Commit the Genesis block
-	_, hash, err := SetupGenesisBlock(db, nil)
+	_, hash, err := SetupGenesisBlock(db, genesis)
 	assert.Nil(t, err)
 	assert.Equal(t, params.MainnetGenesisHash, hash)
 
@@ -741,7 +742,7 @@ func TestGenesisRestoreState(t *testing.T) {
 	db.DeleteTrieNode(root)
 
 	// Setup again to restore the state trie
-	_, hash, err = SetupGenesisBlock(db, nil)
+	_, hash, err = SetupGenesisBlock(db, genesis)
 	assert.Nil(t, err)
 	assert.Equal(t, params.MainnetGenesisHash, hash)
 	ok, _ := db.HasTrieNode(root)


### PR DESCRIPTION
## Proposed changes

The `--override-osaka` CLI flag fails on private network nodes when restarting (`cn.New()` path).

For private networks, `cn.New()` calls `SetupGenesisBlock(db, genesis=nil)` — because the genesis was already committed to the database during `init`. This caused `commitGenesisState()` with invalid genesis block.

```
commitGenesisState(genesis=nil, ...) {
  if genesis == nil: genesis = DefaultGenesisBlock() // Mainnet genesis block
}
```

Then `overrides.apply(mainnetConfig)` validated `--override-osaka N` against Mainnet's Prague hardfork number instead of the private network's, causing a fork-order error:

```
// given all fork blocks zero with `--override-osaka 2`
Fatal: Error starting protocol stack: unsupported fork ordering: pragueBlock enabled at 190670000, but osakaBlock enabled at 2
```

The fix is to skip `commitGenesisState()` when genesis is nil; when genesis is not given, it is infeasible to generate the genesis state.

Note: The previous incorrect behavior introduced with `commitGenesisState()` did not corrupt private network genesis state. Since the state trie is content-addressed, the Mainnet trie nodes were written under a different root hash than the one stored in the private network's genesis block header, making them unreferenced and harmless.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

