### PR TITLE
modernize: atomic and stdlib helper usage

### DIFF
--- a/blockchain/bloombits/matcher.go
+++ b/blockchain/bloombits/matcher.go
@@ -89,7 +89,7 @@ type Matcher struct {
 	retrievals chan chan *Retrieval // Retriever processes waiting for task allocations
 	deliveries chan *Retrieval      // Retriever processes waiting for task response deliveries
 
-	running uint32 // Atomic flag whether a session is live or not
+	running atomic.Uint32 // Atomic flag whether a session is live or not
 }
 
 // NewMatcher creates a new pipeline for retrieving bloom bit streams and doing
@@ -152,10 +152,10 @@ func (m *Matcher) addScheduler(idx uint) {
 // channel is closed.
 func (m *Matcher) Start(ctx context.Context, begin, end uint64, results chan uint64) (*MatcherSession, error) {
 	// Make sure we're not creating concurrent sessions
-	if atomic.SwapUint32(&m.running, 1) == 1 {
+	if m.running.Swap(1) == 1 {
 		return nil, errors.New("matcher already running")
 	}
-	defer atomic.StoreUint32(&m.running, 0)
+	defer m.running.Store(0)
 
 	// Initiate a new matching round
 	session := &MatcherSession{

--- a/blockchain/bloombits/scheduler_test.go
+++ b/blockchain/bloombits/scheduler_test.go
@@ -52,14 +52,14 @@ func testScheduler(t *testing.T, clients int, fetchers int, requests int) {
 	fetch := make(chan *request, 16)
 	defer close(fetch)
 
-	var delivered uint32
+	var delivered atomic.Uint32
 	for i := 0; i < fetchers; i++ {
 		go func() {
 			defer fetchPend.Done()
 
 			for req := range fetch {
 				time.Sleep(time.Duration(rand.Intn(int(100 * time.Microsecond))))
-				atomic.AddUint32(&delivered, 1)
+				delivered.Add(1)
 
 				f.deliver([]uint64{
 					req.section + uint64(requests), // Non-requested data (ensure it doesn't go out of bounds)
@@ -105,7 +105,7 @@ func testScheduler(t *testing.T, clients int, fetchers int, requests int) {
 	}
 	pend.Wait()
 
-	if have := atomic.LoadUint32(&delivered); int(have) != requests {
+	if have := delivered.Load(); int(have) != requests {
 		t.Errorf("request count mismatch: have %v, want %v", have, requests)
 	}
 }

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -106,7 +106,7 @@ type Transaction struct {
 	// The account's nonce is checked only if `checkNonce` is true.
 	checkNonce bool
 	// This value is set when the tx is invalidated in block tx validation, and is used to remove pending tx in txPool.
-	markedUnexecutable int32
+	markedUnexecutable atomic.Int32
 
 	// lock for protecting fields in Transaction struct
 	mu sync.RWMutex
@@ -873,11 +873,11 @@ func (tx *Transaction) MarkUnexecutable(b bool) {
 	if b {
 		v = 1
 	}
-	atomic.StoreInt32(&tx.markedUnexecutable, v)
+	tx.markedUnexecutable.Store(v)
 }
 
 func (tx *Transaction) IsMarkedUnexecutable() bool {
-	return atomic.LoadInt32(&tx.markedUnexecutable) == 1
+	return tx.markedUnexecutable.Load() == 1
 }
 
 func (tx *Transaction) RawSignatureValues() TxSignatures {

--- a/blockchain/vm/evm.go
+++ b/blockchain/vm/evm.go
@@ -162,7 +162,7 @@ type EVM struct {
 	interpreter *EVMInterpreter
 	// abort is used to abort the EVM calling operations
 	// NOTE: must be set atomically
-	abort int32
+	abort atomic.Int32
 	// callGasTemp holds the gas available for the current call. This is needed because the
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
@@ -219,8 +219,8 @@ func (evm *EVM) Reset(txCtx TxContext, statedb StateDB) {
 // it's safe to be called multiple times.
 func (evm *EVM) Cancel(reason int32) {
 	for {
-		abort := atomic.LoadInt32(&evm.abort)
-		swapped := atomic.CompareAndSwapInt32(&evm.abort, abort, abort|reason)
+		abort := evm.abort.Load()
+		swapped := evm.abort.CompareAndSwap(abort, abort|reason)
 		if swapped {
 			break
 		}
@@ -233,7 +233,7 @@ func (evm *EVM) IsPrefetching() bool {
 
 // Cancelled returns true if Cancel has been called
 func (evm *EVM) Cancelled() bool {
-	return atomic.LoadInt32(&evm.abort) == 1
+	return evm.abort.Load() == 1
 }
 
 // Call executes the contract associated with the addr with the given input as

--- a/blockchain/vm/internaltx_tracer.go
+++ b/blockchain/vm/internaltx_tracer.go
@@ -60,8 +60,8 @@ type InternalTxTracer struct {
 	initialized      bool
 	revertString     string
 
-	interrupt uint32 // Atomic flag to signal execution interruption
-	reason    error  // Textual reason for the interruption
+	interrupt atomic.Uint32 // Atomic flag to signal execution interruption
+	reason    error         // Textual reason for the interruption
 
 	gasLimit uint64 // Amount of gas bought for the whole tx
 }
@@ -198,7 +198,7 @@ func wrapError(context string, err error) error {
 // Stop terminates execution of the tracer at the first opportune moment.
 func (t *InternalTxTracer) Stop(err error) {
 	t.reason = err
-	atomic.StoreUint32(&t.interrupt, 1)
+	t.interrupt.Store(1)
 }
 
 // CaptureState implements the Tracer interface to trace a single step of VM execution.
@@ -210,7 +210,7 @@ func (t *InternalTxTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cos
 			t.initialized = true
 		}
 		// If tracing was interrupted, set the error and stop
-		if atomic.LoadUint32(&t.interrupt) > 0 {
+		if t.interrupt.Load() > 0 {
 			t.err = t.reason
 			return
 		}

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -25,7 +25,6 @@ package vm
 import (
 	"fmt"
 	"hash"
-	"sync/atomic"
 	"time"
 
 	"github.com/kaiachain/kaia/common"
@@ -224,7 +223,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 	// explicit STOP, RETURN or SELFDESTRUCT is executed, an error occurred during
 	// the execution of one of the operations or until the done flag is set by the
 	// parent context.
-	for atomic.LoadInt32(&in.evm.abort) == 0 {
+	for in.evm.abort.Load() == 0 {
 		if in.evm.Config.EnableOpDebug {
 			opExecStart = time.Now()
 		}
@@ -312,7 +311,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 		pc++
 	}
 
-	abort := atomic.LoadInt32(&in.evm.abort)
+	abort := in.evm.abort.Load()
 	if (abort & CancelByTotalTimeLimit) != 0 {
 		return nil, ErrTotalTimeLimitReached // TODO-Klaytn-Issue615
 	}

--- a/datasync/chaindatafetcher/api_chaindatafetcher.go
+++ b/datasync/chaindatafetcher/api_chaindatafetcher.go
@@ -20,7 +20,6 @@ package chaindatafetcher
 
 import (
 	"errors"
-	"sync/atomic"
 
 	"github.com/kaiachain/kaia/datasync/chaindatafetcher/types"
 )
@@ -78,7 +77,7 @@ func (api *ChainDataFetcherAPI) ReadCheckpoint() (int64, error) {
 }
 
 func (api *ChainDataFetcherAPI) WriteCheckpoint(checkpoint int64) error {
-	isRunning := atomic.LoadUint32(&api.f.fetchingStarted)
+	isRunning := api.f.fetchingStarted.Load()
 	if isRunning == running {
 		return errors.New("call stopFetching before writing checkpoint manually")
 	}

--- a/datasync/chaindatafetcher/chaindata_fetcher.go
+++ b/datasync/chaindatafetcher/chaindata_fetcher.go
@@ -87,10 +87,10 @@ type ChainDataFetcher struct {
 	checkpointDB CheckpointDB
 	setters      []ComponentSetter
 
-	fetchingStarted      uint32
+	fetchingStarted      atomic.Uint32
 	fetchingStopCh       chan struct{}
 	fetchingWg           sync.WaitGroup
-	rangeFetchingStarted uint32
+	rangeFetchingStarted atomic.Uint32
 	rangeFetchingStopCh  chan struct{}
 	rangeFetchingWg      sync.WaitGroup
 
@@ -226,7 +226,7 @@ func (f *ChainDataFetcher) sendRequests(startBlock, endBlock uint64, reqType cfT
 }
 
 func (f *ChainDataFetcher) startFetching() error {
-	if !atomic.CompareAndSwapUint32(&f.fetchingStarted, stopped, running) {
+	if !f.fetchingStarted.CompareAndSwap(stopped, running) {
 		return errors.New("fetching is already started")
 	}
 
@@ -253,7 +253,7 @@ func (f *ChainDataFetcher) startFetching() error {
 }
 
 func (f *ChainDataFetcher) stopFetching() error {
-	if !atomic.CompareAndSwapUint32(&f.fetchingStarted, running, stopped) {
+	if !f.fetchingStarted.CompareAndSwap(running, stopped) {
 		return errors.New("fetching is not running")
 	}
 
@@ -265,21 +265,21 @@ func (f *ChainDataFetcher) stopFetching() error {
 }
 
 func (f *ChainDataFetcher) startRangeFetching(startBlock, endBlock uint64, reqType cfTypes.RequestType) error {
-	if !atomic.CompareAndSwapUint32(&f.rangeFetchingStarted, stopped, running) {
+	if !f.rangeFetchingStarted.CompareAndSwap(stopped, running) {
 		return errors.New("range fetching is already started")
 	}
 
 	f.rangeFetchingStopCh = make(chan struct{})
 	f.rangeFetchingWg.Go(func() {
 		f.sendRequests(startBlock, endBlock, reqType, false, f.rangeFetchingStopCh)
-		atomic.StoreUint32(&f.rangeFetchingStarted, stopped)
+		f.rangeFetchingStarted.Store(stopped)
 	})
 	logger.Info("range fetching is started", "startBlock", startBlock, "endBlock", endBlock, "reqType", reqType)
 	return nil
 }
 
 func (f *ChainDataFetcher) stopRangeFetching() error {
-	if !atomic.CompareAndSwapUint32(&f.rangeFetchingStarted, running, stopped) {
+	if !f.rangeFetchingStarted.CompareAndSwap(running, stopped) {
 		return errors.New("range fetching is not running")
 	}
 	close(f.rangeFetchingStopCh)
@@ -591,5 +591,5 @@ func (f *ChainDataFetcher) retryFunc(insert HandleChainEventFn) HandleChainEvent
 }
 
 func (f *ChainDataFetcher) status() string {
-	return fmt.Sprintf("{fetching: %v, rangeFetching: %v}", atomic.LoadUint32(&f.fetchingStarted), atomic.LoadUint32(&f.rangeFetchingStarted))
+	return fmt.Sprintf("{fetching: %v, rangeFetching: %v}", f.fetchingStarted.Load(), f.rangeFetchingStarted.Load())
 }

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -132,8 +132,8 @@ type Downloader struct {
 
 	// Status
 	synchroniseMock func(id string, hash common.Hash) error // Replacement for synchronise during testing
-	synchronising   int32
-	notified        int32
+	synchronising   atomic.Int32
+	notified        atomic.Int32
 	committed       int32
 
 	// Channels
@@ -310,7 +310,7 @@ func (d *Downloader) getMode() SyncMode {
 
 // Synchronising returns whether the downloader is currently retrieving blocks.
 func (d *Downloader) Synchronising() bool {
-	return atomic.LoadInt32(&d.synchronising) > 0
+	return d.synchronising.Load() > 0
 }
 
 // RegisterPeer injects a new download peer into the set of block source to be
@@ -398,13 +398,13 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 	}
 	// TODO-Kaia-Downloader Below code can be replaced by mutex.
 	// Make sure only one goroutine is ever allowed past this point at once
-	if !atomic.CompareAndSwapInt32(&d.synchronising, 0, 1) {
+	if !d.synchronising.CompareAndSwap(0, 1) {
 		return errBusy
 	}
-	defer atomic.StoreInt32(&d.synchronising, 0)
+	defer d.synchronising.Store(0)
 
 	// Post a user notification of the sync (only once per session)
-	if atomic.CompareAndSwapInt32(&d.notified, 0, 1) {
+	if d.notified.CompareAndSwap(0, 1) {
 		logger.Info("Block synchronisation started")
 	}
 	// If we are already full syncing, but have a fast-sync bloom filter laying

--- a/datasync/downloader/resultstore.go
+++ b/datasync/downloader/resultstore.go
@@ -39,7 +39,7 @@ type resultStore struct {
 	// Internal index of first non-completed entry, updated atomically when needed.
 	// If all items are complete, this will equal length(items), so
 	// *important* : is not safe to use for indexing without checking against length
-	indexIncomplete int32 // atomic access
+	indexIncomplete atomic.Int32 // atomic access
 
 	// throttleThreshold is the limit up to which we _want_ to fill the
 	// results. If blocks are large, we want to limit the results to less
@@ -152,7 +152,7 @@ func (r *resultStore) HasCompletedItems() bool {
 func (r *resultStore) countCompleted() int {
 	// We iterate from the already known complete point, and see
 	// if any more has completed since last count
-	index := atomic.LoadInt32(&r.indexIncomplete)
+	index := r.indexIncomplete.Load()
 	for ; ; index++ {
 		if index >= int32(len(r.items)) {
 			break
@@ -162,7 +162,7 @@ func (r *resultStore) countCompleted() int {
 			break
 		}
 	}
-	atomic.StoreInt32(&r.indexIncomplete, index)
+	r.indexIncomplete.Store(index)
 	return int(index)
 }
 
@@ -185,7 +185,7 @@ func (r *resultStore) GetCompleted(limit int) []*fetchResult {
 	}
 	// Advance the expected block number of the first cache entry
 	r.resultOffset += uint64(limit)
-	atomic.AddInt32(&r.indexIncomplete, int32(-limit))
+	r.indexIncomplete.Add(int32(-limit))
 
 	return results
 }

--- a/kaiax/gov/headergov/impl/getter_test.go
+++ b/kaiax/gov/headergov/impl/getter_test.go
@@ -144,9 +144,7 @@ func TestGetPartialParamSet_ConcurrentAccess(t *testing.T) {
 	)
 
 	// Writer goroutine continuously mutates h.governances under write lock.
-	wgWriter.Add(1)
-	go func() {
-		defer wgWriter.Done()
+	wgWriter.Go(func() {
 		var i uint64 = 1
 		for !stopSig.Load() {
 			h.AddGov(i*100, headergov.NewGovData(gov.PartialParamSet{gov.GovernanceUnitPrice: i}))
@@ -155,19 +153,17 @@ func TestGetPartialParamSet_ConcurrentAccess(t *testing.T) {
 				i = 1
 			}
 		}
-	}()
+	})
 
 	// Reader goroutines continuously call GetPartialParamSet.
 	const readers = 8
 	for r := 0; r < readers; r++ {
-		wgReader.Add(1)
-		go func() {
-			defer wgReader.Done()
+		wgReader.Go(func() {
 			for i := 0; i < 5000; i++ {
 				ps := h.GetPartialParamSet(1000)
 				_ = ps[gov.GovernanceUnitPrice]
 			}
-		}()
+		})
 	}
 
 	wgReader.Wait()

--- a/kaiax/supply/impl/getter.go
+++ b/kaiax/supply/impl/getter.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"math/big"
 	"strings"
-	"sync/atomic"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
@@ -208,7 +207,7 @@ func (s *SupplyModule) accumulateRewards(fromNum, toNum uint64, fromAccReward *s
 	accReward := fromAccReward.Copy() // make a copy because we're updating it in-place.
 
 	for num := fromNum + 1; num <= toNum; num++ {
-		if atomic.LoadUint32(&s.quit) == 1 { // Received quit signal
+		if s.quit.Load() == 1 { // Received quit signal
 			return nil, supply.ErrSupplyModuleQuit
 		}
 

--- a/kaiax/supply/impl/init.go
+++ b/kaiax/supply/impl/init.go
@@ -64,7 +64,7 @@ type SupplyModule struct {
 	lastAccReward *supply.AccReward // Last AccReward
 
 	// Stops long-running tasks.
-	quit   uint32         // stops the synchronous loop in accumulateCheckpoint
+	quit   atomic.Uint32  // stops the synchronous loop in accumulateCheckpoint
 	quitCh chan struct{}  // stops the goroutine in select loop
 	wg     sync.WaitGroup // wait for the goroutine to finish
 
@@ -101,7 +101,7 @@ func (s *SupplyModule) Start() error {
 	s.memoCache.Purge()
 
 	// Reset the quit state.
-	atomic.StoreUint32(&s.quit, 0)
+	s.quit.Store(0)
 	s.quitCh = make(chan struct{}, 1)
 	s.wg.Add(1)
 	go s.catchup()
@@ -109,7 +109,7 @@ func (s *SupplyModule) Start() error {
 }
 
 func (s *SupplyModule) Stop() {
-	atomic.StoreUint32(&s.quit, 1)
+	s.quit.Store(1)
 	s.quitCh <- struct{}{}
 	s.wg.Wait()
 }

--- a/networks/p2p/discover/discover_api_test.go
+++ b/networks/p2p/discover/discover_api_test.go
@@ -19,6 +19,7 @@
 package discover
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
@@ -153,13 +154,7 @@ func TestTable_GetBucketEntries(t *testing.T) {
 			t.Error("the length of actual data is different from the result of GetBucketEntries")
 		}
 		for _, node := range storage.data {
-			existed := false
-			for _, node2 := range entries {
-				if node.CompareNode(node2) {
-					existed = true
-					break
-				}
-			}
+			existed := slices.ContainsFunc(entries, node.CompareNode)
 			if !existed {
 				t.Error("node does not existed", "nodeid", node.ID)
 			}

--- a/networks/p2p/discover/discover_storage_simple_test.go
+++ b/networks/p2p/discover/discover_storage_simple_test.go
@@ -21,6 +21,7 @@ package discover
 import (
 	"crypto/rand"
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
@@ -123,12 +124,7 @@ func (*simpleTestnet) waitping(from NodeID) error                  { return nil 
 func (*simpleTestnet) ping(toid NodeID, toaddr *net.UDPAddr) error { return nil }
 
 func isIn(candidate *Node, list []*Node) bool {
-	for _, node := range list {
-		if candidate.CompareNode(node) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(list, candidate.CompareNode)
 }
 
 func TestShuffle(t *testing.T) {

--- a/networks/p2p/discover/node.go
+++ b/networks/p2p/discover/node.go
@@ -33,6 +33,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -289,10 +290,8 @@ func (n *Node) AddSubport(port uint16) {
 	if n.TCPs == nil {
 		n.TCPs = []uint16{}
 	}
-	for _, val := range n.TCPs {
-		if val == port {
-			return
-		}
+	if slices.Contains(n.TCPs, port) {
+		return
 	}
 	n.TCPs = append(n.TCPs, port)
 }

--- a/networks/p2p/peer.go
+++ b/networks/p2p/peer.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -151,10 +152,8 @@ func (p *Peer) Name() string {
 // versions is supported by both this node and the peer p.
 func (p *Peer) RunningCap(protocol string, versions []uint) bool {
 	if protos, ok := p.running[protocol]; ok {
-		for _, ver := range versions {
-			if protos[ConnDefault].Version == ver {
-				return true
-			}
+		if slices.Contains(versions, protos[ConnDefault].Version) {
+			return true
 		}
 	}
 	return false
@@ -602,7 +601,7 @@ type protoRW struct {
 	werr   chan<- error    // for write results
 	offset uint64
 	w      MsgWriter
-	count  uint64 // count the number of WriteMsg calls
+	count  atomic.Uint64 // count the number of WriteMsg calls
 	tc     RWTimerConfig
 }
 
@@ -611,7 +610,7 @@ func (rw *protoRW) WriteMsg(msg Msg) (err error) {
 		return newPeerError(errInvalidMsgCode, "not handled, (code %x) (size %d)", msg.Code, msg.Size)
 	}
 	msg.Code += rw.offset
-	rwCount := atomic.AddUint64(&rw.count, 1)
+	rwCount := rw.count.Add(1)
 	if rwCount%rw.tc.Interval == 0 {
 		timer := time.NewTimer(rw.tc.WaitTime)
 		defer timer.Stop()

--- a/networks/p2p/peer_test.go
+++ b/networks/p2p/peer_test.go
@@ -430,11 +430,17 @@ func TestNewPeer(t *testing.T) {
 	p.Disconnect(DiscAlreadyConnected) // Should not hang
 }
 
+type expectedProtoMatch struct {
+	Name    string
+	Version uint
+	offset  uint64
+}
+
 func TestMatchProtocols(t *testing.T) {
 	tests := []struct {
 		Remote []Cap
 		Local  []Protocol
-		Match  map[string]protoRW
+		Match  map[string]expectedProtoMatch
 	}{
 		{
 			// No remote capabilities
@@ -453,20 +459,20 @@ func TestMatchProtocols(t *testing.T) {
 			// Some matches, some differences
 			Remote: []Cap{{Name: "local"}, {Name: "match1"}, {Name: "match2"}},
 			Local:  []Protocol{{Name: "match1"}, {Name: "match2"}, {Name: "remote"}},
-			Match: map[string]protoRW{
-				"match1": {Protocol: Protocol{Name: "match1"}, tc: defaultRWTimerConfig},
-				"match2": {Protocol: Protocol{Name: "match2"}, tc: defaultRWTimerConfig},
+			Match: map[string]expectedProtoMatch{
+				"match1": {Name: "match1"},
+				"match2": {Name: "match2"},
 			},
 		},
 		{
 			// Various alphabetical ordering
 			Remote: []Cap{{Name: "aa"}, {Name: "ab"}, {Name: "bb"}, {Name: "ba"}},
 			Local:  []Protocol{{Name: "ba"}, {Name: "bb"}, {Name: "ab"}, {Name: "aa"}},
-			Match: map[string]protoRW{
-				"aa": {Protocol: Protocol{Name: "aa"}, tc: defaultRWTimerConfig},
-				"ab": {Protocol: Protocol{Name: "ab"}, tc: defaultRWTimerConfig},
-				"ba": {Protocol: Protocol{Name: "ba"}, tc: defaultRWTimerConfig},
-				"bb": {Protocol: Protocol{Name: "bb"}, tc: defaultRWTimerConfig},
+			Match: map[string]expectedProtoMatch{
+				"aa": {Name: "aa"},
+				"ab": {Name: "ab"},
+				"ba": {Name: "ba"},
+				"bb": {Name: "bb"},
 			},
 		},
 		{
@@ -478,27 +484,27 @@ func TestMatchProtocols(t *testing.T) {
 			// Multiple versions, single common
 			Remote: []Cap{{Version: 1}, {Version: 2}},
 			Local:  []Protocol{{Version: 2}, {Version: 3}},
-			Match:  map[string]protoRW{"": {Protocol: Protocol{Version: 2}, tc: defaultRWTimerConfig}},
+			Match:  map[string]expectedProtoMatch{"": {Version: 2}},
 		},
 		{
 			// Multiple versions, multiple common
 			Remote: []Cap{{Version: 1}, {Version: 2}, {Version: 3}, {Version: 4}},
 			Local:  []Protocol{{Version: 2}, {Version: 3}},
-			Match:  map[string]protoRW{"": {Protocol: Protocol{Version: 3}, tc: defaultRWTimerConfig}},
+			Match:  map[string]expectedProtoMatch{"": {Version: 3}},
 		},
 		{
 			// Various version orderings
 			Remote: []Cap{{Version: 4}, {Version: 1}, {Version: 3}, {Version: 2}},
 			Local:  []Protocol{{Version: 2}, {Version: 3}, {Version: 1}},
-			Match:  map[string]protoRW{"": {Protocol: Protocol{Version: 3}, tc: defaultRWTimerConfig}},
+			Match:  map[string]expectedProtoMatch{"": {Version: 3}},
 		},
 		{
 			// Versions overriding sub-protocol lengths
 			Remote: []Cap{{Version: 1}, {Version: 2}, {Version: 3}, {Name: "a"}},
 			Local:  []Protocol{{Version: 1, Length: 1}, {Version: 2, Length: 2}, {Version: 3, Length: 3}, {Name: "a"}},
-			Match: map[string]protoRW{
-				"":  {Protocol: Protocol{Version: 3}, tc: defaultRWTimerConfig},
-				"a": {Protocol: Protocol{Name: "a"}, offset: 3, tc: defaultRWTimerConfig},
+			Match: map[string]expectedProtoMatch{
+				"":  {Version: 3},
+				"a": {Name: "a", offset: 3},
 			},
 		},
 	}

--- a/networks/p2p/simulations/http_test.go
+++ b/networks/p2p/simulations/http_test.go
@@ -230,7 +230,7 @@ func (t *testService) Snapshot() ([]byte, error) {
 type TestAPI struct {
 	state     *atomic.Value
 	peerCount *int64
-	counter   int64
+	counter   atomic.Int64
 	feed      event.Feed
 }
 
@@ -239,11 +239,11 @@ func (t *TestAPI) PeerCount() int64 {
 }
 
 func (t *TestAPI) Get() int64 {
-	return atomic.LoadInt64(&t.counter)
+	return t.counter.Load()
 }
 
 func (t *TestAPI) Add(delta int64) {
-	atomic.AddInt64(&t.counter, delta)
+	t.counter.Add(delta)
 	t.feed.Send(delta)
 }
 

--- a/node/cn/filters/filter.go
+++ b/node/cn/filters/filter.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"slices"
 	"strconv"
 
 	"github.com/kaiachain/kaia/blockchain"
@@ -312,13 +313,7 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) (logs [
 }
 
 func includes(addresses []common.Address, a common.Address) bool {
-	for _, addr := range addresses {
-		if addr == a {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(addresses, a)
 }
 
 // filterLogs creates a slice of logs matching the given criteria.
@@ -342,11 +337,8 @@ Logs:
 		}
 		for i, topics := range topics {
 			match := len(topics) == 0 // empty rule set == wildcard
-			for _, topic := range topics {
-				if log.Topics[i] == topic {
-					match = true
-					break
-				}
+			if slices.Contains(topics, log.Topics[i]) {
+				match = true
 			}
 			if !match {
 				continue Logs

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -101,9 +101,9 @@ func errResp(code errCode, format string, v ...interface{}) error {
 type ProtocolManager struct {
 	networkId uint64
 
-	fastSync  uint32 // Flag whether fast sync is enabled (gets disabled if we already have blocks)
-	snapSync  uint32 // Flag whether fast sync should operate on top of the snap protocol
-	acceptTxs uint32 // Flag whether we're considered synchronised (enables transaction processing)
+	fastSync  uint32        // Flag whether fast sync is enabled (gets disabled if we already have blocks)
+	snapSync  uint32        // Flag whether fast sync should operate on top of the snap protocol
+	acceptTxs atomic.Uint32 // Flag whether we're considered synchronised (enables transaction processing)
 
 	txpool      work.TxPool
 	blockchain  work.BlockChain
@@ -349,7 +349,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 				logger.Warn("Discarded bad propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
 				return 0, nil
 			}
-			atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
+			manager.acceptTxs.Store(1) // Mark initial sync done on any fetcher import
 			return manager.blockchain.InsertChain(blocks)
 		}
 		manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, manager.BroadcastBlock, manager.BroadcastBlockHash, heighter, inserter, manager.removePeer)
@@ -1446,7 +1446,7 @@ func handleNewBlockMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 // handleTxMsg handles transaction-propagating message.
 func handleTxMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// Transactions arrived, make sure we have a valid and fresh chain to handle them
-	if atomic.LoadUint32(&pm.acceptTxs) == 0 {
+	if pm.acceptTxs.Load() == 0 {
 		return nil
 	}
 	// Transactions can be processed, parse all of them and deliver to the pool
@@ -1869,7 +1869,7 @@ func (pm *ProtocolManager) ProtocolVersion() int {
 }
 
 func (pm *ProtocolManager) SetAcceptTxs() {
-	atomic.StoreUint32(&pm.acceptTxs, 1)
+	pm.acceptTxs.Store(1)
 }
 
 func (pm *ProtocolManager) NodeType() common.ConnType {

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"math/big"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -277,7 +276,7 @@ func TestHandleTxMsg(t *testing.T) {
 	}
 	// If pm.acceptTxs == 1, TxPool.HandleTxMsg is called.
 	{
-		atomic.StoreUint32(&pm.acceptTxs, 1)
+		pm.acceptTxs.Store(1)
 		mockTxPool := mocks.NewMockTxPool(mockCtrl)
 
 		// The time field in received transaction through pm.handleMsg() has different value from generated transaction(`tx1`).
@@ -295,7 +294,7 @@ func TestHandleTxMsg_KZGVerificationError(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	pm := &ProtocolManager{}
-	atomic.StoreUint32(&pm.acceptTxs, 1)
+	pm.acceptTxs.Store(1)
 	mockTxPool := mocks.NewMockTxPool(mockCtrl)
 	pm.txpool = mockTxPool
 

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"math/big"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
@@ -1147,12 +1148,7 @@ func TestReBroadcastTxsSortedByTime(t *testing.T) {
 }
 
 func contains(addrs []common.Address, item common.Address) bool {
-	for _, a := range addrs {
-		if a == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(addrs, item)
 }
 
 func createAndRegisterPeers(mockCtrl *gomock.Controller, peers *peerSet) (*MockPeer, *MockPeer, *MockPeer) {

--- a/node/cn/peer_set_test.go
+++ b/node/cn/peer_set_test.go
@@ -20,6 +20,7 @@ package cn
 
 import (
 	"math/big"
+	"slices"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -1005,12 +1006,7 @@ func TestPeerSet_TypePeersWithoutBlock(t *testing.T) {
 }
 
 func containsPeer(target Peer, peers []Peer) bool {
-	for _, peer := range peers {
-		if target == peer {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(peers, target)
 }
 
 func countPeerType(t common.ConnType, peers []Peer) int {

--- a/node/cn/sync.go
+++ b/node/cn/sync.go
@@ -225,7 +225,7 @@ func (pm *ProtocolManager) synchronise(peer Peer) {
 		logger.Info("Snap sync complete, auto disabling")
 		atomic.StoreUint32(&pm.snapSync, 0)
 	}
-	atomic.StoreUint32(&pm.acceptTxs, 1) // Mark initial sync done
+	pm.acceptTxs.Store(1) // Mark initial sync done
 	if head := pm.blockchain.CurrentBlock(); head.NumberU64() > 0 {
 		// We've completed a sync cycle, notify all peers of new state. This path is
 		// essential in star-topology networks where a gateway node needs to notify

--- a/node/cn/tracers/tracer.go
+++ b/node/cn/tracers/tracer.go
@@ -394,8 +394,8 @@ type Tracer struct {
 	ctx map[string]interface{} // Transaction context gathered throughout execution
 	err error                  // Error, if one has occurred
 
-	interrupt uint32 // Atomic flag to signal execution interruption
-	reason    error  // Textual reason for the interruption
+	interrupt atomic.Uint32 // Atomic flag to signal execution interruption
+	reason    error         // Textual reason for the interruption
 
 	gasLimit        uint64 // Amount of gas bought for the whole tx
 	traceSteps      bool   // When true, will invoke step() on each opcode
@@ -632,7 +632,7 @@ func New(code string, ctx *Context, unsafeTrace bool) (*Tracer, error) {
 // Stop terminates execution of the tracer at the first opportune moment.
 func (jst *Tracer) Stop(err error) {
 	jst.reason = err
-	atomic.StoreUint32(&jst.interrupt, 1)
+	jst.interrupt.Store(1)
 }
 
 // call executes a method on a JS object, catching any errors, formatting and
@@ -706,7 +706,7 @@ func (jst *Tracer) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost,
 		jst.inited = true
 	}
 	// If tracing was interrupted, set the error and stop
-	if atomic.LoadUint32(&jst.interrupt) > 0 {
+	if jst.interrupt.Load() > 0 {
 		jst.err = jst.reason
 		// env.Cancel()
 		return
@@ -767,7 +767,7 @@ func (jst *Tracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 		return
 	}
 	// If tracing was interrupted, set the error and stop
-	if atomic.LoadUint32(&jst.interrupt) > 0 {
+	if jst.interrupt.Load() > 0 {
 		jst.err = jst.reason
 		return
 	}
@@ -797,7 +797,7 @@ func (jst *Tracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 		return
 	}
 	// If tracing was interrupted, set the error and stop
-	if atomic.LoadUint32(&jst.interrupt) > 0 {
+	if jst.interrupt.Load() > 0 {
 		jst.err = jst.reason
 		return
 	}

--- a/snapshot/difflayer.go
+++ b/snapshot/difflayer.go
@@ -88,8 +88,8 @@ type diffLayer struct {
 	parent snapshot   // Parent snapshot modified by this one, never nil
 	memory uint64     // Approximate guess as to how much memory we use
 
-	root  common.Hash // Root hash to which this snapshot diff belongs to
-	stale uint32      // Signals that the layer became stale (state progressed)
+	root  common.Hash   // Root hash to which this snapshot diff belongs to
+	stale atomic.Uint32 // Signals that the layer became stale (state progressed)
 
 	// destructSet is a very special helper marker. If an account is marked as
 	// deleted, then it's recorded in this set. However it's allowed that an account
@@ -251,7 +251,7 @@ func (dl *diffLayer) Parent() snapshot {
 // Stale return whether this layer has become stale (was flattened across) or if
 // it's still live.
 func (dl *diffLayer) Stale() bool {
-	return atomic.LoadUint32(&dl.stale) != 0
+	return dl.stale.Load() != 0
 }
 
 // Account directly retrieves the account associated with a particular hash in
@@ -443,7 +443,7 @@ func (dl *diffLayer) flatten() snapshot {
 
 	// Before actually writing all our data to the parent, first ensure that the
 	// parent hasn't been 'corrupted' by someone else already flattening into it
-	if atomic.SwapUint32(&parent.stale, 1) != 0 {
+	if parent.stale.Swap(1) != 0 {
 		panic("parent diff layer is stale") // we've flattened into the same parent from two children, boo
 	}
 	// Overwrite all the updated accounts blindly, merge the sorted list

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/kaiachain/kaia/blockchain/types/account"
 	"github.com/kaiachain/kaia/common"
@@ -270,7 +269,7 @@ func (t *Tree) Disable() {
 		case *diffLayer:
 			// If the layer is a simple diff, simply mark as stale
 			layer.lock.Lock()
-			atomic.StoreUint32(&layer.stale, 1)
+			layer.stale.Store(1)
 			layer.lock.Unlock()
 
 		default:
@@ -734,7 +733,7 @@ func (t *Tree) Rebuild(root common.Hash) {
 		case *diffLayer:
 			// If the layer is a simple diff, simply mark as stale
 			layer.lock.Lock()
-			atomic.StoreUint32(&layer.stale, 1)
+			layer.stale.Store(1)
 			layer.lock.Unlock()
 
 		default:

--- a/storage/statedb/sync_bloom.go
+++ b/storage/statedb/sync_bloom.go
@@ -60,9 +60,9 @@ func (f syncBloomHasher) Sum64() uint64                     { return binary.BigE
 // returning live results once that's finished.
 type SyncBloom struct {
 	bloom  *bloomfilter.Filter
-	inited uint32
+	inited atomic.Uint32
 	closer sync.Once
-	closed uint32
+	closed atomic.Uint32
 	pend   sync.WaitGroup
 }
 
@@ -107,7 +107,7 @@ func (b *SyncBloom) init(db database.Iteratee) {
 		start = time.Now()
 		swap  = time.Now()
 	)
-	for it.Next() && atomic.LoadUint32(&b.closed) == 0 {
+	for it.Next() && b.closed.Load() == 0 {
 		// If the database entry is a trie node, add it to the bloom
 		key := it.Key()
 		if len(key) == common.HashLength {
@@ -135,7 +135,7 @@ func (b *SyncBloom) init(db database.Iteratee) {
 
 	// Mark the bloom filter inited and return
 	logger.Info("Initialized fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate(), "elapsed", common.PrettyDuration(time.Since(start)))
-	atomic.StoreUint32(&b.inited, 1)
+	b.inited.Store(1)
 }
 
 // meter periodically recalculates the false positive error rate of the bloom
@@ -147,7 +147,7 @@ func (b *SyncBloom) meter() {
 
 		// Wait one second, but check termination more frequently
 		for i := 0; i < 10; i++ {
-			if atomic.LoadUint32(&b.closed) == 1 {
+			if b.closed.Load() == 1 {
 				return
 			}
 			time.Sleep(100 * time.Millisecond)
@@ -160,13 +160,13 @@ func (b *SyncBloom) meter() {
 func (b *SyncBloom) Close() error {
 	b.closer.Do(func() {
 		// Ensure the initializer is stopped
-		atomic.StoreUint32(&b.closed, 1)
+		b.closed.Store(1)
 		b.pend.Wait()
 
 		// Wipe the bloom, but mark it "uninited" just in case someone attempts an access
 		logger.Info("Deallocated fast sync bloom", "items", b.bloom.N(), "errorrate", b.errorRate())
 
-		atomic.StoreUint32(&b.inited, 0)
+		b.inited.Store(0)
 		b.bloom = nil
 	})
 	return nil
@@ -174,7 +174,7 @@ func (b *SyncBloom) Close() error {
 
 // Add inserts a new trie node hash into the bloom filter.
 func (b *SyncBloom) Add(hash []byte) {
-	if atomic.LoadUint32(&b.closed) == 1 {
+	if b.closed.Load() == 1 {
 		return
 	}
 	b.bloom.Add(syncBloomHasher(hash))
@@ -188,7 +188,7 @@ func (b *SyncBloom) Add(hash []byte) {
 // While the bloom is being initialized, any query will return true.
 func (b *SyncBloom) Contains(hash []byte) bool {
 	bloomTestMeter.Mark(1)
-	if atomic.LoadUint32(&b.inited) == 0 {
+	if b.inited.Load() == 0 {
 		// We didn't load all the trie nodes from the previous run of Geth yet. As
 		// such, we can't say for sure if a hash is not present for anything. Until
 		// the init is done, we're faking "possible presence" for everything.

--- a/work/agent.go
+++ b/work/agent.go
@@ -41,7 +41,7 @@ type CpuAgent struct {
 	chain  consensus.ChainReader
 	engine consensus.Engine
 
-	isMining int32 // isMining indicates whether the agent is currently mining
+	isMining atomic.Int32 // isMining indicates whether the agent is currently mining
 
 	nodetype common.ConnType
 }
@@ -61,7 +61,7 @@ func (self *CpuAgent) Work() chan<- *Task            { return self.workCh }
 func (self *CpuAgent) SetReturnCh(ch chan<- *Result) { self.returnCh = ch }
 
 func (self *CpuAgent) Stop() {
-	if !atomic.CompareAndSwapInt32(&self.isMining, 1, 0) {
+	if !self.isMining.CompareAndSwap(1, 0) {
 		return // agent already stopped
 	}
 	self.stop <- struct{}{}
@@ -77,7 +77,7 @@ done:
 }
 
 func (self *CpuAgent) Start() {
-	if !atomic.CompareAndSwapInt32(&self.isMining, 0, 1) {
+	if !self.isMining.CompareAndSwap(0, 1) {
 		return // agent already started
 	}
 	go self.update()

--- a/work/builder/bundle.go
+++ b/work/builder/bundle.go
@@ -17,6 +17,8 @@
 package builder
 
 import (
+	"slices"
+
 	"github.com/kaiachain/kaia/common"
 )
 
@@ -82,10 +84,8 @@ func (b *Bundle) IsConflict(newBundle *Bundle) bool {
 	}
 
 	// 2-2. Check for overlapping txs
-	for _, txOrGen := range newBundle.BundleTxs {
-		if b.Has(txOrGen) {
-			return true
-		}
+	if slices.ContainsFunc(newBundle.BundleTxs, b.Has) {
+		return true
 	}
 
 	// 2-3. Check for TargetTxHash breaking current bundle.

--- a/work/remote_agent.go
+++ b/work/remote_agent.go
@@ -51,7 +51,7 @@ type RemoteAgent struct {
 	hashrateMu sync.RWMutex
 	hashrate   map[common.Hash]hashrate
 
-	running int32 // running indicates whether the agent is active. Call atomically
+	running atomic.Int32 // running indicates whether the agent is active. Call atomically
 }
 
 func NewRemoteAgent(chain consensus.ChainReader, engine consensus.Engine) *RemoteAgent {
@@ -79,7 +79,7 @@ func (a *RemoteAgent) SetReturnCh(returnCh chan<- *Result) {
 }
 
 func (a *RemoteAgent) Start() {
-	if !atomic.CompareAndSwapInt32(&a.running, 0, 1) {
+	if !a.running.CompareAndSwap(0, 1) {
 		return
 	}
 	a.quitCh = make(chan struct{})
@@ -88,7 +88,7 @@ func (a *RemoteAgent) Start() {
 }
 
 func (a *RemoteAgent) Stop() {
-	if !atomic.CompareAndSwapInt32(&a.running, 1, 0) {
+	if !a.running.CompareAndSwap(1, 0) {
 		return
 	}
 	close(a.quitCh)

--- a/work/work.go
+++ b/work/work.go
@@ -99,12 +99,12 @@ type Backend interface {
 type Miner struct {
 	mux     *event.TypeMux
 	worker  *worker
-	mining  int32
+	mining  atomic.Int32
 	backend Backend
 	engine  consensus.Engine
 
-	canStart    int32 // can start indicates whether we can start the mining operation
-	shouldStart int32 // should start indicates whether we should start after sync
+	canStart    int32        // can start indicates whether we can start the mining operation
+	shouldStart atomic.Int32 // should start indicates whether we should start after sync
 }
 
 func New(backend Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, nodetype common.ConnType, nodeAddr common.Address, TxResendUseLegacy bool, govModule gov.GovModule) *Miner {
@@ -135,14 +135,14 @@ out:
 			atomic.StoreInt32(&self.canStart, 0)
 			if self.Mining() {
 				self.Stop()
-				atomic.StoreInt32(&self.shouldStart, 1)
+				self.shouldStart.Store(1)
 				logger.Info("Mining aborted due to sync")
 			}
 		case downloader.DoneEvent, downloader.FailedEvent:
-			shouldStart := atomic.LoadInt32(&self.shouldStart) == 1
+			shouldStart := self.shouldStart.Load() == 1
 
 			atomic.StoreInt32(&self.canStart, 1)
-			atomic.StoreInt32(&self.shouldStart, 0)
+			self.shouldStart.Store(0)
 			if shouldStart {
 				self.Start()
 			}
@@ -155,13 +155,13 @@ out:
 }
 
 func (self *Miner) Start() {
-	atomic.StoreInt32(&self.shouldStart, 1)
+	self.shouldStart.Store(1)
 
 	if atomic.LoadInt32(&self.canStart) == 0 {
 		logger.Info("Network syncing, will start work afterwards")
 		return
 	}
-	atomic.StoreInt32(&self.mining, 1)
+	self.mining.Store(1)
 
 	if self.worker.nodetype == common.CONSENSUSNODE {
 		logger.Info("Starting mining operation")
@@ -172,8 +172,8 @@ func (self *Miner) Start() {
 
 func (self *Miner) Stop() {
 	self.worker.stop()
-	atomic.StoreInt32(&self.mining, 0)
-	atomic.StoreInt32(&self.shouldStart, 0)
+	self.mining.Store(0)
+	self.shouldStart.Store(0)
 }
 
 func (self *Miner) Register(agent Agent) {
@@ -188,7 +188,7 @@ func (self *Miner) Unregister(agent Agent) {
 }
 
 func (self *Miner) Mining() bool {
-	return atomic.LoadInt32(&self.mining) > 0
+	return self.mining.Load() > 0
 }
 
 func (self *Miner) HashRate() (tot int64) {

--- a/work/worker.go
+++ b/work/worker.go
@@ -201,8 +201,8 @@ type worker struct {
 	snapshotState    *state.StateDB
 
 	// atomic status counters
-	mining int32
-	atWork int32
+	mining atomic.Int32
+	atWork atomic.Int32
 
 	nodetype common.ConnType
 }
@@ -244,7 +244,7 @@ func (self *worker) setExtra(extra []byte) {
 }
 
 func (self *worker) pending() (*types.Block, types.Receipts, *state.StateDB) {
-	if atomic.LoadInt32(&self.mining) == 0 {
+	if self.mining.Load() == 0 {
 		// return a snapshot to avoid contention on currentMu mutex
 		self.snapshotMu.RLock()
 		defer self.snapshotMu.RUnlock()
@@ -262,7 +262,7 @@ func (self *worker) pending() (*types.Block, types.Receipts, *state.StateDB) {
 }
 
 func (self *worker) pendingBlock() *types.Block {
-	if atomic.LoadInt32(&self.mining) == 0 {
+	if self.mining.Load() == 0 {
 		// return a snapshot to avoid contention on currentMu mutex
 		self.snapshotMu.RLock()
 		defer self.snapshotMu.RUnlock()
@@ -281,7 +281,7 @@ func (self *worker) start() {
 	self.mu.Lock()
 	defer self.mu.Unlock()
 
-	atomic.StoreInt32(&self.mining, 1)
+	self.mining.Store(1)
 
 	// istanbul BFT
 	if istanbul, ok := self.engine.(consensus.Istanbul); ok {
@@ -299,7 +299,7 @@ func (self *worker) stop() {
 
 	self.mu.Lock()
 	defer self.mu.Unlock()
-	if atomic.LoadInt32(&self.mining) == 1 {
+	if self.mining.Load() == 1 {
 		for agent := range self.agents {
 			agent.Stop()
 		}
@@ -310,8 +310,8 @@ func (self *worker) stop() {
 		istanbul.Stop()
 	}
 
-	atomic.StoreInt32(&self.mining, 0)
-	atomic.StoreInt32(&self.atWork, 0)
+	self.mining.Store(0)
+	self.atWork.Store(0)
 }
 
 func (self *worker) register(agent Agent) {
@@ -335,7 +335,7 @@ func (self *worker) handleTxsCh(quitByErr chan bool) {
 		select {
 		// Handle NewTxsEvent
 		case <-self.txsCh:
-			if atomic.LoadInt32(&self.mining) != 0 {
+			if self.mining.Load() != 0 {
 				// If we're mining, but nothing is being processed, wake on new transactions
 				// Clique consensus removed - no longer needed
 			}
@@ -387,7 +387,7 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 	for {
 		mustCommitNewWork := true
 		for result := range self.recv {
-			atomic.AddInt32(&self.atWork, -1)
+			self.atWork.Add(-1)
 			ResultChGauge.Update(ResultChGauge.Value() - 1)
 			if result == nil {
 				continue
@@ -499,11 +499,11 @@ func (self *worker) wait(TxResendUseLegacy bool) {
 
 // push sends a new work task to currently live work agents.
 func (self *worker) push(work *Task) {
-	if atomic.LoadInt32(&self.mining) != 1 {
+	if self.mining.Load() != 1 {
 		return
 	}
 	for agent := range self.agents {
-		atomic.AddInt32(&self.atWork, 1)
+		self.atWork.Add(1)
 		if ch := agent.Work(); ch != nil {
 			ch <- work
 		}
@@ -644,7 +644,7 @@ func (self *worker) commitNewWork() {
 		finishedFinalize := time.Now()
 
 		// We only care about logging if we're actually mining.
-		if atomic.LoadInt32(&self.mining) == 1 {
+		if self.mining.Load() == 1 {
 			// Update the metrics subsystem with all the measurements
 			accountReadTimer.Update(work.state.AccountReads)
 			accountHashTimer.Update(work.state.AccountHashes)
@@ -751,9 +751,9 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc Bl
 	)
 
 	// Limit the execution time of all transactions in a block
-	var abort int32 = 0            // To break the below `CommitTransactionLoop` for loop when timed out
-	var isExecutingBundleTxs int32 // To wait for abort while the bundle is running
-	chDone := make(chan bool)      // To stop the goroutine below when processing txs is completed
+	var abort int32 = 0                   // To break the below `CommitTransactionLoop` for loop when timed out
+	var isExecutingBundleTxs atomic.Int32 // To wait for abort while the bundle is running
+	chDone := make(chan bool)             // To stop the goroutine below when processing txs is completed
 
 	// chEVM is used to notify the below goroutine of the running EVM so it can call evm.Cancel
 	// when timed out.  We use a buffered channel to prevent the main EVM execution routine
@@ -781,7 +781,7 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc Bl
 			if timeout && evm != nil {
 				// Allow the first transaction to complete although it exceeds the time limit.
 				// Even in this case, the evm will not be canceled if the bundle is running.
-				if env.tcount > 0 && atomic.LoadInt32(&isExecutingBundleTxs) == 0 {
+				if env.tcount > 0 && isExecutingBundleTxs.Load() == 0 {
 					// The total time limit reached, thus we stop the currently running EVM.
 					evm.Cancel(vm.CancelByTotalTimeLimit)
 				} else if env.tcount == 0 && len(arrayTxs) > 0 {
@@ -889,7 +889,7 @@ CommitTransactionLoop:
 		//}
 		// Start executing the transaction
 		if len(targetBundle.BundleTxs) != 0 {
-			atomic.StoreInt32(&isExecutingBundleTxs, 1)
+			isExecutingBundleTxs.Store(1)
 			err, tx, logs = env.commitBundleTransaction(targetBundle, bc, nodeAddr, vmConfig)
 			if err != nil && tx != nil {
 				// override sender to error tx
@@ -948,7 +948,7 @@ CommitTransactionLoop:
 		}
 		if len(targetBundle.BundleTxs) != 0 {
 			// After the last tx in the bundle finishes, set executingBundleTxs back to 0.
-			atomic.StoreInt32(&isExecutingBundleTxs, 0)
+			isExecutingBundleTxs.Store(0)
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

Run go-modernize with the following options (others=false):
```
-atomic=true -fmtappendf=true -minmax=true -reflecttypefor=true -slicescontains=true -slicessort=true -stringscut=true -stringscutprefix=true -waitgroup=true
```

- Typed atomics instead of package-level atomic helpers
  - `atomic.LoadInt32(&x)` becomes `x.Load()`
  - `atomic.CompareAndSwapInt32(&x, old, new)` becomes `x.CompareAndSwap(old, new)`
- Standard-library slice helpers instead of manual membership loops
  - `slices.Contains`, `slices.ContainsFunc`
- Fix test `networks/p2p/peer_test.go` to avoid copying protoRW, which became non-copyable after count changed to atomic.Uint64. It has been detected by [go vet copylocks](https://pkg.go.dev/cmd/vet#pkg-overview) check.

Other options are coming in next PRs.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

The exact command:

```bash
go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -any=false -atomic=false -fmtappendf=false -forvar=false -mapsloop=false -minmax=false -newexpr=false -omitzero=false -plusbuild=false -rangeint=false -reflecttypefor=false -slicescontains=false -slicessort=false -stditerators=false -stringsbuilder=false -stringscut=false -stringscutprefix=false -stringsseq=false -testingcontext=false -unsafefuncs=false -waitgroup=false -atomic=true -fmtappendf=true -minmax=true -reflecttypefor=true -slicescontains=true -slicessort=true -stringscut=true -stringscutprefix=true -waitgroup=true -fix ./...
```
