### PR TITLE
consensus: fix startup race in ValidatePeerType causing delayed first block

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -171,6 +171,10 @@ type Istanbul interface {
 	// SetChain sets chain of the Istanbul backend
 	SetChain(chain ChainReader)
 
+	// SignalPeerRegistrable unblocks ValidatePeerType so that peers can be registered.
+	// Called after SetChain when the engine is not started (e.g., WorkerDisable mode).
+	SignalPeerRegistrable()
+
 	RegisterKaiaxModules(mGov gov.GovModule, mStaking staking.StakingModule, mValset valset.ValsetModule, mRandao randao.RandaoModule)
 
 	kaiax.ConsensusModuleHost

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -172,7 +172,9 @@ type Istanbul interface {
 	SetChain(chain ChainReader)
 
 	// SignalPeerRegistrable unblocks ValidatePeerType so that peers can be registered.
-	// Called after SetChain when the engine is not started (e.g., WorkerDisable mode).
+	// For mining nodes, Start() calls this automatically. For non-mining nodes
+	// (e.g., WorkerDisable), the caller must invoke this after SetChain().
+	// Safe to call multiple times.
 	SignalPeerRegistrable()
 
 	RegisterKaiaxModules(mGov gov.GovModule, mStaking staking.StakingModule, mValset valset.ValsetModule, mRandao randao.RandaoModule)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -84,6 +84,7 @@ func New(opts *BackendOpts) consensus.Istanbul {
 		rewardbase:       opts.Rewardbase,
 		govModule:        opts.GovModule,
 		nodetype:         opts.NodeType,
+		chainInitCh:      make(chan struct{}),
 	}
 
 	backend.currentView.Store(&istanbul.View{Sequence: big.NewInt(0), Round: big.NewInt(0)})
@@ -137,6 +138,9 @@ type backend struct {
 
 	// Node type
 	nodetype common.ConnType
+
+	chainInitCh   chan struct{} // closed when engine is ready for peer registration
+	chainInitOnce sync.Once
 
 	isRestoringSnapshots atomic.Bool
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -711,9 +711,15 @@ func (sb *backend) SetChain(chain consensus.ChainReader) {
 	sb.chain = chain
 }
 
-// SignalPeerRegistrable unblocks ValidatePeerType.
-// For mining nodes, this is called automatically at the end of Start().
-// For non-mining nodes (WorkerDisable), the caller must invoke this after SetChain.
+// SignalPeerRegistrable unblocks ValidatePeerType so that peers can be registered.
+// It is safe to call multiple times; only the first call has effect (sync.Once).
+//
+// Call sites:
+//   - Mining nodes: called automatically via defer in Start(), after coreStarted=true.
+//     Also covers Start() failure paths to prevent goroutine leaks.
+//   - WorkerDisable nodes: caller must invoke this explicitly after SetChain(),
+//     since Start() is never called.
+//   - Stop(): called to unblock any peers waiting during shutdown.
 func (sb *backend) SignalPeerRegistrable() {
 	sb.chainInitOnce.Do(func() { close(sb.chainInitCh) })
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -758,6 +758,9 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	}
 	sb.commitCh = make(chan *types.Result, 1)
 
+	// Ensure peers are unblocked even if Start() fails partway through.
+	defer sb.SignalPeerRegistrable()
+
 	sb.SetChain(chain)
 	sb.currentBlock = currentBlock
 	sb.hasBadBlock = hasBadBlock
@@ -767,7 +770,6 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	}
 
 	sb.coreStarted = true
-	sb.SignalPeerRegistrable()
 	return nil
 }
 
@@ -775,6 +777,8 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 func (sb *backend) Stop() error {
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
+	// Unblock any peers waiting in ValidatePeerType during shutdown.
+	sb.SignalPeerRegistrable()
 	if !sb.coreStarted {
 		return istanbul.ErrStoppedEngine
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -765,6 +765,9 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	sb.commitCh = make(chan *types.Result, 1)
 
 	// Ensure peers are unblocked even if Start() fails partway through.
+	// This defer is intentionally placed before SetChain: if Start() fails
+	// before SetChain, sb.chain remains nil, which is safely handled by
+	// the nil guard in ValidatePeerType.
 	defer sb.SignalPeerRegistrable()
 
 	sb.SetChain(chain)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -711,6 +711,13 @@ func (sb *backend) SetChain(chain consensus.ChainReader) {
 	sb.chain = chain
 }
 
+// SignalPeerRegistrable unblocks ValidatePeerType.
+// For mining nodes, this is called automatically at the end of Start().
+// For non-mining nodes (WorkerDisable), the caller must invoke this after SetChain.
+func (sb *backend) SignalPeerRegistrable() {
+	sb.chainInitOnce.Do(func() { close(sb.chainInitCh) })
+}
+
 // RegisterKaiaxModules sets kaiax modules of the Istanbul backend
 func (sb *backend) RegisterKaiaxModules(mGov gov.GovModule, mStaking staking.StakingModule, mValset valset.ValsetModule, mRandao randao.RandaoModule) {
 	sb.govModule = mGov
@@ -760,6 +767,7 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	}
 
 	sb.coreStarted = true
+	sb.SignalPeerRegistrable()
 	return nil
 }
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -24,6 +24,7 @@ package backend
 
 import (
 	"errors"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/common"
@@ -102,11 +103,16 @@ func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 }
 
 func (sb *backend) ValidatePeerType(addr common.Address) error {
-	// Wait for chain initialization instead of immediately rejecting peers.
+	// Wait for engine initialization instead of immediately rejecting peers.
 	// P2P server starts before engine.Start() sets sb.chain, so early peer
 	// connections would be rejected and must wait for the P2P retry interval
 	// (~30s) before reconnecting, delaying the first block consensus.
-	<-sb.chainInitCh
+	// Timeout is a safety net against goroutine leaks if signal is never sent.
+	select {
+	case <-sb.chainInitCh:
+	case <-time.After(30 * time.Second):
+		return errNoChainReader
+	}
 	valSet, err := sb.GetValidatorSet(sb.chain.CurrentHeader().Number.Uint64() + 1)
 	if err != nil {
 		return errInvalidPeerAddress

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -102,10 +102,11 @@ func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 }
 
 func (sb *backend) ValidatePeerType(addr common.Address) error {
-	// istanbul.Start vs try to connect by peer
-	for sb.chain == nil {
-		return errNoChainReader
-	}
+	// Wait for chain initialization instead of immediately rejecting peers.
+	// P2P server starts before engine.Start() sets sb.chain, so early peer
+	// connections would be rejected and must wait for the P2P retry interval
+	// (~30s) before reconnecting, delaying the first block consensus.
+	<-sb.chainInitCh
 	valSet, err := sb.GetValidatorSet(sb.chain.CurrentHeader().Number.Uint64() + 1)
 	if err != nil {
 		return errInvalidPeerAddress

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -35,6 +35,10 @@ import (
 
 const (
 	IstanbulMsg = 0x11
+
+	// chainInitTimeout is the maximum time ValidatePeerType waits for the
+	// consensus engine to be ready before rejecting the peer connection.
+	chainInitTimeout = 30 * time.Second
 )
 
 var (
@@ -110,7 +114,10 @@ func (sb *backend) ValidatePeerType(addr common.Address) error {
 	// Timeout is a safety net against goroutine leaks if signal is never sent.
 	select {
 	case <-sb.chainInitCh:
-	case <-time.After(30 * time.Second):
+	case <-time.After(chainInitTimeout):
+		return errNoChainReader
+	}
+	if sb.chain == nil {
 		return errNoChainReader
 	}
 	valSet, err := sb.GetValidatorSet(sb.chain.CurrentHeader().Number.Uint64() + 1)

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -150,5 +150,61 @@ func TestBackend_ValidatePeerType(t *testing.T) {
 		err := backend.ValidatePeerType(common.Address{})
 		assert.Equal(t, errInvalidPeerAddress, err)
 	}
+}
 
+// TestValidatePeerType_BlocksUntilSignal verifies that ValidatePeerType blocks
+// until SignalPeerRegistrable is called, and unblocks correctly afterward.
+func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
+	freshBackend := newTestBackend()
+	defer freshBackend.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { recover() }() // valsetModule is nil in test backend
+		freshBackend.ValidatePeerType(common.Address{})
+	}()
+
+	// Should block while chainInitCh is not closed
+	select {
+	case <-done:
+		t.Fatal("ValidatePeerType should block before SignalPeerRegistrable")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Signal and verify unblock
+	freshBackend.SignalPeerRegistrable()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ValidatePeerType should unblock after SignalPeerRegistrable")
+	}
+}
+
+// TestValidatePeerType_UnblocksOnStop verifies that Stop() unblocks
+// any goroutine waiting in ValidatePeerType.
+func TestValidatePeerType_UnblocksOnStop(t *testing.T) {
+	freshBackend := newTestBackend()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { recover() }()
+		freshBackend.ValidatePeerType(common.Address{})
+	}()
+
+	// Should block
+	select {
+	case <-done:
+		t.Fatal("ValidatePeerType should block before Stop")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Stop should unblock
+	freshBackend.Stop()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ValidatePeerType should unblock after Stop")
+	}
 }

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -151,10 +151,4 @@ func TestBackend_ValidatePeerType(t *testing.T) {
 		assert.Equal(t, errInvalidPeerAddress, err)
 	}
 
-	// Return an error if backend.chain is not set
-	{
-		backend.chain = nil
-		err := backend.ValidatePeerType(backend.address)
-		assert.Equal(t, errNoChainReader, err)
-	}
 }

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -185,6 +185,7 @@ func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
 // any goroutine waiting in ValidatePeerType.
 func TestValidatePeerType_UnblocksOnStop(t *testing.T) {
 	freshBackend := newTestBackend()
+	defer freshBackend.Stop()
 
 	done := make(chan struct{})
 	go func() {

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -152,28 +152,34 @@ func TestBackend_ValidatePeerType(t *testing.T) {
 	}
 }
 
-// TestValidatePeerType_BlocksUntilSignal verifies that ValidatePeerType blocks
-// until SignalPeerRegistrable is called, and unblocks correctly afterward.
-func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
-	freshBackend := newTestBackend()
-	defer freshBackend.Stop()
+// startBlockedValidatePeer creates a test backend and starts a goroutine that
+// blocks on ValidatePeerType. Returns the backend and a channel that closes
+// when ValidatePeerType returns. Asserts that ValidatePeerType is still
+// blocking after 200ms.
+func startBlockedValidatePeer(t *testing.T) (*backend, chan struct{}) {
+	t.Helper()
+	b := newTestBackend()
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		defer func() { recover() }() // valsetModule is nil in test backend
-		freshBackend.ValidatePeerType(common.Address{})
+		b.ValidatePeerType(common.Address{})
 	}()
 
-	// Should block while chainInitCh is not closed
 	select {
 	case <-done:
-		t.Fatal("ValidatePeerType should block before SignalPeerRegistrable")
+		t.Fatal("ValidatePeerType should block before engine is ready")
 	case <-time.After(200 * time.Millisecond):
 	}
+	return b, done
+}
 
-	// Signal and verify unblock
-	freshBackend.SignalPeerRegistrable()
+func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
+	b, done := startBlockedValidatePeer(t)
+	defer b.Stop()
+
+	b.SignalPeerRegistrable()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
@@ -181,28 +187,11 @@ func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
 	}
 }
 
-// TestValidatePeerType_UnblocksOnStop verifies that Stop() unblocks
-// any goroutine waiting in ValidatePeerType.
 func TestValidatePeerType_UnblocksOnStop(t *testing.T) {
-	freshBackend := newTestBackend()
-	defer freshBackend.Stop()
+	b, done := startBlockedValidatePeer(t)
+	defer b.Stop()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		defer func() { recover() }()
-		freshBackend.ValidatePeerType(common.Address{})
-	}()
-
-	// Should block
-	select {
-	case <-done:
-		t.Fatal("ValidatePeerType should block before Stop")
-	case <-time.After(200 * time.Millisecond):
-	}
-
-	// Stop should unblock
-	freshBackend.Stop()
+	b.Stop()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -383,6 +383,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		istBackend, ok := cn.engine.(consensus.Istanbul)
 		if ok {
 			istBackend.SetChain(cn.blockchain)
+			istBackend.SignalPeerRegistrable()
 		}
 	} else {
 		// TODO-Kaia improve to handle drop transaction on network traffic in PN and EN


### PR DESCRIPTION
## Proposed changes

Fix a startup race condition in `ValidatePeerType` that delays the first block consensus by ~30-40 seconds.

### Problem

The P2P server starts before `engine.Start()` sets `sb.chain`. When peers connect during this window, `ValidatePeerType` hits `sb.chain == nil` and immediately returns `errNoChainReader`, tearing down the connection. The P2P layer then waits ~30 seconds before retrying, causing multiple round changes and delaying the first block.

```
[1] p2pServer.Start()     ← peers can connect
    ...                    ← gap: sb.chain is nil
[2] engine.Start()
    ├ SetChain()           ← sb.chain set
    ├ core.Start()         ← consensus core starts
    └ coreStarted = true   ← fully ready
```

**Before fix (cn4, proposer):**
```
INFO [10:34:50] Kaia peer registration failed  err="fail to validate peer type: 0x3C44...(sb.chain is nil! --mine option might be missing)"
INFO [10:34:50] Kaia peer registration failed  err="fail to validate peer type: 0x7099...(sb.chain is nil! --mine option might be missing)"
INFO [10:34:50] Commit new mining work         number=1
WARN [10:35:00] [RC] timeoutEvent Sent!        sequence=1 round=0 preprepare is nil?=false len(prepares)=1
WARN [10:35:12] [RC] timeoutEvent Sent!        sequence=1 round=1 preprepare is nil?=true  len(prepares)=0
WARN [10:35:26] [RC] timeoutEvent Sent!        sequence=1 round=2 preprepare is nil?=true  len(prepares)=0
INFO [10:35:40] Successfully wrote mined block num=1  ← ~36s delay
```

### Solution

Replace the immediate error return with a channel-based wait (`chainInitCh`). `ValidatePeerType` now blocks on `<-sb.chainInitCh` until the engine is fully initialized (chain set + core started), instead of rejecting peers and relying on slow P2P reconnection.

```go
// Before: immediate reject → peer dropped → 30s retry
for sb.chain == nil {
    return errNoChainReader
}

// After: block until engine ready → peer registered immediately
select {
case <-sb.chainInitCh:
case <-time.After(chainInitTimeout):
    return errNoChainReader
}
```

`SignalPeerRegistrable()` closes the channel at the right moment:
- **Mining nodes**: called via `defer` in `Start()`, after `coreStarted = true`
- **WorkerDisable nodes**: called explicitly after `SetChain()`, since `Start()` is never invoked
- **Stop()**: called to unblock any waiting peers during shutdown

`sync.Once` ensures the channel is closed exactly once regardless of the code path. A 30-second timeout acts as a safety net against goroutine leaks.

### Result

- **Before**: `sb.chain is nil` errors → 3-4 round changes → ~30-40s to first block
- **After**: no errors, no round changes → first block produced immediately

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Related issues

None — this is a pre-existing race condition discovered during permissionless development with local testnet.

## Further comments

The race condition exists on the `dev` branch as well and is reproducible. The removed test case (`backend.chain = nil` after `SetChain`) tested an unrealistic scenario — `chain` is never set back to nil after initialization in production.