### PR TITLE
ci: Cache go builds

### DIFF
--- a/.github/workflows/test-executor-template.yml
+++ b/.github/workflows/test-executor-template.yml
@@ -24,7 +24,12 @@ jobs:
           fetch-depth: 0 # Fetches full history for test-linter's '--new-from-rev=dev to work
       - name: Add safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
+      # Will override the base image's Go setup. Introduced to cache the builds.
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.3' # The same version as the base image.
+          cache: true
       - name: Run test
         shell: bash
         run: ${{ inputs.test_command }}

--- a/.github/workflows/test-other-executor-template.yml
+++ b/.github/workflows/test-other-executor-template.yml
@@ -46,7 +46,12 @@ jobs:
           fetch-depth: 0 # Fetches full history
       - name: Add safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
+      # Will override the base image's Go setup. Introduced to cache the builds.
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.3' # The same version as the base image.
+          cache: true
       - name: setup python 3.9
         if: ${{ inputs.install_python == true }}
         uses: actions/setup-python@v5

--- a/.github/workflows/test-pr-workflow.yml
+++ b/.github/workflows/test-pr-workflow.yml
@@ -7,15 +7,16 @@ on:
 permissions:
   contents: read
 
-
+# Run the 'build' job first to update the build cache.
 jobs:
   build:
     name: Build
     uses: ./.github/workflows/test-executor-template.yml
     with:
-      test_command: make all
+      test_command: make kcn && make all -j
 
   test-linter:
+    needs: build
     name: Test Linter
     uses: ./.github/workflows/test-executor-template.yml
     with:
@@ -24,18 +25,21 @@ jobs:
         go run build/ci.go lint -v --new-from-rev="origin/${BASE_BRANCH}"
 
   test-networks:
+    needs: build
     name: Test Networks
     uses: ./.github/workflows/test-executor-template.yml
     with:
       test_command: make test-networks
 
   test-node:
+    needs: build
     name: Test Node
     uses: ./.github/workflows/test-executor-template.yml
     with:
       test_command: make test-node
 
   test-tests:
+    needs: build
     name: Test Tests
     uses: ./.github/workflows/test-executor-template.yml
     with:
@@ -44,6 +48,7 @@ jobs:
         make test-tests
 
   test-rpc:
+    needs: build
     name: Test RPC
     permissions:
       contents: write
@@ -68,12 +73,14 @@ jobs:
 
   # Service-dependent test jobs
   test-datasync:
+    needs: build
     name: Test Datasync
     uses: ./.github/workflows/test-other-executor-template.yml
     with:
       test_command: make test-datasync
 
   test-others:
+    needs: build
     name: Test Others
     uses: ./.github/workflows/test-other-executor-template.yml
     with:

--- a/.github/workflows/test-pr-workflow.yml
+++ b/.github/workflows/test-pr-workflow.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
 
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Proposed changes

- Cache go build artifacts in CI.
  - Use `actions/setup-go` to cache build artifacts across PRs
  - The `build` job runs first to populate the build artifacts before testing jobs
- Total running time: 76 min -> 57 min
- Longest running time: 16 min -> 16 min

<p align="center">Before / Gocache / Build first</p>

<p align="center">
  <img width="20%" alt="image" src="https://github.com/user-attachments/assets/def46c19-1a32-4010-ade3-3fb21869252e" />
  <img width="20%" alt="image" src="https://github.com/user-attachments/assets/acd441e9-b02a-4614-9b6d-14c2486636ea" />
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/bd93daf5-732a-4c4d-b50f-10101e8f84aa" />

</p>

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [x] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

