### PR TITLE
permissionless: sync with latest dev (includes #809)

### DIFF
--- a/.github/workflows/test-executor-template.yml
+++ b/.github/workflows/test-executor-template.yml
@@ -24,7 +24,12 @@ jobs:
           fetch-depth: 0 # Fetches full history for test-linter's '--new-from-rev=dev to work
       - name: Add safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
+      # Will override the base image's Go setup. Introduced to cache the builds.
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.3' # The same version as the base image.
+          cache: true
       - name: Run test
         shell: bash
         run: ${{ inputs.test_command }}

--- a/.github/workflows/test-other-executor-template.yml
+++ b/.github/workflows/test-other-executor-template.yml
@@ -46,7 +46,12 @@ jobs:
           fetch-depth: 0 # Fetches full history
       - name: Add safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
+      # Will override the base image's Go setup. Introduced to cache the builds.
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.3' # The same version as the base image.
+          cache: true
       - name: setup python 3.9
         if: ${{ inputs.install_python == true }}
         uses: actions/setup-python@v5

--- a/.github/workflows/test-pr-workflow.yml
+++ b/.github/workflows/test-pr-workflow.yml
@@ -7,15 +7,16 @@ on:
 permissions:
   contents: read
 
-
+# Run the 'build' job first to update the build cache.
 jobs:
   build:
     name: Build
     uses: ./.github/workflows/test-executor-template.yml
     with:
-      test_command: make all
+      test_command: make kcn && make all -j
 
   test-linter:
+    needs: build
     name: Test Linter
     uses: ./.github/workflows/test-executor-template.yml
     with:
@@ -24,18 +25,21 @@ jobs:
         go run build/ci.go lint -v --new-from-rev="origin/${BASE_BRANCH}"
 
   test-networks:
+    needs: build
     name: Test Networks
     uses: ./.github/workflows/test-executor-template.yml
     with:
       test_command: make test-networks
 
   test-node:
+    needs: build
     name: Test Node
     uses: ./.github/workflows/test-executor-template.yml
     with:
       test_command: make test-node
 
   test-tests:
+    needs: build
     name: Test Tests
     uses: ./.github/workflows/test-executor-template.yml
     with:
@@ -44,6 +48,7 @@ jobs:
         make test-tests
 
   test-rpc:
+    needs: build
     name: Test RPC
     permissions:
       contents: write
@@ -68,12 +73,14 @@ jobs:
 
   # Service-dependent test jobs
   test-datasync:
+    needs: build
     name: Test Datasync
     uses: ./.github/workflows/test-other-executor-template.yml
     with:
       test_command: make test-datasync
 
   test-others:
+    needs: build
     name: Test Others
     uses: ./.github/workflows/test-other-executor-template.yml
     with:

--- a/.github/workflows/test-pr-workflow.yml
+++ b/.github/workflows/test-pr-workflow.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
 
+
 jobs:
   build:
     name: Build

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -171,6 +171,10 @@ type Istanbul interface {
 	// SetChain sets chain of the Istanbul backend
 	SetChain(chain ChainReader)
 
+	// SignalPeerRegistrable unblocks ValidatePeerType so that peers can be registered.
+	// Called after SetChain when the engine is not started (e.g., WorkerDisable mode).
+	SignalPeerRegistrable()
+
 	RegisterKaiaxModules(mGov gov.GovModule, mStaking staking.StakingModule, mValset valset.ValsetModule, mRandao randao.RandaoModule)
 
 	kaiax.ConsensusModuleHost

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -172,7 +172,9 @@ type Istanbul interface {
 	SetChain(chain ChainReader)
 
 	// SignalPeerRegistrable unblocks ValidatePeerType so that peers can be registered.
-	// Called after SetChain when the engine is not started (e.g., WorkerDisable mode).
+	// For mining nodes, Start() calls this automatically. For non-mining nodes
+	// (e.g., WorkerDisable), the caller must invoke this after SetChain().
+	// Safe to call multiple times.
 	SignalPeerRegistrable()
 
 	RegisterKaiaxModules(mGov gov.GovModule, mStaking staking.StakingModule, mValset valset.ValsetModule, mRandao randao.RandaoModule)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -84,6 +84,7 @@ func New(opts *BackendOpts) consensus.Istanbul {
 		rewardbase:       opts.Rewardbase,
 		govModule:        opts.GovModule,
 		nodetype:         opts.NodeType,
+		chainInitCh:      make(chan struct{}),
 	}
 
 	backend.currentView.Store(&istanbul.View{Sequence: big.NewInt(0), Round: big.NewInt(0)})
@@ -137,6 +138,9 @@ type backend struct {
 
 	// Node type
 	nodetype common.ConnType
+
+	chainInitCh   chan struct{} // closed when engine is ready for peer registration
+	chainInitOnce sync.Once
 
 	isRestoringSnapshots atomic.Bool
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -711,9 +711,15 @@ func (sb *backend) SetChain(chain consensus.ChainReader) {
 	sb.chain = chain
 }
 
-// SignalPeerRegistrable unblocks ValidatePeerType.
-// For mining nodes, this is called automatically at the end of Start().
-// For non-mining nodes (WorkerDisable), the caller must invoke this after SetChain.
+// SignalPeerRegistrable unblocks ValidatePeerType so that peers can be registered.
+// It is safe to call multiple times; only the first call has effect (sync.Once).
+//
+// Call sites:
+//   - Mining nodes: called automatically via defer in Start(), after coreStarted=true.
+//     Also covers Start() failure paths to prevent goroutine leaks.
+//   - WorkerDisable nodes: caller must invoke this explicitly after SetChain(),
+//     since Start() is never called.
+//   - Stop(): called to unblock any peers waiting during shutdown.
 func (sb *backend) SignalPeerRegistrable() {
 	sb.chainInitOnce.Do(func() { close(sb.chainInitCh) })
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -758,6 +758,9 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	}
 	sb.commitCh = make(chan *types.Result, 1)
 
+	// Ensure peers are unblocked even if Start() fails partway through.
+	defer sb.SignalPeerRegistrable()
+
 	sb.SetChain(chain)
 	sb.currentBlock = currentBlock
 	sb.hasBadBlock = hasBadBlock
@@ -767,7 +770,6 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	}
 
 	sb.coreStarted = true
-	sb.SignalPeerRegistrable()
 	return nil
 }
 
@@ -775,6 +777,8 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 func (sb *backend) Stop() error {
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
+	// Unblock any peers waiting in ValidatePeerType during shutdown.
+	sb.SignalPeerRegistrable()
 	if !sb.coreStarted {
 		return istanbul.ErrStoppedEngine
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -765,6 +765,9 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	sb.commitCh = make(chan *types.Result, 1)
 
 	// Ensure peers are unblocked even if Start() fails partway through.
+	// This defer is intentionally placed before SetChain: if Start() fails
+	// before SetChain, sb.chain remains nil, which is safely handled by
+	// the nil guard in ValidatePeerType.
 	defer sb.SignalPeerRegistrable()
 
 	sb.SetChain(chain)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -711,6 +711,13 @@ func (sb *backend) SetChain(chain consensus.ChainReader) {
 	sb.chain = chain
 }
 
+// SignalPeerRegistrable unblocks ValidatePeerType.
+// For mining nodes, this is called automatically at the end of Start().
+// For non-mining nodes (WorkerDisable), the caller must invoke this after SetChain.
+func (sb *backend) SignalPeerRegistrable() {
+	sb.chainInitOnce.Do(func() { close(sb.chainInitCh) })
+}
+
 // RegisterKaiaxModules sets kaiax modules of the Istanbul backend
 func (sb *backend) RegisterKaiaxModules(mGov gov.GovModule, mStaking staking.StakingModule, mValset valset.ValsetModule, mRandao randao.RandaoModule) {
 	sb.govModule = mGov
@@ -760,6 +767,7 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	}
 
 	sb.coreStarted = true
+	sb.SignalPeerRegistrable()
 	return nil
 }
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -24,6 +24,7 @@ package backend
 
 import (
 	"errors"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/common"
@@ -102,11 +103,16 @@ func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 }
 
 func (sb *backend) ValidatePeerType(addr common.Address) error {
-	// Wait for chain initialization instead of immediately rejecting peers.
+	// Wait for engine initialization instead of immediately rejecting peers.
 	// P2P server starts before engine.Start() sets sb.chain, so early peer
 	// connections would be rejected and must wait for the P2P retry interval
 	// (~30s) before reconnecting, delaying the first block consensus.
-	<-sb.chainInitCh
+	// Timeout is a safety net against goroutine leaks if signal is never sent.
+	select {
+	case <-sb.chainInitCh:
+	case <-time.After(30 * time.Second):
+		return errNoChainReader
+	}
 	valSet, err := sb.GetValidatorSet(sb.chain.CurrentHeader().Number.Uint64() + 1)
 	if err != nil {
 		return errInvalidPeerAddress

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -102,10 +102,11 @@ func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 }
 
 func (sb *backend) ValidatePeerType(addr common.Address) error {
-	// istanbul.Start vs try to connect by peer
-	for sb.chain == nil {
-		return errNoChainReader
-	}
+	// Wait for chain initialization instead of immediately rejecting peers.
+	// P2P server starts before engine.Start() sets sb.chain, so early peer
+	// connections would be rejected and must wait for the P2P retry interval
+	// (~30s) before reconnecting, delaying the first block consensus.
+	<-sb.chainInitCh
 	valSet, err := sb.GetValidatorSet(sb.chain.CurrentHeader().Number.Uint64() + 1)
 	if err != nil {
 		return errInvalidPeerAddress

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -35,6 +35,10 @@ import (
 
 const (
 	IstanbulMsg = 0x11
+
+	// chainInitTimeout is the maximum time ValidatePeerType waits for the
+	// consensus engine to be ready before rejecting the peer connection.
+	chainInitTimeout = 30 * time.Second
 )
 
 var (
@@ -110,7 +114,10 @@ func (sb *backend) ValidatePeerType(addr common.Address) error {
 	// Timeout is a safety net against goroutine leaks if signal is never sent.
 	select {
 	case <-sb.chainInitCh:
-	case <-time.After(30 * time.Second):
+	case <-time.After(chainInitTimeout):
+		return errNoChainReader
+	}
+	if sb.chain == nil {
 		return errNoChainReader
 	}
 	valSet, err := sb.GetValidatorSet(sb.chain.CurrentHeader().Number.Uint64() + 1)

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -150,5 +150,61 @@ func TestBackend_ValidatePeerType(t *testing.T) {
 		err := backend.ValidatePeerType(common.Address{})
 		assert.Equal(t, errInvalidPeerAddress, err)
 	}
+}
 
+// TestValidatePeerType_BlocksUntilSignal verifies that ValidatePeerType blocks
+// until SignalPeerRegistrable is called, and unblocks correctly afterward.
+func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
+	freshBackend := newTestBackend()
+	defer freshBackend.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { recover() }() // valsetModule is nil in test backend
+		freshBackend.ValidatePeerType(common.Address{})
+	}()
+
+	// Should block while chainInitCh is not closed
+	select {
+	case <-done:
+		t.Fatal("ValidatePeerType should block before SignalPeerRegistrable")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Signal and verify unblock
+	freshBackend.SignalPeerRegistrable()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ValidatePeerType should unblock after SignalPeerRegistrable")
+	}
+}
+
+// TestValidatePeerType_UnblocksOnStop verifies that Stop() unblocks
+// any goroutine waiting in ValidatePeerType.
+func TestValidatePeerType_UnblocksOnStop(t *testing.T) {
+	freshBackend := newTestBackend()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { recover() }()
+		freshBackend.ValidatePeerType(common.Address{})
+	}()
+
+	// Should block
+	select {
+	case <-done:
+		t.Fatal("ValidatePeerType should block before Stop")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Stop should unblock
+	freshBackend.Stop()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ValidatePeerType should unblock after Stop")
+	}
 }

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -151,10 +151,4 @@ func TestBackend_ValidatePeerType(t *testing.T) {
 		assert.Equal(t, errInvalidPeerAddress, err)
 	}
 
-	// Return an error if backend.chain is not set
-	{
-		backend.chain = nil
-		err := backend.ValidatePeerType(backend.address)
-		assert.Equal(t, errNoChainReader, err)
-	}
 }

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -185,6 +185,7 @@ func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
 // any goroutine waiting in ValidatePeerType.
 func TestValidatePeerType_UnblocksOnStop(t *testing.T) {
 	freshBackend := newTestBackend()
+	defer freshBackend.Stop()
 
 	done := make(chan struct{})
 	go func() {

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -152,28 +152,34 @@ func TestBackend_ValidatePeerType(t *testing.T) {
 	}
 }
 
-// TestValidatePeerType_BlocksUntilSignal verifies that ValidatePeerType blocks
-// until SignalPeerRegistrable is called, and unblocks correctly afterward.
-func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
-	freshBackend := newTestBackend()
-	defer freshBackend.Stop()
+// startBlockedValidatePeer creates a test backend and starts a goroutine that
+// blocks on ValidatePeerType. Returns the backend and a channel that closes
+// when ValidatePeerType returns. Asserts that ValidatePeerType is still
+// blocking after 200ms.
+func startBlockedValidatePeer(t *testing.T) (*backend, chan struct{}) {
+	t.Helper()
+	b := newTestBackend()
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		defer func() { recover() }() // valsetModule is nil in test backend
-		freshBackend.ValidatePeerType(common.Address{})
+		b.ValidatePeerType(common.Address{})
 	}()
 
-	// Should block while chainInitCh is not closed
 	select {
 	case <-done:
-		t.Fatal("ValidatePeerType should block before SignalPeerRegistrable")
+		t.Fatal("ValidatePeerType should block before engine is ready")
 	case <-time.After(200 * time.Millisecond):
 	}
+	return b, done
+}
 
-	// Signal and verify unblock
-	freshBackend.SignalPeerRegistrable()
+func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
+	b, done := startBlockedValidatePeer(t)
+	defer b.Stop()
+
+	b.SignalPeerRegistrable()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
@@ -181,28 +187,11 @@ func TestValidatePeerType_BlocksUntilSignal(t *testing.T) {
 	}
 }
 
-// TestValidatePeerType_UnblocksOnStop verifies that Stop() unblocks
-// any goroutine waiting in ValidatePeerType.
 func TestValidatePeerType_UnblocksOnStop(t *testing.T) {
-	freshBackend := newTestBackend()
-	defer freshBackend.Stop()
+	b, done := startBlockedValidatePeer(t)
+	defer b.Stop()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		defer func() { recover() }()
-		freshBackend.ValidatePeerType(common.Address{})
-	}()
-
-	// Should block
-	select {
-	case <-done:
-		t.Fatal("ValidatePeerType should block before Stop")
-	case <-time.After(200 * time.Millisecond):
-	}
-
-	// Stop should unblock
-	freshBackend.Stop()
+	b.Stop()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):

--- a/kaiax/gov/headergov/impl/getter_test.go
+++ b/kaiax/gov/headergov/impl/getter_test.go
@@ -144,9 +144,7 @@ func TestGetPartialParamSet_ConcurrentAccess(t *testing.T) {
 	)
 
 	// Writer goroutine continuously mutates h.governances under write lock.
-	wgWriter.Add(1)
-	go func() {
-		defer wgWriter.Done()
+	wgWriter.Go(func() {
 		var i uint64 = 1
 		for !stopSig.Load() {
 			h.AddGov(i*100, headergov.NewGovData(gov.PartialParamSet{gov.GovernanceUnitPrice: i}))
@@ -155,19 +153,17 @@ func TestGetPartialParamSet_ConcurrentAccess(t *testing.T) {
 				i = 1
 			}
 		}
-	}()
+	})
 
 	// Reader goroutines continuously call GetPartialParamSet.
 	const readers = 8
 	for r := 0; r < readers; r++ {
-		wgReader.Add(1)
-		go func() {
-			defer wgReader.Done()
+		wgReader.Go(func() {
 			for i := 0; i < 5000; i++ {
 				ps := h.GetPartialParamSet(1000)
 				_ = ps[gov.GovernanceUnitPrice]
 			}
-		}()
+		})
 	}
 
 	wgReader.Wait()

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -383,6 +383,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		istBackend, ok := cn.engine.(consensus.Istanbul)
 		if ok {
 			istBackend.SetChain(cn.blockchain)
+			istBackend.SignalPeerRegistrable()
 		}
 	} else {
 		// TODO-Kaia improve to handle drop transaction on network traffic in PN and EN


### PR DESCRIPTION
## Proposed changes

Merge latest `dev` into `permissionless` to sync upstream changes, including the `ValidatePeerType` startup race fix (#809).

### Included changes
- **#809**: Fix startup race in `ValidatePeerType` — channel-based wait instead of immediate peer rejection
- Other recent dev commits (CI improvements, fork number updates, etc.)

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

#809