### PR TITLE
modernize: range-based loop iteration

### DIFF
--- a/accounts/abi/bind/backends/blockchain_test.go
+++ b/accounts/abi/bind/backends/blockchain_test.go
@@ -440,7 +440,7 @@ func TestBlockChainSubscribeFilterLogs(t *testing.T) {
 	}()
 
 	// Wait for 2 logs
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case log := <-logs:
 			assert.Equal(t, code1Addr, log.Address)

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -101,7 +101,7 @@ func Bind(types []string, abis []string, bytecodes []string, runtimebytecodes []
 		// isLib is the map used to flag each encountered library as such
 		isLib = make(map[string]struct{})
 	)
-	for i := 0; i < len(types); i++ {
+	for i := range types {
 		// Parse the actual ABI to generate the binding for
 		evmABI, err := abi.JSON(strings.NewReader(abis[i]))
 		if err != nil {
@@ -254,7 +254,7 @@ func Bind(types []string, abis []string, bytecodes []string, runtimebytecodes []
 		}
 	}
 	// Check if that type has already been identified as a library
-	for i := 0; i < len(types); i++ {
+	for i := range types {
 		_, ok := isLib[types[i]]
 		contracts[types[i]].Library = ok
 	}

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -111,7 +111,7 @@ func genIntType(rule int64, size uint) []byte {
 		// extended to common.Hashlength bytes.
 		topic = [common.HashLength]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255}
 	}
-	for i := uint(0); i < size; i++ {
+	for i := range size {
 		topic[common.HashLength-i-1] = byte(rule >> (i * 8))
 	}
 	return topic[:]

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -113,7 +113,7 @@ func (ks *KeyStore) init(keydir string) {
 	// Create the initial list of wallets from the cache
 	accs := ks.cache.accounts()
 	ks.wallets = make([]accounts.Wallet, len(accs))
-	for i := 0; i < len(accs); i++ {
+	for i := range accs {
 		ks.wallets[i] = &keystoreWallet{account: accs[i], keystore: ks}
 	}
 }

--- a/accounts/keystore/keystore_passphrase_test.go
+++ b/accounts/keystore/keystore_passphrase_test.go
@@ -48,7 +48,7 @@ func TestKeyEncryptDecrypt(t *testing.T) {
 	address := common.HexToAddress("45dea0fb0bba44f4fcf290bba71fd57d7117cbb8")
 
 	// Do a few rounds of decryption and encryption
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		// Try a bad password first
 		if _, err := DecryptKey(keyjson, password+"bad"); err == nil {
 			t.Errorf("test %d: json key decrypted with bad password", i)

--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -248,7 +248,7 @@ func TestWalletNotifierLifecycle(t *testing.T) {
 	updates := make(chan accounts.WalletEvent)
 
 	subs := make([]event.Subscription, 2)
-	for i := 0; i < len(subs); i++ {
+	for i := range subs {
 		// Create a new subscription
 		subs[i] = ks.Subscribe(updates)
 
@@ -263,12 +263,12 @@ func TestWalletNotifierLifecycle(t *testing.T) {
 		}
 	}
 	// Unsubscribe and ensure the updater terminates eventually
-	for i := 0; i < len(subs); i++ {
+	for i := range subs {
 		// Close an existing subscription
 		subs[i].Unsubscribe()
 
 		// Ensure the notifier shuts down at and only at the last close
-		for k := 0; k < int(walletRefreshCycle/(250*time.Millisecond))+2; k++ {
+		for range int(walletRefreshCycle/(250*time.Millisecond)) + 2 {
 			ks.mu.RLock()
 			updating = ks.updating
 			ks.mu.RUnlock()
@@ -351,7 +351,7 @@ func TestImportRace(t *testing.T) {
 	var errCnt uint32
 	var wg sync.WaitGroup
 	wg.Add(2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 			if _, err := ks2.Import(json, "new", "new"); err != nil {
@@ -400,7 +400,7 @@ func TestWalletNotifications(t *testing.T) {
 		live       = make(map[common.Address]accounts.Account)
 		wantEvents []walletEvent
 	)
-	for i := 0; i < 1024; i++ {
+	for range 1024 {
 		if create := len(live) == 0 || rand.Int()%4 > 0; create {
 			// Add a new account and ensure wallet notifications arrives
 			account, err := ks.NewAccount("")

--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -3412,7 +3412,7 @@ func TestEthAPI_GetBlobSidecars(t *testing.T) {
 			setupMock: func() {
 				// Create a block with 3 blob transactions (exceeding Max=1 for Osaka)
 				txs := make([]*types.Transaction, 3)
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					txs[i] = blobTx
 				}
 				blockWithManyBlobTxs := types.NewBlock(

--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -288,7 +288,7 @@ func BenchmarkChainWrite_full_100k_badgerDB(b *testing.B) {
 // into a database.
 func makeChainForBench(db database.DBManager, full bool, count uint64) {
 	var hash common.Hash
-	for n := uint64(0); n < count; n++ {
+	for n := range count {
 		num := new(big.Int).SetUint64(n)
 		header := &types.Header{
 			Number:      num,
@@ -346,7 +346,7 @@ func benchReadChain(b *testing.B, full bool, databaseType database.DBType, count
 			b.Fatalf("error creating chain: %v", err)
 		}
 
-		for n := uint64(0); n < count; n++ {
+		for n := range count {
 			header := chain.GetHeaderByNumber(n)
 			if full {
 				hash := header.Hash()

--- a/blockchain/blob_storage_test.go
+++ b/blockchain/blob_storage_test.go
@@ -318,7 +318,7 @@ func createTestSidecar(t *testing.T, numBlobs int) *types.BlobTxSidecar {
 	proofs := make([]kzg4844.Proof, numBlobs)
 
 	// Fill with test data (simple pattern for testing)
-	for i := 0; i < numBlobs; i++ {
+	for i := range numBlobs {
 		// Create a simple blob with pattern
 		var blob kzg4844.Blob
 		for j := 0; j < len(blob) && j < 100; j++ {
@@ -329,7 +329,7 @@ func createTestSidecar(t *testing.T, numBlobs int) *types.BlobTxSidecar {
 		// Create simple commitment and proof
 		var commitment kzg4844.Commitment
 		var proof kzg4844.Proof
-		for j := 0; j < len(commitment); j++ {
+		for j := range len(commitment) {
 			commitment[j] = byte(i + j)
 			proof[j] = byte(i + j + 10)
 		}

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -55,7 +55,7 @@ func TestHeaderVerification(t *testing.T) {
 	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, faker.NewFaker(), vm.Config{})
 	defer chain.Stop()
 
-	for i := 0; i < len(blocks); i++ {
+	for i := range blocks {
 		for j, valid := range []bool{true, false} {
 			var results <-chan error
 
@@ -296,7 +296,7 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 		}
 		// Wait for all the verification results
 		checks := make(map[int]error)
-		for j := 0; j < len(blocks); j++ {
+		for j := range blocks {
 			select {
 			case result := <-results:
 				checks[j] = result
@@ -306,7 +306,7 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 			}
 		}
 		// Check nonce check validity
-		for j := 0; j < len(blocks); j++ {
+		for j := range blocks {
 			want := valid || (j < len(blocks)-2) // We chose the last-but-one nonce in the chain to fail
 			if (checks[j] == nil) != want {
 				t.Errorf("test %d.%d: validity mismatch: have %v, want %v", i, j, checks[j], want)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1216,7 +1216,7 @@ func SetReceiptsData(config *params.ChainConfig, block *types.Block, receipts ty
 		return errors.New("transaction and receipt count mismatch")
 	}
 
-	for j := 0; j < len(receipts); j++ {
+	for j := range receipts {
 		// The transaction hash can be retrieved from the transaction itself
 		receipts[j].TxHash = transactions[j].Hash()
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -399,11 +399,11 @@ func testReorgShort(t *testing.T, full bool) {
 	// we need a fairly long chain of blocks with different difficulties for a short
 	// one to become heavyer than a long one. The 96 is an empirical value.
 	easy := make([]int64, 96)
-	for i := 0; i < len(easy); i++ {
+	for i := range easy {
 		easy[i] = 60
 	}
 	diff := make([]int64, len(easy)-1)
-	for i := 0; i < len(diff); i++ {
+	for i := range diff {
 		diff[i] = -9
 	}
 	// With faker, the longer chain (96 blocks) wins
@@ -674,7 +674,7 @@ func TestFastVsFullChains(t *testing.T) {
 		t.Fatalf("failed to insert receipt %d: %v", n, err)
 	}
 	// Iterate over all chain data components, and cross reference
-	for i := 0; i < len(blocks); i++ {
+	for i := range blocks {
 		bnum, num, hash := blocks[i].Number(), blocks[i].NumberU64(), blocks[i].Hash()
 
 		if ftd, atd := fast.GetTdByHash(hash), archive.GetTdByHash(hash); ftd.Cmp(atd) != 0 {
@@ -954,7 +954,7 @@ func TestReorgSideEvent(t *testing.T) {
 	const trials = 4
 
 	var lastErr error
-	for i := 0; i < trials; i++ {
+	for range trials {
 		if lastErr = testReorgSideEvent(t); lastErr == nil {
 			return // success
 		}
@@ -1228,7 +1228,7 @@ func TestBlockchainHeaderchainReorgConsistency(t *testing.T) {
 
 	// Generate a bunch of fork blocks, each side forking from the canonical chain
 	forks := make([]*types.Block, len(blocks))
-	for i := 0; i < len(forks); i++ {
+	for i := range forks {
 		parent := genesis
 		if i > 0 {
 			parent = blocks[i-1]
@@ -1245,7 +1245,7 @@ func TestBlockchainHeaderchainReorgConsistency(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}
-	for i := 0; i < len(blocks); i++ {
+	for i := range blocks {
 		if _, err := chain.InsertChain(blocks[i : i+1]); err != nil {
 			t.Fatalf("block %d: failed to insert into chain: %v", i, err)
 		}
@@ -1273,7 +1273,7 @@ func TestTrieForkGC(t *testing.T) {
 
 	// Generate a bunch of fork blocks, each side forking from the canonical chain
 	forks := make([]*types.Block, len(blocks))
-	for i := 0; i < len(forks); i++ {
+	for i := range forks {
 		parent := genesis
 		if i > 0 {
 			parent = blocks[i-1]
@@ -1289,7 +1289,7 @@ func TestTrieForkGC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
 	}
-	for i := 0; i < len(blocks); i++ {
+	for i := range blocks {
 		if _, err := chain.InsertChain(blocks[i : i+1]); err != nil {
 			t.Fatalf("block %d: failed to insert into chain: %v", i, err)
 		}
@@ -1298,7 +1298,7 @@ func TestTrieForkGC(t *testing.T) {
 		}
 	}
 	// Dereference all the recent tries and ensure no past trie is left in
-	for i := 0; i < DefaultTriesInMemory; i++ {
+	for i := range DefaultTriesInMemory {
 		chain.stateCache.TrieDB().Dereference(blocks[len(blocks)-1-i].Root())
 		chain.stateCache.TrieDB().Dereference(forks[len(blocks)-1-i].Root())
 	}
@@ -1669,7 +1669,7 @@ func benchmarkLargeNumberOfValueToNonexisting(b *testing.B, numTxs, numBlocks in
 	genesis := gspec.MustCommit(db)
 
 	blockGenerator := func(i int, block *BlockGen) {
-		for txi := 0; txi < numTxs; txi++ {
+		for txi := range numTxs {
 			uniq := uint64(i*numTxs + txi)
 			recipient := recipientFn(uniq)
 			// recipient := common.BigToAddress(big.NewInt(0).SetUint64(1337 + uniq))

--- a/blockchain/bloombits/generator.go
+++ b/blockchain/bloombits/generator.go
@@ -53,7 +53,7 @@ func NewGenerator(sections uint) (*Generator, error) {
 		return nil, errors.New("section count not multiple of 8")
 	}
 	b := &Generator{sections: sections}
-	for i := 0; i < types.BloomBitLength; i++ {
+	for i := range types.BloomBitLength {
 		b.blooms[i] = make([]byte, sections/8)
 	}
 	return b, nil
@@ -73,7 +73,7 @@ func (b *Generator) AddBloom(index uint, bloom types.Bloom) error {
 	byteIndex := b.nextSec / 8
 	bitMask := byte(1) << byte(7-b.nextSec%8)
 
-	for i := 0; i < types.BloomBitLength; i++ {
+	for i := range types.BloomBitLength {
 		bloomByteIndex := types.BloomByteLength - 1 - i/8
 		bloomBitMask := byte(1) << byte(i%8)
 

--- a/blockchain/bloombits/generator_test.go
+++ b/blockchain/bloombits/generator_test.go
@@ -36,8 +36,8 @@ func TestGenerator(t *testing.T) {
 	// Generate the input and the rotated output
 	var input, output [types.BloomBitLength][types.BloomByteLength]byte
 
-	for i := 0; i < types.BloomBitLength; i++ {
-		for j := 0; j < types.BloomBitLength; j++ {
+	for i := range types.BloomBitLength {
+		for j := range types.BloomBitLength {
 			bit := byte(rand.Int() % 2)
 
 			input[i][j/8] |= bit << byte(7-j%8)

--- a/blockchain/bloombits/matcher.go
+++ b/blockchain/bloombits/matcher.go
@@ -45,7 +45,7 @@ func calcBloomIndexes(b []byte) bloomIndexes {
 	b = crypto.Keccak256(b)
 
 	var idxs bloomIndexes
-	for i := 0; i < len(idxs); i++ {
+	for i := range len(idxs) {
 		idxs[i] = (uint(b[2*i])<<8)&2047 + uint(b[2*i+1])
 	}
 	return idxs

--- a/blockchain/bloombits/matcher_test.go
+++ b/blockchain/bloombits/matcher_test.go
@@ -77,7 +77,7 @@ func TestMatcherIntermittent(t *testing.T) {
 
 // Tests the matcher pipeline on random input to hopefully catch anomalies.
 func TestMatcherRandom(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		testMatcherBothModes(t, makeRandomIndexes([]int{1}, 50), 0, 10000, 0)
 		testMatcherBothModes(t, makeRandomIndexes([]int{3}, 50), 0, 10000, 0)
 		testMatcherBothModes(t, makeRandomIndexes([]int{2, 2, 2}, 20), 0, 10000, 0)
@@ -113,8 +113,8 @@ func makeRandomIndexes(lengths []int, max int) [][]bloomIndexes {
 	res := make([][]bloomIndexes, len(lengths))
 	for i, topics := range lengths {
 		res[i] = make([]bloomIndexes, topics)
-		for j := 0; j < topics; j++ {
-			for k := 0; k < len(res[i][j]); k++ {
+		for j := range topics {
+			for k := range len(res[i][j]) {
 				res[i][j][k] = uint(rand.Intn(max-1) + 2)
 			}
 		}
@@ -219,7 +219,7 @@ func testMatcher(t *testing.T, filter [][]bloomIndexes, start, blocks uint64, in
 func startRetrievers(session *MatcherSession, quit chan struct{}, retrievals *uint32, batch int) {
 	requests := make(chan chan *Retrieval)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		// Start a multiplexer to test multiple threaded execution
 		go session.Multiplex(batch, 100*time.Microsecond, requests)
 
@@ -252,8 +252,8 @@ func startRetrievers(session *MatcherSession, quit chan struct{}, retrievals *ui
 // numbers.
 func generateBitset(bit uint, section uint64) []byte {
 	bitset := make([]byte, testSectionSize/8)
-	for i := 0; i < len(bitset); i++ {
-		for b := 0; b < 8; b++ {
+	for i := range bitset {
+		for b := range 8 {
 			blockIdx := section*testSectionSize + uint64(i*8+b)
 			bitset[i] += bitset[i]
 			if (blockIdx % uint64(bit)) == 0 {

--- a/blockchain/bloombits/scheduler_test.go
+++ b/blockchain/bloombits/scheduler_test.go
@@ -53,7 +53,7 @@ func testScheduler(t *testing.T, clients int, fetchers int, requests int) {
 	defer close(fetch)
 
 	var delivered atomic.Uint32
-	for i := 0; i < fetchers; i++ {
+	for range fetchers {
 		go func() {
 			defer fetchPend.Done()
 
@@ -79,7 +79,7 @@ func testScheduler(t *testing.T, clients int, fetchers int, requests int) {
 	var pend sync.WaitGroup
 	pend.Add(clients)
 
-	for i := 0; i < clients; i++ {
+	for range clients {
 		go func() {
 			defer pend.Done()
 
@@ -89,13 +89,13 @@ func testScheduler(t *testing.T, clients int, fetchers int, requests int) {
 			f.run(in, fetch, out, quit, &pend)
 
 			go func() {
-				for j := 0; j < requests; j++ {
+				for j := range requests {
 					in <- uint64(j)
 				}
 				close(in)
 			}()
 
-			for j := 0; j < requests; j++ {
+			for j := range requests {
 				bits := <-out
 				if want := new(big.Int).SetUint64(uint64(j)).Bytes(); !bytes.Equal(bits, want) {
 					t.Errorf("vector %d: delivered content mismatch: have %x, want %x", j, bits, want)

--- a/blockchain/chain_indexer_test.go
+++ b/blockchain/chain_indexer_test.go
@@ -36,7 +36,7 @@ import (
 
 // Runs multiple tests with randomized parameters.
 func TestChainIndexerSingle(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		testChainIndexer(t, 1)
 	}
 }
@@ -61,7 +61,7 @@ func testChainIndexer(t *testing.T, count int) {
 
 	// Create a chain of indexers and ensure they all report empty
 	backends := make([]*testChainIndexBackend, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		var (
 			sectionSize = uint64(rand.Intn(100) + 1)
 			confirmsReq = uint64(rand.Intn(10))
@@ -153,7 +153,7 @@ type testChainIndexBackend struct {
 func (b *testChainIndexBackend) assertSections() {
 	// Keep trying for 3 seconds if it does not match
 	var sections uint64
-	for i := 0; i < 300; i++ {
+	for range 300 {
 		sections, _, _ = b.indexer.Sections()
 		if sections == b.stored {
 			return
@@ -177,7 +177,7 @@ func (b *testChainIndexBackend) assertBlocks(headNum, failNum uint64) (uint64, b
 					// rolled back after processing started, no more process calls expected
 					// wait until updating is done to make sure that processing actually fails
 					var updating bool
-					for i := 0; i < 300; i++ {
+					for range 300 {
 						b.indexer.lock.Lock()
 						updating = b.indexer.knownSections > b.indexer.storedSections
 						b.indexer.lock.Unlock()

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -256,7 +256,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		}
 		return nil, nil
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		statedb, err := state.New(parent.Root(), state.NewDatabase(db), nil, nil)
 		if err != nil {
 			panic(err)

--- a/blockchain/headerchain.go
+++ b/blockchain/headerchain.go
@@ -290,7 +290,7 @@ func (hc *HeaderChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []co
 	}
 	// Iterate the headers until enough is collected or the genesis reached
 	chain := make([]common.Hash, 0, max)
-	for i := uint64(0); i < max; i++ {
+	for range max {
 		next := header.ParentHash
 		if header = hc.GetHeader(next, header.Number.Uint64()-1); header == nil {
 			break

--- a/blockchain/state/state_object_encoder.go
+++ b/blockchain/state/state_object_encoder.go
@@ -50,7 +50,7 @@ func newStateObjectEncoder(numGoRoutines, tasksChSize int) *stateObjectEncoder {
 		tasksCh: make(chan *stateObject, tasksChSize),
 	}
 
-	for i := 0; i < numGoRoutines; i++ {
+	for range numGoRoutines {
 		go encodeStateObject(soe.tasksCh)
 	}
 

--- a/blockchain/state/statedb_test.go
+++ b/blockchain/state/statedb_test.go
@@ -54,7 +54,7 @@ func TestUpdateLeaks(t *testing.T) {
 	state, _ := New(common.Hash{}, NewDatabase(memDBManager), nil, nil)
 
 	// Update it with some accounts
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		addr := common.BytesToAddress([]byte{i})
 		if i%2 == 0 {
 			state.SetState(addr, common.BytesToHash([]byte{i, i, i}), common.BytesToHash([]byte{i, i, i, i}))
@@ -100,14 +100,14 @@ func TestIntermediateLeaks(t *testing.T) {
 	}
 
 	// Modify the transient state.
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		modify(transState, common.Address{byte(i)}, i, 0)
 	}
 	// Write modifications to trie.
 	transState.IntermediateRoot(false)
 
 	// Overwrite all the data with new values in the transient database.
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		modify(transState, common.Address{byte(i)}, i, 99)
 		modify(finalState, common.Address{byte(i)}, i, 99)
 	}
@@ -140,7 +140,7 @@ func TestCopy(t *testing.T) {
 	// Create a random state test to copy and modify "independently"
 	orig, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil, nil)
 
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		obj := orig.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		obj.AddBalance(big.NewInt(int64(i)))
 		orig.updateStateObject(obj)
@@ -153,7 +153,7 @@ func TestCopy(t *testing.T) {
 	// Copy the copy state
 	ccopy := copy.Copy()
 
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		origObj := orig.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		copyObj := copy.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		ccopyObj := ccopy.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
@@ -181,7 +181,7 @@ func TestCopy(t *testing.T) {
 	wg.Wait()
 
 	// Verify that the two states have been updated independently
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		origObj := orig.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		copyObj := copy.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
 		ccopyObj := ccopy.GetOrNewStateObject(common.BytesToAddress([]byte{i}))
@@ -215,7 +215,7 @@ func TestStateObjects(t *testing.T) {
 	stateDB, _ := New(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil, nil)
 
 	// Update each account, it will update StateDB.stateObjects.
-	for i := byte(0); i < 128; i++ {
+	for i := range byte(128) {
 		addr := common.BytesToAddress([]byte{i})
 		stateObj := stateDB.GetOrNewStateObject(addr)
 

--- a/blockchain/state/sync_test.go
+++ b/blockchain/state/sync_test.go
@@ -57,7 +57,7 @@ func makeTestState(t *testing.T) (Database, common.Hash, []*testAccount) {
 
 	// Fill it with some arbitrary data
 	var accounts []*testAccount
-	for i := byte(0); i < 96; i++ {
+	for i := range byte(96) {
 		var obj *stateObject
 		acc := &testAccount{
 			address:    common.BytesToAddress([]byte{i}),

--- a/blockchain/state_migration.go
+++ b/blockchain/state_migration.go
@@ -120,7 +120,7 @@ func (bc *BlockChain) migrateState(rootHash common.Hash) (returnErr error) {
 	hashCh := make(chan common.Hash, threads)
 	resultCh := make(chan statedb.SyncResult, threads)
 
-	for th := 0; th < threads; th++ {
+	for range threads {
 		go bc.concurrentRead(srcState, quitCh, hashCh, resultCh)
 	}
 

--- a/blockchain/system/multicall_test.go
+++ b/blockchain/system/multicall_test.go
@@ -62,7 +62,7 @@ func TestContractCallerForMultiCall(t *testing.T) {
 		common.HexToAddress("0x0000000000000000000000000000000000000F03"),
 		common.HexToAddress("0x0000000000000000000000000000000000000F04"),
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		assert.Equal(t, uint8(i), ret.TypeList[i])
 		assert.Equal(t, expectedAddress[i], ret.AddressList[i])
 	}

--- a/blockchain/tx_cacher.go
+++ b/blockchain/tx_cacher.go
@@ -63,7 +63,7 @@ func newTxSenderCacher(threads int) *txSenderCacher {
 		tasks:   make(chan *txSenderCacherRequest, threads),
 		threads: threads,
 	}
-	for i := 0; i < threads; i++ {
+	for range threads {
 		go cacher.cache()
 	}
 	return cacher

--- a/blockchain/tx_list_test.go
+++ b/blockchain/tx_list_test.go
@@ -40,7 +40,7 @@ func TestStrictTxListAdd(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 
 	txs := make(types.Transactions, 1024)
-	for i := 0; i < len(txs); i++ {
+	for i := range txs {
 		txs[i] = transaction(uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
@@ -74,7 +74,7 @@ func TestTxListReadyWithGasPriceBasic(t *testing.T) {
 
 	txs := make(types.Transactions, nTxs)
 	nonce := startNonce
-	for i := 0; i < len(txs); i++ {
+	for i := range txs {
 		txs[i] = pricedTransaction(uint64(nonce), 0, big.NewInt(50), key)
 		nonce++
 	}
@@ -92,7 +92,7 @@ func TestTxListReadyWithGasPriceBasic(t *testing.T) {
 	}
 
 	nonce = startNonce
-	for i := 0; i < len(ready); i++ {
+	for i := range ready {
 		if result := reflect.DeepEqual(ready[i], txs[i]); !result {
 			t.Error("ready hash : ", ready[i].Hash(), "tx[i] hash : ", txs[i].Hash())
 		}
@@ -125,7 +125,7 @@ func TestTxListReadyWithGasPricePartialFilter(t *testing.T) {
 
 	txs := make(types.Transactions, nTxs)
 	nonce := startNonce
-	for i := 0; i < len(txs); i++ {
+	for i := range txs {
 		// Set the gasPrice of transaction lower than expectedBaseFee.
 		if i == 7 {
 			txs[i] = pricedTransaction(uint64(nonce), 0, big.NewInt(10), key)
@@ -151,7 +151,7 @@ func TestTxListReadyWithGasPricePartialFilter(t *testing.T) {
 	}
 
 	nonce = startNonce
-	for i := 0; i < len(ready); i++ {
+	for i := range ready {
 		if result := reflect.DeepEqual(ready[i], txs[i]); result == false {
 			t.Error("ready hash : ", ready[i].Hash(), "tx[i] hash : ", txs[i].Hash())
 		}

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1369,7 +1369,7 @@ func (pool *TxPool) throttleLoop(spamThrottler *throttler) {
 
 			iterNum := min(len(spamThrottler.throttleCh), throttleNum)
 
-			for i := 0; i < iterNum; i++ {
+			for range iterNum {
 				tx := <-spamThrottler.throttleCh
 				txs = append(txs, tx)
 			}

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -223,7 +223,7 @@ func blobTransaction(nonce uint64, gasLimit uint64, gasFeeCap, gasTipCap, blobFe
 	blobHashes := make([]common.Hash, numBlobs)
 
 	hasher := sha256.New()
-	for i := 0; i < numBlobs; i++ {
+	for i := range numBlobs {
 		// Create an empty blob (all zeros)
 		blob := kzg4844.Blob{}
 		// Optionally fill with some data for testing
@@ -989,7 +989,7 @@ func TestTransactionPostponing(t *testing.T) {
 	keys := make([]*ecdsa.PrivateKey, 2)
 	accs := make([]common.Address, len(keys))
 
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 		accs[i] = crypto.PubkeyToAddress(keys[i].PublicKey)
 
@@ -998,7 +998,7 @@ func TestTransactionPostponing(t *testing.T) {
 	// Add a batch consecutive pending transactions for validation
 	txs := []*types.Transaction{}
 	for i, key := range keys {
-		for j := 0; j < 100; j++ {
+		for j := range 100 {
 			var tx *types.Transaction
 			if (i+j)%2 == 0 {
 				tx = transaction(uint64(j), 25000, key)
@@ -1206,7 +1206,7 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 
 	// Create a number of test accounts and fund them (last one will be the local)
 	keys := make([]*ecdsa.PrivateKey, 5)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
 	}
@@ -1471,7 +1471,7 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 
 	// Create a number of test accounts and fund them
 	keys := make([]*ecdsa.PrivateKey, 5)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
 	}
@@ -1615,7 +1615,7 @@ func TestTransactionPendingMinimumAllowance(t *testing.T) {
 
 	// Create a number of test accounts and fund them
 	keys := make([]*ecdsa.PrivateKey, 5)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 		pool.currentState.AddBalance(crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
 	}
@@ -2511,7 +2511,7 @@ func TestSetCodeTransactions(t *testing.T) {
 			pending: 10,
 			run: func(name string) {
 				var keys []*ecdsa.PrivateKey
-				for i := 0; i < 30; i++ {
+				for range 30 {
 					key, _ := crypto.GenerateKey()
 					keys = append(keys, key)
 					addr := crypto.PubkeyToAddress(key.PublicKey)
@@ -2669,7 +2669,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 
 	// Create the test accounts to check various transaction statuses with
 	keys := make([]*ecdsa.PrivateKey, 3)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
 	}
@@ -2704,7 +2704,7 @@ func TestTransactionStatusCheck(t *testing.T) {
 	statuses := pool.Status(hashes)
 	expect := []TxStatus{TxStatusPending, TxStatusPending, TxStatusQueued, TxStatusQueued, TxStatusUnknown}
 
-	for i := 0; i < len(statuses); i++ {
+	for i := range statuses {
 		if statuses[i] != expect[i] {
 			t.Errorf("transaction %d: status mismatch: have %v, want %v", i, statuses[i], expect[i])
 		}
@@ -3035,7 +3035,7 @@ func TestTransactionsPromotePartial(t *testing.T) {
 	assert.Equal(t, pool.queue[from].Len(), 1)
 
 	// txs[0:2] should be promoted.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		assert.True(t, reflect.DeepEqual(txs[i], pool.pending[from].txs.items[uint64(i)]))
 	}
 
@@ -3055,7 +3055,7 @@ func TestTransactionsPromoteMultipleAccount(t *testing.T) {
 
 	keys := make([]*ecdsa.PrivateKey, 3)
 	froms := make([]common.Address, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		keys[i], _ = crypto.GenerateKey()
 		froms[i] = crypto.PubkeyToAddress(keys[i].PublicKey)
 		testAddBalance(pool, froms[i], big.NewInt(1000000000))
@@ -3075,7 +3075,7 @@ func TestTransactionsPromoteMultipleAccount(t *testing.T) {
 	txs = append(txs, pricedTransaction(2, 100000, big.NewInt(30), keys[2])) // Pending
 	txs = append(txs, pricedTransaction(4, 100000, big.NewInt(10), keys[2])) // Queue
 
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		pool.enqueueTx(txs[i].Hash(), txs[i])
 	}
 
@@ -3113,7 +3113,7 @@ func TestTransactionsDemotionMultipleAccount(t *testing.T) {
 
 	keys := make([]*ecdsa.PrivateKey, 3)
 	froms := make([]common.Address, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		keys[i], _ = crypto.GenerateKey()
 		froms[i] = crypto.PubkeyToAddress(keys[i].PublicKey)
 		testAddBalance(pool, froms[i], big.NewInt(1000000000))
@@ -3133,7 +3133,7 @@ func TestTransactionsDemotionMultipleAccount(t *testing.T) {
 	txs = append(txs, pricedTransaction(2, 100000, big.NewInt(30), keys[2]))
 	txs = append(txs, pricedTransaction(3, 100000, big.NewInt(10), keys[2]))
 
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		pool.enqueueTx(txs[i].Hash(), txs[i])
 	}
 
@@ -3286,7 +3286,7 @@ func TestTransactionJournalingSortedByTime(t *testing.T) {
 
 	// Create the test accounts to check various transaction statuses with
 	keys := make([]*ecdsa.PrivateKey, 3)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
 	}
@@ -3317,7 +3317,7 @@ func TestTransactionJournalingSortedByTime(t *testing.T) {
 
 	txsFromFile := make(types.Transactions, 4)
 	stream := rlp.NewStream(input, 0)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		tx := new(types.Transaction)
 		if err = stream.Decode(tx); err != nil {
 			if err != io.EOF {
@@ -3372,7 +3372,7 @@ func benchmarkPendingDemotion(b *testing.B, size int) {
 	account := crypto.PubkeyToAddress(key.PublicKey)
 	testAddBalance(pool, account, big.NewInt(1000000))
 
-	for i := 0; i < size; i++ {
+	for i := range size {
 		tx := transaction(uint64(i), 100000, key)
 		pool.promoteTx(account, tx.Hash(), tx)
 	}
@@ -3397,7 +3397,7 @@ func benchmarkFuturePromotion(b *testing.B, size int) {
 	account := crypto.PubkeyToAddress(key.PublicKey)
 	testAddBalance(pool, account, big.NewInt(1000000))
 
-	for i := 0; i < size; i++ {
+	for i := range size {
 		tx := transaction(uint64(1+i), 100000, key)
 		pool.enqueueTx(tx.Hash(), tx)
 	}
@@ -3444,7 +3444,7 @@ func benchmarkPoolBatchInsert(b *testing.B, size int) {
 	batches := make([]types.Transactions, b.N)
 	for i := 0; i < b.N; i++ {
 		batches[i] = make(types.Transactions, size)
-		for j := 0; j < size; j++ {
+		for j := range size {
 			batches[i][j] = transaction(uint64(size*i+j), 100000, key)
 		}
 	}
@@ -3697,7 +3697,7 @@ func TestTxPool_sendMissingBlobSidecar(t *testing.T) {
 		ch := pool.SubscribeMissingBlobSidecars()
 
 		// fill channel
-		for i := 0; i < missingBlobSidecarsChSize; i++ {
+		for i := range missingBlobSidecarsChSize {
 			sidecar := &MissingBlobSidecar{
 				BlockNum: big.NewInt(int64(i)),
 				TxIndex:  i,
@@ -3716,7 +3716,7 @@ func TestTxPool_sendMissingBlobSidecar(t *testing.T) {
 
 		// read all data from channel
 		receivedCount := 0
-		for i := 0; i < missingBlobSidecarsChSize; i++ {
+		for range missingBlobSidecarsChSize {
 			select {
 			case <-ch:
 				receivedCount++

--- a/blockchain/types/accountkey/account_key_role_based.go
+++ b/blockchain/types/accountkey/account_key_role_based.go
@@ -242,7 +242,7 @@ func (a *AccountKeyRoleBased) CheckUpdatable(newKey AccountKey, currentBlockNumb
 		if lenNewKey > (int)(RoleLast) {
 			return kerrors.ErrLengthTooLong
 		}
-		for i := 0; i < lenNewKey; i++ {
+		for i := range lenNewKey {
 			switch {
 			// A composite key is not allowed.
 			case (*newKey)[i].IsCompositeType():
@@ -278,7 +278,7 @@ func (a *AccountKeyRoleBased) Update(newKey AccountKey, currentBlockNumber uint6
 	if lenOldKey < lenNewKey {
 		*a = append(*a, (*newRoleKey)[lenOldKey:]...)
 	}
-	for i := 0; i < lenNewKey; i++ {
+	for i := range lenNewKey {
 		if (*newRoleKey)[i].Type() == AccountKeyTypeNil {
 			continue
 		}

--- a/blockchain/types/accountkey/account_key_test.go
+++ b/blockchain/types/accountkey/account_key_test.go
@@ -176,7 +176,7 @@ func genAccountKeyWeightedMultisig() AccountKey {
 	numKeys := 4
 	keys := make(WeightedPublicKeys, numKeys)
 
-	for i := 0; i < numKeys; i++ {
+	for i := range numKeys {
 		k, _ := crypto.GenerateKey()
 		keys[i] = NewWeightedPublicKey(1, (*PublicKeySerializable)(&k.PublicKey))
 	}
@@ -222,7 +222,7 @@ func TestAccountKeyWeightedMultiSig_Validate(t *testing.T) {
 
 	// generate multiSigAccount. weights: [1,1,1,1,1,1,1,1,1,1], threshold: 3
 	keys := make(WeightedPublicKeys, 6)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		k, _ := crypto.GenerateKey()
 		keys[i] = NewWeightedPublicKey(1, (*PublicKeySerializable)(&k.PublicKey))
 	}
@@ -272,7 +272,7 @@ func TestAccountKeyWeightedMultiSig_SigValidationGas(t *testing.T) {
 
 	// generate multiSigAccount
 	keys := make(WeightedPublicKeys, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		k, _ := crypto.GenerateKey()
 		keys[i] = NewWeightedPublicKey(1, (*PublicKeySerializable)(&k.PublicKey))
 	}
@@ -310,7 +310,7 @@ func TestAccountKeyWeightedMultiSig_SigValidationGas(t *testing.T) {
 // getAnonymousKeys returns 'num' number of anonymousKeys which are not belongs to the multiSigAccount
 func getAnonymousPubKeys(num int) []*ecdsa.PublicKey {
 	var pubKeys []*ecdsa.PublicKey
-	for i := 0; i < num; i++ {
+	for range num {
 		k, _ := crypto.GenerateKey()
 		pubKeys = append(pubKeys, &k.PublicKey)
 	}
@@ -320,7 +320,7 @@ func getAnonymousPubKeys(num int) []*ecdsa.PublicKey {
 // getValidKeys returns multiSigAccount[0:num] keys
 func getValidKeys(multiSigAccount AccountKey, num int) []*ecdsa.PublicKey {
 	var pubKeys []*ecdsa.PublicKey
-	for i := 0; i < num; i++ {
+	for i := range num {
 		key := multiSigAccount.(*AccountKeyWeightedMultiSig).Keys[i].Key
 		pubKeys = append(pubKeys, &ecdsa.PublicKey{Curve: key.Curve, X: key.X, Y: key.Y})
 	}

--- a/blockchain/types/derivesha/derive_sha_test.go
+++ b/blockchain/types/derivesha/derive_sha_test.go
@@ -91,7 +91,7 @@ func TestMuxGovernance(t *testing.T) {
 		&params.ChainConfig{DeriveShaImpl: testGovSchedule[0]},
 		&testGov{})
 
-	for num := uint64(0); num < 9; num++ {
+	for num := range uint64(9) {
 		implType := testGovSchedule[num]
 		impl := impls[implType]
 

--- a/blockchain/types/signing_test.go
+++ b/blockchain/types/signing_test.go
@@ -146,7 +146,7 @@ type param struct {
 }
 
 func launchSenderGoroutines(signer *EIP155Signer, num int, paramCh chan param, quitCh chan struct{}) {
-	for i := 0; i < num; i++ {
+	for range num {
 		go func() {
 			for {
 				select {
@@ -198,7 +198,7 @@ func BenchmarkDoubleRecoverEIP155SignerReusedGoroutines(b *testing.B) {
 	}
 	b.StopTimer()
 
-	for i := 0; i < numGoroutine; i++ {
+	for range numGoroutine {
 		quitCh <- struct{}{}
 	}
 }

--- a/blockchain/types/transaction_test.go
+++ b/blockchain/types/transaction_test.go
@@ -476,7 +476,7 @@ func TestRecipientNormal(t *testing.T) {
 func TestTransactionPriceNonceSort(t *testing.T) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 25)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 
@@ -485,7 +485,7 @@ func TestTransactionPriceNonceSort(t *testing.T) {
 	groups := map[common.Address]Transactions{}
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
-		for i := 0; i < 25; i++ {
+		for i := range 25 {
 			tx, _ := SignTx(NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
 			groups[addr] = append(groups[addr], tx)
 		}
@@ -661,7 +661,7 @@ func TestIntrinsicGas(t *testing.T) {
 func TestTransactionTimeSort(t *testing.T) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 5)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	signer := LatestSignerForChainID(big.NewInt(1))
@@ -709,7 +709,7 @@ func TestTransactionTimeSort(t *testing.T) {
 func TestTransactionTimeSortDifferentGasPrice(t *testing.T) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 5)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	signer := LatestSignerForChainID(big.NewInt(1))
@@ -879,7 +879,7 @@ func TestTransactionCoding(t *testing.T) {
 			},
 		}
 	)
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		txData := txDataList[i%len(txDataList)](uint64(i))
 		transaction := Transaction{data: txData}
 		tx, err := SignTx(&transaction, signer, key)
@@ -947,7 +947,7 @@ func TestIsSorted(t *testing.T) {
 	key, _ := crypto.GenerateKey()
 	batches := make(txByPriceAndTime, 10)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tx, _ := SignTx(NewTransaction(uint64(i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(i)), nil), signer, key)
 		txWithFee, _ := newTxWithMinerFee(tx, common.Address{}, big.NewInt(int64(i)))
 		batches[i] = txWithFee
@@ -968,7 +968,7 @@ func TestFilterTransactionWithBaseFee(t *testing.T) {
 	pending := make(map[common.Address]Transactions)
 	keys := make([]*ecdsa.PrivateKey, 3)
 
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 
@@ -1061,7 +1061,7 @@ func benchmarkTxSortByPriceAndTime(b *testing.B, size int) {
 	key, _ := crypto.GenerateKey()
 	batches := make(txByPriceAndTime, size)
 
-	for i := 0; i < size; i++ {
+	for i := range size {
 		gasFeeCap := rand.Int63n(50)
 		tx, _ := SignTx(NewTx(&TxInternalDataEthereumDynamicFee{
 			AccountNonce: uint64(i),
@@ -1104,7 +1104,7 @@ func TestTransactionPriceNonceSort1559(t *testing.T) {
 func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 25)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	signer := LatestSignerForChainID(common.Big1)
@@ -1115,7 +1115,7 @@ func testTransactionPriceNonceSort(t *testing.T, baseFee *big.Int) {
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 		count := 25
-		for i := 0; i < 25; i++ {
+		for i := range 25 {
 			var tx *Transaction
 			gasFeeCap := rand.Intn(50)
 			if baseFee == nil {
@@ -1197,7 +1197,7 @@ func TestEmptyHeap(t *testing.T) {
 func TestHeapCopy(t *testing.T) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 25)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	baseFee := common.Big0
@@ -1207,7 +1207,7 @@ func TestHeapCopy(t *testing.T) {
 	groups := map[common.Address]Transactions{}
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
-		for i := 0; i < 25; i++ {
+		for i := range 25 {
 			tx, _ := SignTx(NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
 			groups[addr] = append(groups[addr], tx)
 		}
@@ -1219,7 +1219,7 @@ func TestHeapCopy(t *testing.T) {
 
 	assert.False(t, txset.Empty())
 	assert.False(t, txsetCopy.Empty())
-	for i := 0; i < 25; i++ {
+	for range 25 {
 		txset.Pop()
 	}
 	assert.True(t, txset.Empty())

--- a/blockchain/types/tx_internal_data_test.go
+++ b/blockchain/types/tx_internal_data_test.go
@@ -337,7 +337,7 @@ func TestSidecar_ValidateWithBlobHashes(t *testing.T) {
 		blobHashes := make([]common.Hash, numBlobs)
 		hasher := sha256.New()
 
-		for i := 0; i < numBlobs; i++ {
+		for i := range numBlobs {
 			blob := kzg4844.Blob{}
 			commitment, _ := kzg4844.BlobToCommitment(&blob)
 			cellProofs, _ := kzg4844.ComputeCellProofs(&blob)

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -907,11 +907,11 @@ func (c *blake2F) Run(input []byte, contract *Contract, evm *EVM) ([]byte, error
 		m [16]uint64
 		t [2]uint64
 	)
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		offset := 4 + i*8
 		h[i] = binary.LittleEndian.Uint64(input[offset : offset+8])
 	}
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		offset := 68 + i*8
 		m[i] = binary.LittleEndian.Uint64(input[offset : offset+8])
 	}
@@ -922,7 +922,7 @@ func (c *blake2F) Run(input []byte, contract *Contract, evm *EVM) ([]byte, error
 	blake2b.F(&h, m, t, final, rounds)
 
 	output := make([]byte, 64)
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		offset := i * 8
 		binary.LittleEndian.PutUint64(output[offset:offset+8], h[i])
 	}
@@ -1089,7 +1089,7 @@ func (c *validateSender) validateSender(input []byte, picker types.AccountKeyPic
 
 	numSigs := len(ptr) / common.SignatureLength
 	pubs := make([]*ecdsa.PublicKey, numSigs)
-	for i := 0; i < numSigs; i++ {
+	for i := range numSigs {
 		p, err := crypto.Ecrecover(msg, ptr[0:common.SignatureLength])
 		if err != nil {
 			return err
@@ -1191,7 +1191,7 @@ func (c *bls12381G1MultiExp) Run(input []byte, contract *Contract, evm *EVM) ([]
 	scalars := make([]fr.Element, k)
 
 	// Decode point scalar pairs
-	for i := 0; i < k; i++ {
+	for i := range k {
 		off := 160 * i
 		t0, t1, t2 := off, off+128, off+160
 		// Decode G1 point
@@ -1297,7 +1297,7 @@ func (c *bls12381G2MultiExp) Run(input []byte, contract *Contract, evm *EVM) ([]
 	scalars := make([]fr.Element, k)
 
 	// Decode point scalar pairs
-	for i := 0; i < k; i++ {
+	for i := range k {
 		off := 288 * i
 		t0, t1, t2 := off, off+256, off+288
 		// Decode G2 point
@@ -1355,7 +1355,7 @@ func (c *bls12381Pairing) Run(input []byte, contract *Contract, evm *EVM) ([]byt
 	)
 
 	// Decode pairs
-	for i := 0; i < k; i++ {
+	for i := range k {
 		off := 384 * i
 		t0, t1, t2 := off, off+128, off+384
 
@@ -1454,7 +1454,7 @@ func decodeBLS12381FieldElement(in []byte) (fp.Element, error) {
 		return fp.Element{}, errors.New("invalid field element length")
 	}
 	// check top bytes
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		if in[i] != byte(0x00) {
 			return fp.Element{}, errBLS12381InvalidFieldElementTopBytes
 		}

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -374,7 +374,7 @@ func TestPrecompiledModExpOverflow(t *testing.T) {
 	modLen := make([]byte, 32)
 
 	// Set all bytes to 0xFF to get maximum values
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		baseLen[i] = 0xFF
 		expLen[i] = 0xFF
 		modLen[i] = 0xFF
@@ -579,12 +579,12 @@ func TestConsoleLog(t *testing.T) {
 					if len(paramType) > 5 && paramType[:5] == "Bytes" {
 						size, _ := strconv.Atoi(string(paramType[5:]))
 						b := make([]byte, size)
-						for i := 0; i < size; i++ {
+						for i := range size {
 							b[i] = byte(i)
 						}
 						arrayType := reflect.ArrayOf(size, reflect.TypeFor[byte]())
 						array := reflect.New(arrayType).Elem()
-						for i := 0; i < size; i++ {
+						for i := range size {
 							array.Index(i).Set(reflect.ValueOf(byte(i)))
 						}
 						inputs = append(inputs, array.Interface())

--- a/blockchain/vm/instructions.go
+++ b/blockchain/vm/instructions.go
@@ -880,7 +880,7 @@ func makeLog(size int) executionFunc {
 		topics := make([]common.Hash, size)
 		stack := scope.Stack
 		mStart, mSize := stack.pop(), stack.pop()
-		for i := 0; i < size; i++ {
+		for i := range size {
 			addr := stack.pop()
 			topics[i] = addr.Bytes32()
 		}

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -1514,7 +1514,7 @@ func genStacksForLog(size int) []string {
 }
 
 func fillStacks(stacks []string, n int) []string {
-	for i := 0; i < n; i++ {
+	for i := range n {
 		stacks[i] = "FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"
 	}
 	return stacks

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -324,7 +324,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte) (ret []byte, err
 
 func PrintOpCodeExecTime() {
 	logger.Info("Printing the execution time of the opcodes during this node operation")
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		if opCnt[i] > 0 {
 			logger.Info("op "+OpCode(i).String(), "cnt", opCnt[i], "avg", opTime[i]/opCnt[i])
 		}

--- a/blockchain/vm/runtime/runtime_test.go
+++ b/blockchain/vm/runtime/runtime_test.go
@@ -151,7 +151,7 @@ func BenchmarkCall(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 400; j++ {
+		for range 400 {
 			Execute(code, cpurchase, nil)
 			Execute(code, creceived, nil)
 			Execute(code, refund, nil)

--- a/client/kaia_client_test.go
+++ b/client/kaia_client_test.go
@@ -142,7 +142,7 @@ func (s *MockHttpServerTestSuite) initTestAccount() {
 
 func (s *MockHttpServerTestSuite) initBlocksAndTxs() {
 	s.blocks = make([]*types.Block, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		s.blocks[i] = types.NewBlockWithHeader(s.genMockHeader(i))
 	}
 

--- a/cmd/homi/common/utils.go
+++ b/cmd/homi/common/utils.go
@@ -61,7 +61,7 @@ func GenerateRandomDir() (string, error) {
 }
 
 func GenerateKeys(num int) (keys []*ecdsa.PrivateKey, nodekeys []string, addrs []common.Address) {
-	for i := 0; i < num; i++ {
+	for range num {
 		nodekey := RandomHex()[2:]
 		nodekeys = append(nodekeys, nodekey)
 
@@ -107,7 +107,7 @@ func GenerateKeysFromMnemonic(num int, mnemonic, path string) (keys []*ecdsa.Pri
 		}
 	}
 
-	for i := 0; i < num; i++ {
+	for i := range num {
 		derived, _ := key.NewChildKey(uint32(i))
 		nodekey := hexutil.Encode(derived.Key)[2:]
 		nodekeys = append(nodekeys, nodekey)

--- a/cmd/homi/docker/compose/homi.go
+++ b/cmd/homi/docker/compose/homi.go
@@ -62,7 +62,7 @@ func (ist *Homi) init(number int, addresses, nodeKeys []string, genesis, scGenes
 	networkId, parentChainId int, proxyNodeKeys, enNodeKeys, scnNodeKeys, spnNodeKeys, senNodeKeys []string, txGenOpt service.TxGenOption,
 ) {
 	var validatorNames []string
-	for i := 0; i < number; i++ {
+	for i := range number {
 		s := service.NewValidator(i,
 			genesis,
 			"",
@@ -91,7 +91,7 @@ func (ist *Homi) init(number int, addresses, nodeKeys []string, genesis, scGenes
 	}
 
 	numPNs := len(proxyNodeKeys)
-	for i := 0; i < numPNs; i++ {
+	for i := range numPNs {
 		s := service.NewValidator(i,
 			genesis,
 			"",
@@ -120,7 +120,7 @@ func (ist *Homi) init(number int, addresses, nodeKeys []string, genesis, scGenes
 	}
 
 	numENs := len(enNodeKeys)
-	for i := 0; i < len(enNodeKeys); i++ {
+	for i := range enNodeKeys {
 		s := service.NewValidator(i,
 			genesis,
 			"",
@@ -158,7 +158,7 @@ func (ist *Homi) init(number int, addresses, nodeKeys []string, genesis, scGenes
 		scnParentChainId = 0
 		scnBridgeNodes = ""
 	}
-	for i := 0; i < len(scnNodeKeys); i++ {
+	for i := range scnNodeKeys {
 		s := service.NewValidator(i,
 			"",
 			scGenesis,
@@ -193,7 +193,7 @@ func (ist *Homi) init(number int, addresses, nodeKeys []string, genesis, scGenes
 		spnParentChainId = 0
 		spnBridgeNodes = ""
 	}
-	for i := 0; i < len(spnNodeKeys); i++ {
+	for i := range spnNodeKeys {
 		s := service.NewValidator(i,
 			"",
 			scGenesis,
@@ -221,7 +221,7 @@ func (ist *Homi) init(number int, addresses, nodeKeys []string, genesis, scGenes
 		validatorNames = append(validatorNames, s.Name)
 	}
 
-	for i := 0; i < len(senNodeKeys); i++ {
+	for i := range senNodeKeys {
 		s := service.NewValidator(i,
 			"",
 			scGenesis,

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -975,7 +975,7 @@ func makeValidators(num int, isWorkOnSingleHost bool, nodeAddrs []common.Address
 ) []*ValidatorInfo {
 	var validatorPort uint16
 	var validators []*ValidatorInfo
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if isWorkOnSingleHost {
 			validatorPort = lastIssuedPortNum
 			lastIssuedPortNum++
@@ -1004,7 +1004,7 @@ func makeValidatorsWithIp(num int, isWorkOnSingleHost bool, nodeAddrs []common.A
 ) []*ValidatorInfo {
 	var validatorPort uint16
 	var validators []*ValidatorInfo
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if isWorkOnSingleHost {
 			validatorPort = lastIssuedPortNum
 			lastIssuedPortNum++
@@ -1057,7 +1057,7 @@ func makeProxys(ctx *cli.Context, num int, isWorkOnSingleHost bool) ([]*Validato
 	var p2pPort uint16
 	var proxies []*ValidatorInfo
 	var proxyNodeKeys []string
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if isWorkOnSingleHost {
 			p2pPort = lastIssuedPortNum
 			lastIssuedPortNum++
@@ -1102,7 +1102,7 @@ func makeEndpoints(ctx *cli.Context, num int, isWorkOnSingleHost bool) ([]*Valid
 	var p2pPort uint16
 	var endpoints []*ValidatorInfo
 	var endpointsNodeKeys []string
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if isWorkOnSingleHost {
 			p2pPort = lastIssuedPortNum
 			lastIssuedPortNum++
@@ -1133,7 +1133,7 @@ func makeSCNs(num int, isWorkOnSingleHost bool) ([]*ValidatorInfo, []string) {
 	var p2pPort uint16
 	var scn []*ValidatorInfo
 	var scnKeys []string
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if isWorkOnSingleHost {
 			p2pPort = lastIssuedPortNum
 			lastIssuedPortNum++
@@ -1164,7 +1164,7 @@ func makeSPNs(num int, isWorkOnSingleHost bool) ([]*ValidatorInfo, []string) {
 	var p2pPort uint16
 	var proxies []*ValidatorInfo
 	var proxyNodeKeys []string
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if isWorkOnSingleHost {
 			p2pPort = lastIssuedPortNum
 			lastIssuedPortNum++
@@ -1195,7 +1195,7 @@ func makeSENs(num int, isWorkOnSingleHost bool) ([]*ValidatorInfo, []string) {
 	var p2pPort uint16
 	var endpoints []*ValidatorInfo
 	var endpointsNodeKeys []string
-	for i := 0; i < num; i++ {
+	for i := range num {
 		if isWorkOnSingleHost {
 			p2pPort = lastIssuedPortNum
 			lastIssuedPortNum++

--- a/cmd/utils/nodecmd/accountcmd.go
+++ b/cmd/utils/nodecmd/accountcmd.go
@@ -277,7 +277,7 @@ func UnlockAccount(ctx *cli.Context, ks *keystore.KeyStore, address string, i in
 	if err != nil {
 		log.Fatalf("Could not list accounts: %v", err)
 	}
-	for trials := 0; trials < 3; trials++ {
+	for trials := range 3 {
 		prompt := fmt.Sprintf("Unlocking account %s | Attempt %d/%d", address, trials+1, 3)
 		password := getPassPhrase(prompt, false, i, passwords)
 		err = ks.Unlock(account, password)

--- a/cmd/utils/nodecmd/util.go
+++ b/cmd/utils/nodecmd/util.go
@@ -201,7 +201,7 @@ func decodeExtra(headerFile string) (map[string]interface{}, error) {
 		return nil, err
 	}
 	cSeals := make([]string, len(istanbulExtra.CommittedSeal))
-	for i := 0; i < len(cSeals); i++ {
+	for i := range cSeals {
 		cSeals[i] = hexutil.Encode(istanbulExtra.CommittedSeal[i])
 	}
 

--- a/common/bitutil/bitutil.go
+++ b/common/bitutil/bitutil.go
@@ -38,7 +38,7 @@ func fastXORBytes(dst, a, b []byte) int {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
 		aw := *(*[]uintptr)(unsafe.Pointer(&a))
 		bw := *(*[]uintptr)(unsafe.Pointer(&b))
-		for i := 0; i < w; i++ {
+		for i := range w {
 			dw[i] = aw[i] ^ bw[i]
 		}
 	}
@@ -52,7 +52,7 @@ func fastXORBytes(dst, a, b []byte) int {
 // it supports unaligned read/writes or not.
 func safeXORBytes(dst, a, b []byte) int {
 	n := min(len(b), len(a))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		dst[i] = a[i] ^ b[i]
 	}
 	return n
@@ -76,7 +76,7 @@ func fastANDBytes(dst, a, b []byte) int {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
 		aw := *(*[]uintptr)(unsafe.Pointer(&a))
 		bw := *(*[]uintptr)(unsafe.Pointer(&b))
-		for i := 0; i < w; i++ {
+		for i := range w {
 			dw[i] = aw[i] & bw[i]
 		}
 	}
@@ -90,7 +90,7 @@ func fastANDBytes(dst, a, b []byte) int {
 // it supports unaligned read/writes or not.
 func safeANDBytes(dst, a, b []byte) int {
 	n := min(len(b), len(a))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		dst[i] = a[i] & b[i]
 	}
 	return n
@@ -114,7 +114,7 @@ func fastORBytes(dst, a, b []byte) int {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
 		aw := *(*[]uintptr)(unsafe.Pointer(&a))
 		bw := *(*[]uintptr)(unsafe.Pointer(&b))
-		for i := 0; i < w; i++ {
+		for i := range w {
 			dw[i] = aw[i] | bw[i]
 		}
 	}
@@ -128,7 +128,7 @@ func fastORBytes(dst, a, b []byte) int {
 // it supports unaligned read/writes or not.
 func safeORBytes(dst, a, b []byte) int {
 	n := min(len(b), len(a))
-	for i := 0; i < n; i++ {
+	for i := range n {
 		dst[i] = a[i] | b[i]
 	}
 	return n
@@ -149,7 +149,7 @@ func fastTestBytes(p []byte) bool {
 	w := n / wordSize
 	if w > 0 {
 		pw := *(*[]uintptr)(unsafe.Pointer(&p))
-		for i := 0; i < w; i++ {
+		for i := range w {
 			if pw[i] != 0 {
 				return true
 			}
@@ -166,7 +166,7 @@ func fastTestBytes(p []byte) bool {
 // safeTestBytes tests for set bits one byte at a time. It works on all
 // architectures, independent if it supports unaligned read/writes or not.
 func safeTestBytes(p []byte) bool {
-	for i := 0; i < len(p); i++ {
+	for i := range p {
 		if p[i] != 0 {
 			return true
 		}

--- a/common/bitutil/bitutil_test.go
+++ b/common/bitutil/bitutil_test.go
@@ -17,16 +17,16 @@ import (
 
 // Tests that bitwise XOR works for various alignments.
 func TestXOR(t *testing.T) {
-	for alignP := 0; alignP < 2; alignP++ {
-		for alignQ := 0; alignQ < 2; alignQ++ {
-			for alignD := 0; alignD < 2; alignD++ {
+	for alignP := range 2 {
+		for alignQ := range 2 {
+			for alignD := range 2 {
 				p := make([]byte, 1023)[alignP:]
 				q := make([]byte, 1023)[alignQ:]
 
-				for i := 0; i < len(p); i++ {
+				for i := range p {
 					p[i] = byte(i)
 				}
-				for i := 0; i < len(q); i++ {
+				for i := range q {
 					q[i] = byte(len(q) - i)
 				}
 				d1 := make([]byte, 1023+alignD)[alignD:]
@@ -44,16 +44,16 @@ func TestXOR(t *testing.T) {
 
 // Tests that bitwise AND works for various alignments.
 func TestAND(t *testing.T) {
-	for alignP := 0; alignP < 2; alignP++ {
-		for alignQ := 0; alignQ < 2; alignQ++ {
-			for alignD := 0; alignD < 2; alignD++ {
+	for alignP := range 2 {
+		for alignQ := range 2 {
+			for alignD := range 2 {
 				p := make([]byte, 1023)[alignP:]
 				q := make([]byte, 1023)[alignQ:]
 
-				for i := 0; i < len(p); i++ {
+				for i := range p {
 					p[i] = byte(i)
 				}
-				for i := 0; i < len(q); i++ {
+				for i := range q {
 					q[i] = byte(len(q) - i)
 				}
 				d1 := make([]byte, 1023+alignD)[alignD:]
@@ -71,16 +71,16 @@ func TestAND(t *testing.T) {
 
 // Tests that bitwise OR works for various alignments.
 func TestOR(t *testing.T) {
-	for alignP := 0; alignP < 2; alignP++ {
-		for alignQ := 0; alignQ < 2; alignQ++ {
-			for alignD := 0; alignD < 2; alignD++ {
+	for alignP := range 2 {
+		for alignQ := range 2 {
+			for alignD := range 2 {
 				p := make([]byte, 1023)[alignP:]
 				q := make([]byte, 1023)[alignQ:]
 
-				for i := 0; i < len(p); i++ {
+				for i := range p {
 					p[i] = byte(i)
 				}
-				for i := 0; i < len(q); i++ {
+				for i := range q {
 					q[i] = byte(len(q) - i)
 				}
 				d1 := make([]byte, 1023+alignD)[alignD:]
@@ -98,7 +98,7 @@ func TestOR(t *testing.T) {
 
 // Tests that bit testing works for various alignments.
 func TestTest(t *testing.T) {
-	for align := 0; align < 2; align++ {
+	for align := range 2 {
 		// Test for bits set in the bulk part
 		p := make([]byte, 1023)[align:]
 		p[100] = 1

--- a/common/bitutil/compress_test.go
+++ b/common/bitutil/compress_test.go
@@ -173,7 +173,7 @@ func benchmarkEncoding(b *testing.B, bytes int, fill float64) {
 	data := make([]byte, bytes)
 	bits := int(float64(bytes) * 8 * fill)
 
-	for i := 0; i < bits; i++ {
+	for range bits {
 		idx := random.Int63() % int64(len(data))
 		bit := uint(random.Int63() % 8)
 		data[idx] |= 1 << bit

--- a/common/bytes.go
+++ b/common/bytes.go
@@ -194,7 +194,7 @@ type Entry struct {
 // CreateEntries creates random key/value pairs.
 func CreateEntries(entryNum int) []Entry {
 	entries := make([]Entry, entryNum)
-	for i := 0; i < entryNum; i++ {
+	for i := range entryNum {
 		entries[i] = Entry{Key: MakeRandomBytes(256), Val: MakeRandomBytes(300)}
 	}
 	return entries

--- a/common/cache.go
+++ b/common/cache.go
@@ -261,7 +261,7 @@ func (c LRUShardConfig) newCache() (Cache, error) {
 	lruShard := &lruShardCache{shards: make([]*lru.Cache, numShards), shardIndexMask: numShards - 1}
 	shardsSize := cacheSize / numShards
 	var err error
-	for i := 0; i < numShards; i++ {
+	for i := range numShards {
 		lruShard.shards[i], err = lru.NewWithEvict(shardsSize, nil)
 		if err != nil {
 			return nil, err

--- a/common/lru/basiclru_test.go
+++ b/common/lru/basiclru_test.go
@@ -30,7 +30,7 @@ import (
 func TestBasicLRU(t *testing.T) {
 	cache := NewBasicLRU[int, int](128)
 
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		cache.Add(i, i)
 	}
 	if cache.Len() != 128 {
@@ -55,7 +55,7 @@ func TestBasicLRU(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 128; i++ {
+	for i := range 128 {
 		_, ok := cache.Get(i)
 		if ok {
 			t.Fatalf("%d should be evicted", i)
@@ -116,7 +116,7 @@ func TestBasicLRUAddExistingKey(t *testing.T) {
 // This test checks GetOldest and RemoveOldest.
 func TestBasicLRUGetOldest(t *testing.T) {
 	cache := NewBasicLRU[int, int](128)
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		cache.Add(i, i)
 	}
 
@@ -212,7 +212,7 @@ func BenchmarkLRU(b *testing.B) {
 	})
 	b.Run("Get/BasicLRU", func(b *testing.B) {
 		cache := NewBasicLRU[string, []byte](capacity)
-		for i := 0; i < capacity; i++ {
+		for i := range capacity {
 			index := indexes[i]
 			cache.Add(keys[index], values[index])
 		}

--- a/common/lru/blob_lru_test.go
+++ b/common/lru/blob_lru_test.go
@@ -33,7 +33,7 @@ func TestSizeConstrainedCache(t *testing.T) {
 	lru := NewSizeConstrainedCache[testKey, []byte](100)
 	var want uint64
 	// Add 11 items of 10 byte each. First item should be swapped out
-	for i := 0; i < 11; i++ {
+	for i := range 11 {
 		k := mkKey(i)
 		v := fmt.Sprintf("value-%04d", i)
 		lru.Add(k, []byte(v))
@@ -71,7 +71,7 @@ func TestSizeConstrainedCacheOverflow(t *testing.T) {
 	lru := NewSizeConstrainedCache[testKey, []byte](100)
 
 	// Add 10 items of 10 byte each, filling the cache
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		k := mkKey(i)
 		v := fmt.Sprintf("value-%04d", i)
 		lru.Add(k, []byte(v))
@@ -112,7 +112,7 @@ func TestSizeConstrainedCacheSameItem(t *testing.T) {
 	// Add one 10 byte-item 10 times.
 	k := mkKey(0)
 	v := fmt.Sprintf("value-%04d", 0)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		lru.Add(k, []byte(v))
 	}
 
@@ -127,7 +127,7 @@ func TestSizeConstrainedCacheEmpties(t *testing.T) {
 	lru := NewSizeConstrainedCache[testKey, []byte](100)
 
 	// This test abuses the lru a bit, using different keys for identical value(s).
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		lru.Add(testKey{byte(i)}, []byte{})
 		lru.Add(testKey{byte(255 - i)}, nil)
 	}
@@ -139,7 +139,7 @@ func TestSizeConstrainedCacheEmpties(t *testing.T) {
 		t.Fatalf("size wrong, have %d want %d", have, want)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if v, ok := lru.Get(testKey{byte(i)}); !ok {
 			t.Fatalf("test %d: expected presence", i)
 		} else if v == nil {

--- a/common/math/big.go
+++ b/common/math/big.go
@@ -212,7 +212,7 @@ func Exp(base, exponent *big.Int) *big.Int {
 	result := big.NewInt(1)
 
 	for _, word := range exponent.Bits() {
-		for i := 0; i < wordBits; i++ {
+		for range wordBits {
 			if word&1 == 1 {
 				U256(result.Mul(result, base))
 			}

--- a/common/prque/prque_test.go
+++ b/common/prque/prque_test.go
@@ -18,13 +18,13 @@ func TestPrque(t *testing.T) {
 	size := 16 * blockSize
 	prio := rand.Perm(size)
 	data := make([]int, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		data[i] = rand.Int()
 	}
 	queue := New()
-	for rep := 0; rep < 2; rep++ {
+	for range 2 {
 		// Fill a priority queue with the above data
-		for i := 0; i < size; i++ {
+		for i := range size {
 			queue.Push(data[i], int64(prio[i]))
 			if queue.Size() != i+1 {
 				t.Errorf("queue size mismatch: have %v, want %v.", queue.Size(), i+1)
@@ -32,7 +32,7 @@ func TestPrque(t *testing.T) {
 		}
 		// Create a map the values to the priorities for easier verification
 		dict := make(map[int64]int)
-		for i := 0; i < size; i++ {
+		for i := range size {
 			dict[int64(prio[i])] = data[i]
 		}
 		// Pop out the elements in priority order and verify them
@@ -56,13 +56,13 @@ func TestReset(t *testing.T) {
 	size := 16 * blockSize
 	prio := rand.Perm(size)
 	data := make([]int, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		data[i] = rand.Int()
 	}
 	queue := New()
-	for rep := 0; rep < 2; rep++ {
+	for range 2 {
 		// Fill a priority queue with the above data
-		for i := 0; i < size; i++ {
+		for i := range size {
 			queue.Push(data[i], int64(prio[i]))
 			if queue.Size() != i+1 {
 				t.Errorf("queue size mismatch: have %v, want %v.", queue.Size(), i+1)
@@ -70,7 +70,7 @@ func TestReset(t *testing.T) {
 		}
 		// Create a map the values to the priorities for easier verification
 		dict := make(map[int64]int)
-		for i := 0; i < size; i++ {
+		for i := range size {
 			dict[int64(prio[i])] = data[i]
 		}
 		// Pop out half the elements in priority order and verify them
@@ -98,14 +98,14 @@ func BenchmarkPush(b *testing.B) {
 	// Create some initial data
 	data := make([]int, b.N)
 	prio := make([]int64, b.N)
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		data[i] = rand.Int()
 		prio[i] = rand.Int63()
 	}
 	// Execute the benchmark
 	b.ResetTimer()
 	queue := New()
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		queue.Push(data[i], prio[i])
 	}
 }
@@ -114,12 +114,12 @@ func BenchmarkPop(b *testing.B) {
 	// Create some initial data
 	data := make([]int, b.N)
 	prio := make([]int64, b.N)
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		data[i] = rand.Int()
 		prio[i] = rand.Int63()
 	}
 	queue := New()
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		queue.Push(data[i], prio[i])
 	}
 	// Execute the benchmark

--- a/common/prque/sstack_test.go
+++ b/common/prque/sstack_test.go
@@ -18,14 +18,14 @@ func TestSstack(t *testing.T) {
 	// Create some initial data
 	size := 16 * blockSize
 	data := make([]*item, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		data[i] = &item{rand.Int(), rand.Int63()}
 	}
 	stack := newSstack()
-	for rep := 0; rep < 2; rep++ {
+	for range 2 {
 		// Push all the data into the stack, pop out every second
 		secs := []*item{}
-		for i := 0; i < size; i++ {
+		for i := range size {
 			stack.Push(data[i])
 			if i%2 == 0 {
 				secs = append(secs, stack.Pop().(*item))
@@ -36,7 +36,7 @@ func TestSstack(t *testing.T) {
 			rest = append(rest, stack.Pop().(*item))
 		}
 		// Make sure the contents of the resulting slices are ok
-		for i := 0; i < size; i++ {
+		for i := range size {
 			if i%2 == 0 && data[i] != secs[i/2] {
 				t.Errorf("push/pop mismatch: have %v, want %v.", secs[i/2], data[i])
 			}
@@ -51,7 +51,7 @@ func TestSstackSort(t *testing.T) {
 	// Create some initial data
 	size := 16 * blockSize
 	data := make([]*item, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		data[i] = &item{rand.Int(), int64(i)}
 	}
 	// Push all the data into the stack
@@ -73,14 +73,14 @@ func TestSstackReset(t *testing.T) {
 	// Create some initial data
 	size := 16 * blockSize
 	data := make([]*item, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		data[i] = &item{rand.Int(), rand.Int63()}
 	}
 	stack := newSstack()
-	for rep := 0; rep < 2; rep++ {
+	for range 2 {
 		// Push all the data into the stack, pop out every second
 		secs := []*item{}
-		for i := 0; i < size; i++ {
+		for i := range size {
 			stack.Push(data[i])
 			if i%2 == 0 {
 				secs = append(secs, stack.Pop().(*item))
@@ -91,7 +91,7 @@ func TestSstackReset(t *testing.T) {
 		if stack.Len() != 0 {
 			t.Errorf("stack not empty after reset: %v", stack)
 		}
-		for i := 0; i < size; i++ {
+		for i := range size {
 			if i%2 == 0 && data[i] != secs[i/2] {
 				t.Errorf("push/pop mismatch: have %v, want %v.", secs[i/2], data[i])
 			}

--- a/common/types.go
+++ b/common/types.go
@@ -386,7 +386,7 @@ func (a Address) Hex() string {
 	hash := sha.Sum(nil)
 
 	result := []byte(unchecksummed)
-	for i := 0; i < len(result); i++ {
+	for i := range result {
 		hashByte := hash[i/2]
 		if i%2 == 0 {
 			hashByte = hashByte >> 4

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -126,7 +126,7 @@ func (f *Faker) VerifyHeaders(chain consensus.ChainReader, headers []*types.Head
 	// If we're running a full engine faking, accept all headers as valid
 	if f.fullFake || len(headers) == 0 {
 		go func() {
-			for i := 0; i < len(headers); i++ {
+			for range headers {
 				results <- nil
 			}
 		}()

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -222,7 +222,7 @@ func (sb *backend) getTargetReceivers() map[common.Address]bool {
 	// calculates a map of target nodes which need to receive a message
 	// committee[currentView].Union(committee[nextView]) => targets
 	targets := make(map[common.Address]bool)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		roundCommittee, err := sb.GetCommitteeStateByRound(cv.Sequence.Uint64(), cv.Round.Uint64()+uint64(i))
 		if err != nil {
 			return nil

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -79,16 +79,16 @@ func TestBackend_GetTargetReceivers(t *testing.T) {
 	// from 0 to 4: before istanbul hard fork
 	// from 5 to 100: after istanbul hard fork
 	var previousBlock, currentBlock *types.Block = nil, chain.CurrentBlock()
-	for i := int64(0); i < maxBlockNum; i++ {
+	for range maxBlockNum {
 		previousBlock = currentBlock
 		currentBlock = makeBlockWithSeal(chain, istBackend, previousBlock)
 		_, err := chain.InsertChain(types.Blocks{currentBlock})
 		assert.NoError(t, err)
 	}
 
-	for i := int64(0); i < maxBlockNum; i++ {
+	for i := range maxBlockNum {
 		// Test for round 0 to round 14
-		for round := int64(0); round < 14; round++ {
+		for round := range int64(14) {
 			currentCouncilState, err := istBackend.GetCommitteeStateByRound(uint64(i), uint64(round))
 			assert.NoError(t, err)
 

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -148,7 +148,7 @@ func disableVotes(paramNames []gov.ParamName) {
 func setNodeKeys(n int, governingNode *ecdsa.PrivateKey) ([]*ecdsa.PrivateKey, []common.Address) {
 	nodeKeys = make([]*ecdsa.PrivateKey, n)
 	addrs = make([]common.Address, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i == 0 && governingNode != nil {
 			nodeKeys[i] = governingNode
 		} else {
@@ -241,7 +241,7 @@ func newBlockChain(n int, items ...interface{}) (*blockchain.BlockChain, *backen
 	if genesis.Config.RandaoCompatibleBlock != nil {
 		// Generate BLS keys for all nodes
 		nodeBlsKeys := make([]bls.SecretKey, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			nodeBlsKeys[i], _ = bls.DeriveFromECDSA(nodeKeys[i])
 		}
 
@@ -709,7 +709,7 @@ func TestVerifyHeaders(t *testing.T) {
 	size := 100
 
 	var previousBlock, currentBlock *types.Block = nil, chain.Genesis()
-	for i := 0; i < size; i++ {
+	for i := range size {
 		// 100 headers with 50 of them empty committed seals, 50 of them invalid committed seals.
 		previousBlock = currentBlock
 		currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
@@ -1179,7 +1179,7 @@ func Test_AfterMinimumStakingVotes(t *testing.T) {
 			require.NotNil(t, vote, fmt.Sprintf("vote is nil for %v %v", v.key, v.value))
 			engine.govModule.(*gov_impl.GovModule).Hgm.PushMyVotes(vote)
 
-			for i := 0; i < testEpoch; i++ {
+			for range testEpoch {
 				previousBlock = currentBlock
 				currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
 				_, err := chain.InsertChain(types.Blocks{currentBlock})
@@ -1945,7 +1945,7 @@ func TestGovernance_Votes(t *testing.T) {
 		}
 
 		// insert blocks until the vote is applied
-		for i := 0; i < 6; i++ {
+		for range 6 {
 			previousBlock = currentBlock
 			currentBlock = makeBlockWithSeal(chain, engine, previousBlock)
 			_, err = chain.InsertChain(types.Blocks{currentBlock})

--- a/consensus/istanbul/backend/randao.go
+++ b/consensus/istanbul/backend/randao.go
@@ -96,7 +96,7 @@ func calcRandaoMsg(number *big.Int) common.Hash {
 func calcMixHash(randomReveal, prevMixHash []byte) []byte {
 	mixHash := make([]byte, 32)
 	revealHash := crypto.Keccak256(randomReveal)
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		mixHash[i] = prevMixHash[i] ^ revealHash[i]
 	}
 	return mixHash

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -112,7 +112,7 @@ func genValidators(n int) ([]common.Address, map[common.Address]*ecdsa.PrivateKe
 	addrs := make([]common.Address, n)
 	keyMap := make(map[common.Address]*ecdsa.PrivateKey, n)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		key, _ := crypto.GenerateKey()
 		addrs[i] = crypto.PubkeyToAddress(key.PublicKey)
 		keyMap[addrs[i]] = key

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -137,7 +137,7 @@ func TestSubjectCmp(t *testing.T) {
 	min, max, n := 1, 9999, 10000
 	var identity bool
 	var s1, s2 *istanbul.Subject
-	for i := 0; i < n; i++ {
+	for range n {
 		s1 = genSubject(min, max)
 		if rand.Intn(2) == 0 {
 			identity = true

--- a/consensus/istanbul/core/vrank_test.go
+++ b/consensus/istanbul/core/vrank_test.go
@@ -44,7 +44,7 @@ func TestVrank(t *testing.T) {
 
 	// Simulate messages for each round up to testRound
 	for round := uint64(0); round <= testRound; round++ {
-		for i := 0; i < quorum; i++ {
+		for i := range quorum {
 			r := (1 + time.Duration(rand.Int63n(10))) * time.Millisecond
 			time.Sleep(r)
 			vrank.AddPreprepare(committee[i], round, time.Now())
@@ -63,7 +63,7 @@ func TestVrank(t *testing.T) {
 
 		// round change messages (not for round 0)
 		if round > 0 {
-			for i := 0; i < N; i++ {
+			for i := range N {
 				r := time.Duration(round*10+uint64(rand.Int63n(10))) * time.Millisecond
 				vrank.AddRoundChange(committee[i], round, time.Now().Add(r))
 			}

--- a/console/jsre/pretty.go
+++ b/console/jsre/pretty.go
@@ -139,7 +139,7 @@ func (ctx ppctx) printObject(obj *goja.Object, level int, inArray bool) {
 			return
 		}
 		fmt.Fprint(ctx.w, "[")
-		for i := int64(0); i < len; i++ {
+		for i := range len {
 			el := obj.Get(strconv.FormatInt(i, 10))
 			if el != nil {
 				ctx.printValue(el, level+1, true)

--- a/crypto/blake2b/blake2b.go
+++ b/crypto/blake2b/blake2b.go
@@ -193,7 +193,7 @@ func (d *digest) MarshalBinary() ([]byte, error) {
 	}
 	b := make([]byte, 0, marshaledSize)
 	b = append(b, magic...)
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		b = appendUint64(b, d.h[i])
 	}
 	b = appendUint64(b, d.c[0])
@@ -213,7 +213,7 @@ func (d *digest) UnmarshalBinary(b []byte) error {
 		return errors.New("crypto/blake2b: invalid hash state size")
 	}
 	b = b[len(magic):]
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		b, d.h[i] = consumeUint64(b)
 	}
 	b, d.c[0] = consumeUint64(b)

--- a/crypto/blake2b/blake2b_test.go
+++ b/crypto/blake2b/blake2b_test.go
@@ -76,7 +76,7 @@ func TestMarshal(t *testing.T) {
 		input[i] = byte(i)
 	}
 	for _, size := range []int{Size, Size256, Size384, 12, 25, 63} {
-		for i := 0; i < 256; i++ {
+		for i := range 256 {
 			h, err := New(size, nil)
 			if err != nil {
 				t.Fatalf("size=%d, len(input)=%d: error from New(%v, nil): %v", size, i, size, err)
@@ -140,7 +140,7 @@ func testHashes(t *testing.T) {
 		}
 
 		h.Reset()
-		for j := 0; j < i; j++ {
+		for j := range i {
 			h.Write(input[j : j+1])
 		}
 
@@ -182,10 +182,10 @@ func testHashes2X(t *testing.T) {
 		}
 
 		h.Reset()
-		for j := 0; j < len(input); j++ {
+		for j := range input {
 			h.Write(input[j : j+1])
 		}
-		for j := 0; j < len(sum); j++ {
+		for j := range sum {
 			h = h.Clone()
 			if _, err := h.Read(sum[j : j+1]); err != nil {
 				t.Fatalf("#%d (byte-by-byte) - Read %d: error from Read: %v", i, j, err)

--- a/crypto/bls/blst/bench_test.go
+++ b/crypto/bls/blst/bench_test.go
@@ -159,11 +159,11 @@ func BenchmarkParallelVerify(b *testing.B) {
 		wg.Add(threads)
 
 		jobs := make(chan int, len(tc.sigbs))
-		for i := 0; i < L; i++ {
+		for i := range L {
 			jobs <- i
 		}
 
-		for i := 0; i < threads; i++ {
+		for range threads {
 			go func() {
 				for i := range jobs {
 					sig, _ := SignatureFromBytes(tc.sigbs[i])
@@ -235,7 +235,7 @@ func BenchmarkVerifyMultipleNaive(b *testing.B) {
 
 	fn := func() {
 		pks, _ := MultiplePublicKeysFromBytes(tc.pkbs)
-		for i := 0; i < L; i++ {
+		for i := range L {
 			VerifySignature(tc.sigbs[i], tc.msgs[i], pks[i])
 		}
 	}
@@ -264,7 +264,7 @@ func generateBenchmarkMaterial(L int) *benchmarkTestCase {
 
 	rand.Read(tc.msg)
 
-	for i := 0; i < L; i++ {
+	for i := range L {
 		sk, _ := RandKey()
 		pk := sk.PublicKey()
 		sig := Sign(sk, tc.msg)
@@ -296,7 +296,7 @@ func generateBenchmarkMaterialMulti(L int) *benchmarkTestCaseMulti {
 	tc.sigs = make([]types.Signature, L)
 	tc.sigbs = make([][]byte, L)
 
-	for i := 0; i < L; i++ {
+	for i := range L {
 		sk, _ := RandKey()
 		pk := sk.PublicKey()
 		rand.Read(tc.msgs[i][:])

--- a/crypto/bls/blst/public_key_test.go
+++ b/crypto/bls/blst/public_key_test.go
@@ -71,7 +71,7 @@ func TestMultiplePublicKeysFromBytes(t *testing.T) {
 	// [0:L/2] are cached and [L/2:L] are uncached
 	pks, err = MultiplePublicKeysFromBytes(tc.pkbs)
 	assert.Nil(t, err)
-	for i := 0; i < L; i++ {
+	for i := range L {
 		assert.Equal(t, tc.pks[i].Marshal(), pks[i].Marshal())
 	}
 

--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -175,7 +175,7 @@ func PopVerify(pk types.PublicKey, sig types.Signature) bool {
 
 func FastAggregateVerify(sig types.Signature, msg []byte, pks []types.PublicKey) bool {
 	pubPs := make([]*blstPublicKey, len(pks))
-	for i := 0; i < len(pks); i++ {
+	for i := range pks {
 		pubPs[i] = pks[i].(*publicKey).p
 	}
 
@@ -218,7 +218,7 @@ func VerifyMultipleSignatures(sigbs [][]byte, msgs [][32]byte, pks []types.Publi
 		pkPs  = make([]*blstPublicKey, count)
 		msgPs = make([]blstMessage, count)
 	)
-	for i := 0; i < len(sigs); i++ {
+	for i := range sigs {
 		sigPs[i] = sigs[i].(*signature).p
 		pkPs[i] = pks[i].(*publicKey).p
 		msgPs[i] = msgs[i][:]

--- a/crypto/bls/blst/signature_test.go
+++ b/crypto/bls/blst/signature_test.go
@@ -71,7 +71,7 @@ func TestMultipleSignaturesFromBytes(t *testing.T) {
 	// [0:L/2] are cached and [L/2:L] are uncached
 	sigs, err = MultipleSignaturesFromBytes(tc.sigbs)
 	assert.Nil(t, err)
-	for i := 0; i < L; i++ {
+	for i := range L {
 		assert.Equal(t, tc.sigs[i].Marshal(), sigs[i].Marshal())
 	}
 

--- a/crypto/bn256/cloudflare/bn256.go
+++ b/crypto/bn256/cloudflare/bn256.go
@@ -301,7 +301,7 @@ func PairingCheck(a []*G1, b []*G2) bool {
 	acc := new(gfP12)
 	acc.SetOne()
 
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		if a[i].p.IsInfinity() || b[i].p.IsInfinity() {
 			continue
 		}

--- a/crypto/bn256/cloudflare/bn256_test.go
+++ b/crypto/bn256/cloudflare/bn256_test.go
@@ -45,7 +45,7 @@ func TestG2Marshal(t *testing.T) {
 }
 
 func TestBilinearity(t *testing.T) {
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		a, p1, _ := RandomG1(rand.Reader)
 		b, p2, _ := RandomG2(rand.Reader)
 		e1 := Pair(p1, p2)

--- a/crypto/bn256/cloudflare/gfp.go
+++ b/crypto/bn256/cloudflare/gfp.go
@@ -37,8 +37,8 @@ func (e *gfP) Invert(f *gfP) {
 	sum.Set(rN1)
 	power.Set(f)
 
-	for word := 0; word < 4; word++ {
-		for bit := uint(0); bit < 64; bit++ {
+	for word := range 4 {
+		for bit := range uint(64) {
 			if (bits[word]>>bit)&1 == 1 {
 				gfpMul(sum, sum, power)
 			}
@@ -51,8 +51,8 @@ func (e *gfP) Invert(f *gfP) {
 }
 
 func (e *gfP) Marshal(out []byte) {
-	for w := uint(0); w < 4; w++ {
-		for b := uint(0); b < 8; b++ {
+	for w := range uint(4) {
+		for b := range uint(8) {
 			out[8*w+b] = byte(e[3-w] >> (56 - 8*b))
 		}
 	}
@@ -60,8 +60,8 @@ func (e *gfP) Marshal(out []byte) {
 
 func (e *gfP) Unmarshal(in []byte) error {
 	// Unmarshal the bytes into little endian form
-	for w := uint(0); w < 4; w++ {
-		for b := uint(0); b < 8; b++ {
+	for w := range uint(4) {
+		for b := range uint(8) {
 			e[3-w] += uint64(in[8*w+b]) << (56 - 8*b)
 		}
 	}

--- a/crypto/bn256/cloudflare/lattice.go
+++ b/crypto/bn256/cloudflare/lattice.go
@@ -53,7 +53,7 @@ func (l *lattice) decompose(k *big.Int) []*big.Int {
 
 	// Calculate closest vector in lattice to <k,0,0,...> with Babai's rounding.
 	c := make([]*big.Int, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		c[i] = new(big.Int).Mul(k, l.inverse[i])
 		round(c[i], l.det)
 	}
@@ -62,10 +62,10 @@ func (l *lattice) decompose(k *big.Int) []*big.Int {
 	out := make([]*big.Int, n)
 	temp := new(big.Int)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		out[i] = new(big.Int)
 
-		for j := 0; j < n; j++ {
+		for j := range n {
 			temp.Mul(c[j], l.vectors[j][i])
 			out[i].Add(out[i], temp)
 		}
@@ -82,8 +82,8 @@ func (l *lattice) Precompute(add func(i, j uint)) {
 	n := uint(len(l.vectors))
 	total := uint(1) << n
 
-	for i := uint(0); i < n; i++ {
-		for j := uint(0); j < total; j++ {
+	for i := range n {
+		for j := range total {
 			if (j>>i)&1 == 1 {
 				add(i, j)
 			}

--- a/crypto/bn256/cloudflare/main_test.go
+++ b/crypto/bn256/cloudflare/main_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRandomG2Marshal(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		n, g2, err := RandomG2(rand.Reader)
 		if err != nil {
 			t.Error(err)

--- a/crypto/bn256/google/bn256.go
+++ b/crypto/bn256/google/bn256.go
@@ -399,7 +399,7 @@ func PairingCheck(a []*G1, b []*G2) bool {
 	acc := newGFp12(pool)
 	acc.SetOne()
 
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		if a[i].p.IsInfinity() || b[i].p.IsInfinity() {
 			continue
 		}

--- a/crypto/bn256/google/bn256_test.go
+++ b/crypto/bn256/google/bn256_test.go
@@ -198,7 +198,7 @@ func TestOrderGT(t *testing.T) {
 }
 
 func TestBilinearity(t *testing.T) {
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		a, p1, _ := RandomG1(rand.Reader)
 		b, p2, _ := RandomG2(rand.Reader)
 		e1 := Pair(p1, p2)

--- a/crypto/bn256/google/main_test.go
+++ b/crypto/bn256/google/main_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestRandomG2Marshal(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		n, g2, err := RandomG2(rand.Reader)
 		if err != nil {
 			t.Error(err)

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -286,7 +286,7 @@ func BenchmarkParallelEcrecover(b *testing.B) {
 func generateBenchmarkMaterial(L int) (data []byte, sigs [][]byte) {
 	data = common.HexToHash("0xabcd").Bytes()
 	sigs = make([][]byte, L)
-	for i := 0; i < L; i++ {
+	for i := range L {
 		// any nonzero integer less than the order is a valid privkey
 		priv := ToECDSAUnsafe(big.NewInt(int64(i + 1)).Bytes())
 		sig, _ := Sign(data, priv)
@@ -305,7 +305,7 @@ func parallelEcrecover(data []byte, sigs [][]byte) {
 		jobs <- sig
 	}
 
-	for i := 0; i < threads; i++ {
+	for range threads {
 		go func() {
 			for sig := range jobs {
 				Ecrecover(data, sig)

--- a/crypto/secp256k1/secp256_test.go
+++ b/crypto/secp256k1/secp256_test.go
@@ -146,7 +146,7 @@ func TestRandomMessagesWithRandomKeys(t *testing.T) {
 }
 
 func signAndRecoverWithRandomMessages(t *testing.T, keys func() ([]byte, []byte)) {
-	for i := 0; i < TestCount; i++ {
+	for range TestCount {
 		pubkey1, seckey := keys()
 		msg := csprngEntropy(32)
 		sig, err := Sign(msg, seckey)
@@ -178,7 +178,7 @@ func TestRecoveryOfRandomSignature(t *testing.T) {
 	pubkey1, _ := generateKeyPair()
 	msg := csprngEntropy(32)
 
-	for i := 0; i < TestCount; i++ {
+	for i := range TestCount {
 		// recovery can sometimes work, but if so should always give wrong pubkey
 		pubkey2, _ := RecoverPubkey(msg, randSig())
 		if bytes.Equal(pubkey1, pubkey2) {
@@ -192,7 +192,7 @@ func TestRandomMessagesAgainstValidSig(t *testing.T) {
 	msg := csprngEntropy(32)
 	sig, _ := Sign(msg, seckey)
 
-	for i := 0; i < TestCount; i++ {
+	for i := range TestCount {
 		msg = csprngEntropy(32)
 		pubkey2, _ := RecoverPubkey(msg, sig)
 		// recovery can sometimes work, but if so should always give wrong pubkey

--- a/crypto/sha3/sha3_test.go
+++ b/crypto/sha3/sha3_test.go
@@ -234,7 +234,7 @@ func benchmarkHash(b *testing.B, h hash.Hash, size, num int) {
 
 	var state []byte
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < num; j++ {
+		for range num {
 			h.Write(data)
 		}
 		state = h.Sum(state[:0])
@@ -256,7 +256,7 @@ func benchmarkShake(b *testing.B, h ShakeHash, size, num int) {
 
 	for i := 0; i < b.N; i++ {
 		h.Reset()
-		for j := 0; j < num; j++ {
+		for range num {
 			h.Write(data)
 		}
 		h.Read(d)

--- a/crypto/sha3/xor_generic.go
+++ b/crypto/sha3/xor_generic.go
@@ -12,7 +12,7 @@ import "encoding/binary"
 func xorInGeneric(d *state, buf []byte) {
 	n := len(buf) / 8
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		a := binary.LittleEndian.Uint64(buf)
 		d.a[i] ^= a
 		buf = buf[8:]

--- a/crypto/signature_test.go
+++ b/crypto/signature_test.go
@@ -125,7 +125,7 @@ func TestCompressPubkey(t *testing.T) {
 func TestPubkeyRandom(t *testing.T) {
 	const runs = 200
 
-	for i := 0; i < runs; i++ {
+	for i := range runs {
 		key, err := GenerateKey()
 		if err != nil {
 			t.Fatalf("iteration %d: %v", i, err)

--- a/datasync/chaindatafetcher/kafka/kafka_test.go
+++ b/datasync/chaindatafetcher/kafka/kafka_test.go
@@ -145,7 +145,7 @@ func (s *KafkaSuite) TestKafka_setupTopic() {
 func (s *KafkaSuite) TestKafka_setupTopicConcurrency() {
 	topicName := "test-setup-concurrency-topic"
 	wg := sync.WaitGroup{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Go(func() {
 			kaf, err := NewKafka(s.conf)
 			s.NoError(err)
@@ -175,7 +175,7 @@ func (s *KafkaSuite) TestKafka_CreateAndDeleteTopic() {
 	// deleted a topic successfully
 	s.Nil(s.kfk.DeleteTopic(s.topic))
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		topics, err := s.kfk.ListTopics()
 		s.NoError(err)
 		if _, exist := topics[s.topic]; !exist {
@@ -197,7 +197,7 @@ func (d *kafkaData) Key() string {
 
 func publishRandomData(t *testing.T, producer *Kafka, topic string, numTests, testBytesSize int) []*kafkaData {
 	var expected []*kafkaData
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		testData := &kafkaData{i, common.MakeRandomBytes(testBytesSize)}
 		assert.NoError(t, producer.Publish(topic, testData))
 		expected = append(expected, testData)
@@ -230,7 +230,7 @@ func (s *KafkaSuite) subscribeData(topic, groupId string, numTests int, handler 
 
 	// wait for all data to be consumed
 	timeout := time.NewTimer(10 * time.Second)
-	for i := 0; i < numTests; i++ {
+	for i := range numTests {
 		select {
 		case <-numCheckCh:
 			s.T().Logf("test count: %v, total tests: %v", i+1, numTests)
@@ -369,7 +369,7 @@ func (s *KafkaSuite) TestKafka_PubSubWithV1Segments() {
 
 	// make multi producers
 	var producers []*Kafka
-	for i := 0; i < numProducers; i++ {
+	for range numProducers {
 		config := GetDefaultKafkaConfig()
 		config.Brokers = s.kfk.config.Brokers
 		config.SegmentSizeBytes = segmentSize
@@ -448,7 +448,7 @@ func (s *KafkaSuite) TestKafka_PubSubWithSegements_BufferOverflow() {
 	s.NoError(err)
 
 	// insert incomplete message segments
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		msg := s.kfk.makeProducerMessage(topic, "test-key-"+strconv.Itoa(i), common.MakeRandomBytes(10), 0, 2)
 		_, _, err = s.kfk.producer.SendMessage(msg)
 		s.NoError(err)

--- a/datasync/chaindatafetcher/kas/repository.go
+++ b/datasync/chaindatafetcher/kas/repository.go
@@ -79,7 +79,7 @@ func NewRepository(config *KASConfig) (*repository, error) {
 		db  *gorm.DB
 		err error
 	)
-	for i := 0; i < maxDBRetryCount; i++ {
+	for range maxDBRetryCount {
 		db, err = gorm.Open("mysql", endpoint)
 		if err != nil {
 			logger.Warn("Retrying to connect DB", "endpoint", endpoint, "err", err)
@@ -128,14 +128,14 @@ func (r *repository) HandleChainEvent(event blockchain.ChainEvent, reqType types
 }
 
 func makeEOAListStr(eoaList map[common.Address]struct{}) string {
-	eoaStrList := ""
+	var eoaStrList strings.Builder
 	for key := range eoaList {
-		eoaStrList += "\""
-		eoaStrList += strings.ToLower(key.String())
-		eoaStrList += "\""
-		eoaStrList += ","
+		eoaStrList.WriteString("\"")
+		eoaStrList.WriteString(strings.ToLower(key.String()))
+		eoaStrList.WriteString("\"")
+		eoaStrList.WriteString(",")
 	}
-	return eoaStrList[:len(eoaStrList)-1]
+	return eoaStrList.String()[:len(eoaStrList.String())-1]
 }
 
 func makeBasicAuthWithParam(param string) string {

--- a/datasync/chaindatafetcher/kas/repository_test.go
+++ b/datasync/chaindatafetcher/kas/repository_test.go
@@ -105,7 +105,7 @@ func makeChainEventsWithInternalTraces(numBlocks int, genTxs func(i int, block *
 	}
 
 	var events []blockchain.ChainEvent
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		timer := time.NewTimer(1 * time.Second)
 		select {
 		case <-timer.C:
@@ -163,7 +163,7 @@ func Test_repository_InvalidateCacheEOAList(t *testing.T) {
 	testAuth := "test-auth"
 	testEOAs := make(map[common.Address]struct{})
 	numEOAs := 10
-	for i := 0; i < numEOAs; i++ {
+	for range numEOAs {
 		testEOAs[*genRandomAddress()] = struct{}{}
 	}
 

--- a/datasync/chaindatafetcher/kas/repository_transactions_test.go
+++ b/datasync/chaindatafetcher/kas/repository_transactions_test.go
@@ -151,7 +151,7 @@ func createChainEventsWithTooManyTxs() ([]blockchain.ChainEvent, error) {
 	// make a chain event including a value transfer transaction
 	numBlocks := 1
 	return makeChainEventsWithInternalTraces(numBlocks, func(i int, block *blockchain.BlockGen) {
-		for idx := 0; idx < maxPlaceholders/placeholdersPerTxItem+1; idx++ {
+		for range maxPlaceholders/placeholdersPerTxItem + 1 {
 			nonce := new(big.Int).SetUint64(block.TxNonce(from))
 			tx := genNewValueTransfer(from, to, nonce, amount, gasLimit, gasPrice)
 			block.AddTx(tx)

--- a/datasync/dbsyncer/query_engine.go
+++ b/datasync/dbsyncer/query_engine.go
@@ -78,10 +78,10 @@ func newQueryEngine(ds *DBSyncer, taskQueue int, insertQueue int) *QueryEngine {
 		taskQueue:   taskQueue,
 		insertQueue: insertQueue,
 	}
-	for i := 0; i < taskQueue; i++ {
+	for range taskQueue {
 		go queryEngine.processing()
 	}
-	for i := 0; i < insertQueue; i++ {
+	for range insertQueue {
 		go queryEngine.executing()
 	}
 
@@ -184,7 +184,7 @@ func (qe *QueryEngine) executeBulkInsert(bulkInserts []*BulkInsertQuery, result 
 
 	// Ensure we have meaningful task sizes and schedule the recoveries
 	tasks := min(len(bulkInserts), qe.insertQueue)
-	for i := 0; i < tasks; i++ {
+	for i := range tasks {
 		qe.inserts <- &BulkInsertRequest{
 			bulkInserts: bulkInserts[i:],
 			inc:         tasks,

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -571,7 +571,7 @@ func (d *Downloader) spawnSync(fetchers []func() error, peerID string) error {
 	}
 	// Wait for the first error, then terminate the others.
 	var err error
-	for i := 0; i < len(fetchers); i++ {
+	for i := range fetchers {
 		if i == len(fetchers)-1 {
 			// Close the queue when all fetchers have exited.
 			// This will cause the block processor to end when
@@ -867,7 +867,7 @@ func (d *Downloader) findAncestor(p *peerConnection, height uint64) (uint64, err
 				return 0, errEmptyHeaderSet
 			}
 			// Make sure the peer's reply conforms to the request
-			for i := 0; i < len(headers); i++ {
+			for i := range headers {
 				if number := headers[i].Number.Int64(); number != from+int64(i)*16 {
 					p.logger.Error("Head headers broke chain ordering", "index", i, "requested", from+int64(i)*16, "received", number)
 					return 0, fmt.Errorf("%w: %v", errInvalidChain, errors.New("head headers broke chain ordering"))

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -1183,7 +1183,7 @@ func testMultiSynchronisation(t *testing.T, protocol int, mode SyncMode) {
 	targetBlocks := targetPeers*blockCacheMaxItems - 15
 	hashes, headers, blocks, receipts, stakingInfos := tester.makeChain(targetBlocks, 0, tester.genesis, nil, false)
 
-	for i := 0; i < targetPeers; i++ {
+	for i := range targetPeers {
 		id := fmt.Sprintf("peer #%d", i)
 		tester.newPeer(id, protocol, hashes[i*blockCacheMaxItems:], headers, blocks, receipts, stakingInfos)
 	}
@@ -1895,7 +1895,7 @@ func testDeliverHeadersHang(t *testing.T, protocol int, mode SyncMode) {
 	defer master.terminate()
 
 	hashes, headers, blocks, receipts, stakingInfos := master.makeChain(5, 0, master.genesis, nil, false)
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		tester := newTester(t)
 		tester.peerDb = master.peerDb
 
@@ -1992,7 +1992,7 @@ func TestCalcStakingBlockNumber(t *testing.T) {
 		{86400, 259201, 172800},
 	}
 
-	for i := 0; i < len(testCase); i++ {
+	for i := range testCase {
 		result := calcStakingBlockNumber(testCase[i].blockNu, testCase[i].interval)
 
 		if result != testCase[i].result {

--- a/datasync/downloader/queue_test.go
+++ b/datasync/downloader/queue_test.go
@@ -482,13 +482,13 @@ func XTestDelivery(t *testing.T) {
 		}
 	}()
 	wg.Go(func() {
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			time.Sleep(300 * time.Millisecond)
 			// world.tick()
 			// fmt.Printf("trying to progress\n")
 			world.progress(rand.Intn(100))
 		}
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			time.Sleep(2990 * time.Millisecond)
 		}
 	})

--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -194,7 +194,7 @@ func New(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBloc
 func (f *Fetcher) Start() {
 	go f.loop()
 
-	for i := 0; i < numInsertWorkers; i++ {
+	for range numInsertWorkers {
 		go f.insertWorker()
 	}
 }

--- a/datasync/fetcher/fetcher_test.go
+++ b/datasync/fetcher/fetcher_test.go
@@ -252,7 +252,7 @@ func verifyImportEvent(t *testing.T, imported chan *types.Block, arrive bool) {
 // verifyImportCount verifies that exactly count number of events arrive on an
 // import hook channel.
 func verifyImportCount(t *testing.T, imported chan *types.Block, count int) {
-	for i := 0; i < count; i++ {
+	for i := range count {
 		select {
 		case <-imported:
 		case <-time.After(time.Second):
@@ -360,7 +360,7 @@ func testOverlappingAnnouncements(t *testing.T, protocol int) {
 	// Iteratively announce blocks, but overlap them continuously
 	overlap := 16
 	imported := make(chan *types.Block, len(hashes)-1)
-	for i := 0; i < overlap; i++ {
+	for range overlap {
 		imported <- nil
 	}
 	tester.fetcher.importedHook = func(block *types.Block) { imported <- block }
@@ -718,7 +718,7 @@ func testHashMemoryExhaustionAttack(t *testing.T, protocol int) {
 	attackerBodyFetcher := tester.makeBodyFetcher("attacker", nil, 0)
 
 	// Feed the tester a huge hashset from the attacker, and a limited from the valid peer
-	for i := 0; i < len(attack); i++ {
+	for i := range attack {
 		if i < maxQueueDist {
 			tester.fetcher.Notify("valid", hashes[len(hashes)-2-i], uint64(i+1), time.Now(), validHeaderFetcher, validBodyFetcher)
 		}
@@ -773,7 +773,7 @@ func TestBlockMemoryExhaustionAttack(t *testing.T) {
 		t.Fatalf("queued block count mismatch: have %d, want %d", queued, blockLimit)
 	}
 	// Queue up a batch of valid blocks, and check that a new peer is allowed to do so
-	for i := 0; i < maxQueueDist-1; i++ {
+	for i := range maxQueueDist - 1 {
 		tester.fetcher.Enqueue("valid", blocks[hashes[len(hashes)-3-i]])
 	}
 	time.Sleep(100 * time.Millisecond)

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -130,13 +130,13 @@ func TestMuxConcurrent(t *testing.T) {
 	go poster()
 	go poster()
 	nsubs := 1000
-	for i := 0; i < nsubs; i++ {
+	for i := range nsubs {
 		go sub(i)
 	}
 
 	// wait until everyone has been served
 	counts := make(map[int]int, nsubs)
-	for i := 0; i < nsubs; i++ {
+	for range nsubs {
 		counts[<-recv]++
 	}
 	for i, count := range counts {
@@ -162,7 +162,7 @@ func BenchmarkPost1000(b *testing.B) {
 	)
 	subscribed.Add(nsubs)
 	done.Add(nsubs)
-	for i := 0; i < nsubs; i++ {
+	for range nsubs {
 		go func() {
 			s := mux.Subscribe(testEvent(0))
 			subscribed.Done()
@@ -199,7 +199,7 @@ func BenchmarkPostConcurrent(b *testing.B) {
 		wg.Done()
 	}
 	wg.Add(5)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		go poster()
 	}
 	wg.Wait()

--- a/event/example_feed_test.go
+++ b/event/example_feed_test.go
@@ -40,7 +40,7 @@ func ExampleFeed_acknowledgedEvents() {
 	// Consumers wait for events on the feed and acknowledge processing.
 	done := make(chan struct{})
 	defer close(done)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		ch := make(chan ackedEvent, 100)
 		sub := feed.Subscribe(ch)
 		go func() {
@@ -59,10 +59,10 @@ func ExampleFeed_acknowledgedEvents() {
 
 	// The producer sends values of type ackedEvent with increasing values of i.
 	// It waits for all consumers to acknowledge before sending the next event.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		acksignal := make(chan struct{})
 		n := feed.Send(ackedEvent{i, acksignal})
-		for ack := 0; ack < n; ack++ {
+		for range n {
 			<-acksignal
 		}
 	}

--- a/event/example_subscription_test.go
+++ b/event/example_subscription_test.go
@@ -32,7 +32,7 @@ func ExampleNewSubscription() {
 	// Create a subscription that sends 10 integers on ch.
 	ch := make(chan int)
 	sub := event.NewSubscription(func(quit <-chan struct{}) error {
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			select {
 			case ch <- i:
 			case <-quit:

--- a/event/feed_test.go
+++ b/event/feed_test.go
@@ -117,7 +117,7 @@ func TestFeed(t *testing.T) {
 	const n = 1000
 	done.Add(n)
 	subscribed.Add(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go subscriber(i)
 	}
 	subscribed.Wait()
@@ -146,7 +146,7 @@ func TestFeedSubscribeSameChannel(t *testing.T) {
 		done.Done()
 	}
 	expectRecv := func(wantValue, n int) {
-		for i := 0; i < n; i++ {
+		for range n {
 			if v := <-ch; v != wantValue {
 				t.Errorf("received %d, want %d", v, wantValue)
 			}
@@ -185,7 +185,7 @@ func TestFeedSubscribeBlockedPost(t *testing.T) {
 
 	feed.Subscribe(ch1)
 	wg.Add(nsends)
-	for i := 0; i < nsends; i++ {
+	for range nsends {
 		go func() {
 			feed.Send(99)
 			wg.Done()
@@ -222,7 +222,7 @@ func TestFeedUnsubscribeBlockedPost(t *testing.T) {
 
 	// Queue up some Sends. None of these can make progress while bchan isn't read.
 	wg.Add(nsends)
-	for i := 0; i < nsends; i++ {
+	for range nsends {
 		go func() {
 			feed.Send(99)
 			wg.Done()
@@ -316,7 +316,7 @@ func BenchmarkFeedSend1000(b *testing.B) {
 		done.Done()
 	}
 	done.Add(nsubs)
-	for i := 0; i < nsubs; i++ {
+	for range nsubs {
 		ch := make(chan int, 200)
 		feed.Subscribe(ch)
 		go subscriber(ch)

--- a/event/subscription_test.go
+++ b/event/subscription_test.go
@@ -33,7 +33,7 @@ var errInts = errors.New("error in subscribeInts")
 
 func subscribeInts(max, fail int, c chan<- int) Subscription {
 	return NewSubscription(func(quit <-chan struct{}) error {
-		for i := 0; i < max; i++ {
+		for i := range max {
 			if i >= fail {
 				return errInts
 			}
@@ -53,7 +53,7 @@ func TestNewSubscriptionError(t *testing.T) {
 	channel := make(chan int)
 	sub := subscribeInts(10, 2, channel)
 loop:
-	for want := 0; want < 10; want++ {
+	for want := range 10 {
 		select {
 		case got := <-channel:
 			if got != want {

--- a/kaiax/auction/impl/bid_pool_test.go
+++ b/kaiax/auction/impl/bid_pool_test.go
@@ -562,7 +562,7 @@ func benchmarkAddBidParallel(b *testing.B, numBids int) {
 
 	// Pre-generate bids
 	bids := make([]*auction.Bid, numBids)
-	for i := 0; i < numBids; i++ {
+	for i := range numBids {
 		searcherKey, _ := crypto.GenerateKey()
 		tx := types.NewTransaction(uint64(i), testSearcher1, big.NewInt(10000000), 10000000, big.NewInt(10000000), []byte{})
 		bid := &auction.Bid{BidData: auction.BidData{

--- a/kaiax/auction/impl/builder_test.go
+++ b/kaiax/auction/impl/builder_test.go
@@ -38,7 +38,7 @@ func TestFilterTxs(t *testing.T) {
 	mAuction := prep(t)
 	txs := make(map[common.Address]types.Transactions)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		// tx.Time is set to current time
 		tx := types.NewTransaction(uint64(i), tx1Sender, big.NewInt(1), 1000000, big.NewInt(1), nil)
 		tx2 := types.NewTransaction(uint64(i), tx2Sender, big.NewInt(1), 1000000, big.NewInt(1), nil)
@@ -75,7 +75,7 @@ func TestFilterTxs_TargetTx(t *testing.T) {
 	mAuction := prep(t)
 	txs := make(map[common.Address]types.Transactions)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		// tx.Time is set to current time
 		tx := types.NewTransaction(uint64(i), tx1Sender, big.NewInt(1), 1000000, big.NewInt(1), nil)
 		tx2 := types.NewTransaction(uint64(i), tx2Sender, big.NewInt(1), 1000000, big.NewInt(1), nil)
@@ -109,7 +109,7 @@ func TestFilterTxs_GaslessTx(t *testing.T) {
 	mAuction := prep(t)
 	txs := make(map[common.Address]types.Transactions)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		// tx.Time is set to current time
 		tx := types.NewTransaction(uint64(i), tx1Sender, big.NewInt(1), 1000000, big.NewInt(1), nil)
 		tx2 := types.NewTransaction(uint64(i), tx2Sender, big.NewInt(1), 1000000, big.NewInt(1), nil)

--- a/kaiax/auction/impl/handler_test.go
+++ b/kaiax/auction/impl/handler_test.go
@@ -178,7 +178,7 @@ func TestHandler_RateLimit(t *testing.T) {
 
 	// Create many test bids with different target transactions to avoid duplicate rejection
 	testBids := make([]*auction.Bid, 400)
-	for i := 0; i < 400; i++ {
+	for i := range 400 {
 		key, _ := crypto.GenerateKey()
 		bid := &auction.Bid{}
 
@@ -202,7 +202,7 @@ func TestHandler_RateLimit(t *testing.T) {
 
 	// Test rate limiting for peer1
 	// Send 350 bids rapidly (should be limited to 300 by rate limit)
-	for i := 0; i < 350; i++ {
+	for i := range 350 {
 		module.HandleBid(testPeerID1, testBids[i])
 	}
 
@@ -224,7 +224,7 @@ func TestHandler_RateLimit(t *testing.T) {
 	time.Sleep(1100 * time.Millisecond) // Wait for rate limit to reset
 
 	// Send another batch from peer1
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		module.HandleBid(testPeerID1, testBids[i])
 	}
 
@@ -293,7 +293,7 @@ func TestHandler_SubscribeNewBid(t *testing.T) {
 	}()
 
 	// Verify we receive the bids in order
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		select {
 		case bid := <-newBidCh:
 			assert.Equal(t, handlerTestBids[i].Hash(), bid.Hash())

--- a/kaiax/gov/contractgov/impl/getter.go
+++ b/kaiax/gov/contractgov/impl/getter.go
@@ -91,7 +91,7 @@ func (c *contractGovModule) contractAddrAt(blockNum uint64) (common.Address, err
 
 func ParseContractCall(names []string, values [][]byte) gov.PartialParamSet {
 	ret := make(gov.PartialParamSet)
-	for i := 0; i < len(names); i++ {
+	for i := range names {
 		ret.Add(names[i], values[i])
 	}
 

--- a/kaiax/gov/contractgov/impl/getter_test.go
+++ b/kaiax/gov/contractgov/impl/getter_test.go
@@ -25,7 +25,7 @@ func createSimulateBackend(t *testing.T) ([]*bind.TransactOpts, *backends.Simula
 	// Create accounts and simulated blockchain
 	accounts := []*bind.TransactOpts{}
 	alloc := blockchain.GenesisAlloc{}
-	for i := 0; i < 1; i++ {
+	for range 1 {
 		key, _ := crypto.GenerateKey()
 		account := bind.NewKeyedTransactor(key)
 		account.GasLimit = 10000000

--- a/kaiax/gov/headergov/history_test.go
+++ b/kaiax/gov/headergov/history_test.go
@@ -34,7 +34,7 @@ func TestSearch(t *testing.T) {
 	}
 
 	gh := GovsToHistory(govs)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		t.Run(fmt.Sprintf("Block %d", i), func(t *testing.T) {
 			gp, err := gh.Search(uint64(i))
 			assert.Nil(t, err)

--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -1,7 +1,6 @@
 package impl
 
 import (
-	maps0 "maps"
 	"reflect"
 	"slices"
 
@@ -245,7 +244,7 @@ func (h *headerGovModule) getVotesInEpoch(epochIdx uint64) map[uint64]headergov.
 
 		h.mu.RLock()
 		defer h.mu.RUnlock()
-		maps0.Copy(votes, h.groupedVotes[epochIdx])
+		maps.Copy(votes, h.groupedVotes[epochIdx])
 		return votes
 	} else {
 		logger.Debug("Scanning votes slowpath")

--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	maps0 "maps"
 	"reflect"
 	"slices"
 
@@ -244,9 +245,7 @@ func (h *headerGovModule) getVotesInEpoch(epochIdx uint64) map[uint64]headergov.
 
 		h.mu.RLock()
 		defer h.mu.RUnlock()
-		for blockNum, vote := range h.groupedVotes[epochIdx] {
-			votes[blockNum] = vote
-		}
+		maps0.Copy(votes, h.groupedVotes[epochIdx])
 		return votes
 	} else {
 		logger.Debug("Scanning votes slowpath")

--- a/kaiax/gov/headergov/impl/execution_test.go
+++ b/kaiax/gov/headergov/impl/execution_test.go
@@ -80,7 +80,7 @@ func TestAddVote(t *testing.T) {
 	config.Istanbul.Epoch = 3
 	h := newHeaderGovModule(t, config)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		h.AddVote(uint64(i), v)
 	}
 
@@ -97,7 +97,7 @@ func TestAddGov(t *testing.T) {
 	config.Istanbul.Epoch = 1
 	h := newHeaderGovModule(t, config)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		h.AddGov(uint64(i), g)
 	}
 

--- a/kaiax/gov/headergov/impl/getter_test.go
+++ b/kaiax/gov/headergov/impl/getter_test.go
@@ -157,9 +157,9 @@ func TestGetPartialParamSet_ConcurrentAccess(t *testing.T) {
 
 	// Reader goroutines continuously call GetPartialParamSet.
 	const readers = 8
-	for r := 0; r < readers; r++ {
+	for range readers {
 		wgReader.Go(func() {
-			for i := 0; i < 5000; i++ {
+			for range 5000 {
 				ps := h.GetPartialParamSet(1000)
 				_ = ps[gov.GovernanceUnitPrice]
 			}

--- a/kaiax/reward/impl/api.go
+++ b/kaiax/reward/impl/api.go
@@ -126,7 +126,7 @@ func (api *RewardGovAPI) accumulateRewards(lower, upper uint64) (*reward.RewardS
 	)
 	defer cancel()
 
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		wg.Go(func() {
 			for {
 				select {

--- a/kaiax/supply/impl/init_test.go
+++ b/kaiax/supply/impl/init_test.go
@@ -81,7 +81,7 @@ func (s *SupplyTestSuite) TestWithCatchup() {
 }
 
 func (s *SupplyTestSuite) waitCatchup() {
-	for i := 0; i < 1000; i++ { // wait 10 seconds until catchup complete
+	for range 1000 { // wait 10 seconds until catchup complete
 		if s.s.lastAccNum == 400 {
 			return
 		}

--- a/kaiax/valset/address_set_test.go
+++ b/kaiax/valset/address_set_test.go
@@ -152,11 +152,11 @@ func TestAddressHexCache(t *testing.T) {
 	var wg sync.WaitGroup
 	errCh := make(chan error, 100)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				addr := addrs[(id+j)%len(addrs)]
 				got := hexCache.Get(addr)
 				want := addr.String()

--- a/kaiax/valset/impl/getter_council_test.go
+++ b/kaiax/valset/impl/getter_council_test.go
@@ -107,7 +107,7 @@ func TestGetCouncilDB(t *testing.T) {
 		v := &ValsetModule{InitOpts: InitOpts{ChainKv: db}}
 		writeLowestScannedVoteNum(db, tc.lowestScannedVoteNum)
 
-		for i := uint64(0); i < 7; i++ {
+		for i := range uint64(7) {
 			council, ok, err := v.getCouncilDB(i)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expected[i].ok, ok)

--- a/kaiax/valset/impl/getter_proposers_test.go
+++ b/kaiax/valset/impl/getter_proposers_test.go
@@ -126,7 +126,7 @@ func TestGetProposers_GetRemoveVotesInInterval(t *testing.T) {
 	// Mock qualified validators
 	for blkNum, data := range mockQualifiedValidators {
 		stakingAmounts := make([]uint64, len(data))
-		for i := 0; i < len(data); i++ {
+		for i := range data {
 			stakingAmounts[i] = uint64(5000000)
 		}
 		mockStaking.EXPECT().GetStakingInfo(blkNum).Return(&staking.StakingInfo{

--- a/log/log_modules.go
+++ b/log/log_modules.go
@@ -40,7 +40,7 @@ func GetModuleName(mi ModuleID) string {
 
 func GetModuleID(moduleName string) ModuleID {
 	moduleName = strings.ToLower(moduleName)
-	for i := 0; i < len(moduleNames); i++ {
+	for i := range len(moduleNames) {
 		if moduleName == moduleNames[i] {
 			return ModuleID(i)
 		}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -22,7 +22,7 @@ import "testing"
 
 // TestLogModulesLengthCheck checks if all ModuleID have corresponding moduleNames.
 func TestLogModulesLengthCheck(t *testing.T) {
-	for i := 0; i < int(ModuleNameLen); i++ {
+	for i := range int(ModuleNameLen) {
 		if moduleNames[i] == "" {
 			t.Fatalf("Module name should be specified! index: %v", i)
 		}

--- a/metrics/utils/metrics.go
+++ b/metrics/utils/metrics.go
@@ -92,7 +92,7 @@ func CollectProcessMetrics(refresh time.Duration) {
 	// Create the various data collectors
 	memstats := make([]*runtime.MemStats, 2)
 	diskstats := make([]*DiskStats, 2)
-	for i := 0; i < len(memstats); i++ {
+	for i := range memstats {
 		memstats[i] = new(runtime.MemStats)
 		diskstats[i] = new(DiskStats)
 	}

--- a/networks/p2p/discover/database_test.go
+++ b/networks/p2p/discover/database_test.go
@@ -89,13 +89,13 @@ func TestNodeDBInt64(t *testing.T) {
 	defer db.close()
 
 	tests := nodeDBInt64Tests
-	for i := 0; i < len(tests); i++ {
+	for i := range tests {
 		// Insert the next value
 		if err := db.storeInt64(tests[i].key, tests[i].value); err != nil {
 			t.Errorf("test %d: failed to store value: %v", i, err)
 		}
 		// Check all existing and non existing values
-		for j := 0; j < len(tests); j++ {
+		for j := range tests {
 			num := db.fetchInt64(tests[j].key)
 			switch {
 			case j <= i && num != tests[j].value:

--- a/networks/p2p/discover/discover_storage_kademlia.go
+++ b/networks/p2p/discover/discover_storage_kademlia.go
@@ -155,7 +155,7 @@ func (s *KademliaStorage) doRefresh() {
 	// (not hash-sized) and it is not easily possible to generate a
 	// sha3 preimage that falls into a chosen bucket.
 	// We perform a few lookups with a random target instead.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var target NodeID
 		rand.Read(target[:])
 		s.lookup(target, false, s.targetType)
@@ -214,7 +214,7 @@ func (s *KademliaStorage) getReplacements() []*Node {
 	s.bucketsMu.Lock()
 	defer s.bucketsMu.Unlock()
 	var nodes []*Node
-	for i := 0; i < nBuckets; i++ {
+	for i := range nBuckets {
 		nodes = append(nodes, s.buckets[i].replacements...)
 	}
 	return nodes
@@ -225,7 +225,7 @@ func (s *KademliaStorage) getBucketEntries() []*Node {
 	defer s.bucketsMu.Unlock()
 
 	var nodes []*Node
-	for i := 0; i < nBuckets; i++ {
+	for i := range nBuckets {
 		nodes = append(nodes, s.buckets[i].entries...)
 	}
 	return nodes

--- a/networks/p2p/discover/table_test.go
+++ b/networks/p2p/discover/table_test.go
@@ -166,7 +166,7 @@ func TestTable_IPLimit(t *testing.T) {
 	go tab.loop()
 	defer tab.Close()
 
-	for i := 0; i < tableIPLimit+1; i++ {
+	for i := range tableIPLimit + 1 {
 		n := nodeAtDistance(tab.self.sha, i, NodeTypeUnknown)
 		n.IP = net.IP{172, 0, 1, byte(i)}
 		tab.add(n)
@@ -193,7 +193,7 @@ func TestTable_BucketIPLimit(t *testing.T) {
 	defer tab.Close()
 
 	d := 3
-	for i := 0; i < bucketIPLimit+1; i++ {
+	for i := range bucketIPLimit + 1 {
 		n := nodeAtDistance(tab.self.sha, d, NodeTypeUnknown)
 		n.NType = NodeTypeUnknown
 		n.IP = net.IP{172, 0, 1, byte(i)}
@@ -347,7 +347,7 @@ func TestTable_ReadRandomNodesGetAll(t *testing.T) {
 		defer tab.Close()
 		<-tab.initDone
 
-		for i := 0; i < len(buf); i++ {
+		for range buf {
 			ld := cfg.Rand.Intn(len(tab.storages[NodeTypeUnknown].(*KademliaStorage).buckets))
 			tab.stuff([]*Node{nodeAtDistance(tab.self.sha, ld, NodeTypeUnknown)}, NodeTypeUnknown)
 		}

--- a/networks/p2p/discover/udp_test.go
+++ b/networks/p2p/discover/udp_test.go
@@ -172,7 +172,7 @@ func TestUDP_responseTimeouts(t *testing.T) {
 		nilErr     = make(chan error, nReqs) // for requests that get a reply
 		timeoutErr = make(chan error, nReqs) // for requests that time out
 	)
-	for i := 0; i < nReqs; i++ {
+	for i := range nReqs {
 		// Create a matcher for a random request in udp.loop. Requests
 		// with ptype <= 128 will not get a reply and should time out.
 		// For all other requests, a reply is scheduled to arrive
@@ -204,7 +204,7 @@ func TestUDP_responseTimeouts(t *testing.T) {
 		recvDeadline        = time.After(20 * time.Second)
 		nTimeoutsRecv, nNil = 0, 0
 	)
-	for i := 0; i < nReqs; i++ {
+	for i := range nReqs {
 		select {
 		case err := <-timeoutErr:
 			if err != errTimeout {
@@ -254,7 +254,7 @@ func TestUDP_findnode(t *testing.T) {
 	// take care not to overflow any bucket.
 	targetHash := crypto.Keccak256Hash(testTarget[:])
 	nodes := &nodesByDistance{target: targetHash}
-	for i := 0; i < bucketSize; i++ {
+	for i := range bucketSize {
 		nodes.push(nodeAtDistance(test.table.self.sha, i+2, NodeTypeUnknown), bucketSize)
 	}
 	test.table.stuff(nodes.entries, NodeTypeUnknown)

--- a/networks/p2p/message_test.go
+++ b/networks/p2p/message_test.go
@@ -49,7 +49,7 @@ func ExampleMsgPipe() {
 
 func TestMsgPipeUnblockWrite(t *testing.T) {
 loop:
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		rw1, rw2 := MsgPipe()
 		done := make(chan struct{})
 		go func() {
@@ -80,7 +80,7 @@ loop:
 // This test should panic if concurrent close isn't implemented correctly.
 func TestMsgPipeConcurrentClose(t *testing.T) {
 	rw1, _ := MsgPipe()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go rw1.Close()
 	}
 }

--- a/networks/p2p/netutil/error_test.go
+++ b/networks/p2p/netutil/error_test.go
@@ -39,7 +39,7 @@ func TestIsPacketTooBig(t *testing.T) {
 
 	sendN := 1800
 	recvN := 300
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		go func() {
 			buf := make([]byte, sendN)
 			for i := range buf {

--- a/networks/p2p/peer_test.go
+++ b/networks/p2p/peer_test.go
@@ -82,7 +82,7 @@ func testPeerWithRWs(protos []Protocol, channelSize int) (func(), []*conn, *Peer
 	serverSideConn := make([]*conn, 0, channelSize)
 	peerSideConn := make([]*conn, 0, channelSize)
 
-	for i := 0; i < channelSize; i++ {
+	for range channelSize {
 		var (
 			fd1, fd2   = net.Pipe()
 			id1, id2   = randomID(), randomID()
@@ -214,7 +214,7 @@ func TestPeerDisconnect(t *testing.T) {
 func TestPeerDisconnectRace(t *testing.T) {
 	maybe := func() bool { return rand.Intn(2) == 1 }
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		protoclose := make(chan error)
 		protodisc := make(chan DiscReason)
 		closer, rw, p, disc := testPeer([]Protocol{
@@ -340,7 +340,7 @@ func TestMultiChannelPeerPing(t *testing.T) {
 
 func TestMultiChannelPeerDisconnect(t *testing.T) {
 	channelSize := 2
-	for i := 0; i < channelSize; i++ {
+	for i := range channelSize {
 		closer, rws, _, disc := testPeerWithRWs(nil, channelSize)
 		defer closer()
 
@@ -365,7 +365,7 @@ func TestMultiChannelPeerDisconnectRace(t *testing.T) {
 	maybe := func() bool { return rand.Intn(2) == 1 }
 	channelSize := 2
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		protoclose := make(chan error)
 		protodisc := make(chan DiscReason)
 		closer, rws, p, disc := testPeerWithRWs([]Protocol{

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -352,7 +352,7 @@ func TestServerTaskScheduling(t *testing.T) {
 	}()
 
 	var gotdone []*testTask
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		gotdone = append(gotdone, <-done)
 	}
 	for i, task := range gotdone {
@@ -422,7 +422,7 @@ func TestServerManyTasks(t *testing.T) {
 			}
 		case <-timeout:
 			t.Errorf("%d of %d tasks got done within 2s", len(doneset), len(alltasks))
-			for i := 0; i < len(alltasks); i++ {
+			for i := range alltasks {
 				if !doneset[i] {
 					t.Logf("task %d not done", i)
 				}
@@ -487,7 +487,7 @@ func TestServerAtCap(t *testing.T) {
 	}
 
 	// Inject a few connections to fill up the peer set.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		c := newconn(randomID())
 		if err := srv.checkpoint(c, srv.addpeer); err != nil {
 			t.Fatalf("could not add conn %d: %v", i, err)

--- a/networks/p2p/simulations/adapters/inproc_test.go
+++ b/networks/p2p/simulations/adapters/inproc_test.go
@@ -39,7 +39,7 @@ func TestTCPPipe(t *testing.T) {
 	go func() {
 		msgs := 50
 		size := 1024
-		for i := 0; i < msgs; i++ {
+		for i := range msgs {
 			msg := make([]byte, size)
 			_ = binary.PutUvarint(msg, uint64(i))
 
@@ -50,7 +50,7 @@ func TestTCPPipe(t *testing.T) {
 			}
 		}
 
-		for i := 0; i < msgs; i++ {
+		for i := range msgs {
 			msg := make([]byte, size)
 			_ = binary.PutUvarint(msg, uint64(i))
 
@@ -87,7 +87,7 @@ func TestTCPPipeBidirections(t *testing.T) {
 	go func() {
 		msgs := 50
 		size := 7
-		for i := 0; i < msgs; i++ {
+		for i := range msgs {
 			msg := fmt.Appendf(nil, "ping %02d", i)
 
 			_, err := c1.Write(msg)
@@ -97,7 +97,7 @@ func TestTCPPipeBidirections(t *testing.T) {
 			}
 		}
 
-		for i := 0; i < msgs; i++ {
+		for i := range msgs {
 			expected := fmt.Appendf(nil, "ping %02d", i)
 
 			out := make([]byte, size)
@@ -120,7 +120,7 @@ func TestTCPPipeBidirections(t *testing.T) {
 			}
 		}
 
-		for i := 0; i < msgs; i++ {
+		for i := range msgs {
 			expected := fmt.Appendf(nil, "pong %02d", i)
 
 			out := make([]byte, size)
@@ -158,7 +158,7 @@ func TestNetPipe(t *testing.T) {
 		size := 1024
 		// netPipe is blocking, so writes are emitted asynchronously
 		go func() {
-			for i := 0; i < msgs; i++ {
+			for i := range msgs {
 				msg := make([]byte, size)
 				_ = binary.PutUvarint(msg, uint64(i))
 
@@ -170,7 +170,7 @@ func TestNetPipe(t *testing.T) {
 			}
 		}()
 
-		for i := 0; i < msgs; i++ {
+		for i := range msgs {
 			msg := make([]byte, size)
 			_ = binary.PutUvarint(msg, uint64(i))
 
@@ -213,7 +213,7 @@ func TestNetPipeBidirections(t *testing.T) {
 
 		// netPipe is blocking, so writes are emitted asynchronously
 		go func() {
-			for i := 0; i < msgs; i++ {
+			for i := range msgs {
 				msg := fmt.Appendf(nil, pingTemplate, i)
 
 				_, err := c1.Write(msg)
@@ -226,7 +226,7 @@ func TestNetPipeBidirections(t *testing.T) {
 
 		// netPipe is blocking, so reads for pong are emitted asynchronously
 		go func() {
-			for i := 0; i < msgs; i++ {
+			for i := range msgs {
 				expected := fmt.Appendf(nil, pongTemplate, i)
 
 				out := make([]byte, size)
@@ -246,7 +246,7 @@ func TestNetPipeBidirections(t *testing.T) {
 		}()
 
 		// expect to read pings, and respond with pongs to the alternate connection
-		for i := 0; i < msgs; i++ {
+		for i := range msgs {
 			expected := fmt.Appendf(nil, pingTemplate, i)
 
 			out := make([]byte, size)

--- a/networks/p2p/simulations/http_test.go
+++ b/networks/p2p/simulations/http_test.go
@@ -136,7 +136,7 @@ func (t *testService) handshake(rw p2p.MsgReadWriter, code uint64) error {
 	errc := make(chan error, 2)
 	go func() { errc <- p2p.Send(rw, code, struct{}{}) }()
 	go func() { errc <- p2p.ExpectMsg(rw, code, struct{}{}) }()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := <-errc; err != nil {
 			return err
 		}
@@ -357,7 +357,7 @@ func startTestNetwork(t *testing.T, client *Client) []string {
 	// create two nodes
 	nodeCount := 2
 	nodeIDs := make([]string, nodeCount)
-	for i := 0; i < nodeCount; i++ {
+	for i := range nodeCount {
 		config := adapters.RandomNodeConfig()
 		node, err := client.CreateNode(config)
 		if err != nil {
@@ -604,7 +604,7 @@ func TestHTTPSnapshot(t *testing.T) {
 	client := NewClient(s.URL)
 	nodeCount := 2
 	nodes := make([]*p2p.NodeInfo, nodeCount)
-	for i := 0; i < nodeCount; i++ {
+	for i := range nodeCount {
 		config := adapters.RandomNodeConfig()
 		node, err := client.CreateNode(config)
 		if err != nil {

--- a/networks/p2p/simulations/mocker.go
+++ b/networks/p2p/simulations/mocker.go
@@ -176,7 +176,7 @@ func probabilistic(net *Network, quit chan struct{}, nodeCount int) {
 // connect nodeCount number of nodes in a ring
 func connectNodesInRing(net *Network, nodeCount int) ([]discover.NodeID, error) {
 	ids := make([]discover.NodeID, nodeCount)
-	for i := 0; i < nodeCount; i++ {
+	for i := range nodeCount {
 		conf := adapters.RandomNodeConfig()
 		node, err := net.NewNodeWithConfig(conf)
 		if err != nil {

--- a/networks/p2p/simulations/network.go
+++ b/networks/p2p/simulations/network.go
@@ -801,7 +801,7 @@ type Snapshot struct {
 
 // NodeSnapshot represents the state of a node in the network
 type NodeSnapshot struct {
-	Node Node `json:"node,omitempty"`
+	Node Node `json:"node"`
 
 	// Snapshots is arbitrary data gathered from calling node.Snapshots()
 	Snapshots map[string][]byte `json:"snapshots,omitempty"`

--- a/networks/p2p/simulations/network_test.go
+++ b/networks/p2p/simulations/network_test.go
@@ -46,7 +46,7 @@ func TestNetworkSimulation(t *testing.T) {
 	defer network.Shutdown()
 	nodeCount := 20
 	ids := make([]discover.NodeID, nodeCount)
-	for i := 0; i < nodeCount; i++ {
+	for i := range nodeCount {
 		conf := adapters.RandomNodeConfig()
 		node, err := network.NewNodeWithConfig(conf)
 		if err != nil {

--- a/networks/rpc/client_test.go
+++ b/networks/rpc/client_test.go
@@ -173,7 +173,7 @@ func testClientCancel(transport string, t *testing.T) {
 	)
 	caller := func(index int) {
 		defer wg.Done()
-		for i := 0; i < nreqs; i++ {
+		for range nreqs {
 			var (
 				ctx     context.Context
 				cancel  func()
@@ -202,7 +202,7 @@ func testClientCancel(transport string, t *testing.T) {
 		}
 	}
 	wg.Add(ncallers)
-	for i := 0; i < ncallers; i++ {
+	for i := range ncallers {
 		go caller(i)
 	}
 	wg.Wait()
@@ -250,7 +250,7 @@ func TestClientSubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatal("can't subscribe:", err)
 	}
-	for i := 0; i < count; i++ {
+	for i := range count {
 		if val := <-nc; val != i {
 			t.Fatalf("value mismatch: got %d, want %d", val, i)
 		}
@@ -282,7 +282,7 @@ func TestClientSubscribeCustomNamespace(t *testing.T) {
 	if err != nil {
 		t.Fatal("can't subscribe:", err)
 	}
-	for i := 0; i < count; i++ {
+	for i := range count {
 		if val := <-nc; val != i {
 			t.Fatalf("value mismatch: got %d, want %d", val, i)
 		}
@@ -389,7 +389,7 @@ func TestClientNotificationStorm(t *testing.T) {
 		defer sub.Unsubscribe()
 
 		// Process each notification, try to run a call in between each of them.
-		for i := 0; i < count; i++ {
+		for i := range count {
 			select {
 			case val := <-nc:
 				if val != i {
@@ -669,7 +669,7 @@ func TestClientCloseUnsubscribeRace(t *testing.T) {
 	server := newTestServer("kaia", service)
 	defer server.Stop()
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		client := DialInProc(server)
 		nc := make(chan int)
 		sub, err := client.KaiaSubscribe(context.Background(), nc, "someSubscription", 3, 1)

--- a/networks/rpc/server_test.go
+++ b/networks/rpc/server_test.go
@@ -169,7 +169,7 @@ func TestServerShortLivedConn(t *testing.T) {
 		wantResp = `{"jsonrpc":"2.0","id":1,"result":{"rpc":"1.0","service":"1.0"}}` + "\n"
 		deadline = time.Now().Add(10 * time.Second)
 	)
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		conn, err := net.Dial("tcp", listener.Addr().String())
 		if err != nil {
 			t.Fatal("can't dial:", err)

--- a/networks/rpc/subscription_test.go
+++ b/networks/rpc/subscription_test.go
@@ -65,7 +65,7 @@ func (s *NotificationTestService) SomeSubscription(ctx context.Context, n, val i
 		// test expects n events, if we begin sending event immediately some events
 		// will probably be dropped since the subscription ID might not be send to
 		// the client.
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if err := notifier.Notify(subscription.ID, val+i); err != nil {
 				return
 			}
@@ -103,7 +103,7 @@ func (s *NotificationTestService) HangSubscription(ctx context.Context, val int)
 
 func TestNewID(t *testing.T) {
 	hexchars := "0123456789ABCDEFabcdef"
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		id := string(NewID())
 		if !strings.HasPrefix(id, "0x") {
 			t.Fatalf("invalid ID prefix, want '0x...', got %s", id)
@@ -162,7 +162,7 @@ func TestNotifications(t *testing.T) {
 		t.Fatalf("expected subscription id, got %T", response.Result)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		var notification jsonNotification
 		if err := in.Decode(&notification); err != nil {
 			t.Fatalf("%v", err)

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -361,7 +361,7 @@ func (b *CNAPIBackend) BloomStatus() (uint64, uint64) {
 }
 
 func (b *CNAPIBackend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
-	for i := 0; i < bloomFilterThreads; i++ {
+	for range bloomFilterThreads {
 		go session.Multiplex(bloomRetrievalBatch, bloomRetrievalWait, b.cn.bloomRequests)
 	}
 }

--- a/node/cn/bloombits.go
+++ b/node/cn/bloombits.go
@@ -55,7 +55,7 @@ const (
 // startBloomHandlers starts a batch of goroutines to accept bloom bit database
 // retrievals from possibly a range of filters and serving the data to satisfy.
 func (cn *CN) startBloomHandlers() {
-	for i := 0; i < bloomServiceThreads; i++ {
+	for range bloomServiceThreads {
 		go func() {
 			for {
 				select {
@@ -138,7 +138,7 @@ func (b *BloomIndexer) Commit() error {
 	batch := b.db.NewBatch(database.MiscDB)
 	defer batch.Release()
 
-	for i := 0; i < types.BloomBitLength; i++ {
+	for i := range types.BloomBitLength {
 		bits, err := b.gen.Bitset(uint(i))
 		if err != nil {
 			return err

--- a/node/cn/channel_manager.go
+++ b/node/cn/channel_manager.go
@@ -45,7 +45,7 @@ func NewChannelManager(channelSize int) *ChannelManager {
 		msgCodes:    make(map[uint64]uint),
 	}
 
-	for i := 0; i < channelSize; i++ {
+	for range channelSize {
 		channelMgr.msgChannels = append(channelMgr.msgChannels, make([]chan p2p.Msg, MaxChannel, MaxChannel))
 	}
 

--- a/node/cn/channel_manager_test.go
+++ b/node/cn/channel_manager_test.go
@@ -53,10 +53,10 @@ func testChannelManager(t *testing.T, chSize int) {
 	channel := make(chan p2p.Msg, channelSizePerPeer)
 	consensusChannel := make(chan p2p.Msg, channelSizePerPeer)
 
-	for chIdx := 0; chIdx < chSize; chIdx++ {
+	for chIdx := range chSize {
 		// Before calling RegisterChannelWithIndex,
 		// calling GetChannelWithMsgCode with registered MsgCode should return no channel and no error.
-		for i := StatusMsg; i < MsgCodeEnd; i++ {
+		for i := range MsgCodeEnd {
 			if i == Unused10 || i == Unused11 {
 				// skip for dummy messages
 				continue
@@ -77,17 +77,17 @@ func testChannelManager(t *testing.T, chSize int) {
 	}
 
 	// Register channels with the port index.
-	for chIdx := 0; chIdx < chSize; chIdx++ {
+	for chIdx := range chSize {
 		cm.RegisterChannelWithIndex(chIdx, BlockChannel, channel)
 		cm.RegisterChannelWithIndex(chIdx, TxChannel, channel)
 		cm.RegisterChannelWithIndex(chIdx, MiscChannel, channel)
 		cm.RegisterChannelWithIndex(chIdx, ConsensusChannel, consensusChannel)
 	}
 
-	for chIdx := 0; chIdx < chSize; chIdx++ {
+	for chIdx := range chSize {
 		// After calling RegisterChannelWithIndex,
 		// calling GetChannelWithMsgCode with registered MsgCode should return a channel but no error.
-		for i := StatusMsg; i < MsgCodeEnd; i++ {
+		for i := range MsgCodeEnd {
 			if i == Unused10 || i == Unused11 {
 				// skip for dummy messages
 				continue

--- a/node/cn/filters/filter_system.go
+++ b/node/cn/filters/filter_system.go
@@ -313,7 +313,7 @@ func (es *EventSystem) eventLoop() {
 	}()
 
 	index := make(filterIndex)
-	for i := UnknownSubscription; i < LastIndexSubscription; i++ {
+	for i := range LastIndexSubscription {
 		index[i] = make(map[rpc.ID]*subscription)
 	}
 

--- a/node/cn/filters/filter_system_test.go
+++ b/node/cn/filters/filter_system_test.go
@@ -611,7 +611,7 @@ func TestPendingTxFilterDeadlock(t *testing.T) {
 
 	// Create a bunch of filters
 	fids := make([]rpc.ID, 20)
-	for i := 0; i < len(fids); i++ {
+	for i := range fids {
 		fid := api.NewPendingTransactionFilter()
 		fids[i] = fid
 		// Wait for at least one tx to arrive in filter

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1682,7 +1682,7 @@ func samplingPeers(peers []Peer, pickSize int) []Peer {
 
 	picker := rand.New(rand.NewSource(time.Now().Unix()))
 	peerCount := len(peers)
-	for i := 0; i < peerCount; i++ {
+	for i := range peerCount {
 		randIndex := picker.Intn(peerCount)
 		peers[i], peers[randIndex] = peers[randIndex], peers[i]
 	}

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -1007,7 +1007,7 @@ func TestProtocolManager_SetWsEndPoint(t *testing.T) {
 func TestBroadcastTxsSortedByPriceAndTime(t *testing.T) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 10)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	signer := types.LatestSignerForChainID(big.NewInt(1))
@@ -1079,7 +1079,7 @@ func TestBroadcastTxsSortedByPriceAndTime(t *testing.T) {
 func TestReBroadcastTxsSortedByTime(t *testing.T) {
 	// Generate a batch of accounts to start with
 	keys := make([]*ecdsa.PrivateKey, 10)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 	signer := types.LatestSignerForChainID(big.NewInt(1))
@@ -1222,7 +1222,7 @@ func TestGetBlockHeaders(t *testing.T) {
 		unknown[i] = byte(i)
 	}
 	getHashes := func(from, limit uint64) (hashes []common.Hash) {
-		for i := uint64(0); i < limit; i++ {
+		for i := range limit {
 			hashes = append(hashes, backend.GetBlockByNumber(from-1-i).Hash())
 		}
 		return hashes

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -540,7 +540,7 @@ func (p *basePeer) SendNewBlockHashes(hashes []common.Hash, numbers []uint64) er
 		p.AddToKnownBlocks(hash)
 	}
 	request := make(newBlockHashesData, len(hashes))
-	for i := 0; i < len(hashes); i++ {
+	for i := range hashes {
 		request[i].Hash = hashes[i]
 		request[i].Number = numbers[i]
 	}
@@ -727,7 +727,7 @@ func (p *basePeer) Handshake(network uint64, chainID, td *big.Int, head common.H
 	}()
 	timeout := time.NewTimer(handshakeTimeout)
 	defer timeout.Stop()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case err := <-errc:
 			if err != nil {
@@ -964,7 +964,7 @@ func (p *multiChannelPeer) SendNewBlockHashes(hashes []common.Hash, numbers []ui
 		p.AddToKnownBlocks(hash)
 	}
 	request := make(newBlockHashesData, len(hashes))
-	for i := 0; i < len(hashes); i++ {
+	for i := range hashes {
 		request[i].Hash = hashes[i]
 		request[i].Number = numbers[i]
 	}

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -142,7 +142,7 @@ func TestBasePeer_AsyncSendTransactions(t *testing.T) {
 	basePeer, _, _ := newBasePeer()
 
 	// To queuedTxs be filled with transactions
-	for i := 0; i < maxQueuedTxs; i++ {
+	for range maxQueuedTxs {
 		basePeer.AsyncSendTransactions(sentTxs)
 	}
 	// lastTxs shouldn't go into the queuedTxs

--- a/node/cn/snap/sync.go
+++ b/node/cn/snap/sync.go
@@ -750,7 +750,7 @@ func (s *Syncer) loadSyncStatus() {
 			big.NewInt(int64(accountConcurrency)),
 		), common.Big1,
 	)
-	for i := 0; i < accountConcurrency; i++ {
+	for i := range accountConcurrency {
 		last := common.BigToHash(new(big.Int).Add(next.Big(), step))
 		if i == accountConcurrency-1 {
 			// Make sure we don't overflow if the step is not a proper divisor

--- a/node/cn/snap/sync_test.go
+++ b/node/cn/snap/sync_test.go
@@ -73,7 +73,7 @@ func TestHashing(t *testing.T) {
 	t.Parallel()
 
 	bytecodes := make([][]byte, 10)
-	for i := 0; i < len(bytecodes); i++ {
+	for i := range bytecodes {
 		buf := make([]byte, 100)
 		rand.Read(buf)
 		bytecodes[i] = buf
@@ -81,7 +81,7 @@ func TestHashing(t *testing.T) {
 	var want, got string
 	old := func() {
 		hasher := sha3.NewLegacyKeccak256()
-		for i := 0; i < len(bytecodes); i++ {
+		for i := range bytecodes {
 			hasher.Reset()
 			hasher.Write(bytecodes[i])
 			hash := hasher.Sum(nil)
@@ -91,7 +91,7 @@ func TestHashing(t *testing.T) {
 	new := func() {
 		hasher := sha3.NewLegacyKeccak256().(statedb.KeccakState)
 		hash := make([]byte, 32)
-		for i := 0; i < len(bytecodes); i++ {
+		for i := range bytecodes {
 			hasher.Reset()
 			hasher.Write(bytecodes[i])
 			hasher.Read(hash)
@@ -107,14 +107,14 @@ func TestHashing(t *testing.T) {
 
 func BenchmarkHashing(b *testing.B) {
 	bytecodes := make([][]byte, 10000)
-	for i := 0; i < len(bytecodes); i++ {
+	for i := range bytecodes {
 		buf := make([]byte, 100)
 		rand.Read(buf)
 		bytecodes[i] = buf
 	}
 	old := func() {
 		hasher := sha3.NewLegacyKeccak256()
-		for i := 0; i < len(bytecodes); i++ {
+		for i := range bytecodes {
 			hasher.Reset()
 			hasher.Write(bytecodes[i])
 			hasher.Sum(nil)
@@ -123,7 +123,7 @@ func BenchmarkHashing(b *testing.B) {
 	new := func() {
 		hasher := sha3.NewLegacyKeccak256().(statedb.KeccakState)
 		hash := make([]byte, 32)
-		for i := 0; i < len(bytecodes); i++ {
+		for i := range bytecodes {
 			hasher.Reset()
 			hasher.Write(bytecodes[i])
 			hasher.Read(hash)
@@ -1570,7 +1570,7 @@ func makeUnevenStorageTrie(slots int, db *statedb.Database) (*statedb.Trie, entr
 		trie, _ = statedb.NewTrie(types.EmptyRootHash, db, nil)
 		chosen  = make(map[byte]struct{})
 	)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		var n int
 		for {
 			n = mrand.Intn(15) // the last range is set empty deliberately

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -113,7 +113,7 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 			}
 		}
 		// Database does not have the state for the given block, try to regenerate
-		for i := uint64(0); i < reexec; i++ {
+		for range reexec {
 			if current.NumberU64() == 0 {
 				return nil, nil, errors.New("genesis state is missing")
 			}

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -387,7 +387,7 @@ func (api *CommonAPI) traceChain(start, end *types.Block, config *TraceConfig, n
 		localctx = context.Background()
 		reler    = new(releaser)
 	)
-	for th := 0; th < threads; th++ {
+	for range threads {
 		pend.Go(func() {
 
 			// Fetch and execute the block trace tasks
@@ -698,7 +698,7 @@ func (api *CommonAPI) traceBlock(ctx context.Context, block *types.Block, config
 	)
 
 	threads := min(runtime.NumCPU(), len(txs))
-	for th := 0; th < threads; th++ {
+	for range threads {
 		pend.Go(func() {
 
 			// Fetch and execute the next transaction trace tasks

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -525,7 +525,7 @@ func (a Accounts) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a Accounts) Less(i, j int) bool { return bytes.Compare(a[i].addr.Bytes(), a[j].addr.Bytes()) < 0 }
 
 func newAccounts(n int) (accounts Accounts) {
-	for i := 0; i < n; i++ {
+	for range n {
 		key, _ := crypto.GenerateKey()
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 		accounts = append(accounts, Account{key: key, addr: addr})

--- a/node/node.go
+++ b/node/node.go
@@ -795,7 +795,7 @@ func NtpCheckWithLocal(n *Node) error {
 
 	ntpRetryTime := time.Duration(1)
 	var remote *time.Time
-	for i := 0; i < ntpMaxRetry; i++ {
+	for range ntpMaxRetry {
 		time.Sleep(ntpRetryTime)
 		remote, err = ntpclient.GetNetworkTime(url, portNum)
 		if remote != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -50,7 +50,7 @@ func TestNodeLifeCycle(t *testing.T) {
 		t.Fatalf("failed to create protocol stack: %v", err)
 	}
 	// Ensure that a stopped node can be stopped again
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := stack.Stop(); err != ErrNodeStopped {
 			t.Fatalf("iter %d: stop failure mismatch: have %v, want %v", i, err, ErrNodeStopped)
 		}
@@ -63,7 +63,7 @@ func TestNodeLifeCycle(t *testing.T) {
 		t.Fatalf("start failure mismatch: have %v, want %v ", err, ErrNodeRunning)
 	}
 	// Ensure that a node can be restarted arbitrarily many times
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := stack.Restart(); err != nil {
 			t.Fatalf("iter %d: failed to restart node: %v", i, err)
 		}
@@ -224,7 +224,7 @@ func TestServiceRestarts(t *testing.T) {
 		t.Fatalf("running/started mismatch: have %v/%d, want true/1", running, started)
 	}
 	// Restart the stack a few times and check successful service restarts
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := stack.Restart(); err != nil {
 			t.Fatalf("iter %d: failed to restart stack: %v", i, err)
 		}
@@ -267,7 +267,7 @@ func TestServiceConstructionAbortion(t *testing.T) {
 		t.Fatalf("failer registration failed: %v", err)
 	}
 	// Start the protocol stack and ensure none of the services get started
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if err := stack.Start(); err != failure {
 			t.Fatalf("iter %d: stack startup failure mismatch: have %v, want %v", i, err, failure)
 		}
@@ -318,7 +318,7 @@ func TestServiceStartupAbortion(t *testing.T) {
 		t.Fatalf("failer registration failed: %v", err)
 	}
 	// Start the protocol stack and ensure all started services stop
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if err := stack.Start(); err != failure {
 			t.Fatalf("iter %d: stack startup failure mismatch: have %v, want %v", i, err, failure)
 		}
@@ -370,7 +370,7 @@ func TestServiceTerminationGuarantee(t *testing.T) {
 		t.Fatalf("failer registration failed: %v", err)
 	}
 	// Start the protocol stack, and ensure that a failing shut down terminates all
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		// Start the stack and make sure all is online
 		if err := stack.Start(); err != nil {
 			t.Fatalf("iter %d: failed to start protocol stack: %v", i, err)
@@ -459,7 +459,7 @@ func TestProtocolGather(t *testing.T) {
 	}
 	for id, config := range services {
 		protocols := make([]p2p.Protocol, config.Count)
-		for i := 0; i < len(protocols); i++ {
+		for i := range protocols {
 			protocols[i].Name = id
 			protocols[i].Version = uint(i)
 		}
@@ -485,7 +485,7 @@ func TestProtocolGather(t *testing.T) {
 	for id, config := range services {
 		for ver := 0; ver < config.Count; ver++ {
 			launched := false
-			for i := 0; i < len(protocols); i++ {
+			for i := range protocols {
 				if protocols[i].Name == id && protocols[i].Version == uint(ver) {
 					launched = true
 					break

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -271,7 +271,7 @@ func TestBridgeManager(t *testing.T) {
 	testURIs := []string{"", "testURI", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
 	// 6. Register (Mint) an NFT to Alice
 	{
-		for i := 0; i < len(nftTokenIDs); i++ {
+		for i := range nftTokenIDs {
 			tx, err = nft.MintWithTokenURI(&bind.TransactOpts{From: alice.From, Signer: alice.Signer, GasLimit: testGasLimit}, alice.From, big.NewInt(int64(nftTokenIDs[i])), testURIs[i])
 			assert.NoError(t, err)
 			t.Log("Register NFT Transaction", tx.Hash().Hex())
@@ -307,7 +307,7 @@ func TestBridgeManager(t *testing.T) {
 
 	// 9. Request NFT transfer from Alice to Bob
 	{
-		for i := 0; i < len(nftTokenIDs); i++ {
+		for i := range nftTokenIDs {
 			tx, err = nft.RequestValueTransfer(&bind.TransactOpts{From: alice.From, Signer: alice.Signer, GasLimit: testGasLimit}, big.NewInt(int64(nftTokenIDs[i])), bob.From, nil)
 			assert.NoError(t, err)
 			t.Log("nft.RequestValueTransfer Transaction", tx.Hash().Hex())
@@ -340,7 +340,7 @@ func TestBridgeManager(t *testing.T) {
 
 	// 12. Check NFT owner sent by RequestValueTransfer()
 	{
-		for i := 0; i < len(nftTokenIDs); i++ {
+		for i := range nftTokenIDs {
 			owner, err := nft.OwnerOf(nil, big.NewInt(int64(nftTokenIDs[i])))
 			assert.Equal(t, nil, err)
 			assert.Equal(t, bob.From, owner)
@@ -1062,7 +1062,7 @@ func TestMethodRestoreBridges(t *testing.T) {
 	assert.NoError(t, err)
 
 	var bridgeAddrs [4]common.Address
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		if i%2 == 0 {
 			bridgeAddrs[i], err = bm.DeployBridgeTest(sim, 10000, true)
 		} else {
@@ -1095,13 +1095,13 @@ func TestMethodRestoreBridges(t *testing.T) {
 	}
 
 	// Case 1: check bridge contract creation.
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		info, _ := bm.GetBridgeInfo(bridgeAddrs[i])
 		assert.NotEqual(t, nil, info.bridge)
 	}
 
 	// Case 2: check subscription
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		info, _ := bm.GetBridgeInfo(bridgeAddrs[i])
 		assert.Equal(t, true, info.subscribed)
 	}
@@ -2719,7 +2719,7 @@ func TestGetBridgeContractBalance(t *testing.T) {
 
 	// Case 2 - ? (Random)
 	{
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			initialChildbridgeBalance, initialParentbridgeBalance := rand.Int63n(10000), rand.Int63n(10000)
 			cBridgeAddr, err := bm.DeployBridgeTest(sim, initialChildbridgeBalance, true)
 			assert.NoError(t, err)

--- a/node/sc/bridge_test.go
+++ b/node/sc/bridge_test.go
@@ -1218,7 +1218,7 @@ func TestBridgeRequestHandleGasUsed(t *testing.T) {
 	}
 
 	// handle 0 ~ 499 nonce
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		handleFunc(i)
 	}
 
@@ -1323,7 +1323,7 @@ func TestBridgeMaxOperatorHandleTxGasUsed(t *testing.T) {
 		t.Log("Handle value transfer tx receipt", "gasUsed", receipt.GasUsed, "status", receipt.Status)
 	}
 
-	for i := 0; i < maxOperator; i++ {
+	for i := range maxOperator {
 		handleFunc(authList[i], 0)
 	}
 
@@ -1343,7 +1343,7 @@ func TestBridgeThresholdLimit(t *testing.T) {
 	maxOperator := 12
 
 	var authList []*bind.TransactOpts
-	for i := 0; i < maxOperator; i++ {
+	for i := range maxOperator {
 		authKey, _ := crypto.GenerateKey()
 		authList = append(authList, bind.NewKeyedTransactor(authKey))
 		authList[i].GasLimit = DefaultBridgeTxGasLimit

--- a/node/sc/bridgepeer.go
+++ b/node/sc/bridgepeer.go
@@ -288,7 +288,7 @@ func (p *baseBridgePeer) Handshake(network uint64, chainID, td *big.Int, head co
 	}()
 	timeout := time.NewTimer(handshakeTimeout)
 	defer timeout.Stop()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case err := <-errc:
 			if err != nil {

--- a/node/sc/bridgepool/sorted_map_list_test.go
+++ b/node/sc/bridgepool/sorted_map_list_test.go
@@ -48,7 +48,7 @@ func TestSortedMap_Put(t *testing.T) {
 	sortedMap := NewItemSortedMap(sizeOfSortedMap)
 
 	// test a sortedMap without a size limit.
-	for i := uint64(0); i < 10000000; i++ {
+	for i := range uint64(10000000) {
 		err := sortedMap.Put(newItem(i))
 		assert.NoError(t, err)
 		assert.Equal(t, int(i+1), sortedMap.Len())

--- a/node/sc/kas/anchor_test.go
+++ b/node/sc/kas/anchor_test.go
@@ -153,7 +153,7 @@ func testBlockToAnchoringDataInternalType0(t *testing.T, period uint64) {
 	pastCnt := [100]uint64{}
 	txCnt := uint64(0)
 
-	for blkNum := uint64(0); blkNum < testBlkN; blkNum++ {
+	for blkNum := range testBlkN {
 		// Gen random block
 		header := &types.Header{Number: big.NewInt(int64(blkNum))}
 		block := types.NewBlockWithHeader(header)
@@ -185,7 +185,7 @@ func genTransactions(n uint64) (types.Transactions, error) {
 
 	txs := types.Transactions{}
 
-	for i := uint64(0); i < n; i++ {
+	for range n {
 		tx, _ := types.SignTx(
 			types.NewTransaction(0, addr,
 				big.NewInt(int64(n)), 0, big.NewInt(int64(n)), nil), signer, key)

--- a/node/sc/multi_bridge_test.go
+++ b/node/sc/multi_bridge_test.go
@@ -76,7 +76,7 @@ func prepareMultiBridgeEventTest(t *testing.T) *multiBridgeTestInfo {
 	accountMap := make(map[common.Address]blockchain.GenesisAccount)
 	res.accounts = make([]*bind.TransactOpts, maxAccounts)
 
-	for i := 0; i < maxAccounts; i++ {
+	for i := range maxAccounts {
 		accKey, _ := crypto.GenerateKey()
 		res.accounts[i] = bind.NewKeyedTransactor(accKey)
 		accountMap[res.accounts[i].From] = blockchain.GenesisAccount{Balance: big.NewInt(params.KAIA)}
@@ -94,7 +94,7 @@ func prepareMultiBridgeEventTest(t *testing.T) *multiBridgeTestInfo {
 	assert.Nil(t, bind.CheckWaitMined(res.sim, tx))
 
 	owner := res.accounts[0]
-	for i := 0; i < maxAccounts; i++ {
+	for i := range maxAccounts {
 		acc := res.accounts[i]
 		opts := &bind.TransactOpts{From: owner.From, Signer: owner.Signer, GasLimit: DefaultBridgeTxGasLimit}
 		_, _ = b.RegisterOperator(opts, acc.From)
@@ -1206,7 +1206,7 @@ func TestNoncesAndBlockNumberUnordered(t *testing.T) {
 		{3, 400, 3, 4, 400},
 	}
 
-	for i := 0; i < len(testCases); i++ {
+	for i := range testCases {
 		sentNonce := testCases[i].requestNonce
 		sentBlockNumber := testCases[i].requestBlkNum
 		t.Log("test round", "i", i, "nonce", sentNonce, "blk", sentBlockNumber)
@@ -1230,7 +1230,7 @@ func TestNoncesAndBlockNumberUnordered(t *testing.T) {
 	lowerHandleNonce, _ := info.b.LowerHandleNonce(nil)
 	assert.Equal(t, uint64(4), lowerHandleNonce)
 
-	for i := 0; i < len(testCases); i++ {
+	for i := range testCases {
 		sentNonce := testCases[i].requestNonce
 		sentBlockNumber := testCases[i].requestBlkNum
 		t.Log("test round", "i", i, "nonce", sentNonce, "blk", sentBlockNumber)

--- a/node/sc/vt_contract_test.go
+++ b/node/sc/vt_contract_test.go
@@ -42,7 +42,7 @@ func TestTokenPublicVariables(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -89,7 +89,7 @@ func TestNFTPublicVariables(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -110,7 +110,7 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 
 	// 1. Init dummy chain and do some value transfers.
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -180,9 +180,9 @@ func TestKLAYTransferLongRangeRecovery(t *testing.T) {
 
 	// 1. Init dummy chain and do some value transfers.
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
-			for i := uint64(0); i < filterLogsStride; i++ {
+			for range filterLogsStride {
 				info.sim.Commit()
 			}
 		}
@@ -247,7 +247,7 @@ func TestBasicTokenTransferRecovery(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[ERC20].request(info, info.localInfo)
 		}
 	})
@@ -287,7 +287,7 @@ func TestBasicNFTTransferRecovery(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[ERC721].request(info, info.localInfo)
 		}
 	})
@@ -326,7 +326,7 @@ func TestMethodRecover(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -364,7 +364,7 @@ func TestMethodStop(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -401,7 +401,7 @@ func TestFlagVTRecovery(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -428,7 +428,7 @@ func TestAlreadyStartedVTRecovery(t *testing.T) {
 		}
 	}()
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -456,7 +456,7 @@ func TestScenarioMainChainRecovery(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.remoteInfo)
 		}
 	})
@@ -494,7 +494,7 @@ func TestScenarioAutomaticRecovery(t *testing.T) {
 	}()
 
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -535,7 +535,7 @@ func TestMultiOperatorRequestRecovery(t *testing.T) {
 
 	// 1. Init dummy chain and do some value transfers.
 	info := prepare(t, func(info *testInfo) {
-		for i := 0; i < testTxCount; i++ {
+		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
 	})
@@ -754,7 +754,7 @@ func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 	assert.Nil(t, bind.CheckWaitMined(sim, tx))
 
 	// Register an NFT to chain account (minting)
-	for i := 0; i < testTxCount; i++ {
+	for i := range testTxCount {
 		opts := &bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}
 		tx, err = nftLocal.MintWithTokenURI(opts, cAcc.From, big.NewInt(testNFT+int64(i)), "testURI")
 		assert.NoError(t, err)

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -82,7 +82,7 @@ func TestNewListStream(t *testing.T) {
 	if size, err := ls.List(); size != 3 || err != nil {
 		t.Errorf("List() returned (%d, %v), expected (3, nil)", size, err)
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if val, err := ls.Uint(); val != 1 || err != nil {
 			t.Errorf("Uint() returned (%d, %v), expected (1, nil)", val, err)
 		}
@@ -1236,7 +1236,7 @@ func BenchmarkDecodeU256Ints(b *testing.B) {
 
 func encodeTestSlice(n uint) []byte {
 	s := make([]uint, n)
-	for i := uint(0); i < n; i++ {
+	for i := range n {
 		s[i] = i
 	}
 	b, err := EncodeToBytes(s)

--- a/rlp/encode.go
+++ b/rlp/encode.go
@@ -314,7 +314,7 @@ func makeSliceWriter(typ reflect.Type, ts rlpstruct.Tags) (writer, error) {
 		// w.list is not called for them.
 		wfn = func(val reflect.Value, w *encBuffer) error {
 			vlen := val.Len()
-			for i := 0; i < vlen; i++ {
+			for i := range vlen {
 				if err := etypeinfo.writer(val.Index(i), w); err != nil {
 					return err
 				}
@@ -330,7 +330,7 @@ func makeSliceWriter(typ reflect.Type, ts rlpstruct.Tags) (writer, error) {
 				return nil
 			}
 			listOffset := w.list()
-			for i := 0; i < vlen; i++ {
+			for i := range vlen {
 				if err := etypeinfo.writer(val.Index(i), w); err != nil {
 					return err
 				}

--- a/rlp/encode_test.go
+++ b/rlp/encode_test.go
@@ -493,9 +493,9 @@ func TestEncodeToReaderPiecewise(t *testing.T) {
 func TestEncodeToReaderReturnToPool(t *testing.T) {
 	buf := make([]byte, 50)
 	wg := new(sync.WaitGroup)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		wg.Go(func() {
-			for i := 0; i < 1000; i++ {
+			for range 1000 {
 				_, r, _ := EncodeToReader("foo")
 				io.ReadAll(r)
 				r.Read(buf)

--- a/snapshot/conversion.go
+++ b/snapshot/conversion.go
@@ -216,7 +216,7 @@ func generateTrieRoot(it Iterator, accountHash common.Hash, generatorFn trieGene
 	// processing and gathering results.
 	threads := runtime.NumCPU()
 	results := make(chan error, threads)
-	for i := 0; i < threads; i++ {
+	for range threads {
 		results <- nil // fill the semaphore
 	}
 	// stop is a helper function to shutdown the background threads
@@ -224,7 +224,7 @@ func generateTrieRoot(it Iterator, accountHash common.Hash, generatorFn trieGene
 	stop := func(fail error) (common.Hash, error) {
 		close(in)
 		result := <-out
-		for i := 0; i < threads; i++ {
+		for range threads {
 			if err := <-results; err != nil && fail == nil {
 				fail = err
 			}

--- a/snapshot/difflayer_test.go
+++ b/snapshot/difflayer_test.go
@@ -65,7 +65,7 @@ func TestMergeBasics(t *testing.T) {
 		storage   = make(map[common.Hash]map[common.Hash][]byte)
 	)
 	// Fill up a parent
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		h := randomHash()
 		data := randomAccount()
 

--- a/snapshot/disklayer_test.go
+++ b/snapshot/disklayer_test.go
@@ -223,7 +223,7 @@ func TestDiskMerge(t *testing.T) {
 func TestDiskPartialMerge(t *testing.T) {
 	// Iterate the test a few times to ensure we pick various internal orderings
 	// for the data slots as well as the progress marker.
-	for i := 0; i < 1024; i++ {
+	for i := range 1024 {
 		// Create some accounts in the disk layer
 		db := database.NewMemoryDBManager()
 

--- a/snapshot/generate_test.go
+++ b/snapshot/generate_test.go
@@ -616,7 +616,7 @@ func TestGenerateCorruptStorageTrie(t *testing.T) {
 
 func getStorageTrie(n int, triedb *statedb.Database) *statedb.SecureTrie {
 	stTrie, _ := statedb.NewSecureTrie(common.Hash{}, triedb, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		k := fmt.Sprintf("key-%d", i)
 		v := fmt.Sprintf("val-%d", i)
 		stTrie.Update([]byte(k), []byte(v))
@@ -705,7 +705,7 @@ func TestGenerateWithManyExtraAccounts(t *testing.T) {
 		diskdb.WriteStorageSnapshot(key, hashData([]byte("key-3")), []byte("val-3"))
 	}
 	{ // 100 accounts exist only in snapshot
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			acc, _ := genExternallyOwnedAccount(uint64(i), big.NewInt(int64(i)))
 			val, _ := rlp.EncodeToBytes(acc)
 			key := hashData(fmt.Appendf(nil, "acc-%d", i))
@@ -838,7 +838,7 @@ func TestGenerateFromEmptySnap(t *testing.T) {
 	helper := newHelper()
 	stRoot := helper.makeStorageTrie([]string{"key-1", "key-2", "key-3"}, []string{"val-1", "val-2", "val-3"})
 	// Add 1K accounts to the trie
-	for i := 0; i < 400; i++ {
+	for i := range 400 {
 		acc, _ := genSmartContractAccount(0, big.NewInt(1), stRoot, types.EmptyCodeHash.Bytes())
 		helper.addTrieAccount(fmt.Sprintf("acc-%d", i), acc)
 	}
@@ -875,13 +875,13 @@ func TestGenerateWithIncompleteStorage(t *testing.T) {
 	// We add 8 accounts, each one is missing exactly one of the storage slots. This means
 	// we don't have to order the keys and figure out exactly which hash-key winds up
 	// on the sensitive spots at the boundaries
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		accKey := fmt.Sprintf("acc-%d", i)
 		acc, _ := genSmartContractAccount(0, big.NewInt(1), stRoot, types.EmptyCodeHash.Bytes())
 		helper.addAccount(accKey, acc)
 		var moddedKeys []string
 		var moddedVals []string
-		for ii := 0; ii < 8; ii++ {
+		for ii := range 8 {
 			if ii != i {
 				moddedKeys = append(moddedKeys, stKeys[ii])
 				moddedVals = append(moddedVals, stVals[ii])

--- a/snapshot/iterator_test.go
+++ b/snapshot/iterator_test.go
@@ -43,7 +43,7 @@ func TestAccountIteratorBasics(t *testing.T) {
 		storage   = make(map[common.Hash]map[common.Hash][]byte)
 	)
 	// Fill up a parent
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		h := randomHash()
 		data := randomAccount()
 
@@ -77,7 +77,7 @@ func TestStorageIteratorBasics(t *testing.T) {
 		storage    = make(map[common.Hash]map[common.Hash][]byte)
 	)
 	// Fill some random data
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		h := randomHash()
 		accounts[h] = randomAccount()
 
@@ -85,7 +85,7 @@ func TestStorageIteratorBasics(t *testing.T) {
 		value := make([]byte, 32)
 
 		var nilstorage int
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			crand.Read(value)
 			if rand.Intn(2) == 0 {
 				accStorage[randomHash()] = common.CopyBytes(value)
@@ -526,7 +526,7 @@ func TestAccountIteratorLargeTraversal(t *testing.T) {
 	// Create a custom account factory to recreate the same addresses
 	makeAccounts := func(num int) map[common.Hash][]byte {
 		accounts := make(map[common.Hash][]byte)
-		for i := 0; i < num; i++ {
+		for i := range num {
 			h := common.Hash{}
 			binary.BigEndian.PutUint64(h[:], uint64(i+1))
 			accounts[h] = randomAccount()
@@ -852,7 +852,7 @@ func BenchmarkAccountIteratorTraversal(b *testing.B) {
 	// Create a custom account factory to recreate the same addresses
 	makeAccounts := func(num int) map[common.Hash][]byte {
 		accounts := make(map[common.Hash][]byte)
-		for i := 0; i < num; i++ {
+		for i := range num {
 			h := common.Hash{}
 			binary.BigEndian.PutUint64(h[:], uint64(i+1))
 			accounts[h] = randomAccount()
@@ -948,7 +948,7 @@ func BenchmarkAccountIteratorLargeBaselayer(b *testing.B) {
 	// Create a custom account factory to recreate the same addresses
 	makeAccounts := func(num int) map[common.Hash][]byte {
 		accounts := make(map[common.Hash][]byte)
-		for i := 0; i < num; i++ {
+		for i := range num {
 			h := common.Hash{}
 			binary.BigEndian.PutUint64(h[:], uint64(i+1))
 			accounts[h] = randomAccount()

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -373,7 +373,7 @@ func TestSnaphots(t *testing.T) {
 		last = common.HexToHash("0x01")
 		head common.Hash
 	)
-	for i := 0; i < 129; i++ {
+	for i := range 129 {
 		head = makeRoot(uint64(i + 2))
 		snaps.Update(head, last, nil, setAccount(fmt.Sprintf("%d", i+2)), nil)
 		last = head

--- a/storage/database/database_test.go
+++ b/storage/database/database_test.go
@@ -301,7 +301,7 @@ func (ts *commonDatabaseTestSuite) TestParallelPutGet() {
 	var pending sync.WaitGroup
 
 	pending.Add(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go func(key string) {
 			defer pending.Done()
 			err := db.Put([]byte(key), []byte("v"+key))
@@ -313,7 +313,7 @@ func (ts *commonDatabaseTestSuite) TestParallelPutGet() {
 	pending.Wait()
 
 	pending.Add(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go func(key string) {
 			defer pending.Done()
 			data, err := db.Get([]byte(key))
@@ -328,7 +328,7 @@ func (ts *commonDatabaseTestSuite) TestParallelPutGet() {
 	pending.Wait()
 
 	pending.Add(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go func(key string) {
 			defer pending.Done()
 			err := db.Delete([]byte(key))
@@ -340,7 +340,7 @@ func (ts *commonDatabaseTestSuite) TestParallelPutGet() {
 	pending.Wait()
 
 	pending.Add(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go func(key string) {
 			defer pending.Done()
 			_, err := db.Get([]byte(key))
@@ -356,7 +356,7 @@ func (ts *commonDatabaseTestSuite) TestParallelPutGet() {
 // specified for every DBEntryType.
 func TestDBEntryLengthCheck(t *testing.T) {
 	dbRatioSum := 0
-	for i := 0; i < int(databaseEntryTypeSize); i++ {
+	for i := range int(databaseEntryTypeSize) {
 		if dbBaseDirs[i] == "" {
 			t.Fatalf("Database directory should be specified! index: %v", i)
 		}
@@ -393,7 +393,7 @@ func (d testDataSlice) Less(i, j int) bool {
 
 func insertRandomData(db KeyValueWriter, prefix []byte, num int) (testDataSlice, error) {
 	ret := testDataSlice{}
-	for i := 0; i < num; i++ {
+	for range num {
 		key := common.MakeRandomBytes(32)
 		val := append(key, key...)
 		if len(prefix) > 0 {
@@ -606,7 +606,7 @@ func (ts *commonDatabaseTestSuite) Test_BatchWrite() {
 	batch := db.NewBatch()
 	defer batch.Release()
 	data := testDataSlice{}
-	for i := 0; i < numIter; i++ {
+	for range numIter {
 		inserted, _ := insertRandomData(batch, nil, numData)
 		batch.Write()
 		batch.Reset()

--- a/storage/database/database_test_util.go
+++ b/storage/database/database_test_util.go
@@ -34,7 +34,7 @@ func NewLevelDBManagerForTest(dbc *DBConfig, levelDBOption *opt.Options) (DBMana
 
 	var ldb *levelDB
 	var err error
-	for i := 0; i < int(databaseEntryTypeSize); i++ {
+	for i := range int(databaseEntryTypeSize) {
 		if dbm.config.SingleDB {
 			if i == 0 {
 				ldb, err = NewLevelDBWithOption(dbc.Dir, levelDBOption)

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -387,7 +387,7 @@ var dbConfigRatio = [databaseEntryTypeSize]int{
 // If it isn't, logger.Crit is called.
 func checkDBEntryConfigRatio() {
 	entryConfigRatioSum := 0
-	for i := 0; i < int(databaseEntryTypeSize); i++ {
+	for i := range int(databaseEntryTypeSize) {
 		entryConfigRatioSum += dbConfigRatio[i]
 	}
 	if entryConfigRatioSum != 100 {
@@ -493,7 +493,7 @@ func singleDatabaseDBManager(dbc *DBConfig) (DBManager, error) {
 	}
 
 	db.Meter(dbMetricPrefix)
-	for i := 0; i < int(databaseEntryTypeSize); i++ {
+	for i := range int(databaseEntryTypeSize) {
 		dbm.dbs[i] = db
 	}
 	return dbm, nil
@@ -968,23 +968,23 @@ func (dbm *databaseManager) TryCatchUpWithPrimary() error {
 }
 
 func (dbm *databaseManager) Stat(property string) (string, error) {
-	stats := ""
-	errs := ""
+	var stats strings.Builder
+	var errs strings.Builder
 	for idx, db := range dbm.dbs {
 		if db != nil {
 			stat, err := db.Stat(property)
 			headInfo := fmt.Sprintf(" [%s:%s]\n", DBEntryType(idx), db.Type())
 			if err == nil {
-				stats += headInfo + stat
+				stats.WriteString(headInfo + stat)
 			} else {
-				errs += headInfo + err.Error()
+				errs.WriteString(headInfo + err.Error())
 			}
 		}
 	}
-	if errs == "" {
-		return stats, nil
+	if errs.String() == "" {
+		return stats.String(), nil
 	} else {
-		return stats, errors.New(errs)
+		return stats.String(), errors.New(errs.String())
 	}
 }
 

--- a/storage/database/db_migration.go
+++ b/storage/database/db_migration.go
@@ -120,7 +120,7 @@ func (dbm *databaseManager) StartDBMigration(dstdbm DBManager) error {
 	// from non single DB
 	if !dbm.config.SingleDB {
 		errChan := make(chan error, databaseEntryTypeSize)
-		for et := MiscDB; et < databaseEntryTypeSize; et++ {
+		for et := range databaseEntryTypeSize {
 			srcDB := dbm.getDatabase(et)
 
 			dstDB := dstdbm.getDatabase(MiscDB)
@@ -146,7 +146,7 @@ func (dbm *databaseManager) StartDBMigration(dstdbm DBManager) error {
 			}()
 		}
 
-		for et := MiscDB; et < databaseEntryTypeSize; et++ {
+		for range databaseEntryTypeSize {
 			err := <-errChan
 			if err != nil {
 				logger.Error("copyDB got an error", "err", err)
@@ -170,7 +170,7 @@ func (dbm *databaseManager) StartDBMigration(dstdbm DBManager) error {
 	// If the current src DB is misc DB, clear all db dir on dst
 	// TODO: If DB Migration supports non-single db, change the checking logic
 	if path.Base(dbm.config.Dir) == dbBaseDirs[MiscDB] {
-		for i := uint8(MiscDB); i < uint8(databaseEntryTypeSize); i++ {
+		for i := range uint8(databaseEntryTypeSize) {
 			dstdbm.setDBDir(DBEntryType(i), "")
 		}
 	}

--- a/storage/database/dynamodb.go
+++ b/storage/database/dynamodb.go
@@ -459,7 +459,7 @@ func (dynamo *dynamoDB) NewIterator(prefix []byte, start []byte) Iterator {
 
 func createBatchWriteWorkerPool() {
 	dynamoWriteCh = make(chan *batchWriteWorkerInput, itemChanSize)
-	for i := 0; i < WorkerNum; i++ {
+	for range WorkerNum {
 		go createBatchWriteWorker(dynamoWriteCh)
 	}
 	logger.Info("made dynamo batch write workers", "workerNum", WorkerNum)

--- a/storage/database/dynamodb_readonly_test.go
+++ b/storage/database/dynamodb_readonly_test.go
@@ -75,7 +75,7 @@ func TestDynamoDBReadOnly_Write(t *testing.T) {
 
 	itemNum := 25
 	// put items
-	for i := 0; i < itemNum; i++ {
+	for range itemNum {
 		testKey := common.MakeRandomBytes(32)
 		testVal := common.MakeRandomBytes(500)
 
@@ -87,7 +87,7 @@ func TestDynamoDBReadOnly_Write(t *testing.T) {
 	assert.NoError(t, batch.Write())
 
 	// check if not exist
-	for i := 0; i < itemNum; i++ {
+	for i := range itemNum {
 		val, err := dynamo.Get(testKeys[i])
 		assert.Nil(t, val)
 		assert.Error(t, err)

--- a/storage/database/dynamodb_test.go
+++ b/storage/database/dynamodb_test.go
@@ -99,7 +99,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write() {
 	batch := dynamo.NewBatch()
 
 	itemNum := 25
-	for i := 0; i < itemNum; i++ {
+	for range itemNum {
 		testKey := common.MakeRandomBytes(32)
 		testVal := common.MakeRandomBytes(500)
 
@@ -111,7 +111,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write() {
 	s.NoError(batch.Write())
 
 	// check if exist
-	for i := 0; i < itemNum; i++ {
+	for i := range itemNum {
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
 		s.NoError(returnedErr)
 		s.Equal(hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
@@ -128,7 +128,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write_LargeData() {
 	batch := dynamo.NewBatch()
 
 	itemNum := 26
-	for i := 0; i < itemNum; i++ {
+	for range itemNum {
 		testKey := common.MakeRandomBytes(32)
 		testVal := common.MakeRandomBytes(500 * 1024)
 
@@ -140,7 +140,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write_LargeData() {
 	s.NoError(batch.Write())
 
 	// check if exist
-	for i := 0; i < itemNum; i++ {
+	for i := range itemNum {
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
 		s.NoError(returnedErr)
 		s.Equal(hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
@@ -157,7 +157,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write_DuplicatedKey() {
 	batch := dynamo.NewBatch()
 
 	itemNum := 25
-	for i := 0; i < itemNum; i++ {
+	for range itemNum {
 		testKey := common.MakeRandomBytes(256)
 		testVal := common.MakeRandomBytes(600)
 
@@ -171,7 +171,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write_DuplicatedKey() {
 	s.NoError(batch.Write())
 
 	// check if exist
-	for i := 0; i < itemNum; i++ {
+	for i := range itemNum {
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
 		s.NoError(returnedErr)
 		s.Equal(hexutil.Encode(testVals[i]), hexutil.Encode(returnedVal))
@@ -205,9 +205,9 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write_MultiTables() {
 	batch2 := dynamo2.NewBatch()
 
 	itemNum := WorkerNum * 2
-	for i := 0; i < itemNum; i++ {
+	for range itemNum {
 		// write batch items to db1 and db2 in turn
-		for j := 0; j < dynamoBatchSize; j++ {
+		for range dynamoBatchSize {
 			// write key and val to db1
 			testKey := common.MakeRandomBytes(10)
 			testVal := common.MakeRandomBytes(20)
@@ -231,7 +231,7 @@ func (s *SuiteDynamoDB) TestDynamoBatch_Write_MultiTables() {
 	s.NoError(batch2.Write())
 
 	// check if exist
-	for i := 0; i < itemNum; i++ {
+	for i := range itemNum {
 		// dynamodb 1 - check if wrote key and val
 		returnedVal, returnedErr := dynamo.Get(testKeys[i])
 		s.NoError(returnedErr)
@@ -286,7 +286,7 @@ func TestDynamoDB_Retry(t *testing.T) {
 		serverReadyWg.Done()
 
 		// expected request number: dynamoMaxRetry+1. It will wait one more time after all retry done.
-		for i := 0; i < dynamoMaxRetry+1+1; i++ {
+		for range dynamoMaxRetry + 1 + 1 {
 			// Deadline prevents infinite waiting of the fake server
 			// Wait longer than (maxRetries+1) * timeout
 			if err := listen.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {

--- a/storage/database/leveldb_bench_common_test.go
+++ b/storage/database/leveldb_bench_common_test.go
@@ -166,7 +166,7 @@ func benchmarkCacheGetParallel(b *testing.B, cache common.Cache, valueSize int) 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			for i := 0; i < numberOfGet; i++ {
+			for i := range numberOfGet {
 				key := hashKeys[(i*primeNumber)%numDataInsertions]
 				cache.Get(key)
 			}
@@ -218,11 +218,11 @@ func initCacheData(cache common.Cache, valueSize int) []common.Hash {
 func TestLRUShardCacheAddressKey(t *testing.T) {
 	cache := common.NewCache(common.LRUShardConfig{CacheSize: 40960, NumShards: 4096})
 
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		cache.Add(getAddressKey(i), i)
 	}
 
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		data, ok := cache.Get(getAddressKey(i))
 		assert.True(t, ok)
 		assert.Equal(t, i, data.(int))
@@ -234,11 +234,11 @@ func TestLRUShardCacheAddressKey(t *testing.T) {
 func TestLRUShardCacheAddressKeyFromFront(t *testing.T) {
 	cache := common.NewCache(common.LRUShardConfig{CacheSize: 40960, NumShards: 4096})
 
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		cache.Add(getAddressKeyFromFront(i), i)
 	}
 
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		data, ok := cache.Get(getAddressKeyFromFront(i))
 		assert.True(t, ok)
 		assert.Equal(t, i, data.(int))
@@ -250,11 +250,11 @@ func TestLRUShardCacheAddressKeyFromFront(t *testing.T) {
 func TestLRUShardCacheHashKey(t *testing.T) {
 	cache := common.NewCache(common.LRUShardConfig{CacheSize: 40960, NumShards: 4096})
 
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		cache.Add(getHashKey(i), i)
 	}
 
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		data, ok := cache.Get(getHashKey(i))
 		assert.True(t, ok)
 		assert.Equal(t, i, data.(int))

--- a/storage/database/leveldb_bench_options_test.go
+++ b/storage/database/leveldb_bench_options_test.go
@@ -96,14 +96,14 @@ func benchmarkKaiaOptionsGet(b *testing.B, opts *opt.Options, valueLength, numIn
 	require.NoError(b, err)
 	defer db.Close()
 
-	for i := 0; i < numInsertions; i++ {
+	for i := range numInsertions {
 		bs := []byte(strconv.Itoa(i))
 		db.Put(bs, randStrBytes(valueLength))
 	}
 
 	b.StartTimer()
 	for k := 0; k < b.N; k++ {
-		for i := 0; i < numGets; i++ {
+		for i := range numGets {
 			bs := []byte(strconv.Itoa(readTypeFunc(i, numInsertions)))
 			_, err := db.Get(bs)
 			if err != nil {
@@ -191,7 +191,7 @@ func benchmarkKaiaOptionsPut(b *testing.B, opts *opt.Options, valueLength, numIn
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		for k := 0; k < numInsertions; k++ {
+		for range numInsertions {
 			db.Put(randStrBytes(32), randStrBytes(valueLength))
 		}
 	}
@@ -242,7 +242,7 @@ func removeDirs(dirs []string) {
 
 func genDatabases(b *testing.B, dirs []string, opts *opt.Options) []*levelDB {
 	databases := make([]*levelDB, len(dirs), len(dirs))
-	for i := 0; i < len(dirs); i++ {
+	for i := range dirs {
 		databases[i], _ = NewLevelDBWithOption(dirs[i], opts)
 	}
 	return databases
@@ -257,7 +257,7 @@ func closeDBs(databases []*levelDB) {
 func genKeysAndValues(valueLength, numInsertions int) ([][]byte, [][]byte) {
 	keys := make([][]byte, numInsertions, numInsertions)
 	values := make([][]byte, numInsertions, numInsertions)
-	for i := 0; i < numInsertions; i++ {
+	for i := range numInsertions {
 		keys[i] = randStrBytes(32)
 		values[i] = randStrBytes(valueLength)
 	}
@@ -282,7 +282,7 @@ func benchmarkKaiaOptionsBatch(b *testing.B, opts *opt.Options, valueLength, num
 		keys, values := genKeysAndValues(valueLength, numInsertions)
 		b.StartTimer()
 		batch := db.NewBatch()
-		for k := 0; k < numInsertions; k++ {
+		for k := range numInsertions {
 			batch.Put(keys[k], values[k])
 		}
 		batch.Write()
@@ -352,7 +352,7 @@ func benchmarkIdealBatchSize(b *testing.B, bm idealBatchBM) {
 	var wg sync.WaitGroup
 	numBatches := bm.totalSize / bm.batchSize
 	wg.Add(numBatches)
-	for i := 0; i < numBatches; i++ {
+	for range numBatches {
 		batch := db.NewBatch()
 		for k := 0; k < bm.batchSize; k++ {
 			batch.Put(randStrBytes(32), randStrBytes(bm.rowSize))

--- a/storage/database/s3filedb_test.go
+++ b/storage/database/s3filedb_test.go
@@ -108,7 +108,7 @@ func (s *SuiteS3FileDB) TestS3FileDB() {
 func (s *SuiteS3FileDB) TestS3FileDB_Overwrite() {
 	testKey := common.MakeRandomBytes(32)
 	var testVals [][]byte
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		testVals = append(testVals, common.MakeRandomBytes(1024*1024))
 	}
 

--- a/storage/database/sharded_database.go
+++ b/storage/database/sharded_database.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/kaiachain/kaia/common"
@@ -531,34 +532,34 @@ func (sdbBatch *shardedDBBatch) Replay(w KeyValueWriter) error {
 }
 
 func (db *shardedDB) Stat(property string) (string, error) {
-	stats := ""
-	errs := ""
+	var stats strings.Builder
+	var errs strings.Builder
 	for idx, shard := range db.shards {
 		stat, err := shard.Stat(property)
 		if err == nil {
 			headInfo := fmt.Sprintf(" [shard%d:%s]\n", idx, shard.Type())
-			stats += headInfo + stat
+			stats.WriteString(headInfo + stat)
 		} else {
-			errs += fmt.Sprintf("shard[%d]: %s", idx, err.Error())
+			errs.WriteString(fmt.Sprintf("shard[%d]: %s", idx, err.Error()))
 		}
 	}
-	if errs == "" {
-		return stats, nil
+	if errs.String() == "" {
+		return stats.String(), nil
 	} else {
-		return stats, errors.New(errs)
+		return stats.String(), errors.New(errs.String())
 	}
 }
 
 func (db *shardedDB) Compact(start []byte, limit []byte) error {
-	errs := ""
+	var errs strings.Builder
 	for idx, shard := range db.shards {
 		if err := shard.Compact(start, limit); err != nil {
-			errs += fmt.Sprintf("shard[%d]: %s", idx, err.Error())
+			errs.WriteString(fmt.Sprintf("shard[%d]: %s", idx, err.Error()))
 		}
 	}
-	if errs == "" {
+	if errs.String() == "" {
 		return nil
 	} else {
-		return errors.New(errs)
+		return errors.New(errs.String())
 	}
 }

--- a/storage/database/sharded_database_test.go
+++ b/storage/database/sharded_database_test.go
@@ -213,7 +213,7 @@ func TestShardedDBIterator_Release(t *testing.T) {
 			defer it.Release()
 
 			// check if data exists
-			for i := 0; i < shardedDBCombineChanSize+1; i++ {
+			for range shardedDBCombineChanSize + 1 {
 				assert.True(t, it.Next())
 			}
 		}
@@ -224,7 +224,7 @@ func TestShardedDBIterator_Release(t *testing.T) {
 			it.Release()
 
 			// flush data in channel
-			for i := 0; i < shardedDBCombineChanSize+1; i++ {
+			for range shardedDBCombineChanSize + 1 {
 				it.Next()
 			}
 
@@ -242,7 +242,7 @@ func TestShardedDBIteratorUnsorted_Release(t *testing.T) {
 			defer it.Release()
 
 			// check if data exists
-			for i := 0; i < shardedDBCombineChanSize+1; i++ {
+			for range shardedDBCombineChanSize + 1 {
 				assert.True(t, it.Next())
 			}
 		}
@@ -253,7 +253,7 @@ func TestShardedDBIteratorUnsorted_Release(t *testing.T) {
 			it.Release()
 
 			// flush data in channel
-			for i := 0; i < shardedDBCombineChanSize+1; i++ {
+			for range shardedDBCombineChanSize + 1 {
 				it.Next()
 			}
 
@@ -274,7 +274,7 @@ func TestShardedDBParallelIterator_Release(t *testing.T) {
 
 				for _, ch := range it.Channels() {
 					// check if channel is not closed
-					for i := 0; i < shardedDBSubChannelSize+1; i++ {
+					for range shardedDBSubChannelSize + 1 {
 						e, ok := <-ch
 						assert.NotNil(t, e)
 						assert.True(t, ok)
@@ -289,7 +289,7 @@ func TestShardedDBParallelIterator_Release(t *testing.T) {
 				for _, ch := range it.Channels() {
 
 					// flush data in channel
-					for i := 0; i < shardedDBSubChannelSize+1; i++ {
+					for range shardedDBSubChannelSize + 1 {
 						<-ch
 					}
 

--- a/storage/statedb/cache_redis.go
+++ b/storage/statedb/cache_redis.go
@@ -97,7 +97,7 @@ func newRedisCache(config *TrieNodeCacheConfig) (*RedisCache, error) {
 	}
 
 	workerNum := runtime.NumCPU()/2 + 1
-	for i := 0; i < workerNum; i++ {
+	for range workerNum {
 		go func() {
 			for item := range cache.setItemCh {
 				cache.Set(item.key, item.value)

--- a/storage/statedb/cache_redis_test.go
+++ b/storage/statedb/cache_redis_test.go
@@ -168,7 +168,7 @@ func TestRedisCache_SetAsync_LargeNumberItems(t *testing.T) {
 
 	itemsLen := redisSetItemChannelSize * 2
 	items := make([]setItem, itemsLen)
-	for i := 0; i < itemsLen; i++ {
+	for i := range itemsLen {
 		items[i].key = randBytes(32)
 		items[i].value = randBytes(500)
 	}
@@ -177,7 +177,7 @@ func TestRedisCache_SetAsync_LargeNumberItems(t *testing.T) {
 		// wait for a while to avoid redis setItem channel full
 		time.Sleep(sleepDurationForAsyncBehavior)
 
-		for i := 0; i < itemsLen; i++ {
+		for i := range itemsLen {
 			if i == redisSetItemChannelSize {
 				// sleep for a while because Set command can drop an item if setItem channel is full
 				time.Sleep(2 * time.Second)

--- a/storage/statedb/cache_test.go
+++ b/storage/statedb/cache_test.go
@@ -59,7 +59,7 @@ func TestFastCache_SaveAndLoad(t *testing.T) {
 	// Generate test data
 	var keys [][]byte
 	var vals [][]byte
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		keys = append(keys, common.MakeRandomBytes(128))
 		vals = append(vals, common.MakeRandomBytes(128))
 	}

--- a/storage/statedb/database.go
+++ b/storage/statedb/database.go
@@ -220,7 +220,7 @@ func gatherChildren(n node, children *[]common.ExtHash) {
 		gatherChildren(n.Val, children)
 
 	case rawFullNode:
-		for i := 0; i < 16; i++ {
+		for i := range 16 {
 			gatherChildren(n[i], children)
 		}
 	case hashNode:
@@ -244,7 +244,7 @@ func simplifyNode(n node) node {
 	case *fullNode:
 		// Full nodes discard the flags and cascade
 		node := rawFullNode(n.Children)
-		for i := 0; i < len(node); i++ {
+		for i := range len(node) {
 			if node[i] != nil {
 				node[i] = simplifyNode(node[i])
 			}
@@ -280,7 +280,7 @@ func expandNode(hash hashNode, n node) node {
 				hash: hash,
 			},
 		}
-		for i := 0; i < len(node.Children); i++ {
+		for i := range len(node.Children) {
 			if n[i] != nil {
 				node.Children[i] = expandNode(nil, n[i])
 			}
@@ -394,7 +394,7 @@ func (db *Database) NodeChildren(hash common.ExtHash) ([]common.ExtHash, error) 
 	case *shortNode:
 		children = []node{n.Val}
 	case *fullNode:
-		for i := 0; i < 17; i++ {
+		for i := range 17 {
 			if n.Children[i] != nil {
 				children = append(children, n.Children[i])
 			}

--- a/storage/statedb/database_test.go
+++ b/storage/statedb/database_test.go
@@ -120,7 +120,7 @@ func TestCache(t *testing.T) {
 	memDB := database.NewMemoryDBManager()
 	db := NewDatabaseWithNewCache(memDB, &TrieNodeCacheConfig{CacheType: CacheTypeLocal, LocalCacheSizeMiB: 10})
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		key, value := common.MakeRandomBytes(256), common.MakeRandomBytes(63*1024) // fastcache can store entrie under 64KB
 		db.trieNodeCache.Set(key, value)
 		rValue, found := db.trieNodeCache.Has(key)

--- a/storage/statedb/flat_trie_test.go
+++ b/storage/statedb/flat_trie_test.go
@@ -227,7 +227,7 @@ func checkNodeIterator(t *testing.T, accountTrie trieInterface, storageTries map
 func randTrie(t *testing.T, r *rand.Rand, numAccounts, maxSlotsPerAccount int) ([][2]string, [][3]string) {
 	accounts := make([][2]string, numAccounts)
 	storages := make([][3]string, 0)
-	for i := 0; i < len(accounts); i++ {
+	for i := range accounts {
 		if i%2 == 0 { // EOA
 			accounts[i] = [2]string{randAddr(r).Hex(), hexutil.Encode(randEOA(t, r))}
 			continue
@@ -244,7 +244,7 @@ func randTrie(t *testing.T, r *rand.Rand, numAccounts, maxSlotsPerAccount int) (
 
 func randStorage(r *rand.Rand, addr string, maxSlotsPerAccount int) [][3]string {
 	storage := make([][3]string, r.Intn(maxSlotsPerAccount+1)) // [0, maxSlotsPerAccount)
-	for j := 0; j < len(storage); j++ {
+	for j := range storage {
 		// value with some leading zeros
 		value := randHash(r).Bytes()
 		value = value[:r.Intn(32)]
@@ -264,7 +264,7 @@ func randStorage(r *rand.Rand, addr string, maxSlotsPerAccount int) [][3]string 
 
 func correctStorageRoot(storage [][3]string) common.Hash {
 	trie := newEmptySecureTrie()
-	for i := 0; i < len(storage); i++ {
+	for i := range storage {
 		k, v := []byte(storage[i][1]), []byte(storage[i][2])
 		trie.TryUpdate(k, v)
 	}
@@ -320,7 +320,7 @@ func randAccountKey(r *rand.Rand) accountkey.AccountKey {
 			m = r.Intn(n-1) + 1 // [1, n]
 		}
 		keys := make(accountkey.WeightedPublicKeys, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			keys[i] = accountkey.NewWeightedPublicKey(uint(r.Intn(10)), (*accountkey.PublicKeySerializable)(randPub(r)))
 		}
 		return accountkey.NewAccountKeyWeightedMultiSigWithValues(uint(m), keys)

--- a/storage/statedb/hasher.go
+++ b/storage/statedb/hasher.go
@@ -165,7 +165,7 @@ func (h *hasher) hashChildren(original node, db *Database, onRoot bool) (node, n
 		if onRoot {
 			var wg sync.WaitGroup
 			wg.Add(16)
-			for i := 0; i < 16; i++ {
+			for i := range 16 {
 				if n.Children[i] != nil {
 					go func(i int) {
 						childHasher := newHasher(&h.hasherOpts)
@@ -179,7 +179,7 @@ func (h *hasher) hashChildren(original node, db *Database, onRoot bool) (node, n
 			}
 			wg.Wait()
 		} else {
-			for i := 0; i < 16; i++ {
+			for i := range 16 {
 				if n.Children[i] != nil {
 					collapsed.Children[i], cached.Children[i] = h.hash(n.Children[i], db, false)
 				}
@@ -242,7 +242,7 @@ func (h *hasher) store(n node, db *Database, force bool, onRoot bool) (node, uin
 					h.onleaf(nil, nil, child, hash, 0)
 				}
 			case *fullNode:
-				for i := 0; i < 16; i++ {
+				for i := range 16 {
 					if child, ok := n.Children[i].(valueNode); ok {
 						h.onleaf(nil, nil, child, hash, 0)
 					}

--- a/storage/statedb/iterator_test.go
+++ b/storage/statedb/iterator_test.go
@@ -72,7 +72,7 @@ func TestIteratorLargeData(t *testing.T) {
 	trie := newEmptyTrie()
 	vals := make(map[string]*kv)
 
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}
 		value2 := &kv{common.LeftPadBytes([]byte{10, i}, 32), []byte{i}, false}
 		trie.Update(value.k, value.v)
@@ -356,7 +356,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	} else {
 		diskKeys = diskdb.Keys()
 	}
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		// Create trie that will load all nodes from DB.
 		tr, _ := NewTrie(tr.Hash(), triedb, nil)
 

--- a/storage/statedb/node.go
+++ b/storage/statedb/node.go
@@ -169,7 +169,7 @@ func decodeShort(hash, elems []byte) (node, error) {
 
 func decodeFull(hash, elems []byte) (*fullNode, error) {
 	n := &fullNode{flags: nodeFlag{hash: hash}}
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		cld, rest, err := decodeRef(elems)
 		if err != nil {
 			return n, wrapError(err, fmt.Sprintf("[%d]", i))

--- a/storage/statedb/proof_test.go
+++ b/storage/statedb/proof_test.go
@@ -108,7 +108,7 @@ func TestRangeProof(t *testing.T) {
 		entries = append(entries, kv)
 	}
 	sort.Sort(entries)
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		start := mrand.Intn(len(entries))
 		end := mrand.Intn(len(entries)-start) + start + 1
 
@@ -141,7 +141,7 @@ func TestRangeProofWithNonExistentProof(t *testing.T) {
 		entries = append(entries, kv)
 	}
 	sort.Sort(entries)
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		start := mrand.Intn(len(entries))
 		end := mrand.Intn(len(entries)-start) + start + 1
 		proof := database.NewMemoryDBManager()
@@ -400,10 +400,10 @@ func TestAllElementsProof(t *testing.T) {
 
 // TestSingleSideRangeProof tests the range starts from zero.
 func TestSingleSideRangeProof(t *testing.T) {
-	for i := 0; i < 64; i++ {
+	for range 64 {
 		trie := new(Trie)
 		entries := entrySlice{}
-		for i := 0; i < 4096; i++ {
+		for range 4096 {
 			value := &kv{randBytes(32), randBytes(20), false}
 			trie.Update(value.k, value.v)
 			entries = append(entries, value)
@@ -435,10 +435,10 @@ func TestSingleSideRangeProof(t *testing.T) {
 
 // TestReverseSingleSideRangeProof tests the range ends with 0xffff...fff.
 func TestReverseSingleSideRangeProof(t *testing.T) {
-	for i := 0; i < 64; i++ {
+	for range 64 {
 		trie := new(Trie)
 		entries := entrySlice{}
-		for i := 0; i < 4096; i++ {
+		for range 4096 {
 			value := &kv{randBytes(32), randBytes(20), false}
 			trie.Update(value.k, value.v)
 			entries = append(entries, value)
@@ -479,7 +479,7 @@ func TestBadRangeProof(t *testing.T) {
 	}
 	sort.Sort(entries)
 
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		start := mrand.Intn(len(entries))
 		end := mrand.Intn(len(entries)-start) + start + 1
 		proof := database.NewMemoryDBManager()
@@ -545,7 +545,7 @@ func TestBadRangeProof(t *testing.T) {
 func TestGappedRangeProof(t *testing.T) {
 	trie := new(Trie)
 	var entries []*kv // Sorted entries
-	for i := byte(0); i < 10; i++ {
+	for i := range byte(10) {
 		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}
 		trie.Update(value.k, value.v)
 		entries = append(entries, value)
@@ -619,7 +619,7 @@ func TestSameSideProofs(t *testing.T) {
 func TestHasRightElement(t *testing.T) {
 	trie := new(Trie)
 	var entries entrySlice
-	for i := 0; i < 4096; i++ {
+	for range 4096 {
 		value := &kv{randBytes(32), randBytes(20), false}
 		trie.Update(value.k, value.v)
 		entries = append(entries, value)
@@ -829,7 +829,7 @@ func BenchmarkVerifyProof(b *testing.B) {
 func randomTrie(n int) (*Trie, map[string]*kv) {
 	trie := new(Trie)
 	vals := make(map[string]*kv)
-	for i := byte(0); i < 100; i++ {
+	for i := range byte(100) {
 		value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}
 		value2 := &kv{common.LeftPadBytes([]byte{i + 10}, 32), []byte{i}, false}
 		trie.Update(value.k, value.v)
@@ -837,7 +837,7 @@ func randomTrie(n int) (*Trie, map[string]*kv) {
 		vals[string(value.k)] = value
 		vals[string(value2.k)] = value2
 	}
-	for i := 0; i < n; i++ {
+	for range n {
 		value := &kv{randBytes(32), randBytes(20), false}
 		trie.Update(value.k, value.v)
 		vals[string(value.k)] = value

--- a/storage/statedb/secure_trie_test.go
+++ b/storage/statedb/secure_trie_test.go
@@ -47,7 +47,7 @@ func makeTestSecureTrie() (*Database, *SecureTrie, map[string][]byte) {
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		// Map the same data under multiple keys
 		key, val := common.LeftPadBytes([]byte{1, i}, 32), []byte{i}
 		content[string(key)] = val
@@ -118,18 +118,18 @@ func TestSecureTrieConcurrency(t *testing.T) {
 
 	threads := runtime.NumCPU()
 	tries := make([]*SecureTrie, threads)
-	for i := 0; i < threads; i++ {
+	for i := range threads {
 		cpy := *trie
 		tries[i] = &cpy
 	}
 	// Start a batch of goroutines interactng with the trie
 	pend := new(sync.WaitGroup)
 	pend.Add(threads)
-	for i := 0; i < threads; i++ {
+	for i := range threads {
 		go func(index int) {
 			defer pend.Done()
 
-			for j := byte(0); j < 255; j++ {
+			for j := range byte(255) {
 				// Map the same data under multiple keys
 				key, val := common.LeftPadBytes([]byte{byte(index), 1, j}, 32), []byte{j}
 				tries[index].Update(key, val)

--- a/storage/statedb/stacktrie_test.go
+++ b/storage/statedb/stacktrie_test.go
@@ -333,7 +333,7 @@ func TestStacktrieNotModifyValues(t *testing.T) {
 			return big.NewInt(int64(i)).Bytes()
 		}
 	}
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		key := common.BigToHash(keyB)
 		value := getValue(i)
 		st.TryUpdate(key.Bytes(), value)
@@ -342,7 +342,7 @@ func TestStacktrieNotModifyValues(t *testing.T) {
 		keyDelta.Add(keyDelta, common.Big1)
 	}
 	st.Hash()
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		want := getValue(i)
 
 		have := vals[i]
@@ -371,7 +371,7 @@ func TestStacktrieSerialization(t *testing.T) {
 			return big.NewInt(int64(i)).Bytes()
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		vals = append(vals, getValue(i))
 		keys = append(keys, common.BigToHash(keyB).Bytes())
 		keyB = keyB.Add(keyB, keyDelta)

--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -437,7 +437,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 			depth: req.depth + len(node.Key),
 		}}
 	case *fullNode:
-		for i := 0; i < 17; i++ {
+		for i := range 17 {
 			if node.Children[i] != nil {
 				children = append(children, child{
 					node:  node.Children[i],
@@ -554,7 +554,7 @@ func (s *TrieSync) CalcProgressPercentage() float64 {
 	// 4	 	65,536 	 	0.00153
 	// 5	 	1,048,576 	0.00010
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		c, r := s.CommittedByDepth(i), s.RetrievedByDepth(i)
 
 		var progressByDepth float64

--- a/storage/statedb/sync_bloom.go
+++ b/storage/statedb/sync_bloom.go
@@ -146,7 +146,7 @@ func (b *SyncBloom) meter() {
 		bloomErrorGauge.Update(int64(b.errorRate() * 100000))
 
 		// Wait one second, but check termination more frequently
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			if b.closed.Load() == 1 {
 				return
 			}

--- a/storage/statedb/sync_test.go
+++ b/storage/statedb/sync_test.go
@@ -42,7 +42,7 @@ func makeTestTrie() (*Database, *SecureTrie, map[string][]byte) {
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
-	for i := byte(0); i < 255; i++ {
+	for i := range byte(255) {
 		// Map the same data under multiple keys
 		key, val := common.LeftPadBytes([]byte{1, i}, 32), []byte{i}
 		content[string(key)] = val

--- a/storage/statedb/trie_test.go
+++ b/storage/statedb/trie_test.go
@@ -192,7 +192,7 @@ func TestGet(t *testing.T) {
 	updateString(trie, "dog", "puppy")
 	updateString(trie, "dogglesworth", "cat")
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		res := getString(trie, "dog")
 		if !bytes.Equal(res, []byte("puppy")) {
 			t.Errorf("expected puppy got %x", res)
@@ -497,7 +497,7 @@ func (randTest) Generate(r *rand.Rand, size int) reflect.Value {
 	}
 
 	var steps randTest
-	for i := 0; i < size; i++ {
+	for i := range size {
 		step := randTestStep{op: r.Intn(opMax)}
 		switch step.op {
 		case opUpdate:
@@ -594,7 +594,7 @@ func benchGet(b *testing.B, commit bool) {
 	}
 
 	k := make([]byte, 32)
-	for i := 0; i < benchElemCount; i++ {
+	for i := range benchElemCount {
 		binary.LittleEndian.PutUint64(k, uint64(i))
 		trie.Update(k, k)
 	}
@@ -630,13 +630,13 @@ func BenchmarkHash(b *testing.B) {
 
 	// Create a realistic account trie to hash
 	addresses := make([][20]byte, b.N)
-	for i := 0; i < len(addresses); i++ {
-		for j := 0; j < len(addresses[i]); j++ {
+	for i := range addresses {
+		for j := range len(addresses[i]) {
 			addresses[i][j] = byte(random.Intn(256))
 		}
 	}
 	accounts := make([][]byte, len(addresses))
-	for i := 0; i < len(accounts); i++ {
+	for i := range accounts {
 		var (
 			nonce   = uint64(random.Int63())
 			balance = new(big.Int).Rand(random, new(big.Int).Exp(common.Big2, common.Big256, nil))
@@ -647,7 +647,7 @@ func BenchmarkHash(b *testing.B) {
 	}
 	// Insert the accounts into the trie and hash it
 	trie := newEmptyTrie()
-	for i := 0; i < len(addresses); i++ {
+	for i := range addresses {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	b.ResetTimer()
@@ -669,7 +669,7 @@ func benchmarkCommitAfterHash(b *testing.B) {
 	// Make the random benchmark deterministic
 	addresses, accounts := makeAccounts(b.N)
 	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
-	for i := 0; i < len(addresses); i++ {
+	for i := range addresses {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	// Insert the accounts into the trie and hash it
@@ -771,7 +771,7 @@ func BenchmarkHashFixedSize(b *testing.B) {
 func benchmarkHashFixedSize(b *testing.B, addresses [][20]byte, accounts [][]byte) {
 	b.ReportAllocs()
 	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
-	for i := 0; i < len(addresses); i++ {
+	for i := range addresses {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	// Insert the accounts into the trie and hash it
@@ -822,7 +822,7 @@ func BenchmarkCommitAfterHashFixedSize(b *testing.B) {
 func benchmarkCommitAfterHashFixedSize(b *testing.B, addresses [][20]byte, accounts [][]byte) {
 	b.ReportAllocs()
 	trie, _ := NewTrie(common.Hash{}, NewDatabase(database.NewMemoryDBManager()), nil)
-	for i := 0; i < len(addresses); i++ {
+	for i := range addresses {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	// Insert the accounts into the trie and hash it
@@ -875,7 +875,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 	b.ReportAllocs()
 	triedb := NewDatabase(database.NewMemoryDBManager())
 	trie, _ := NewTrie(common.Hash{}, triedb, nil)
-	for i := 0; i < len(addresses); i++ {
+	for i := range addresses {
 		trie.Update(crypto.Keccak256(addresses[i][:]), accounts[i])
 	}
 	h := trie.Hash()
@@ -905,7 +905,7 @@ func TestDecodeNode(t *testing.T) {
 		hash  = make([]byte, 20)
 		elems = make([]byte, 20)
 	)
-	for i := 0; i < 5000000; i++ {
+	for range 5000000 {
 		crand.Read(hash)
 		crand.Read(elems)
 		decodeNode(hash, elems)

--- a/tests/addtx_test.go
+++ b/tests/addtx_test.go
@@ -134,11 +134,11 @@ func benchAddTx(b *testing.B, maxAccounts, numValidators int, parallel string, n
 
 	if parallel == "queueing" {
 		txChs = make([]chan *types.Transaction, numQueue)
-		for i := 0; i < numQueue; i++ {
+		for i := range numQueue {
 			txChs[i] = make(chan *types.Transaction, 100)
 		}
 
-		for i := 0; i < numQueue; i++ {
+		for i := range numQueue {
 			go txDispatcher(txChs[i], txpool, &wait)
 		}
 	}

--- a/tests/apply_tx_test.go
+++ b/tests/apply_tx_test.go
@@ -674,7 +674,7 @@ func genAccountKeyWeightedMultisig() (accountkey.AccountKey, []*ecdsa.PrivateKey
 	keys := make(accountkey.WeightedPublicKeys, numKeys)
 	prvKeys := make([]*ecdsa.PrivateKey, numKeys)
 
-	for i := 0; i < numKeys; i++ {
+	for i := range numKeys {
 		prvKeys[i], _ = crypto.GenerateKey()
 		keys[i] = accountkey.NewWeightedPublicKey(1, (*accountkey.PublicKeySerializable)(&prvKeys[i].PublicKey))
 	}

--- a/tests/benchmarks/bloomfilter_test.go
+++ b/tests/benchmarks/bloomfilter_test.go
@@ -181,7 +181,7 @@ func bloomBitAND(bloom1, bloom2 types.Bloom) types.Bloom {
 	bloom2Bytes := bloom2.Bytes()
 	var resultBytes types.Bloom
 
-	for i := 0; i < types.BloomByteLength; i++ {
+	for i := range types.BloomByteLength {
 		resultBytes[i] = bloom1Bytes[i] & bloom2Bytes[i]
 	}
 
@@ -192,7 +192,7 @@ func ldbBloomBitAND(bloom1, bloom2 []byte) []byte {
 	lenFilter := len(bloom1)
 	resultBytes := make([]byte, lenFilter)
 
-	for i := 0; i < lenFilter; i++ {
+	for i := range lenFilter {
 		resultBytes[i] = bloom1[i] & bloom2[i]
 	}
 
@@ -398,7 +398,7 @@ func Benchmark_LDBBloom_Lookup(b *testing.B) {
 func benchmark_LDBBloom_Compare(b *testing.B, bloomFilter filter.Filter, filterInstance1 []byte, opt *testOption) {
 	numAddrs := len(opt.testAddrs)
 	generator2 := bloomFilter.NewGenerator()
-	for i := 0; i < len(addrs); i++ {
+	for i := range addrs {
 		generator2.Add([]byte(opt.testAddrs[i%numAddrs]))
 	}
 	buf2 := &util.Buffer{}
@@ -433,7 +433,7 @@ func Benchmark_LDBBloom_Compare(b *testing.B) {
 
 func benchmark_LDBBloom_BitAND(b *testing.B, bloomFilter filter.Filter, filterInstance1 []byte, opt *testOption) {
 	generator2 := bloomFilter.NewGenerator()
-	for i := 0; i < len(addrs); i++ {
+	for range addrs {
 		generator2.Add([]byte(opt.testAddrs[0]))
 	}
 	buf2 := &util.Buffer{}

--- a/tests/evm_op_benchmark_test.go
+++ b/tests/evm_op_benchmark_test.go
@@ -229,7 +229,7 @@ func BenchmarkEvmOp(t *testing.B) {
 	{
 		hash := crypto.Keccak256Hash(multisig10.Addr.Bytes())
 		sigs := make([][]byte, 10)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			s, err := crypto.Sign(hash.Bytes(), multisig10.Keys[i])
 			require.NoError(t, err)
 			sigs[i] = s

--- a/tests/kaia_blockchain_test.go
+++ b/tests/kaia_blockchain_test.go
@@ -57,14 +57,14 @@ func TestSimpleBlockchain(t *testing.T) {
 	richAccount, accounts, contractAccounts := createAccount(t, numAccounts, validator)
 
 	contractDeployCode := "0x608060405234801561001057600080fd5b506000808190555060646001819055506101848061002f6000396000f300608060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806302e5329e14610067578063197e70e41461009457806349b667d2146100c157806367e0badb146100ec575b600080fd5b34801561007357600080fd5b5061009260048036038101908080359060200190929190505050610117565b005b3480156100a057600080fd5b506100bf60048036038101908080359060200190929190505050610121565b005b3480156100cd57600080fd5b506100d6610145565b6040518082815260200191505060405180910390f35b3480156100f857600080fd5b5061010161014f565b6040518082815260200191505060405180910390f35b8060018190555050565b806000540160008190555060015460005481151561013b57fe5b0660008190555050565b6000600154905090565b600080549050905600a165627a7a72305820ef4e7e564c744de3a36cb74000c35687f7de9ecf1d29abdd3c4bcc66db981c160029"
-	for i := 0; i < numAccounts; i++ {
+	for i := range numAccounts {
 		_, contractAccounts[i].Addr = deployContractDeployTx(t, node.TxPool(), chainId, richAccount, contractDeployCode)
 	}
 	time.Sleep(time.Second) // need to make a block before contract execution
 
 	// deploy
 	calldata := "0x197e70e40000000000000000000000000000000000000000000000000000000000000001"
-	for i := 0; i < numAccounts; i++ {
+	for i := range numAccounts {
 		deployRandomTxs(t, node.TxPool(), chainId, richAccount, 10)
 		deployValueTransferTx(t, node.TxPool(), chainId, richAccount, accounts[i%numAccounts])
 		deployContractExecutionTx(t, node.TxPool(), chainId, richAccount, contractAccounts[i%numAccounts].Addr, calldata)
@@ -132,7 +132,7 @@ func createAccount(t *testing.T, numAccounts int, validator *TestAccountType) (*
 	}
 
 	var err error
-	for i := 0; i < numAccounts; i++ {
+	for i := range numAccounts {
 		if accounts[i], err = createAnonymousAccount(getRandomPrivateKeyString(t)); err != nil {
 			t.Fatal()
 		}
@@ -245,7 +245,7 @@ func deployRandomTxs(t *testing.T, txpool work.TxPool, chainId *big.Int, sender 
 	gasPrice := txpool.GasPrice()
 
 	txNuminABlock := 100
-	for i := 0; i < txNum; i++ {
+	for i := range txNum {
 		if i%txNuminABlock == 0 {
 			time.Sleep(time.Second)
 		}

--- a/tests/kaia_scenario_test.go
+++ b/tests/kaia_scenario_test.go
@@ -2059,7 +2059,7 @@ func testTxBundleRevertScenario(t *testing.T, bcdata *BCData, rewardBase, valida
 	var txs types.Transactions
 
 	// 1. Transfer (rewardBase -> anon) using a legacy transaction four times.
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		amount := new(big.Int).Mul(common.Big1, new(big.Int).SetUint64(params.KAIA))
 		var tx *types.Transaction
 		if i == 3 {
@@ -2081,7 +2081,7 @@ func testTxBundleRevertScenario(t *testing.T, bcdata *BCData, rewardBase, valida
 	}
 
 	// 2. Transfer (validator -> anon) using a legacy transaction two times.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		amount := new(big.Int).Mul(common.Big1, new(big.Int).SetUint64(params.KAIA))
 		tx := types.NewTransaction(validator.Nonce,
 			anon.Addr, amount, gasLimit, gasPrice, []byte{})
@@ -2230,7 +2230,7 @@ func testTxBundleTimeOutScenario(t *testing.T, bcdata *BCData, rewardBase, valid
 	var txs types.Transactions
 
 	// 1. Transfer (rewardBase -> anon) using a legacy transaction twenty times.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		amount := new(big.Int).Mul(common.Big1, new(big.Int).SetUint64(params.KAIA))
 		tx := types.NewTransaction(rewardBase.Nonce,
 			anon.Addr, amount, gasLimit, gasPrice, []byte{})
@@ -2280,7 +2280,7 @@ func makeTestTxBundleLivePruningScenario(livePruningEnabled bool) func(*testing.
 		// 2. Transfer (anon -> validator) using a legacy transaction two times.
 		{
 			txs := []*types.Transaction{}
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				amount := new(big.Int).Mul(common.Big1, new(big.Int).SetUint64(params.Kei))
 				nonce := anon.Nonce
 				if i == 1 {

--- a/tests/kaia_test.go
+++ b/tests/kaia_test.go
@@ -72,7 +72,7 @@ func makeTransactionsFrom(bcdata *BCData, accountMap *AccountMap, signer types.S
 	txs := make(types.Transactions, 0, numTransactions)
 	nonce := accountMap.GetNonce(from)
 
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		a := toAddrs[i%numAddrs]
 		txamount := amount
 		if txamount == nil {
@@ -110,7 +110,7 @@ func makeIndependentTransactions(bcdata *BCData, accountMap *AccountMap, signer 
 
 	txs := make(types.Transactions, 0, numTransactions)
 
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		txamount := amount
@@ -151,7 +151,7 @@ func makeTransactionsToRandom(bcdata *BCData, accountMap *AccountMap, signer typ
 
 	txs := make(types.Transactions, 0, numTransactions)
 
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		txamount := amount
@@ -199,7 +199,7 @@ func makeNewTransactionsToRandom(bcdata *BCData, accountMap *AccountMap, signer 
 
 	txs := make(types.Transactions, 0, numTransactions)
 
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		txamount := amount
@@ -265,7 +265,7 @@ func makeNewTransactionsToRing(bcdata *BCData, accountMap *AccountMap, signer ty
 	}
 	var gasLimit uint64 = 1000000
 	gasPrice := new(big.Int).SetInt64(0)
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		fromIdx := i % numAddrs
 
 		toIdx := (fromIdx + 1) % numAddrs

--- a/tests/kaia_test_blockchain_test.go
+++ b/tests/kaia_test_blockchain_test.go
@@ -631,7 +631,7 @@ func createAccounts(numAccounts int) ([]*common.Address, []*ecdsa.PrivateKey, er
 	accs := make([]*common.Address, numAccounts)
 	privKeys := make([]*ecdsa.PrivateKey, numAccounts)
 
-	for i := 0; i < numAccounts; i++ {
+	for i := range numAccounts {
 		k, err := crypto.GenerateKey()
 		if err != nil {
 			return nil, nil, err

--- a/tests/kip103_test.go
+++ b/tests/kip103_test.go
@@ -85,7 +85,7 @@ func TestRebalanceTreasury_EOA(t *testing.T) {
 	totalNewbieAlloc := state.GetBalance(validator.Addr)
 	t.Log("Total Newbie amount: ", totalNewbieAlloc)
 
-	for i := 0; i < numNewbie; i++ {
+	for i := range numNewbie {
 		newbieAccs[i] = genKaiaLegacyAccount(t)
 		newbieAllocs[i] = new(big.Int).Div(totalNewbieAlloc, big.NewInt(2))
 		totalNewbieAlloc.Sub(totalNewbieAlloc, newbieAllocs[i])

--- a/tests/pregenerated_data_generation_test.go
+++ b/tests/pregenerated_data_generation_test.go
@@ -106,7 +106,7 @@ func makeTxsWithNonceMap(isGenerate bool, nonceMap map[common.Address]uint64, fr
 		transferValue = new(big.Int).Mul(big.NewInt(1e3), big.NewInt(params.Kei))
 	}
 
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		fromIdx := indexPicker(i, lenFromAddrs)
 		toIdx := indexPicker(i, lenToAddrs)
 

--- a/tests/pregenerated_data_util_test.go
+++ b/tests/pregenerated_data_util_test.go
@@ -239,7 +239,7 @@ func getValidatorAddrsAndKeys(addrs []*common.Address, privateKeys []*ecdsa.Priv
 	validatorAddresses := make([]common.Address, numValidators)
 	validatorPrivateKeys := make([]*ecdsa.PrivateKey, numValidators)
 
-	for i := 0; i < numValidators; i++ {
+	for i := range numValidators {
 		validatorPrivateKeys[i] = privateKeys[i]
 		validatorAddresses[i] = *addrs[i]
 	}

--- a/tests/randao_fork_test.go
+++ b/tests/randao_fork_test.go
@@ -192,7 +192,7 @@ func testRandao_allocRegistry(ownerAddr, kip113Addr common.Address) blockchain.G
 // Allocate the KIP-113 with all node BLS public keys
 func testRandao_allocKip113(numNodes int, ownerAddr, kip113Addr common.Address) blockchain.GenesisAlloc {
 	infos := make(system.BlsPublicKeyInfos)
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		var (
 			key   = deriveTestAccount(i)
 			addr  = crypto.PubkeyToAddress(key.PublicKey)

--- a/tests/resend_nil_test.go
+++ b/tests/resend_nil_test.go
@@ -89,7 +89,7 @@ func BenchmarkResendNilDereference(t *testing.B) {
 		// fmt.Println("creating transaction start!")
 		time.Sleep(1 * time.Nanosecond)
 		// make ring transactions
-		for i := 0; i < num; i++ {
+		for range num {
 			// fmt.Println("tx gen num", i)
 
 			tx, err := types.NewTransactionWithMap(types.TxTypeValueTransfer, map[types.TxValueKeyType]interface{}{
@@ -121,7 +121,7 @@ func BenchmarkResendNilDereference(t *testing.B) {
 
 	go func(iter int) {
 		// fmt.Println("Thread1 start!")
-		for i := 0; i < iter; i++ {
+		for range iter {
 			// fmt.Println("CachedPendingTxsByCount num", i)
 			time.Sleep(1 * time.Nanosecond)
 			txpool.CachedPendingTxsByCount(20000)
@@ -132,7 +132,7 @@ func BenchmarkResendNilDereference(t *testing.B) {
 
 	go func(iter int) {
 		// fmt.Println("Thread2 start!")
-		for i := 0; i < iter; i++ {
+		for range iter {
 			// fmt.Println("Content num", i)
 			time.Sleep(1 * time.Nanosecond)
 			txpool.Content()

--- a/tests/role_based_account_test.go
+++ b/tests/role_based_account_test.go
@@ -48,7 +48,7 @@ type TestRoleBasedAccountType struct {
 func genTestKeys(len int) []*ecdsa.PrivateKey {
 	keys := make([]*ecdsa.PrivateKey, len)
 
-	for i := 0; i < len; i++ {
+	for i := range len {
 		keys[i], _ = crypto.GenerateKey()
 	}
 

--- a/tests/smartcontract_creation_test.go
+++ b/tests/smartcontract_creation_test.go
@@ -48,7 +48,7 @@ func makeContractCreationTransactions(bcdata *BCData, accountMap *AccountMap, si
 
 	txs := make(types.Transactions, 0, numTransactions)
 
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		txamount := new(big.Int).SetInt64(0)

--- a/tests/smartcontract_execution_test.go
+++ b/tests/smartcontract_execution_test.go
@@ -138,7 +138,7 @@ func makeRewardTransactions(c *deployedContract, accountMap *AccountMap, bcdata 
 	for i, addr := range bcdata.addrs {
 		fromNonces[i] = accountMap.GetNonce(*addr)
 	}
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		addr := bcdata.addrs[idx]
@@ -183,7 +183,7 @@ func makeBalanceOf(c *deployedContract, accountMap *AccountMap, bcdata *BCData,
 	for i, addr := range bcdata.addrs {
 		fromNonces[i] = accountMap.GetNonce(*addr)
 	}
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		addr := bcdata.addrs[idx]
@@ -245,7 +245,7 @@ func makeQuickSortTransactions(c *deployedContract, accountMap *AccountMap, bcda
 	for i, addr := range bcdata.addrs {
 		fromNonces[i] = accountMap.GetNonce(*addr)
 	}
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		data, err := abii.Pack("sort", big.NewInt(100), big.NewInt(123))
@@ -464,7 +464,7 @@ func makeStorageTrieTransactions(c *deployedContract, accountMap *AccountMap, bc
 	}
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		idx := i % numAddrs
 
 		// function insertIdentity(string _serialNumber, string _publicKey, string _hash)

--- a/tests/state_migration_test.go
+++ b/tests/state_migration_test.go
@@ -45,7 +45,7 @@ func TestMigration_ContinuousRestartAndMigration(t *testing.T) {
 	stateTriePath := []byte("statetrie")
 
 	numTxs := []int{10, 100}
-	for i := 0; i < len(numTxs); i++ {
+	for i := range numTxs {
 		numTx := numTxs[i%len(numTxs)]
 		t.Log("attempt", strconv.Itoa(i), " : deployRandomTxs of", strconv.Itoa(numTx))
 		deployRandomTxs(t, node.TxPool(), chainID, richAccount, numTx)
@@ -112,7 +112,7 @@ func writeRandomValueToStateTrieDB(t *testing.T, dbm database.DBManager) map[str
 	batch := dbm.NewBatch(database.StateTrieDB)
 	entries := make(map[string]string, 10)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		key, value := common.MakeRandomBytes(common.HashLength), common.MakeRandomBytes(400)
 		dbm.PutTrieNodeToBatch(batch, common.BytesToExtHash(key), value)
 		entries[string(key)] = string(value)
@@ -124,7 +124,7 @@ func writeRandomValueToStateTrieDB(t *testing.T, dbm database.DBManager) map[str
 
 func checkIfStoredInDB(t *testing.T, numShard uint, dir string, entries map[string]string) {
 	dbs := make([]*leveldb.DB, numShard)
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		var err error
 		dbs[i], err = leveldb.OpenFile(dir+"/"+strconv.Itoa(i), nil)
 		assert.NoError(t, err)
@@ -132,7 +132,7 @@ func checkIfStoredInDB(t *testing.T, numShard uint, dir string, entries map[stri
 	}
 	for k, v := range entries {
 		datas := make([][]byte, 4)
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			datas[i], _ = dbs[i].Get([]byte(k), nil)
 		}
 		assert.Contains(t, datas, []byte(v), "value written in stateDB does not actually exist in DB")

--- a/tests/testutil_blockchain_test.go
+++ b/tests/testutil_blockchain_test.go
@@ -131,7 +131,7 @@ func (ctx *blockchainTestContext) setAccounts(count int) {
 	ctx.accountKeys = make([]*ecdsa.PrivateKey, count)
 	ctx.accountAddrs = make([]common.Address, count)
 	ctx.accounts = make([]*bind.TransactOpts, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		privateKey := deriveTestAccount(i)
 		ctx.accountKeys[i] = privateKey
 		ctx.accountAddrs[i] = crypto.PubkeyToAddress(privateKey.PublicKey)
@@ -177,7 +177,7 @@ func (ctx *blockchainTestContext) setWorkspace() {
 
 func (ctx *blockchainTestContext) setNodes(numNodes int) error {
 	ctx.nodes = make([]*blockchainTestNode, numNodes)
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		if err := ctx.setNode(i); err != nil {
 			return err
 		}

--- a/tests/tx_root_test.go
+++ b/tests/tx_root_test.go
@@ -123,7 +123,7 @@ func genTxs(num uint64) (types.Transactions, error) {
 		return tx, err
 	}
 	var txs types.Transactions
-	for i := uint64(0); i < num; i++ {
+	for i := range num {
 		tx, err := newTx(i)
 		if err != nil {
 			return nil, err

--- a/work/builder/builder_test.go
+++ b/work/builder/builder_test.go
@@ -209,7 +209,7 @@ func TestArrayify(t *testing.T) {
 	keyLen := 10
 	txLen := 30
 	keys := make([]*ecdsa.PrivateKey, keyLen)
-	for i := 0; i < len(keys); i++ {
+	for i := range keys {
 		keys[i], _ = crypto.GenerateKey()
 	}
 
@@ -219,7 +219,7 @@ func TestArrayify(t *testing.T) {
 	hashes := map[common.Hash]bool{}
 	for start, key := range keys {
 		addr := crypto.PubkeyToAddress(key.PublicKey)
-		for i := 0; i < txLen; i++ {
+		for i := range txLen {
 			tx, _ := types.SignTx(types.NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
 			groups[addr] = append(groups[addr], tx)
 			hashes[tx.Hash()] = true


### PR DESCRIPTION
## Proposed changes

Run go-modernize with the following options (others=false):

```
-forvar=true -mapsloop=true -rangeint=true -stditerators=true -stringsseq=true -omitzero=true -plusbuild=true -stringsbuilder=true
```

- Range-based loop iteration instead of index/count loops
  - `for i := 0; i < n; i++` becomes `for i := range n`
  - `for i := 0; i < len(xs); i++` becomes `for i := range xs`
  - Count-only loops become `for range n`
- Use string builder
- Remove meaningless `omitempty`


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

#807

## Further comments

The exact command:

```bash
go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -any=false -atomic=false -fmtappendf=false -forvar=false -mapsloop=false -minmax=false -newexpr=false -omitzero=false -plusbuild=false -rangeint=false -reflecttypefor=false -slicescontains=false -slicessort=false -stditerators=false -stringsbuilder=false -stringscut=false -stringscutprefix=false -stringsseq=false -testingcontext=false -unsafefuncs=false -waitgroup=false -forvar=true -mapsloop=true -rangeint=true -stditerators=true -stringsseq=true -omitzero=true -plusbuild=true -stringsbuilder=true -fix ./...
```