### PR TITLE
[PR5] Permissionless foundation: types, ABv2, genesis alloc

### DIFF
--- a/accounts/abi/bind/backends/blockchain_state.go
+++ b/accounts/abi/bind/backends/blockchain_state.go
@@ -41,6 +41,8 @@ type StateBlockchainContractCaller struct {
 
 var _ bind.ContractCaller = (*StateBlockchainContractCaller)(nil)
 
+// NewStateBlockchainContractBackend creates a ContractCaller that reads from the given statedb directly.
+// Used when Chain.StateAt is unavailable (e.g., cold start or uncommitted state).
 func NewStateBlockchainContractBackend(bc BlockChainForCaller, state *state.StateDB) (*StateBlockchainContractCaller, error) {
 	if state == nil {
 		return nil, errors.New("statedb is nil")

--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -1,0 +1,242 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"bytes"
+	"math/big"
+	"sort"
+	"time"
+
+	"github.com/kaiachain/kaia/accounts/abi/bind"
+	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	abv2contracts "github.com/kaiachain/kaia/contracts_permissionless/contracts/AddressBookV2"
+	abv2data "github.com/kaiachain/kaia/contracts_permissionless/contracts/AddressBookV2/abv2data"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/params"
+)
+
+// ReadABv2Implementation reads the ABv2 logic contract address from ABv2DataContract.
+// ABv2DataContract is resolved from Registry and stores the implementation as an immutable.
+func ReadABv2Implementation(backend bind.ContractCaller, num *big.Int) (common.Address, error) {
+	dataContractAddr, err := ReadActiveAddressFromRegistry(backend, "ABv2DataContract", num)
+	if err != nil {
+		return common.Address{}, err
+	}
+	caller, err := abv2data.NewABv2DataContractCaller(dataContractAddr, backend)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return caller.Implementation(&bind.CallOpts{BlockNumber: num})
+}
+
+// InstallAddressBookV2 sets up the AddressBookV2 UUPS proxy at AddressBookAddr (0x400).
+// logicAddr is the pre-deployed ABv2 implementation contract address
+// (stored in ABv2DataContract.implementation()).
+func InstallAddressBookV2(state *state.StateDB, logicAddr common.Address) error {
+	// Set ERC1967 proxy code at 0x400
+	if err := state.SetCode(AddressBookAddr, ERC1967ProxyV5Code); err != nil {
+		return err
+	}
+	// Point proxy's implementation slot to the logic contract
+	state.SetState(AddressBookAddr, common.BytesToHash(ImplementationSlot), lpad32(logicAddr))
+
+	return nil
+}
+
+// EncodeInitializeABv2 encodes the initialize() call for AddressBookV2 proxy.
+// ABv2.initialize() takes no parameters — it reads all genesis data from ABv2DataContract via Registry.
+func EncodeInitializeABv2(rules params.Rules) (common.Address, *types.Transaction, error) {
+	data, err := AddressBookV2ABI.Pack("initialize")
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+	from := params.SystemAddress
+	gasLimit := params.UpperGasLimit
+	intrinsicGas, err := types.IntrinsicGas(data, nil, nil, false, rules)
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+	var (
+		to  = AddressBookAddr
+		msg = types.NewMessage(from, &to, 0, common.Big0, gasLimit, common.Big0, nil, nil, nil, data, false, intrinsicGas, nil, nil, nil, nil, nil)
+	)
+	return from, msg, nil
+}
+
+func EncodeWriteNodes(
+	rules params.Rules,
+	validators valset.NodeStateMap,
+) (common.Address, *types.Transaction, error) {
+	nodeIds := make([]common.Address, 0, len(validators))
+	for addr := range validators {
+		nodeIds = append(nodeIds, addr)
+	}
+	// Sort for deterministic ABI encoding across all nodes
+	sort.Slice(nodeIds, func(i, j int) bool {
+		return bytes.Compare(nodeIds[i].Bytes(), nodeIds[j].Bytes()) < 0
+	})
+
+	var (
+		newStates  = make([]uint8, len(nodeIds))
+		timeoutAts = make([]*big.Int, len(nodeIds))
+	)
+	for idx, addr := range nodeIds {
+		vs := validators[addr]
+		newStates[idx] = vs.State.ToUint8()
+		var timeout time.Time
+		switch vs.State {
+		case valset.ValPaused:
+			timeout = vs.PausedTimeout
+		case valset.ValReady, valset.ValInactive:
+			timeout = vs.IdleTimeout
+		}
+		if timeout.IsZero() {
+			timeoutAts[idx] = big.NewInt(0)
+		} else {
+			timeoutAts[idx] = big.NewInt(timeout.Unix())
+		}
+	}
+
+	data, err := AddressBookV2ABI.Pack("processSystemTransition", nodeIds, newStates, timeoutAts)
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+	var (
+		from     = params.SystemAddress
+		gasLimit = params.UpperGasLimit
+		to       = AddressBookAddr
+	)
+	intrinsicGas, err := types.IntrinsicGas(data, nil, nil, false, rules)
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+	msg := types.NewMessage(
+		from,         // from common.Address,
+		&to,          // to *common.Address,
+		0,            // nonce uint64,
+		common.Big0,  // amount *big.Int,
+		gasLimit,     // gasLimit uint64,
+		common.Big0,  // gasPrice *big.Int
+		nil,          // gasFeeCap *big.Int
+		nil,          // gasTipCap *big.Int
+		nil,          // blobGasFeeCap *big.Int
+		data,         // data []byte
+		false,        // checkNonce bool
+		intrinsicGas, // intrinsicGas uint64
+		nil,          // list AccessList
+		nil,          // chainId *big.Int
+		nil,          // blobHashes []common.Hash
+		nil,          // sidecar *BlobTxSidecar
+		nil,          // auth []SetCodeAuthorization
+	)
+	return from, msg, nil
+}
+
+// ReadABv2Timeouts reads pauseTimeout and idleTimeout durations from the AddressBookV2 contract.
+func ReadABv2Timeouts(
+	backend bind.ContractCaller,
+	num *big.Int,
+) (pauseTimeout, idleTimeout time.Duration, err error) {
+	caller, err := abv2contracts.NewAddressBookV2Caller(AddressBookAddr, backend)
+	if err != nil {
+		return 0, 0, err
+	}
+	opts := &bind.CallOpts{BlockNumber: num}
+	pause, idle, err := caller.GetTimeouts(opts)
+	if err != nil {
+		return 0, 0, err
+	}
+	return time.Duration(pause.Int64()) * time.Second,
+		time.Duration(idle.Int64()) * time.Second,
+		nil
+}
+
+// ReadABv2MaxCounts reads maxValidatorCount and maxReadyCandidateCount from the AddressBookV2 contract.
+func ReadABv2MaxCounts(
+	backend bind.ContractCaller,
+	num *big.Int,
+) (maxValidatorCount, maxReadyCandidateCount uint64, err error) {
+	caller, err := abv2contracts.NewAddressBookV2Caller(AddressBookAddr, backend)
+	if err != nil {
+		return 0, 0, err
+	}
+	opts := &bind.CallOpts{BlockNumber: num}
+	valCount, candCount, err := caller.GetMaxCounts(opts)
+	if err != nil {
+		return 0, 0, err
+	}
+	return valCount.Uint64(), candCount.Uint64(), nil
+}
+
+func ReadGetAllValidators(
+	statedb *state.StateDB,
+	chain backends.BlockChainForCaller,
+	header *types.Header,
+) (valset.NodeStateMap, error) {
+	caller, err := NewMultiCallContractCaller(statedb, chain, header)
+	if err != nil {
+		return nil, err
+	}
+	opts := &bind.CallOpts{BlockNumber: header.Number}
+
+	res, err := caller.MultiCallStakingInfoPermissionless(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	validators := make(valset.NodeStateMap)
+	for i, p := range res.Profiles {
+		nodeState := valset.State(p.State)
+		vs := &valset.ValidatorState{
+			State:         nodeState,
+			StakingAmount: new(big.Int).Div(res.StakingAmounts[i], big.NewInt(params.KAIA)).Uint64(),
+		}
+		switch nodeState {
+		case valset.ValReady, valset.ValInactive:
+			if p.TimeoutAt.Sign() > 0 {
+				vs.IdleTimeout = time.Unix(p.TimeoutAt.Int64(), 0)
+			}
+		case valset.ValPaused:
+			if p.TimeoutAt.Sign() > 0 {
+				vs.PausedTimeout = time.Unix(p.TimeoutAt.Int64(), 0)
+			}
+		}
+		validators[p.NodeId] = vs
+	}
+	return validators, nil
+}
+
+// ReadAddressBookV2BlsAll reads BLS public key info for all nodes from AddressBookV2.
+// Used for permissionless blocks where ABv2 is the BLS source of truth.
+func ReadAddressBookV2BlsAll(backend bind.ContractCaller, num *big.Int) (BlsPublicKeyInfos, error) {
+	caller, err := abv2contracts.NewAddressBookV2Caller(AddressBookAddr, backend)
+	if err != nil {
+		return nil, err
+	}
+	opts := &bind.CallOpts{BlockNumber: num}
+	ret, err := caller.GetAllBlsInfo(opts)
+	if err != nil {
+		return nil, err
+	}
+	return buildBlsPublicKeyInfos(ret.NodeIdList, len(ret.PubkeyList), func(i int) ([]byte, []byte) {
+		return ret.PubkeyList[i].PublicKey, ret.PubkeyList[i].Pop
+	})
+}

--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -61,6 +61,20 @@ func InstallAddressBookV2(state *state.StateDB, logicAddr common.Address) error 
 	return nil
 }
 
+// encodeSystemMessage creates a system transaction message for the given target and data.
+func encodeSystemMessage(rules params.Rules, to common.Address, data []byte) (common.Address, *types.Transaction, error) {
+	var (
+		from     = params.SystemAddress
+		gasLimit = params.UpperGasLimit
+	)
+	intrinsicGas, err := types.IntrinsicGas(data, nil, nil, false, rules)
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+	msg := types.NewMessage(from, &to, 0, common.Big0, gasLimit, common.Big0, nil, nil, nil, data, false, intrinsicGas, nil, nil, nil, nil, nil)
+	return from, msg, nil
+}
+
 // EncodeInitializeABv2 encodes the initialize() call for AddressBookV2 proxy.
 // ABv2.initialize() takes no parameters — it reads all genesis data from ABv2DataContract via Registry.
 func EncodeInitializeABv2(rules params.Rules) (common.Address, *types.Transaction, error) {
@@ -68,19 +82,10 @@ func EncodeInitializeABv2(rules params.Rules) (common.Address, *types.Transactio
 	if err != nil {
 		return common.Address{}, nil, err
 	}
-	from := params.SystemAddress
-	gasLimit := params.UpperGasLimit
-	intrinsicGas, err := types.IntrinsicGas(data, nil, nil, false, rules)
-	if err != nil {
-		return common.Address{}, nil, err
-	}
-	var (
-		to  = AddressBookAddr
-		msg = types.NewMessage(from, &to, 0, common.Big0, gasLimit, common.Big0, nil, nil, nil, data, false, intrinsicGas, nil, nil, nil, nil, nil)
-	)
-	return from, msg, nil
+	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
+// EncodeWriteNodes encodes the processSystemTransition call with the given validator state changes.
 func EncodeWriteNodes(
 	rules params.Rules,
 	validators valset.NodeStateMap,
@@ -119,35 +124,7 @@ func EncodeWriteNodes(
 	if err != nil {
 		return common.Address{}, nil, err
 	}
-	var (
-		from     = params.SystemAddress
-		gasLimit = params.UpperGasLimit
-		to       = AddressBookAddr
-	)
-	intrinsicGas, err := types.IntrinsicGas(data, nil, nil, false, rules)
-	if err != nil {
-		return common.Address{}, nil, err
-	}
-	msg := types.NewMessage(
-		from,         // from common.Address,
-		&to,          // to *common.Address,
-		0,            // nonce uint64,
-		common.Big0,  // amount *big.Int,
-		gasLimit,     // gasLimit uint64,
-		common.Big0,  // gasPrice *big.Int
-		nil,          // gasFeeCap *big.Int
-		nil,          // gasTipCap *big.Int
-		nil,          // blobGasFeeCap *big.Int
-		data,         // data []byte
-		false,        // checkNonce bool
-		intrinsicGas, // intrinsicGas uint64
-		nil,          // list AccessList
-		nil,          // chainId *big.Int
-		nil,          // blobHashes []common.Hash
-		nil,          // sidecar *BlobTxSidecar
-		nil,          // auth []SetCodeAuthorization
-	)
-	return from, msg, nil
+	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
 // ReadABv2Timeouts reads pauseTimeout and idleTimeout durations from the AddressBookV2 contract.
@@ -186,6 +163,7 @@ func ReadABv2MaxCounts(
 	return valCount.Uint64(), candCount.Uint64(), nil
 }
 
+// ReadGetAllValidators reads all validator profiles and staking amounts from ABv2 via MultiCall.
 func ReadGetAllValidators(
 	statedb *state.StateDB,
 	chain backends.BlockChainForCaller,

--- a/blockchain/system/addressbook_v2_test.go
+++ b/blockchain/system/addressbook_v2_test.go
@@ -1,0 +1,216 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+package system
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallAddressBookV2(t *testing.T) {
+	backend := backends.NewSimulatedBackend(nil)
+	defer backend.Close()
+
+	header := backend.BlockChain().CurrentHeader()
+	statedb, err := backend.BlockChain().StateAt(header.Root)
+	require.NoError(t, err)
+
+	logicAddr := common.HexToAddress("0xcafebebe")
+
+	// Before install: no code at AddressBookAddr
+	assert.Empty(t, statedb.GetCode(AddressBookAddr))
+
+	err = InstallAddressBookV2(statedb, logicAddr)
+	require.NoError(t, err)
+
+	// Verify proxy code is set at 0x400
+	assert.Equal(t, ERC1967ProxyV5Code, statedb.GetCode(AddressBookAddr))
+
+	// Verify implementation slot points to logicAddr
+	implSlot := statedb.GetState(AddressBookAddr, common.BytesToHash(ImplementationSlot))
+	assert.Equal(t, lpad32(logicAddr), implSlot)
+}
+
+func TestEncodeWriteNodes(t *testing.T) {
+	rules := params.Rules{IsPrague: true} // enable intrinsic gas calculation
+
+	tests := []struct {
+		name       string
+		validators valset.NodeStateMap
+		// expected decoded values (sorted by address)
+		wantAddrs    []common.Address
+		wantStates   []uint8
+		wantTimeouts []*big.Int
+	}{
+		{
+			name:       "empty map",
+			validators: valset.NodeStateMap{},
+			wantAddrs:  []common.Address{},
+		},
+		{
+			name: "single ValActive, no timeout",
+			validators: valset.NodeStateMap{
+				common.HexToAddress("0x01"): {State: valset.ValActive},
+			},
+			wantAddrs:    []common.Address{common.HexToAddress("0x01")},
+			wantStates:   []uint8{valset.ValActive.ToUint8()},
+			wantTimeouts: []*big.Int{big.NewInt(0)},
+		},
+		{
+			name: "ValPaused uses PausedTimeout",
+			validators: valset.NodeStateMap{
+				common.HexToAddress("0x01"): {
+					State:         valset.ValPaused,
+					PausedTimeout: time.Unix(1000, 0),
+				},
+			},
+			wantAddrs:    []common.Address{common.HexToAddress("0x01")},
+			wantStates:   []uint8{valset.ValPaused.ToUint8()},
+			wantTimeouts: []*big.Int{big.NewInt(1000)},
+		},
+		{
+			name: "ValReady uses IdleTimeout",
+			validators: valset.NodeStateMap{
+				common.HexToAddress("0x01"): {
+					State:       valset.ValReady,
+					IdleTimeout: time.Unix(2000, 0),
+				},
+			},
+			wantAddrs:    []common.Address{common.HexToAddress("0x01")},
+			wantStates:   []uint8{valset.ValReady.ToUint8()},
+			wantTimeouts: []*big.Int{big.NewInt(2000)},
+		},
+		{
+			name: "ValInactive uses IdleTimeout",
+			validators: valset.NodeStateMap{
+				common.HexToAddress("0x01"): {
+					State:       valset.ValInactive,
+					IdleTimeout: time.Unix(3000, 0),
+				},
+			},
+			wantAddrs:    []common.Address{common.HexToAddress("0x01")},
+			wantStates:   []uint8{valset.ValInactive.ToUint8()},
+			wantTimeouts: []*big.Int{big.NewInt(3000)},
+		},
+		{
+			name: "ValExiting has zero timeout",
+			validators: valset.NodeStateMap{
+				common.HexToAddress("0x01"): {State: valset.ValExiting},
+			},
+			wantAddrs:    []common.Address{common.HexToAddress("0x01")},
+			wantStates:   []uint8{valset.ValExiting.ToUint8()},
+			wantTimeouts: []*big.Int{big.NewInt(0)},
+		},
+		{
+			name: "multiple validators sorted by address",
+			validators: valset.NodeStateMap{
+				common.HexToAddress("0xcc"): {State: valset.ValActive},
+				common.HexToAddress("0xaa"): {
+					State:         valset.ValPaused,
+					PausedTimeout: time.Unix(500, 0),
+				},
+				common.HexToAddress("0xbb"): {
+					State:       valset.ValInactive,
+					IdleTimeout: time.Unix(999, 0),
+				},
+			},
+			wantAddrs: []common.Address{
+				common.HexToAddress("0xaa"),
+				common.HexToAddress("0xbb"),
+				common.HexToAddress("0xcc"),
+			},
+			wantStates:   []uint8{valset.ValPaused.ToUint8(), valset.ValInactive.ToUint8(), valset.ValActive.ToUint8()},
+			wantTimeouts: []*big.Int{big.NewInt(500), big.NewInt(999), big.NewInt(0)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			from, msg, err := EncodeWriteNodes(rules, tc.validators)
+			require.NoError(t, err)
+
+			// from is always SystemAddress
+			assert.Equal(t, params.SystemAddress, from)
+
+			// to is always AddressBookAddr
+			assert.Equal(t, &AddressBookAddr, msg.To())
+
+			if len(tc.validators) == 0 {
+				return
+			}
+
+			// Decode the ABI-packed data to verify contents
+			method, err := AddressBookV2ABI.MethodById(msg.Data()[:4])
+			require.NoError(t, err)
+			assert.Equal(t, "processSystemTransition", method.Name)
+
+			args, err := method.Inputs.Unpack(msg.Data()[4:])
+			require.NoError(t, err)
+			require.Len(t, args, 3)
+
+			decodedAddrs := args[0].([]common.Address)
+			decodedStates := args[1].([]uint8)
+			decodedTimeouts := args[2].([]*big.Int)
+
+			assert.Equal(t, tc.wantAddrs, decodedAddrs, "addresses should be sorted")
+			assert.Equal(t, tc.wantStates, decodedStates)
+			for i, want := range tc.wantTimeouts {
+				assert.Equal(t, 0, want.Cmp(decodedTimeouts[i]), "timeout[%d]: want %s got %s", i, want, decodedTimeouts[i])
+			}
+		})
+	}
+}
+
+// TestReadAddressBookV2BlsAll tests that BLS pub/pop keys can be read from ABv2.
+func TestReadAddressBookV2BlsAll(t *testing.T) {
+	config := MakeTestPermissionlessConfig(t, 3)
+
+	alloc, err := AllocPermissionless(config)
+	require.NoError(t, err)
+
+	simBackend := backends.NewSimulatedBackend(blockchain.GenesisAlloc(alloc))
+	defer simBackend.Close()
+
+	chain := simBackend.BlockChain()
+	header := chain.CurrentHeader()
+	statedb, err := chain.StateAt(header.Root)
+	require.NoError(t, err)
+
+	readBackend, err := backends.NewStateBlockchainContractBackend(chain, statedb)
+	require.NoError(t, err)
+
+	blsInfos, err := ReadAddressBookV2BlsAll(readBackend, nil)
+	require.NoError(t, err)
+	assert.Len(t, blsInfos, 3)
+
+	// Verify each nodeId has matching BLS keys from config
+	for i, nodeId := range config.NodeIds {
+		info, ok := blsInfos[nodeId]
+		require.True(t, ok, "nodeId %s should have BLS info", nodeId.Hex())
+		assert.Equal(t, config.NodeInfos[i].BlsInfo.PublicKey, info.PublicKey)
+		assert.Equal(t, config.NodeInfos[i].BlsInfo.Pop, info.Pop)
+		assert.NoError(t, info.VerifyErr)
+	}
+}

--- a/blockchain/system/constant.go
+++ b/blockchain/system/constant.go
@@ -28,10 +28,13 @@ import (
 	kip113contract "github.com/kaiachain/kaia/contracts/contracts/system_contracts/kip113"
 	kip149contract "github.com/kaiachain/kaia/contracts/contracts/system_contracts/kip149"
 	misccontract "github.com/kaiachain/kaia/contracts/contracts/system_contracts/misc"
-	"github.com/kaiachain/kaia/contracts/contracts/system_contracts/multicall"
 	proxycontract "github.com/kaiachain/kaia/contracts/contracts/system_contracts/proxy"
 	"github.com/kaiachain/kaia/contracts/contracts/testing/reward"
 	testcontract "github.com/kaiachain/kaia/contracts/contracts/testing/system_contracts"
+	addressbookv2contract "github.com/kaiachain/kaia/contracts_permissionless/contracts/AddressBookV2"
+	permlessproxycontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/Proxy"
+	"github.com/kaiachain/kaia/contracts_permissionless/contracts/multicall"
+	permlesstestcontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/testing"
 	"github.com/kaiachain/kaia/log"
 )
 
@@ -65,9 +68,9 @@ var (
 	RegistryAddr    = common.HexToAddress("0x0000000000000000000000000000000000000401")
 	MultiCallAddr   = common.HexToAddress("0x0000000000000000000000000000000000000402")
 	// The following addresses are only used for testing.
-	Kip113ProxyAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000402")
-	Kip113LogicAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000403")
-	AuctionEntryPointAddrMock = common.HexToAddress("0x0000000000000000000000000000000000000404")
+	Kip113ProxyAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000403")
+	Kip113LogicAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000404")
+	AuctionEntryPointAddrMock = common.HexToAddress("0x0000000000000000000000000000000000000405")
 
 	// Registry will return zero address for non-existent system contract.
 	NonExistentAddress = common.HexToAddress("0x0000000000000000000000000000000000000000")
@@ -83,13 +86,18 @@ var (
 	Kip113MockCode            = hexutil.MustDecode("0x" + testcontract.KIP113MockBinRuntime)
 	AuctionEntryPointMockCode = hexutil.MustDecode("0x" + testcontract.AuctionEntryPointMockBinRuntime)
 
-	ERC1967ProxyCode = hexutil.MustDecode("0x" + proxycontract.ERC1967ProxyBinRuntime)
+	ERC1967ProxyCode   = hexutil.MustDecode("0x" + proxycontract.ERC1967ProxyBinRuntime)
+	ERC1967ProxyV5Code = hexutil.MustDecode("0x" + permlessproxycontract.ERC1967ProxyBinRuntime)
 
 	AddressBookMockTwoCNCode = hexutil.MustDecode("0x" + reward.AddressBookMockTwoCNBinRuntime)
 	Kip113MockThreeCNCode    = hexutil.MustDecode("0x" + testcontract.KIP113MockThreeCNBinRuntime)
 
+	AddressBookV2Code   = hexutil.MustDecode("0x" + addressbookv2contract.AddressBookV2BinRuntime)
+	AddressBookV2ABI, _ = addressbookv2contract.AddressBookV2MetaData.GetAbi()
+
 	MultiCallCode     = hexutil.MustDecode("0x" + multicall.MultiCallContractBinRuntime)
-	MultiCallMockCode = hexutil.MustDecode("0x" + testcontract.MultiCallContractMockBinRuntime)
+	MultiCallMockCode        = hexutil.MustDecode("0x" + testcontract.MultiCallContractMockBinRuntime)
+	MultiCallPermlessMockCode = hexutil.MustDecode("0x" + permlesstestcontract.MultiCallContractMockBinRuntime)
 
 	// Mock for CLRegistry testing
 	CLRegistryMockThreeCLAddr = common.HexToAddress("0x0000000000000000000000000000000000000Ff0")

--- a/blockchain/system/kip113.go
+++ b/blockchain/system/kip113.go
@@ -156,25 +156,24 @@ func ReadKip113All(backend bind.ContractCaller, contractAddr common.Address, num
 	if err != nil {
 		return nil, err
 	}
-
 	opts := &bind.CallOpts{BlockNumber: num}
 	ret, err := caller.GetAllBlsInfo(opts)
 	if err != nil {
 		return nil, err
 	}
+	return buildBlsPublicKeyInfos(ret.NodeIdList, len(ret.PubkeyList), func(i int) ([]byte, []byte) {
+		return ret.PubkeyList[i].PublicKey, ret.PubkeyList[i].Pop
+	})
+}
 
-	if len(ret.NodeIdList) != len(ret.PubkeyList) {
+func buildBlsPublicKeyInfos(nodeIdList []common.Address, pubkeyLen int, getKeyPop func(i int) ([]byte, []byte)) (BlsPublicKeyInfos, error) {
+	if len(nodeIdList) != pubkeyLen {
 		return nil, ErrKip113BadResult
 	}
-
-	infos := make(BlsPublicKeyInfos)
-	for i := 0; i < len(ret.NodeIdList); i++ {
-		addr := ret.NodeIdList[i]
-		infos[addr] = newBlsPublicKeyInfo(
-			ret.PubkeyList[i].PublicKey,
-			ret.PubkeyList[i].Pop,
-		)
+	infos := make(BlsPublicKeyInfos, len(nodeIdList))
+	for i, addr := range nodeIdList {
+		pub, pop := getKeyPop(i)
+		infos[addr] = newBlsPublicKeyInfo(pub, pop)
 	}
-
-	return infos, err
+	return infos, nil
 }

--- a/blockchain/system/kip113_test.go
+++ b/blockchain/system/kip113_test.go
@@ -16,7 +16,6 @@
 package system
 
 import (
-	"crypto/rand"
 	"math/big"
 	"testing"
 
@@ -25,10 +24,9 @@ import (
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/common"
 	contracts "github.com/kaiachain/kaia/contracts/contracts/system_contracts/kip113"
-	proxycontracts "github.com/kaiachain/kaia/contracts/contracts/system_contracts/proxy"
 	testcontracts "github.com/kaiachain/kaia/contracts/contracts/testing/system_contracts"
+	proxycontracts "github.com/kaiachain/kaia/contracts_permissionless/contracts/Proxy"
 	"github.com/kaiachain/kaia/crypto"
-	"github.com/kaiachain/kaia/crypto/bls"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
@@ -182,18 +180,5 @@ func compareStorage(t *testing.T, backend *backends.SimulatedBackend, contractAd
 }
 
 func makeBlsKey() (priv, pub, pop []byte) {
-	ikm := make([]byte, 32)
-	rand.Read(ikm)
-
-	sk, _ := bls.GenerateKey(ikm)
-	pk := sk.PublicKey()
-	sig := bls.PopProve(sk)
-
-	priv = sk.Marshal()
-	pub = pk.Marshal()
-	pop = sig.Marshal()
-	if len(priv) != 32 || len(pub) != 48 || len(pop) != 96 {
-		panic("bad bls key")
-	}
-	return
+	return MakeTestBlsKey()
 }

--- a/blockchain/system/multicall.go
+++ b/blockchain/system/multicall.go
@@ -29,7 +29,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/contracts/contracts/system_contracts/multicall"
+	"github.com/kaiachain/kaia/contracts_permissionless/contracts/multicall"
 )
 
 // ContractCallerForMultiCall is an implementation of ContractCaller only for MultiCall contract.

--- a/blockchain/system/multicall_test.go
+++ b/blockchain/system/multicall_test.go
@@ -21,30 +21,40 @@ import (
 
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
+	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/contracts_permissionless/contracts/multicall"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestContractCallerForMultiCall(t *testing.T) {
+// setupMultiCallMock creates a SimulatedBackend with MultiCallMockCode injected,
+// and returns the caller, call opts, state, and a cleanup function.
+func setupMultiCallMock(t *testing.T) (*multicall.MultiCallContractCaller, *bind.CallOpts, *state.StateDB, func()) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
 	backend := backends.NewSimulatedBackend(nil)
 	originCode := MultiCallCode
-	defer func() {
-		MultiCallCode = originCode
-		backend.Close()
-	}()
-
-	// Temporary code injection
 	MultiCallCode = MultiCallMockCode
 
 	header := backend.BlockChain().CurrentHeader()
 	chain := backend.BlockChain()
+	st, _ := backend.BlockChain().StateAt(header.Root)
+	caller, _ := NewMultiCallContractCaller(st, chain, header)
+	callOpts := &bind.CallOpts{BlockNumber: header.Number}
 
-	state, _ := backend.BlockChain().StateAt(header.Root)
-	caller, _ := NewMultiCallContractCaller(state, chain, header)
-	ret, err := caller.MultiCallStakingInfo(&bind.CallOpts{BlockNumber: header.Number})
+	cleanup := func() {
+		MultiCallCode = originCode
+		backend.Close()
+	}
+	return caller, callOpts, st, cleanup
+}
+
+func TestContractCallerForMultiCall(t *testing.T) {
+	caller, callOpts, state, cleanup := setupMultiCallMock(t)
+	defer cleanup()
+
+	ret, err := caller.MultiCallStakingInfo(callOpts)
 	assert.Nil(t, err)
 
 	// Does not affect the original state
@@ -67,4 +77,49 @@ func TestContractCallerForMultiCall(t *testing.T) {
 		assert.Equal(t, expectedAddress[i], ret.AddressList[i])
 	}
 	assert.Equal(t, new(big.Int).Mul(big.NewInt(7_000_000), big.NewInt(params.KAIA)), ret.StakingAmounts[0])
+}
+
+func TestMultiCallStakingInfoPermissionless(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	backend := backends.NewSimulatedBackend(nil)
+	originCode := MultiCallCode
+	MultiCallCode = MultiCallPermlessMockCode
+	defer func() {
+		MultiCallCode = originCode
+		backend.Close()
+	}()
+
+	header := backend.BlockChain().CurrentHeader()
+	chain := backend.BlockChain()
+	state, _ := backend.BlockChain().StateAt(header.Root)
+	caller, _ := NewMultiCallContractCaller(state, chain, header)
+	callOpts := &bind.CallOpts{BlockNumber: header.Number}
+
+	ret, err := caller.MultiCallStakingInfoPermissionless(callOpts)
+	assert.Nil(t, err)
+
+	// Does not affect the original state
+	assert.Equal(t, []byte(nil), state.GetCode(MultiCallAddr))
+
+	// Verify profiles
+	assert.Equal(t, 2, len(ret.Profiles))
+	assert.Equal(t, common.HexToAddress("0xF00"), ret.Profiles[0].NodeId)
+	assert.Equal(t, common.HexToAddress("0xF01"), ret.Profiles[0].StakingContract)
+	assert.Equal(t, common.HexToAddress("0xF02"), ret.Profiles[0].RewardAddress)
+	assert.Equal(t, uint8(6), ret.Profiles[0].State) // ValActive
+
+	assert.Equal(t, common.HexToAddress("0xF03"), ret.Profiles[1].NodeId)
+	assert.Equal(t, common.HexToAddress("0xF04"), ret.Profiles[1].StakingContract)
+	assert.Equal(t, common.HexToAddress("0xF05"), ret.Profiles[1].RewardAddress)
+	assert.Equal(t, uint8(2), ret.Profiles[1].State) // CandReady
+
+	// Verify staking amounts
+	assert.Equal(t, 2, len(ret.StakingAmounts))
+	assert.Equal(t, new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(params.KAIA)), ret.StakingAmounts[0])
+	assert.Equal(t, new(big.Int).Mul(big.NewInt(10_000_000), big.NewInt(params.KAIA)), ret.StakingAmounts[1])
+
+	// Verify fund addresses
+	assert.Equal(t, common.HexToAddress("0x0a01"), ret.KefAddr)
+	assert.Equal(t, common.HexToAddress("0x0a02"), ret.KifAddr)
+	assert.Equal(t, common.HexToAddress("0x0a03"), ret.KpfAddr)
 }

--- a/blockchain/system/permissionless.go
+++ b/blockchain/system/permissionless.go
@@ -1,0 +1,400 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"fmt"
+	"math"
+	"math/big"
+
+	kaiaABI "github.com/kaiachain/kaia/accounts/abi"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types/account"
+	"github.com/kaiachain/kaia/blockchain/vm/runtime"
+	"github.com/kaiachain/kaia/common"
+	registrycontract "github.com/kaiachain/kaia/contracts/contracts/system_contracts/kip149"
+	addressbookv2contract "github.com/kaiachain/kaia/contracts_permissionless/contracts/AddressBookV2"
+	abv2data "github.com/kaiachain/kaia/contracts_permissionless/contracts/AddressBookV2/abv2data"
+	cnstakingv4 "github.com/kaiachain/kaia/contracts_permissionless/contracts/CnStaking/CnStakingV4"
+	cnstakingv4factory "github.com/kaiachain/kaia/contracts_permissionless/contracts/CnStaking/CnStakingV4Factory"
+	beaconcontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/Proxy/beacon"
+	pdcontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/PublicDelegation"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/storage/database"
+)
+
+// DefaultEpochBlockInterval is the default number of blocks per epoch for ABv2.
+const DefaultEpochBlockInterval = 86400
+
+// AllocPermissionlessConfig holds parameters for genesis permissionless allocation.
+type AllocPermissionlessConfig struct {
+	Owner      common.Address                                  // Owner of beacons, Registry registrant
+	NodeIds    []common.Address                                // Validator node IDs
+	NodeInfos  []addressbookv2contract.NodeInfo                // Validator info — caller fills all fields except StakingContract (set after deployCnStaking)
+	StakeAmts  []*big.Int                                      // Stake amounts per validator
+	DataConfig addressbookv2contract.IABv2DataContractInitData // ABv2DataContract constructor data
+}
+
+// allocPermissionlessResult holds intermediate deployed addresses passed between internal steps.
+type allocPermissionlessResult struct {
+	cnStakingBeacon common.Address
+	pdBeacon        common.Address
+	factory         common.Address
+	abv2Impl        common.Address
+}
+
+// AllocPermissionless deploys all permissionless system contracts into an in-memory
+// statedb using the EVM runtime, and returns the resulting genesis alloc.
+func AllocPermissionless(config *AllocPermissionlessConfig) (map[common.Address]blockchain.GenesisAccount, error) {
+	if len(config.NodeIds) != len(config.NodeInfos) || len(config.NodeIds) != len(config.StakeAmts) {
+		return nil, fmt.Errorf("mismatched lengths: nodeIds=%d, infos=%d, stakeAmts=%d",
+			len(config.NodeIds), len(config.NodeInfos), len(config.StakeAmts))
+	}
+
+	// Create in-memory statedb
+	memDB := database.NewMemoryDBManager()
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(memDB), nil, nil)
+
+	// Install Registry for EVM execution — included in final alloc with patched activations
+	registryConfig := &params.RegistryConfig{
+		Records: make(map[string]common.Address),
+		Owner:   config.Owner,
+	}
+	if err := InstallRegistry(statedb, registryConfig); err != nil {
+		return nil, fmt.Errorf("install registry: %w", err)
+	}
+
+	// Fund each validator's manager with enough KAIA for staking
+	deployer := config.Owner
+	for i, amt := range config.StakeAmts {
+		statedb.AddBalance(config.NodeInfos[i].Manager, amt)
+	}
+
+	// Shared runtime config
+	cfg := &runtime.Config{
+		ChainConfig: params.TestChainConfig,
+		Origin:      deployer,
+		State:       statedb,
+		GasLimit:    math.MaxUint64,
+		GasPrice:    new(big.Int),
+		Value:       new(big.Int),
+		BlockNumber: new(big.Int),
+		Time:        new(big.Int),
+	}
+
+	result := &allocPermissionlessResult{}
+
+	// Step 1: Deploy implementation contracts and their UpgradeableBeacons
+	if err := deployBeaconInfra(cfg, deployer, result); err != nil {
+		return nil, err
+	}
+
+	// Step 2: Deploy CnStakingV4Factory and register in Registry (activation=1, block=0)
+	if err := deployCnStakingFactory(cfg, big.NewInt(1), result); err != nil {
+		return nil, err
+	}
+
+	// Step 3: Deploy CnStaking per validator and stake
+	if err := deployCnStakingPerValidator(cfg, config, result); err != nil {
+		return nil, err
+	}
+	cfg.Origin = deployer // restore after per-validator origin switching
+
+	// Step 4: Deploy ABv2DataContract and register in Registry (activation=1, block=0)
+	if err := deployABv2DataContract(cfg, big.NewInt(1), config, result); err != nil {
+		return nil, err
+	}
+
+	// Advance block number so getActiveAddr finds records with activation=1
+	cfg.BlockNumber = big.NewInt(1)
+
+	// Step 5: Install ABv2 at 0x400 and call initialize()
+	if err := installAndInitABv2(cfg, statedb, result.abv2Impl); err != nil {
+		return nil, err
+	}
+
+	// Patch all Registry activation slots to 0 so contracts are active from genesis
+	patchRegistryActivations(statedb, "CnStakingFactory", "ABv2DataContract")
+
+	// Clean up balances for all managers
+	for _, info := range config.NodeInfos {
+		statedb.SetBalance(info.Manager, new(big.Int))
+	}
+
+	// Commit dirty state to trie so ForEachAccount/ForEachStorage can iterate
+	if _, err := statedb.Commit(false); err != nil {
+		return nil, fmt.Errorf("statedb commit: %w", err)
+	}
+
+	// Extract all changed accounts into genesis alloc.
+	// Exclude manager EOAs (temporary funding) — they are not system contracts.
+	// Registry (0x401) is included — this replaces allocateRegistry when permissionless is active.
+	excludeAddrs := map[common.Address]bool{}
+	for _, info := range config.NodeInfos {
+		excludeAddrs[info.Manager] = true
+	}
+	alloc, err := extractAlloc(statedb, excludeAddrs)
+	if err != nil {
+		return nil, fmt.Errorf("extract alloc: %w", err)
+	}
+
+	return alloc, nil
+}
+
+// deployBeaconInfra deploys CnStakingV4 and PublicDelegation implementations
+// along with their UpgradeableBeacons (step 1).
+func deployBeaconInfra(cfg *runtime.Config, owner common.Address, result *allocPermissionlessResult) error {
+	// Deploy CnStakingV4 implementation
+	cnImplAddr, err := evmCreate(cfg, common.FromHex(cnstakingv4.CnStakingV4Bin))
+	if err != nil {
+		return fmt.Errorf("deploy CnStakingV4 impl: %w", err)
+	}
+
+	// Deploy UpgradeableBeacon for CnStaking
+	beaconABI, _ := beaconcontract.UpgradeableBeaconMetaData.GetAbi()
+	cnBeaconInput, err := packConstructor(beaconABI, common.FromHex(beaconcontract.UpgradeableBeaconBin), cnImplAddr, owner)
+	if err != nil {
+		return fmt.Errorf("pack CnStaking beacon constructor: %w", err)
+	}
+	cnBeaconAddr, err := evmCreate(cfg, cnBeaconInput)
+	if err != nil {
+		return fmt.Errorf("deploy CnStaking beacon: %w", err)
+	}
+	result.cnStakingBeacon = cnBeaconAddr
+
+	// Deploy PublicDelegation implementation + UpgradeableBeacon
+	pdImplAddr, err := evmCreate(cfg, common.FromHex(pdcontract.PublicDelegationBin))
+	if err != nil {
+		return fmt.Errorf("deploy PD impl: %w", err)
+	}
+
+	pdBeaconInput, err := packConstructor(beaconABI, common.FromHex(beaconcontract.UpgradeableBeaconBin), pdImplAddr, owner)
+	if err != nil {
+		return fmt.Errorf("pack PD beacon constructor: %w", err)
+	}
+	pdBeaconAddr, err := evmCreate(cfg, pdBeaconInput)
+	if err != nil {
+		return fmt.Errorf("deploy PD beacon: %w", err)
+	}
+	result.pdBeacon = pdBeaconAddr
+
+	// Deploy AddressBookV2 implementation (used by ABv2DataContract and proxy setup)
+	abv2ABI, _ := addressbookv2contract.AddressBookV2MetaData.GetAbi()
+	abv2ImplInput, err := packConstructor(abv2ABI, common.FromHex(addressbookv2contract.AddressBookV2Bin), big.NewInt(DefaultEpochBlockInterval))
+	if err != nil {
+		return fmt.Errorf("pack ABv2 impl constructor: %w", err)
+	}
+	abv2ImplAddr, err := evmCreate(cfg, abv2ImplInput)
+	if err != nil {
+		return fmt.Errorf("deploy ABv2 impl: %w", err)
+	}
+	result.abv2Impl = abv2ImplAddr
+
+	return nil
+}
+
+// deployCnStakingFactory deploys CnStakingV4Factory and registers it in Registry (step 2).
+func deployCnStakingFactory(cfg *runtime.Config, activation *big.Int, result *allocPermissionlessResult) error {
+	factoryABI, _ := cnstakingv4factory.CnStakingV4FactoryMetaData.GetAbi()
+	factoryInput, err := packConstructor(factoryABI, common.FromHex(cnstakingv4factory.CnStakingV4FactoryBin), result.cnStakingBeacon, result.pdBeacon)
+	if err != nil {
+		return fmt.Errorf("pack factory constructor: %w", err)
+	}
+	factoryAddr, err := evmCreate(cfg, factoryInput)
+	if err != nil {
+		return fmt.Errorf("deploy factory: %w", err)
+	}
+	result.factory = factoryAddr
+
+	registryABI, _ := registrycontract.RegistryMetaData.GetAbi()
+	if err := evmCallABI(cfg, RegistryAddr, registryABI, "register", "CnStakingFactory", factoryAddr, activation); err != nil {
+		return fmt.Errorf("register CnStakingFactory: %w", err)
+	}
+	return nil
+}
+
+// deployCnStakingPerValidator deploys a CnStaking proxy per validator via Factory and
+// stakes KAIA via delegate() (step 3).
+// Switches cfg.Origin to each validator's manager so that Factory tracks the correct deployer.
+func deployCnStakingPerValidator(cfg *runtime.Config, config *AllocPermissionlessConfig, result *allocPermissionlessResult) error {
+	factoryABI, _ := cnstakingv4factory.CnStakingV4FactoryMetaData.GetAbi()
+	cnStakingABI, _ := cnstakingv4.CnStakingV4MetaData.GetAbi()
+
+	for i := range config.NodeIds {
+		cfg.Origin = config.NodeInfos[i].Manager
+		retData, err := evmCallABIReturn(cfg, result.factory, factoryABI, "deployCnStaking", config.NodeInfos[i].Manager)
+		if err != nil {
+			return fmt.Errorf("deployCnStaking[%d]: %w", i, err)
+		}
+		proxyAddr := common.BytesToAddress(retData[12:32])
+
+		cfg.Value = config.StakeAmts[i]
+		if err := evmCallABI(cfg, proxyAddr, cnStakingABI, "delegate"); err != nil {
+			return fmt.Errorf("delegate[%d]: %w", i, err)
+		}
+		cfg.Value = new(big.Int)
+
+		config.NodeInfos[i].StakingContract = proxyAddr
+	}
+	return nil
+}
+
+// deployABv2DataContract deploys ABv2DataContract and registers it in Registry (step 4).
+func deployABv2DataContract(cfg *runtime.Config, activation *big.Int, config *AllocPermissionlessConfig, result *allocPermissionlessResult) error {
+	abv2DataABI, _ := abv2data.ABv2DataContractMetaData.GetAbi()
+	dataInput := convertToABv2DataInitData(config)
+	dataContractInput, err := packConstructor(abv2DataABI, common.FromHex(abv2data.ABv2DataContractBin), result.abv2Impl, dataInput)
+	if err != nil {
+		return fmt.Errorf("pack ABv2DataContract constructor: %w", err)
+	}
+	dataContractAddr, err := evmCreate(cfg, dataContractInput)
+	if err != nil {
+		return fmt.Errorf("deploy ABv2DataContract: %w", err)
+	}
+
+	registryABI, _ := registrycontract.RegistryMetaData.GetAbi()
+	if err := evmCallABI(cfg, RegistryAddr, registryABI, "register", "ABv2DataContract", dataContractAddr, activation); err != nil {
+		return fmt.Errorf("register ABv2DataContract: %w", err)
+	}
+	return nil
+}
+
+// installAndInitABv2 installs ABv2 code at 0x400 and calls initialize() (step 5).
+func installAndInitABv2(cfg *runtime.Config, statedb *state.StateDB, implAddr common.Address) error {
+	if err := InstallAddressBookV2(statedb, implAddr); err != nil {
+		return fmt.Errorf("install ABv2: %w", err)
+	}
+	if err := evmCallABI(cfg, AddressBookAddr, AddressBookV2ABI, "initialize"); err != nil {
+		return fmt.Errorf("ABv2.initialize: %w", err)
+	}
+	return nil
+}
+
+// patchRegistryActivations overwrites activation slots to 0 in Registry storage
+// so that all registered contracts are active from genesis (block 0).
+func patchRegistryActivations(statedb *state.StateDB, names ...string) {
+	for _, name := range names {
+		// Registry storage layout: records[name][0].activation @ Hash(Hash(name, 0)) + 1
+		arraySlot := calcMappingSlot(0, name, 0)
+		activationSlot := calcArraySlot(arraySlot, 2, 0, 1)
+		statedb.SetState(RegistryAddr, activationSlot, common.Hash{})
+	}
+}
+
+// convertToABv2DataInitData converts addressbookv2contract types to abv2data types.
+func convertToABv2DataInitData(config *AllocPermissionlessConfig) abv2data.IABv2DataContractInitData {
+	infos := make([]abv2data.NodeInfo, len(config.NodeInfos))
+	for i, info := range config.NodeInfos {
+		infos[i] = abv2data.NodeInfo{
+			Manager:         info.Manager,
+			StakingContract: info.StakingContract,
+			RewardAddress:   info.RewardAddress,
+			VoterAddress:    info.VoterAddress,
+			TimeoutAt:       info.TimeoutAt,
+			GcId:            info.GcId,
+			BlsInfo: abv2data.BlsPublicKeyInfo{
+				PublicKey: info.BlsInfo.PublicKey,
+				Pop:       info.BlsInfo.Pop,
+			},
+			Metadata: info.Metadata,
+			State:    info.State,
+		}
+	}
+	d := config.DataConfig
+	return abv2data.IABv2DataContractInitData{
+		InitialOwner:           d.InitialOwner,
+		ExitThreshold:          d.ExitThreshold,
+		PauseTimeout:           d.PauseTimeout,
+		IdleTimeout:            d.IdleTimeout,
+		MaxValidatorCount:      d.MaxValidatorCount,
+		MaxReadyCandidateCount: d.MaxReadyCandidateCount,
+		KefAddress:             d.KefAddress,
+		KifAddress:             d.KifAddress,
+		KpfAddress:             d.KpfAddress,
+		NodeIds:                config.NodeIds,
+		Infos:                  infos,
+	}
+}
+
+// evmCreate deploys a contract using the EVM runtime and returns the deployed address.
+func evmCreate(cfg *runtime.Config, input []byte) (common.Address, error) {
+	ret, addr, _, err := runtime.Create(input, cfg)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("%w (revert: %x)", err, ret)
+	}
+	return addr, nil
+}
+
+// evmCallABI encodes a call using ABI and executes it. Returns error if the call fails.
+func evmCallABI(cfg *runtime.Config, to common.Address, parsedABI *kaiaABI.ABI, method string, args ...interface{}) error {
+	_, err := evmCallABIReturn(cfg, to, parsedABI, method, args...)
+	return err
+}
+
+// evmCallABIReturn encodes a call using ABI, executes it, and returns the raw return data.
+func evmCallABIReturn(cfg *runtime.Config, to common.Address, parsedABI *kaiaABI.ABI, method string, args ...interface{}) ([]byte, error) {
+	input, err := parsedABI.Pack(method, args...)
+	if err != nil {
+		return nil, fmt.Errorf("abi pack %s: %w", method, err)
+	}
+	ret, _, err := runtime.Call(to, input, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("call %s: %w (revert: %x)", method, err, ret)
+	}
+	return ret, nil
+}
+
+// packConstructor appends ABI-encoded constructor arguments to the bytecode.
+func packConstructor(parsedABI *kaiaABI.ABI, bytecode []byte, args ...interface{}) ([]byte, error) {
+	packed, err := parsedABI.Pack("", args...)
+	if err != nil {
+		return nil, err
+	}
+	return append(bytecode, packed...), nil
+}
+
+// extractAlloc iterates over all committed accounts in the statedb and builds a genesis alloc map,
+// excluding the specified addresses. statedb.Commit must be called before this function.
+func extractAlloc(statedb *state.StateDB, exclude map[common.Address]bool) (map[common.Address]blockchain.GenesisAccount, error) {
+	alloc := make(map[common.Address]blockchain.GenesisAccount)
+
+	statedb.ForEachAccount(func(addr common.Address, _ account.Account) {
+		if exclude[addr] {
+			return
+		}
+
+		ga := blockchain.GenesisAccount{
+			Balance: statedb.GetBalance(addr),
+			Nonce:   statedb.GetNonce(addr),
+			Code:    statedb.GetCode(addr),
+		}
+
+		storage := make(map[common.Hash]common.Hash)
+		statedb.ForEachStorage(addr, func(key, value common.Hash) bool {
+			storage[key] = value
+			return true
+		})
+		if len(storage) > 0 {
+			ga.Storage = storage
+		}
+
+		alloc[addr] = ga
+	})
+
+	return alloc, nil
+}

--- a/blockchain/system/permissionless_test.go
+++ b/blockchain/system/permissionless_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+package system
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/accounts/abi/bind"
+	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/common"
+	addressbookv2contract "github.com/kaiachain/kaia/contracts_permissionless/contracts/AddressBookV2"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestPermissionlessConfig delegates to the exported MakeTestPermissionlessConfig.
+func makeTestPermissionlessConfig(t *testing.T, n int) *AllocPermissionlessConfig {
+	return MakeTestPermissionlessConfig(t, n)
+}
+
+// verifyPermissionlessAlloc checks alloc-level properties and ABv2 contract state.
+func verifyPermissionlessAlloc(t *testing.T, config *AllocPermissionlessConfig, alloc map[common.Address]blockchain.GenesisAccount) {
+	t.Helper()
+	numNodes := len(config.NodeIds)
+
+	// Alloc should contain Registry and ABv2 at known addresses
+	assert.Contains(t, alloc, RegistryAddr, "Registry should be in alloc")
+	assert.Contains(t, alloc, AddressBookAddr, "ABv2 should be in alloc")
+	assert.NotEmpty(t, alloc[AddressBookAddr].Code, "ABv2 should have code")
+
+	// Manager EOAs should be excluded from alloc
+	for _, info := range config.NodeInfos {
+		assert.NotContains(t, alloc, info.Manager, "manager EOA should be excluded from alloc")
+	}
+
+	// Alloc entries = 10 (fixed) + numNodes (CnStaking proxies):
+	//   1. CnStakingV4Impl         — CREATE by owner
+	//   2. CnStakingBeacon         — UpgradeableBeacon, CREATE by owner
+	//   3. PDImpl                   — CREATE by owner
+	//   4. PDBeacon                 — UpgradeableBeacon, CREATE by owner
+	//   5. CnStakingV4Factory      — CREATE by owner
+	//   6. ABv2DataContract        — CREATE by owner
+	//   7. ABv2 proxy (0x400)      — ERC1967Proxy, SetCode
+	//   8. ABv2 logic              — SetCode at deriveAddressBookV2LogicAddr
+	//   9. Registry (0x401)        — SetCode
+	//  10. Owner EOA               — deployer, nonce > 0 but no code
+	//  11+. CnStaking proxy * N    — BeaconProxy, CREATE2 by Factory
+	assert.Len(t, alloc, 10+numNodes)
+
+	// Registry activation slots should be patched to 0
+	registryAlloc := alloc[RegistryAddr]
+	cnFactoryActivationSlot := calcArraySlot(calcMappingSlot(0, "CnStakingFactory", 0), 2, 0, 1)
+	abv2DataActivationSlot := calcArraySlot(calcMappingSlot(0, "ABv2DataContract", 0), 2, 0, 1)
+	assert.Equal(t, common.Hash{}, registryAlloc.Storage[cnFactoryActivationSlot], "CnStakingFactory activation should be 0")
+	assert.Equal(t, common.Hash{}, registryAlloc.Storage[abv2DataActivationSlot], "ABv2DataContract activation should be 0")
+
+	// StakingContract should have been filled in NodeInfos (side effect)
+	// Each CnStaking proxy should hold the staked KAIA balance
+	for i, info := range config.NodeInfos {
+		assert.NotEqual(t, common.Address{}, info.StakingContract, "StakingContract should be set")
+		require.Contains(t, alloc, info.StakingContract, "StakingContract should be in alloc")
+		assert.NotEmpty(t, alloc[info.StakingContract].Code, "StakingContract should have code")
+		assert.Equal(t, config.StakeAmts[i], alloc[info.StakingContract].Balance, "StakingContract[%d] balance should equal stakeAmt", i)
+	}
+
+	// Owner EOA: nonce > 0 (deployed contracts), no code, zero balance
+	ownerAlloc := alloc[config.Owner]
+	assert.Empty(t, ownerAlloc.Code, "owner should have no code")
+	assert.True(t, ownerAlloc.Nonce > 0, "owner nonce should be > 0")
+	assert.Equal(t, new(big.Int).SetUint64(0), ownerAlloc.Balance, "owner balance should be 0")
+
+	// ABv2 logic contract: read address from ERC1967 implementation slot, verify it's in alloc with code
+	implSlotValue := alloc[AddressBookAddr].Storage[common.BytesToHash(ImplementationSlot)]
+	abv2LogicAddr := common.BytesToAddress(implSlotValue.Bytes())
+	assert.NotEqual(t, common.Address{}, abv2LogicAddr, "ABv2 implementation slot should be set")
+	require.Contains(t, alloc, abv2LogicAddr, "ABv2 logic should be in alloc")
+	assert.NotEmpty(t, alloc[abv2LogicAddr].Code, "ABv2 logic should have code")
+	// ABv2 impl has storage from constructor (_disableInitializers sets initializable slot)
+
+	// All contract entries (except owner) should have code
+	for addr, ga := range alloc {
+		if addr == config.Owner {
+			continue
+		}
+		assert.NotEmpty(t, ga.Code, "contract %s should have code", addr.Hex())
+	}
+
+	// Verify ABv2 contract state via getAllProfiles on a SimulatedBackend built from alloc
+	// This verification leverages EVM execution rather the generated `alloc`, thus auxiliary validation
+	backend := backends.NewSimulatedBackend(blockchain.GenesisAlloc(alloc))
+	caller, err := addressbookv2contract.NewAddressBookV2Caller(AddressBookAddr, backend)
+	require.NoError(t, err)
+
+	profiles, err := caller.GetAllProfiles(&bind.CallOpts{})
+	require.NoError(t, err)
+	assert.Len(t, profiles, numNodes)
+
+	for i, p := range profiles {
+		assert.Equal(t, config.NodeIds[i], p.NodeId, "profile[%d] NodeId", i)
+		assert.Equal(t, config.NodeInfos[i].StakingContract, p.StakingContract, "profile[%d] StakingContract", i)
+		assert.Equal(t, config.NodeInfos[i].RewardAddress, p.RewardAddress, "profile[%d] RewardAddress", i)
+		assert.Equal(t, valset.ValActive.ToUint8(), p.State, "profile[%d] State should be ValActive", i)
+	}
+}
+
+func TestAllocPermissionless(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config := makeTestPermissionlessConfig(t, 4)
+
+	alloc, err := AllocPermissionless(config)
+	require.NoError(t, err)
+	verifyPermissionlessAlloc(t, config, alloc)
+}
+
+func TestAllocPermissionless_SingleValidator(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config := makeTestPermissionlessConfig(t, 1)
+
+	alloc, err := AllocPermissionless(config)
+	require.NoError(t, err)
+	verifyPermissionlessAlloc(t, config, alloc)
+}
+
+func TestAllocPermissionless_MismatchedLengths(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config := makeTestPermissionlessConfig(t, 2)
+
+	// Remove one stakeAmt to create mismatch
+	config.StakeAmts = config.StakeAmts[:1]
+
+	_, err := AllocPermissionless(config)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mismatched lengths")
+}

--- a/blockchain/system/testing.go
+++ b/blockchain/system/testing.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	addressbookv2contract "github.com/kaiachain/kaia/contracts_permissionless/contracts/AddressBookV2"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/bls"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/params"
+)
+
+// MakeTestPermissionlessConfig creates a test AllocPermissionlessConfig with n validators.
+func MakeTestPermissionlessConfig(t *testing.T, n int) *AllocPermissionlessConfig {
+	t.Helper()
+
+	ownerKey, _ := crypto.GenerateKey()
+	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
+
+	nodeIds := make([]common.Address, n)
+	nodeInfos := make([]addressbookv2contract.NodeInfo, n)
+	stakeAmts := make([]*big.Int, n)
+	stakeAmt := new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(params.KAIA))
+
+	for i := 0; i < n; i++ {
+		key, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		_, pub, pop := MakeTestBlsKey()
+
+		nodeIds[i] = addr
+		stakeAmts[i] = new(big.Int).Set(stakeAmt)
+		nodeInfos[i] = addressbookv2contract.NodeInfo{
+			Manager:       addr,
+			RewardAddress: common.BytesToAddress(crypto.Keccak256(addr.Bytes())),
+			VoterAddress:  addr,
+			TimeoutAt:     new(big.Int),
+			GcId:          big.NewInt(int64(i + 1)),
+			BlsInfo: addressbookv2contract.BlsPublicKeyInfo{
+				PublicKey: pub,
+				Pop:       pop,
+			},
+			State: valset.ValActive.ToUint8(),
+		}
+	}
+
+	return &AllocPermissionlessConfig{
+		Owner:     owner,
+		NodeIds:   nodeIds,
+		NodeInfos: nodeInfos,
+		StakeAmts: stakeAmts,
+		DataConfig: addressbookv2contract.IABv2DataContractInitData{
+			InitialOwner:           owner,
+			ExitThreshold:          big.NewInt(2),
+			PauseTimeout:           big.NewInt(8 * 3600),   // 8h
+			IdleTimeout:            big.NewInt(30 * 86400), // 30d
+			MaxValidatorCount:      big.NewInt(50),
+			MaxReadyCandidateCount: big.NewInt(3),
+			KefAddress:             common.HexToAddress("0x1111"),
+			KifAddress:             common.HexToAddress("0x2222"),
+			KpfAddress:             common.HexToAddress("0x3333"),
+		},
+	}
+}
+
+// MakeTestBlsKey generates a random BLS key pair for testing.
+func MakeTestBlsKey() (priv, pub, pop []byte) {
+	ikm := make([]byte, 32)
+	rand.Read(ikm)
+
+	sk, _ := bls.GenerateKey(ikm)
+	pk := sk.PublicKey()
+	sig := bls.PopProve(sk)
+
+	priv = sk.Marshal()
+	pub = pk.Marshal()
+	pop = sig.Marshal()
+	if len(priv) != 32 || len(pub) != 48 || len(pop) != 96 {
+		panic("bad bls key")
+	}
+	return priv, pub, pop
+}

--- a/kaiax/staking/README.md
+++ b/kaiax/staking/README.md
@@ -162,3 +162,25 @@ curl "http://localhost:8551" -X POST -H 'Content-Type: application/json' --data 
   ```
   GetStakingInfo(num) -> StakingInfo
   ```
+
+---
+
+## Permissionless Staking (KIP-287)
+
+After the permissionless hardfork, staking information is read from AddressBookV2 (ABv2) via the MultiCall contract instead of the legacy AddressBook. See [KIP-287](https://kips.kaia.io/KIPs/kip-287) for the full specification.
+
+### Key Changes
+
+- **Single staking contract**: Each validator has exactly one CnStakingV4 contract (no consolidated staking).
+- **Effective staking excludes unstaking**: `effectiveStake = staking() - unstaking()`, preventing reward earning during the 7-day withdrawal lockup.
+- **ABv2 as source of truth**: Validator profiles (nodeId, stakingContract, rewardAddress, state) are read from ABv2's `multiCallStakingInfoPermissionless`.
+- **KPF address**: Treasury fund addresses (KEF, KIF, KPF) are read from ABv2's `getFundAddresses()`.
+
+### ConsolidatedNodes
+
+`ConsolidatedNodes(rules)` behavior differs by fork:
+
+- **Permissioned**: Groups entries by RewardAddr — multiple NodeIds can share one RewardAddr, staking amounts are summed. Uses `consolidateNodes()`.
+- **Permissionless**: No grouping — ABv2 guarantees unique `(NodeId, StakingContract, RewardAddr)` tuples, so each entry maps 1:1. Uses `consolidateNodesPermissionless()` with FCFS for duplicate RewardAddr (infeasible path).
+
+Both paths use the same `consolidatedNode` struct with `NodeIds []common.Address` (plural) to avoid cache argument-dependency issues. In permissionless mode, `NodeIds` always has length 1.

--- a/kaiax/valset/README.md
+++ b/kaiax/valset/README.md
@@ -548,3 +548,86 @@ This module does not expose APIs.
   ```
   GetProposer(num, round) -> common.Address
   ```
+
+---
+
+## Permissionless Validator Lifecycle
+
+After the permissionless hardfork, the validator management transitions from header-governance-based (permissioned) to contract-based (permissionless) using AddressBookV2 (ABv2). See [KIP-286](https://kips.kaia.io/KIPs/kip-286) and [KIP-290](https://kips.kaia.io/KIPs/kip-290) for the full specification.
+
+### Validator States
+
+Each validator has one of the following states, stored in ABv2:
+
+| State | Value | Description |
+|-------|-------|-------------|
+| Registered | 1 | Registered entity; not yet a candidate or validator |
+| CandReady | 2 | Candidate signaling readiness for VRank testing |
+| CandTesting | 3 | Candidate undergoing VRank assessment |
+| ValInactive | 4 | Non-participating validator; must signal readiness or exit before idle timeout |
+| ValReady | 5 | Validator awaiting elevation to ValActive |
+| ValActive | 6 | Active consensus participant earning rewards |
+| ValPaused | 7 | Validator in maintenance/recovery mode |
+| ValExiting | 8 | Transitional state lasting one epoch; becomes ValInactive afterward |
+
+### Council (Permissionless)
+
+In permissionless mode, the council is determined by validator states rather than header votes:
+
+```
+Council(N) = {v ∈ ABv2 | v.State ∈ {ValActive, ValReady, ValPaused}}
+```
+
+- **Qualified (committee-eligible)**: ValActive only
+- **Demoted**: ValReady + ValPaused
+
+This replaces the permissioned model where council membership was governed by `governance.addvalidator` / `governance.removevalidator` votes.
+
+### State Transitions
+
+State transitions are computed at `PostInsertBlock(N-1)` and written to ABv2 at `Initialize(N)`. They fall into three categories:
+
+#### 1. Epoch Transition (every `VRankEpoch` blocks)
+
+Executed in order:
+1. **T1**: ValExiting → ValInactive (clear transitional states)
+2. **T2**: Evaluate VRank for CandTesting candidates (TODO: currently hardcoded pass)
+3. **T3**: Top-N recalculation — promote/demote based on stake ranking (N = `ActiveValidatorCount`)
+4. **T4**: CandReady with MinStake → CandTesting; CandReady below MinStake → Registered
+
+#### 2. Timeout Transition (every block)
+
+- ValPaused exceeding `ValPausedTimeout` → ValInactive
+- ValReady/ValInactive exceeding `ValIdleTimeout` → Registered
+
+#### 3. Violation Transition (every block)
+
+- Staking below MinStake: ValActive → ValExiting
+- Minor VRank violation: ValActive → ValPaused (TODO — KIP-227)
+- Severe VRank violation: ValActive → ValExiting (TODO — KIP-227)
+
+### Block Processing (Permissionless)
+
+```
+PostInsertBlock(N-1):
+  → getOrComputeNodeStates(N) — compute and cache node states for block N
+
+Initialize(N):
+  → WriteStatesToContract(N) — diff cached states vs parent, write changes to ABv2
+
+Finalize(HF-1):
+  → InstallABv2() — one-time ABv2 proxy installation at hardfork boundary
+```
+
+Node states are computed from the parent block's ABv2 contract state, with epoch/timeout/violation transitions applied. The result is cached in `nodeStatesCache` to avoid recomputation.
+
+### Additional Getters (Permissionless)
+
+- `GetCandidates(num)`: Returns addresses of CandTesting validators.
+  ```
+  GetCandidates(num) -> []common.Address
+  ```
+- `GetNodeByState(num, states)`: Returns validators filtered by the given states.
+  ```
+  GetNodeByState(num, states) -> NodeStateMap
+  ```

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -1,0 +1,170 @@
+package valset
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/kaiachain/kaia/common"
+)
+
+type State uint8
+
+const (
+	Unknown     State = iota // 0
+	Registered               // 1
+	CandReady                // 2
+	CandTesting              // 3
+	ValInactive              // 4
+	ValReady                 // 5
+	ValActive                // 6
+	ValPaused                // 7
+	ValExiting               // 8
+)
+
+const (
+	RegisteredStr  = "Registered"
+	CandReadyStr   = "CandReady"
+	CandTestingStr = "CandTesting"
+	ValInactiveStr = "ValInactive"
+	ValPausedStr   = "ValPaused"
+	ValExitingStr  = "ValExiting"
+	ValReadyStr    = "ValReady"
+	ValActiveStr   = "ValActive"
+)
+
+func (s State) ToUint8() uint8 {
+	return uint8(s)
+}
+
+func (s State) String() string {
+	switch s {
+	case Registered:
+		return RegisteredStr
+	case CandReady:
+		return CandReadyStr
+	case CandTesting:
+		return CandTestingStr
+	case ValInactive:
+		return ValInactiveStr
+	case ValPaused:
+		return ValPausedStr
+	case ValExiting:
+		return ValExitingStr
+	case ValReady:
+		return ValReadyStr
+	case ValActive:
+		return ValActiveStr
+	default:
+		return fmt.Sprintf("UnknownState(%d)", s)
+	}
+}
+
+func ParseState(s string) (State, error) {
+	switch s {
+	case RegisteredStr:
+		return Registered, nil
+	case CandReadyStr:
+		return CandReady, nil
+	case CandTestingStr:
+		return CandTesting, nil
+	case ValInactiveStr:
+		return ValInactive, nil
+	case ValPausedStr:
+		return ValPaused, nil
+	case ValExitingStr:
+		return ValExiting, nil
+	case ValReadyStr:
+		return ValReady, nil
+	case ValActiveStr:
+		return ValActive, nil
+	default:
+		return 0, fmt.Errorf("invalid state string: %s", s)
+	}
+}
+
+func (s *State) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	val, err := ParseState(str)
+	if err != nil {
+		return err
+	}
+	*s = val
+	return nil
+}
+
+func (s State) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", s.String())), nil
+}
+
+type ValidatorState struct {
+	State         State     `json:"state"`
+	StakingAmount uint64    `json:"stakingAmount"` // in KAIA unit
+	IdleTimeout   time.Time `json:"idleTimeout"`
+	PausedTimeout time.Time `json:"pausedTimeout"`
+}
+
+type NodeStateMap map[common.Address]*ValidatorState
+
+func (v NodeStateMap) String() string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("NodeStateMap error: %v", err)
+	}
+	return string(b)
+}
+
+func (v NodeStateMap) Copy() NodeStateMap {
+	if v == nil {
+		return nil
+	}
+
+	cp := make(NodeStateMap, len(v))
+	for key, value := range v {
+		if value == nil {
+			cp[key] = nil
+			continue
+		}
+		newValue := *value
+		cp[key] = &newValue
+	}
+	return cp
+}
+
+func (v NodeStateMap) EqualState(other NodeStateMap) bool {
+	if len(v) != len(other) {
+		return false
+	}
+
+	for addr, val := range v {
+		otherVal, exists := other[addr]
+		if !exists {
+			return false
+		}
+		if val == nil || otherVal == nil {
+			if val != otherVal {
+				return false
+			}
+			continue
+		}
+		if val.State != otherVal.State {
+			return false
+		}
+	}
+	return true
+}
+
+// Addresses returns a deterministically sorted list of addresses in the map.
+func (v NodeStateMap) Addresses() []common.Address {
+	addrs := slices.Collect(maps.Keys(v))
+	slices.SortFunc(addrs, func(a, b common.Address) int {
+		return bytes.Compare(a[:], b[:])
+	})
+	return addrs
+}

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -41,6 +41,7 @@ func (s State) ToUint8() uint8 {
 	return uint8(s)
 }
 
+// String returns the human-readable name of the state.
 func (s State) String() string {
 	switch s {
 	case Registered:
@@ -88,6 +89,7 @@ func ParseState(s string) (State, error) {
 	}
 }
 
+// UnmarshalJSON deserializes a JSON string into a State value.
 func (s *State) UnmarshalJSON(b []byte) error {
 	var str string
 	if err := json.Unmarshal(b, &str); err != nil {
@@ -101,10 +103,12 @@ func (s *State) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON serializes the State as a JSON string.
 func (s State) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", s.String())), nil
 }
 
+// ValidatorState represents the current state and metadata of a validator node.
 type ValidatorState struct {
 	State         State     `json:"state"`
 	StakingAmount uint64    `json:"stakingAmount"` // in KAIA unit
@@ -112,6 +116,7 @@ type ValidatorState struct {
 	PausedTimeout time.Time `json:"pausedTimeout"`
 }
 
+// NodeStateMap maps validator addresses to their state. Used for permissionless state transitions.
 type NodeStateMap map[common.Address]*ValidatorState
 
 func (v NodeStateMap) String() string {
@@ -122,6 +127,7 @@ func (v NodeStateMap) String() string {
 	return string(b)
 }
 
+// Copy returns a deep copy of the NodeStateMap.
 func (v NodeStateMap) Copy() NodeStateMap {
 	if v == nil {
 		return nil
@@ -139,6 +145,8 @@ func (v NodeStateMap) Copy() NodeStateMap {
 	return cp
 }
 
+// EqualState returns true if both maps have the same addresses with matching State values.
+// Only compares State field, ignoring StakingAmount and timeouts.
 func (v NodeStateMap) EqualState(other NodeStateMap) bool {
 	if len(v) != len(other) {
 		return false

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -36,6 +36,7 @@ const (
 	ValActiveStr   = "ValActive"
 )
 
+// ToUint8 converts the State to its uint8 representation for ABI encoding.
 func (s State) ToUint8() uint8 {
 	return uint8(s)
 }
@@ -63,6 +64,7 @@ func (s State) String() string {
 	}
 }
 
+// ParseState converts a string to a State value.
 func ParseState(s string) (State, error) {
 	switch s {
 	case RegisteredStr:


### PR DESCRIPTION
## Proposed changes

- Add validator state types (Registered, CandReady, ValActive, etc.) and NodeStateMap
- Add ABv2 Go layer: InstallAddressBookV2, ReadABv2Timeouts, EncodeWriteNodes, ReadGetAllValidators, ReadAddressBookV2BlsAll
- Add ERC1967Proxy v4/v5 split for ABv2 proxy compatibility
- Add genesis allocation (AllocPermissionless, deployBeaconInfra, deployCnStakingFactory)
- Add shared test helpers (MakeTestPermissionlessConfig, MakeTestBlsKey)
- Add StateBlockchainContractCaller for statedb-based contract reads
- Update KIP113 to use ABv2 as BLS source for permissionless blocks
- Update multicall import to contracts_permissionless
- Fix mock address collision with MultiCallAddr (0x402 → 0x403+)

This PR contains only standalone functions and types — no wiring into engine/worker/execution. The state transition logic and integration are in PR6.

## Types of changes

- [x] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- #748

## Context

Part of PR split for #748. See `permissionless/PR_SPLIT_PLAN.md`.

**PR chain:** PR1 (#792) → PR2 (#796) → PR3 (#797) → PR4 (#802) → **PR5 (this)** → PR6

## Deferred to PR6

- `kaiax/valset/impl/` state transition logic (state_transition.go, getters, execution, schema)
- `kaiax/staking/` ConsolidatedNodes refactoring, staking_info changes
- `consensus/engine.go` hooks (WriteStatesToContract, InstallABv2)
- `node/cn/handler.go`, `params/config.go`, `cmd/homi/`, integration
- `state_transition_test.go`, `TestGetCouncilPermissionless`, `TestGetNodeByState`, `TestReadAddressBookV2BlsAll`

> Note: `kaiax/valset/README.md` and `kaiax/staking/README.md` include descriptions of state transition and integration features that are implemented in PR6. They are included here for reference but the corresponding code arrives in PR6.