### PR TITLE
kaiax/reward: Report blob fee burn

### DIFF
--- a/kaiax/reward/impl/getter.go
+++ b/kaiax/reward/impl/getter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/math"
+	"github.com/kaiachain/kaia/consensus/misc/eip4844"
 	"github.com/kaiachain/kaia/kaiax/reward"
 	"github.com/kaiachain/kaia/kaiax/staking"
 )
@@ -30,17 +31,17 @@ import (
 //
 // GetRewardSummary
 // - loadBlockData
-// - - getTotalFee = F
+// - - getExecFee = F
 // - getRewardSummary = MR + DF + NDF
 //
 // GetBlockReward
 // - loadBlockData
-// - - getTotalFee = F
+// - - getExecFee = F
 // - getDeferredReward = MR + DF
 // - specWithNonDeferredFee = MR + DF + NDF
 //
 // GetDeferredReward
-// - getTotalFee = F
+// - getExecFee = F
 // - getDeferredReward = MR + DF
 // - - getDeferredRewardSimple   for istanbul.policy != 2
 // - - getDeferredRewardFull     for istanbul.policy == 2
@@ -51,11 +52,11 @@ import (
 // - - - - specWithProposerAndFunds
 
 func (r *RewardModule) GetRewardSummary(num uint64) (*reward.RewardSummary, error) {
-	config, _, totalFee, err := r.loadBlockData(num)
+	config, header, execFee, err := r.loadBlockData(num)
 	if err != nil {
 		return nil, err
 	}
-	return getRewardSummary(config, totalFee), nil
+	return getRewardSummary(config, execFee, getBlobFee(header)), nil
 }
 
 func (r *RewardModule) loadBlockData(num uint64) (*reward.RewardConfig, *types.Header, *big.Int, error) {
@@ -74,73 +75,89 @@ func (r *RewardModule) loadBlockData(num uint64) (*reward.RewardConfig, *types.H
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	totalFee, err := getTotalFee(config, header, txs, receipts)
+	execFee, err := getExecFee(config, header, txs, receipts)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	return config, header, totalFee, nil
+	return config, header, execFee, nil
 }
 
-func getRewardSummary(config *reward.RewardConfig, totalFee *big.Int) *reward.RewardSummary {
+func getRewardSummary(config *reward.RewardConfig, execFee, blobFee *big.Int) *reward.RewardSummary {
 	minted := new(big.Int).Set(config.MintingAmount)
 
 	burntFee := big.NewInt(0)
 	if config.IsSimple { // simplified getDeferredRewardSimple
 		if config.Rules.IsMagma {
-			burntFee = getBurnAmountMagma(totalFee)
+			burntFee = getBurnAmountMagma(execFee)
 		}
 	} else { // simplified getDeferredRewardFull
 		if config.Rules.IsKore {
-			burntFee = getBurnAmountKore(config, totalFee)
+			burntFee = getBurnAmountKore(config, execFee)
 		} else if config.Rules.IsMagma {
-			burntFee = getBurnAmountMagma(totalFee)
+			burntFee = getBurnAmountMagma(execFee)
 		}
 	}
 
+	// Blob fees (KIP-279) are 100% burned during state transition per EIP-4844 spec,
+	// in both deferred and non-deferred modes.
+	// They are tracked separately because they must not enter the reward-split calculation.
 	summary := reward.NewRewardSummary()
 	summary.Minted = minted
-	summary.TotalFee = totalFee
-	summary.BurntFee = burntFee
+	summary.TotalFee = new(big.Int).Add(execFee, blobFee)
+	summary.BurntFee = new(big.Int).Add(burntFee, blobFee)
 	return summary
 }
 
+// getBlobFee returns the total blob fee burned in the block (blobGasUsed * blobBaseFee).
+// Returns zero if the block has no blob transactions.
+func getBlobFee(header *types.Header) *big.Int {
+	if header.BlobGasUsed == nil || *header.BlobGasUsed == 0 {
+		return big.NewInt(0)
+	}
+	blobBaseFee := eip4844.CalcBlobFee(header.BaseFee)
+	if blobBaseFee == nil {
+		return big.NewInt(0)
+	}
+	return new(big.Int).Mul(new(big.Int).SetUint64(*header.BlobGasUsed), blobBaseFee)
+}
+
 func (r *RewardModule) GetBlockReward(num uint64) (*reward.RewardSpec, error) {
-	config, header, totalFee, err := r.loadBlockData(num)
+	config, header, execFee, err := r.loadBlockData(num)
 	if err != nil {
 		return nil, err
 	}
 
-	spec, err := r.getDeferredReward(config, header, totalFee)
+	spec, err := r.getDeferredReward(config, header, execFee)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.specWithNonDeferredFee(spec, config, header, totalFee)
+	return r.specWithNonDeferredFee(spec, config, header, execFee)
 }
 
 // specWithNonDeferredFee adds non-deferred fees to the reward spec.
-func (r *RewardModule) specWithNonDeferredFee(spec *reward.RewardSpec, config *reward.RewardConfig, header *types.Header, totalFee *big.Int) (*reward.RewardSpec, error) {
+func (r *RewardModule) specWithNonDeferredFee(spec *reward.RewardSpec, config *reward.RewardConfig, header *types.Header, execFee *big.Int) (*reward.RewardSpec, error) {
 	if config.DeferredTxFee {
 		return spec, nil // nothing to do under deferred mode
 	}
 
 	newSpec := spec.Copy()
 
+	blobFee := getBlobFee(header)
 	if config.Rules.IsMagma {
-		burntFee := getBurnAmountMagma(totalFee)
-		distributedFee := new(big.Int).Sub(totalFee, burntFee)
-
-		newSpec.TotalFee.Add(newSpec.TotalFee, totalFee)
-		newSpec.BurntFee.Add(newSpec.BurntFee, burntFee)
+		burntFee := getBurnAmountMagma(execFee)
+		distributedFee := new(big.Int).Sub(execFee, burntFee)
+		newSpec.TotalFee.Add(newSpec.TotalFee, new(big.Int).Add(execFee, blobFee))
+		newSpec.BurntFee.Add(newSpec.BurntFee, new(big.Int).Add(burntFee, blobFee))
 		newSpec.Proposer.Add(newSpec.Proposer, distributedFee)
 
 		// Since Magma, non-deferred fees are assigned to header.Rewardbase.
 		newSpec.IncRecipient(config.Rewardbase, distributedFee)
 	} else {
-		distributedFee := new(big.Int).Set(totalFee)
+		distributedFee := new(big.Int).Set(execFee)
 
-		newSpec.TotalFee.Add(newSpec.TotalFee, totalFee)
+		newSpec.TotalFee.Add(newSpec.TotalFee, new(big.Int).Add(execFee, blobFee))
 		newSpec.Proposer.Add(newSpec.Proposer, distributedFee)
 
 		// Before Magma, non-deferred fees are assigned to evm.Coinbase which originates from Engine().Author(header).
@@ -160,40 +177,41 @@ func (r *RewardModule) GetDeferredReward(header *types.Header, txs []*types.Tran
 	if err != nil {
 		return nil, err
 	}
-	totalFee, err := getTotalFee(config, header, txs, receipts)
+	execFee, err := getExecFee(config, header, txs, receipts)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.getDeferredReward(config, header, totalFee)
+	return r.getDeferredReward(config, header, execFee)
 }
 
-func (r *RewardModule) getDeferredReward(config *reward.RewardConfig, header *types.Header, totalFee *big.Int) (*reward.RewardSpec, error) {
+func (r *RewardModule) getDeferredReward(config *reward.RewardConfig, header *types.Header, execFee *big.Int) (*reward.RewardSpec, error) {
+	blobFee := getBlobFee(header)
 	if config.IsSimple {
-		return getDeferredRewardSimple(config, totalFee)
+		return getDeferredRewardSimple(config, execFee, blobFee)
 	} else {
 		si, err := r.StakingModule.GetStakingInfo(header.Number.Uint64())
 		if err != nil {
 			return nil, err
 		}
-		return getDeferredRewardFull(config, totalFee, si)
+		return getDeferredRewardFull(config, execFee, blobFee, si)
 	}
 }
 
-// getTotalFee calculates the total transaction fees in the block.
-func getTotalFee(config *reward.RewardConfig, header *types.Header, txs []*types.Transaction, receipts []*types.Receipt) (*big.Int, error) {
+// getExecFee calculates the total execution gas fees in the block (excludes blob fees).
+func getExecFee(config *reward.RewardConfig, header *types.Header, txs []*types.Transaction, receipts []*types.Receipt) (*big.Int, error) {
 	if config.Rules.IsKaia {
 		// sum { tx[i].gasUsed * tx[i].effectiveGasPrice }
 		// = block.gasUsed * block.baseFeePerGas + sum { tx[i].gasUsed * tx[i].effectiveGasTip }
 		if len(txs) != len(receipts) {
 			return nil, reward.ErrTxReceiptsLenMismatch
 		}
-		totalFee := new(big.Int).Mul(big.NewInt(int64(header.GasUsed)), header.BaseFee)
+		execFee := new(big.Int).Mul(big.NewInt(int64(header.GasUsed)), header.BaseFee)
 		for i, tx := range txs {
 			tip := new(big.Int).Mul(big.NewInt(int64(receipts[i].GasUsed)), tx.EffectiveGasTip(header.BaseFee))
-			totalFee = totalFee.Add(totalFee, tip)
+			execFee = execFee.Add(execFee, tip)
 		}
-		return totalFee, nil
+		return execFee, nil
 	} else if config.Rules.IsMagma {
 		// Optimized to block.gasUsed * block.baseFeePerGas
 		return new(big.Int).Mul(big.NewInt(int64(header.GasUsed)), header.BaseFee), nil
@@ -204,7 +222,7 @@ func getTotalFee(config *reward.RewardConfig, header *types.Header, txs []*types
 }
 
 // getDeferredRewardSimple is for Simple policy.
-func getDeferredRewardSimple(config *reward.RewardConfig, totalFee *big.Int) (*reward.RewardSpec, error) {
+func getDeferredRewardSimple(config *reward.RewardConfig, execFee, blobFee *big.Int) (*reward.RewardSpec, error) {
 	spec := reward.NewRewardSpec()
 	minted := new(big.Int).Set(config.MintingAmount)
 
@@ -215,14 +233,16 @@ func getDeferredRewardSimple(config *reward.RewardConfig, totalFee *big.Int) (*r
 			// In non-deferred mode, no fees to distribute here at the end of block processing.
 			// Just distribute the minting reward to the proposer and stop.
 			proposer = new(big.Int).Set(minted)
-			totalFee = big.NewInt(0)
+			execFee = big.NewInt(0)
 		} else {
 			// But Simple policy had a bug where transaction fees were distributed to the proposer here at the end of block processing
 			// despite configured to non-deferred mode. To keep the backward compatibility, the buggy behavior retains until Magma.
-			proposer = new(big.Int).Add(minted, totalFee)
+			proposer = new(big.Int).Add(minted, execFee)
 		}
 		spec.Minted = new(big.Int).Set(minted)
-		spec.TotalFee = totalFee
+		// Both exec fees and blob fees are burned during state transition in non-deferred mode,
+		// not at finalization. TotalFee/BurntFee are completed by specWithNonDeferredFee (GetBlockReward only).
+		spec.TotalFee = execFee // Note that we've set it to 0 for non-deferred + Magma (see above).
 		spec.BurntFee = big.NewInt(0)
 		spec.Proposer = proposer
 		spec.IncRecipient(config.Rewardbase, proposer)
@@ -232,32 +252,34 @@ func getDeferredRewardSimple(config *reward.RewardConfig, totalFee *big.Int) (*r
 	// Deferred mode
 	burntFee := big.NewInt(0)
 	if config.Rules.IsMagma {
-		burntFee = getBurnAmountMagma(totalFee)
+		burntFee = getBurnAmountMagma(execFee)
 	}
-	proposer := new(big.Int).Add(minted, totalFee)
+	proposer := new(big.Int).Add(minted, execFee)
 	proposer.Sub(proposer, burntFee)
 
 	spec.Minted = minted
-	spec.TotalFee = totalFee
-	spec.BurntFee = burntFee
+	spec.TotalFee = new(big.Int).Add(execFee, blobFee)
+	spec.BurntFee = new(big.Int).Add(burntFee, blobFee)
 	spec.Proposer = proposer
 	spec.IncRecipient(config.Rewardbase, proposer)
 	return spec, nil
 }
 
 // getDeferredRewardFull is for non-Simple policy.
-func getDeferredRewardFull(config *reward.RewardConfig, totalFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
+func getDeferredRewardFull(config *reward.RewardConfig, execFee, blobFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
 	// Non-deferred and deferred modes share most of the logic
-	// except that in non-deferred mode the block fees are considered zero.
+	// except that in non-deferred mode all fees (exec and blob) are burned during state transition,
+	// not at finalization. TotalFee/BurntFee are completed by specWithNonDeferredFee (GetBlockReward only).
 	var burntFee *big.Int
 	if !config.DeferredTxFee {
-		totalFee = big.NewInt(0)
+		execFee = big.NewInt(0)
+		blobFee = big.NewInt(0)
 		burntFee = big.NewInt(0)
 	} else {
 		if config.Rules.IsKore {
-			burntFee = getBurnAmountKore(config, totalFee)
+			burntFee = getBurnAmountKore(config, execFee)
 		} else if config.Rules.IsMagma {
-			burntFee = getBurnAmountMagma(totalFee)
+			burntFee = getBurnAmountMagma(execFee)
 		} else {
 			burntFee = big.NewInt(0)
 		}
@@ -265,20 +287,21 @@ func getDeferredRewardFull(config *reward.RewardConfig, totalFee *big.Int, si *s
 
 	// Both non-deferred and deferred modes
 	if config.Rules.IsOsaka && config.UseFlexReward {
-		return getDeferredRewardFullFlex(config, totalFee, burntFee, si)
+		return getDeferredRewardFullFlex(config, execFee, burntFee, blobFee, si)
 	} else if config.Rules.IsKore {
-		return getDeferredRewardFullKore(config, totalFee, burntFee, si)
+		return getDeferredRewardFullKore(config, execFee, burntFee, blobFee, si)
 	} else {
-		return getDeferredRewardFullLegacy(config, totalFee, burntFee, si)
+		// Legacy is pre-Kore, which predates Osaka. blobFee is always zero here.
+		return getDeferredRewardFullLegacy(config, execFee, burntFee, si)
 	}
 }
 
 // getDeferredRewardFullFlex is for non-Simple policy, after Kore, and with UseFlexReward enabled.
-func getDeferredRewardFullFlex(config *reward.RewardConfig, totalFee, burntFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
+func getDeferredRewardFullFlex(config *reward.RewardConfig, execFee, burntFee, blobFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
 	var (
 		spec             = reward.NewRewardSpec()
 		minted           = new(big.Int).Set(config.MintingAmount)
-		distributableFee = new(big.Int).Sub(totalFee, burntFee)
+		distributableFee = new(big.Int).Sub(execFee, burntFee)
 	)
 
 	// Distribute using RewardRatio (4-part) first. Unlike Legacy, fees are not distributed here
@@ -297,8 +320,8 @@ func getDeferredRewardFullFlex(config *reward.RewardConfig, totalFee, burntFee *
 	proposer.Add(proposer, distributableFee)
 
 	spec.Minted = minted
-	spec.TotalFee = totalFee
-	spec.BurntFee = burntFee
+	spec.TotalFee = new(big.Int).Add(execFee, blobFee)
+	spec.BurntFee = new(big.Int).Add(burntFee, blobFee)
 	spec.Stakers = stakers
 	for addr, amount := range stakersAlloc {
 		spec.IncRecipient(addr, amount)
@@ -309,11 +332,11 @@ func getDeferredRewardFullFlex(config *reward.RewardConfig, totalFee, burntFee *
 }
 
 // getDeferredRewardFullKore is for non-Simple policy and after Kore.
-func getDeferredRewardFullKore(config *reward.RewardConfig, totalFee, burntFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
+func getDeferredRewardFullKore(config *reward.RewardConfig, execFee, burntFee, blobFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
 	var (
 		spec             = reward.NewRewardSpec()
 		minted           = new(big.Int).Set(config.MintingAmount)
-		distributableFee = new(big.Int).Sub(totalFee, burntFee)
+		distributableFee = new(big.Int).Sub(execFee, burntFee)
 	)
 
 	// Distribute using RewardRatio first. Unlike Legacy, fees are not distributed here
@@ -334,8 +357,8 @@ func getDeferredRewardFullKore(config *reward.RewardConfig, totalFee, burntFee *
 	proposer.Add(proposer, distributableFee)
 
 	spec.Minted = minted
-	spec.TotalFee = totalFee
-	spec.BurntFee = burntFee
+	spec.TotalFee = new(big.Int).Add(execFee, blobFee)
+	spec.BurntFee = new(big.Int).Add(burntFee, blobFee)
 	spec.Stakers = stakers
 	for addr, amount := range stakersAlloc {
 		spec.IncRecipient(addr, amount)
@@ -345,11 +368,11 @@ func getDeferredRewardFullKore(config *reward.RewardConfig, totalFee, burntFee *
 }
 
 // getDeferredRewardFullLegacy is for non-Simple policy and before Kore.
-func getDeferredRewardFullLegacy(config *reward.RewardConfig, totalFee, burntFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
+func getDeferredRewardFullLegacy(config *reward.RewardConfig, execFee, burntFee *big.Int, si *staking.StakingInfo) (*reward.RewardSpec, error) {
 	var (
 		spec             = reward.NewRewardSpec()
 		minted           = new(big.Int).Set(config.MintingAmount)
-		distributableFee = new(big.Int).Sub(totalFee, burntFee)
+		distributableFee = new(big.Int).Sub(execFee, burntFee)
 		totalReward      = new(big.Int).Add(minted, distributableFee)
 	)
 
@@ -359,7 +382,7 @@ func getDeferredRewardFullLegacy(config *reward.RewardConfig, totalFee, burntFee
 	kif.Add(kif, ratioRemainder)
 
 	spec.Minted = minted
-	spec.TotalFee = totalFee
+	spec.TotalFee = execFee
 	spec.BurntFee = burntFee
 	spec.Stakers = common.Big0 // No stakers reward before Kore
 	spec = specWithProposerAndFunds(spec, config, proposer, kif, kef, si)
@@ -367,15 +390,15 @@ func getDeferredRewardFullLegacy(config *reward.RewardConfig, totalFee, burntFee
 }
 
 // getBurnAmountMagma returns the amount of fees to be burnt by Magma.
-func getBurnAmountMagma(totalFee *big.Int) *big.Int {
-	return new(big.Int).Div(totalFee, big.NewInt(2))
+func getBurnAmountMagma(execFee *big.Int) *big.Int {
+	return new(big.Int).Div(execFee, big.NewInt(2))
 }
 
 // getBurnAmountKore returns the amount of fees to be burnt by Kore.
 // This includes Magma burnt amount (half of the total fee).
-func getBurnAmountKore(config *reward.RewardConfig, totalFee *big.Int) *big.Int {
-	firstHalf := new(big.Int).Div(totalFee, big.NewInt(2))
-	secondHalf := new(big.Int).Sub(totalFee, firstHalf)
+func getBurnAmountKore(config *reward.RewardConfig, execFee *big.Int) *big.Int {
+	firstHalf := new(big.Int).Div(execFee, big.NewInt(2))
+	secondHalf := new(big.Int).Sub(execFee, firstHalf)
 
 	validatorMintingReward, _, _ := config.RewardRatio.Split(config.MintingAmount)
 	proposerMintingReward, _ := config.Kip82Ratio.Split(validatorMintingReward)

--- a/kaiax/reward/impl/getter_test.go
+++ b/kaiax/reward/impl/getter_test.go
@@ -120,7 +120,7 @@ func TestGetRewardSummary(t *testing.T) {
 		config.IsSimple = tc.simple
 		config.Rules.IsMagma = tc.magma
 		config.Rules.IsKore = tc.kore
-		spec := getRewardSummary(config, tc.totalFee)
+		spec := getRewardSummary(config, tc.totalFee, big.NewInt(0))
 		assert.Equal(t, tc.expected, spec, tc.desc)
 	}
 }
@@ -140,10 +140,10 @@ func TestGetBlockReward(t *testing.T) {
 			&reward.RewardSpec{
 				RewardSummary: reward.RewardSummary{
 					Minted:   big.NewInt(6.4e18),
-					TotalFee: big.NewInt(0.0376e18), // includes non-deferred fee
-					BurntFee: big.NewInt(0.0188e18),
+					TotalFee: big.NewInt(0.0376e18),
+					BurntFee: big.NewInt(0.0188e18), // F/2 burnt in state transition
 				},
-				Proposer: big.NewInt(6.4188e18),
+				Proposer: big.NewInt(6.4188e18), // M + F/2
 				Stakers:  big.NewInt(0),
 				KIF:      big.NewInt(0),
 				KEF:      big.NewInt(0),
@@ -177,7 +177,7 @@ func TestGetBlockReward(t *testing.T) {
 				RewardSummary: reward.RewardSummary{
 					Minted:   big.NewInt(6.4e18),
 					TotalFee: big.NewInt(0.0376e18),
-					BurntFee: big.NewInt(0.0188e18),
+					BurntFee: big.NewInt(0.0188e18), // F/2 burnt in state transition
 				},
 				Proposer: big.NewInt(0.6588e18 + 1), // gpM + remainder + F/2
 				Stakers:  big.NewInt(2.56e18 - 1),   // gsM - remainder
@@ -416,7 +416,7 @@ func TestGetDeferredReward(t *testing.T) {
 	}
 }
 
-func TestGetTotalFee(t *testing.T) {
+func TestGetExecFee(t *testing.T) {
 	testcases := []struct {
 		desc     string
 		config   *reward.RewardConfig
@@ -481,7 +481,7 @@ func TestGetTotalFee(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		totalFee, err := getTotalFee(tc.config, tc.header, tc.txs, tc.receipts)
+		totalFee, err := getExecFee(tc.config, tc.header, tc.txs, tc.receipts)
 		require.Nil(t, err)
 		assert.Equal(t, tc.expected, totalFee, tc.desc)
 	}
@@ -567,7 +567,7 @@ func TestGetDeferredRewardSimple(t *testing.T) {
 		config.DeferredTxFee = tc.deferred
 		config.Rules.IsMagma = tc.magma
 
-		spec, err := getDeferredRewardSimple(config, totalFee)
+		spec, err := getDeferredRewardSimple(config, totalFee, big.NewInt(0))
 		require.Nil(t, err, tc.desc)
 		assert.Equal(t, tc.expected, spec, tc.desc)
 		sanityCheckRewardSpec(t, spec, tc.desc)
@@ -747,7 +747,7 @@ func TestGetDeferredRewardFull(t *testing.T) {
 		config.Rules.IsPrague = tc.prague
 		si := makeTestStakingInfo([]uint64{5_000_001, 5_000_002, 5_000_003, 5_000_000}, tc.prague) // 1:2:3:0
 
-		spec, err := getDeferredRewardFull(config, tc.totalFee, si)
+		spec, err := getDeferredRewardFull(config, tc.totalFee, big.NewInt(0), si)
 		require.Nil(t, err, tc.desc)
 		assert.Equal(t, tc.expected, spec, tc.desc)
 		sanityCheckRewardSpec(t, spec, tc.desc)
@@ -837,7 +837,7 @@ func TestGetDeferredRewardFullFlex_CompatibleWithKore(t *testing.T) {
 		config.Rules.IsOsaka = true
 		si := makeTestStakingInfo([]uint64{5_000_001, 5_000_002, 5_000_003, 5_000_000}, true) // 1:2:3:0
 
-		spec, err := getDeferredRewardFull(config, tc.totalFee, si)
+		spec, err := getDeferredRewardFull(config, tc.totalFee, big.NewInt(0), si)
 		require.Nil(t, err, tc.desc)
 		assert.Equal(t, tc.expected, spec, tc.desc)
 		sanityCheckRewardSpec(t, spec, tc.desc)
@@ -1078,7 +1078,7 @@ func TestGetDeferredRewardFullFlex_CustomConfig(t *testing.T) {
 		si := makeTestStakingInfo([]uint64{5_000_001, 5_000_002, 4_000_003, 5_000_000}, tc.hasCL)
 		si.KPFAddr = tc.kpfAddr
 
-		spec, err := getDeferredRewardFull(config, totalFee, si)
+		spec, err := getDeferredRewardFull(config, totalFee, big.NewInt(0), si)
 		require.Nil(t, err, tc.desc)
 		assert.Equal(t, tc.expected, spec, tc.desc)
 		sanityCheckRewardSpec(t, spec, tc.desc)
@@ -1400,4 +1400,225 @@ func sanityCheckRewardSpec(t *testing.T, spec *reward.RewardSpec, msg interface{
 
 	assert.Equal(t, sumSummary, sumParts, msg)
 	assert.Equal(t, sumSummary, sumRewards, msg)
+}
+
+// TestGetBlobFee tests the getBlobFee helper for nil, zero, and one-blob cases.
+func TestGetBlobFee(t *testing.T) {
+	// nil BlobGasUsed → zero
+	assert.Equal(t, big.NewInt(0), getBlobFee(&types.Header{BaseFee: big.NewInt(27e9)}), "nil BlobGasUsed")
+
+	// zero BlobGasUsed → zero
+	zero := uint64(0)
+	assert.Equal(t, big.NewInt(0), getBlobFee(&types.Header{BlobGasUsed: &zero, BaseFee: big.NewInt(27e9)}), "zero BlobGasUsed")
+
+	// nil BaseFee → CalcBlobFee returns nil → zero
+	blobGasUsed := uint64(params.BlobTxBlobGasPerBlob)
+	assert.Equal(t, big.NewInt(0), getBlobFee(&types.Header{BlobGasUsed: &blobGasUsed}), "nil BaseFee")
+
+	// one blob at baseFee=27e9: 131072 * (27e9 * 8) = 28311552000000000
+	assert.Equal(t, big.NewInt(28311552000000000), getBlobFee(&types.Header{BlobGasUsed: &blobGasUsed, BaseFee: big.NewInt(27e9)}), "one blob")
+}
+
+// TestGetRewardSummary_BlobFee verifies that blobFee is added to both TotalFee and BurntFee
+// without affecting the execution-fee burn ratio.
+func TestGetRewardSummary_BlobFee(t *testing.T) {
+	var (
+		mintingAmount  = big.NewInt(6.4e18)
+		rewardRatio, _ = reward.NewRewardRatio("50/20/30")
+		kip82Ratio, _  = reward.NewRewardKip82Ratio("20/80")
+		config         = &reward.RewardConfig{
+			MintingAmount: mintingAmount,
+			RewardRatio:   rewardRatio,
+			Kip82Ratio:    kip82Ratio,
+		}
+		execFee = big.NewInt(7e16)
+		blobFee = big.NewInt(28311552000000000) // one blob at baseFee=27e9
+	)
+
+	testcases := []struct {
+		desc             string
+		magma, kore      bool
+		expectedBurntFee *big.Int
+	}{
+		// pre-Magma: exec burn = 0, blob burn = blobFee
+		{"pre-magma", false, false, blobFee},
+		// Magma: exec burn = F/2 = 3.5e16, blob burn = blobFee
+		{"magma", true, false, new(big.Int).Add(big.NewInt(3.5e16), blobFee)},
+		// Kore low traffic: exec burn = F = 7e16, blob burn = blobFee
+		{"kore", true, true, new(big.Int).Add(execFee, blobFee)},
+	}
+	for _, tc := range testcases {
+		config.Rules.IsMagma = tc.magma
+		config.Rules.IsKore = tc.kore
+		spec := getRewardSummary(config, execFee, blobFee)
+
+		assert.Equal(t, new(big.Int).Add(execFee, blobFee), spec.TotalFee, tc.desc+" TotalFee")
+		assert.Equal(t, tc.expectedBurntFee, spec.BurntFee, tc.desc+" BurntFee")
+	}
+}
+
+// TestGetBlockReward_BlobFee tests that GetBlockReward correctly reflects blob fees
+// in TotalFee and BurntFee for both deferred and non-deferred modes.
+func TestGetBlockReward_BlobFee(t *testing.T) {
+	// blobFee = BlobTxBlobGasPerBlob * baseFee * BlobBaseFeeMultiplier = 131072 * 27e9 * 8
+	blobFee := big.NewInt(28311552000000000)
+	execFee := big.NewInt(0.0376e18)
+
+	testcases := []struct {
+		desc             string
+		deferred         bool
+		expectedTotalFee *big.Int
+		expectedBurntFee *big.Int
+	}{
+		{
+			// Deferred: specWithNonDeferredFee is a no-op; values come from getDeferredReward.
+			"full deferred", true,
+			new(big.Int).Add(execFee, blobFee),
+			new(big.Int).Add(execFee, blobFee),
+		},
+		{
+			// Non-deferred: specWithNonDeferredFee adds execFee+blobFee to TotalFee,
+			// getBurnAmountMagma(execFee)+blobFee to BurntFee, and F/2 to Proposer.
+			"full non-deferred", false,
+			new(big.Int).Add(execFee, blobFee),
+			new(big.Int).Add(big.NewInt(0.0188e18), blobFee), // F/2 + blobFee
+		},
+	}
+	for _, tc := range testcases {
+		header, txs, receipts := makeTestOsakaBlock(61)
+		r := makeTestRewardModule(t, false, tc.deferred, false, header, txs, receipts)
+
+		spec, err := r.GetBlockReward(header.Number.Uint64())
+		require.Nil(t, err, tc.desc)
+		assert.Equal(t, tc.expectedTotalFee, spec.TotalFee, tc.desc+" TotalFee")
+		assert.Equal(t, tc.expectedBurntFee, spec.BurntFee, tc.desc+" BurntFee")
+		sanityCheckRewardSpec(t, spec, tc.desc)
+	}
+}
+
+// TestGetDeferredReward_BlobFee tests that GetDeferredReward correctly reflects blob fees
+// in deferred mode, and correctly shows zero fees in non-deferred mode (where both exec and
+// blob fees are burned during state transition, not at finalization).
+func TestGetDeferredReward_BlobFee(t *testing.T) {
+	// blobFee = BlobTxBlobGasPerBlob * baseFee * BlobBaseFeeMultiplier = 131072 * 27e9 * 8
+	blobFee := big.NewInt(28311552000000000)
+	execFee := big.NewInt(0.0376e18)
+
+	testcases := []struct {
+		desc             string
+		deferred         bool
+		expectedTotalFee *big.Int
+		expectedBurntFee *big.Int
+	}{
+		{
+			// Deferred: all of execFee is burned (Kore low traffic) plus blobFee.
+			"full deferred", true,
+			new(big.Int).Add(execFee, blobFee),
+			new(big.Int).Add(execFee, blobFee),
+		},
+		{
+			// Non-deferred: exec and blob fees are both burned during state transition.
+			// GetDeferredReward represents what happens at finalization only (minting reward).
+			"full non-deferred", false,
+			big.NewInt(0),
+			big.NewInt(0),
+		},
+	}
+	for _, tc := range testcases {
+		header, txs, receipts := makeTestOsakaBlock(61)
+		r := makeTestRewardModule(t, false, tc.deferred, false, header, txs, receipts)
+
+		spec, err := r.GetDeferredReward(header, txs, receipts)
+		require.Nil(t, err, tc.desc)
+		assert.Equal(t, tc.expectedTotalFee, spec.TotalFee, tc.desc+" TotalFee")
+		assert.Equal(t, tc.expectedBurntFee, spec.BurntFee, tc.desc+" BurntFee")
+	}
+}
+
+// TestGetDeferredRewardSimple_BlobFee verifies that in deferred mode blobFee is added to TotalFee
+// and BurntFee, while in non-deferred mode it is left for specWithNonDeferredFee.
+func TestGetDeferredRewardSimple_BlobFee(t *testing.T) {
+	var (
+		mintingAmount = big.NewInt(6.4e18)
+		config        = &reward.RewardConfig{
+			Rewardbase:    common.HexToAddress("0xfff"),
+			MintingAmount: mintingAmount,
+			Rules:         params.Rules{IsMagma: true},
+		}
+		execFee = big.NewInt(7e16)
+		blobFee = big.NewInt(28311552000000000) // one blob at baseFee=27e9
+	)
+
+	// Deferred mode: blobFee is included in TotalFee and BurntFee.
+	// BurntFee = getBurnAmountMagma(execFee) + blobFee = 3.5e16 + blobFee
+	config.DeferredTxFee = true
+	spec, err := getDeferredRewardSimple(config, execFee, blobFee)
+	require.Nil(t, err)
+	assert.Equal(t, new(big.Int).Add(execFee, blobFee), spec.TotalFee, "deferred TotalFee")
+	assert.Equal(t, new(big.Int).Add(big.NewInt(3.5e16), blobFee), spec.BurntFee, "deferred BurntFee")
+	sanityCheckRewardSpec(t, spec, "simple deferred with blob")
+
+	// Non-deferred mode: both exec and blob fees are burned during state transition, not at
+	// finalization. GetDeferredReward reports neither; specWithNonDeferredFee completes the
+	// picture for GetBlockReward only.
+	config.DeferredTxFee = false
+	spec, err = getDeferredRewardSimple(config, execFee, blobFee)
+	require.Nil(t, err)
+	assert.Equal(t, big.NewInt(0), spec.TotalFee, "non-deferred TotalFee")
+	assert.Equal(t, big.NewInt(0), spec.BurntFee, "non-deferred BurntFee")
+	sanityCheckRewardSpec(t, spec, "simple non-deferred with blob")
+}
+
+// TestGetDeferredRewardFull_BlobFee verifies blobFee handling in the Kore and Flex paths,
+// and confirms it is zeroed in non-deferred mode.
+func TestGetDeferredRewardFull_BlobFee(t *testing.T) {
+	var (
+		mintingAmount  = big.NewInt(6.4e18)
+		rewardRatio, _ = reward.NewRewardRatio("50/20/30")
+		kip82Ratio, _  = reward.NewRewardKip82Ratio("20/80")
+		config         = &reward.RewardConfig{
+			DeferredTxFee: true,
+			Rewardbase:    common.HexToAddress("0xfff"),
+			MintingAmount: mintingAmount,
+			MinimumStake:  big.NewInt(5_000_000),
+			RewardRatio:   rewardRatio,
+			Kip82Ratio:    kip82Ratio,
+		}
+		execFee = big.NewInt(7e16)              // low traffic
+		blobFee = big.NewInt(28311552000000000) // one blob at baseFee=27e9
+		si      = makeTestStakingInfo([]uint64{5_000_001, 5_000_002, 5_000_003, 5_000_000}, false)
+	)
+
+	// Kore deferred: TotalFee and BurntFee both include blobFee.
+	// Kore low traffic: burntKore(execFee) = execFee (all burned), so BurntFee = execFee + blobFee.
+	// Reward distribution (proposer/stakers) is identical to the zero-blob case.
+	config.Rules = params.Rules{IsMagma: true, IsKore: true}
+	spec, err := getDeferredRewardFull(config, execFee, blobFee, si)
+	require.Nil(t, err, "kore deferred")
+	assert.Equal(t, new(big.Int).Add(execFee, blobFee), spec.TotalFee, "kore deferred TotalFee")
+	assert.Equal(t, new(big.Int).Add(execFee, blobFee), spec.BurntFee, "kore deferred BurntFee")
+	assert.Equal(t, big.NewInt(0.64e18+1), spec.Proposer, "kore deferred Proposer unchanged")
+	sanityCheckRewardSpec(t, spec, "kore deferred with blob")
+
+	// Kore non-deferred: both exec and blob fees are burned during state transition, not at
+	// finalization. GetDeferredReward reports neither; specWithNonDeferredFee completes the
+	// picture for GetBlockReward only.
+	config.DeferredTxFee = false
+	spec, err = getDeferredRewardFull(config, execFee, blobFee, si)
+	require.Nil(t, err, "kore non-deferred")
+	assert.Equal(t, big.NewInt(0), spec.TotalFee, "kore non-deferred TotalFee")
+	assert.Equal(t, big.NewInt(0), spec.BurntFee, "kore non-deferred BurntFee")
+	sanityCheckRewardSpec(t, spec, "kore non-deferred with blob")
+
+	// Flex (Osaka + UseFlexReward) deferred: same TotalFee/BurntFee pattern as Kore.
+	siPrague := makeTestStakingInfo([]uint64{5_000_001, 5_000_002, 5_000_003, 5_000_000}, true)
+	config.DeferredTxFee = true
+	config.UseFlexReward = true
+	config.StakingRewardThreshold = big.NewInt(5_000_000)
+	config.Rules = params.Rules{IsMagma: true, IsKore: true, IsPrague: true, IsOsaka: true}
+	spec, err = getDeferredRewardFull(config, execFee, blobFee, siPrague)
+	require.Nil(t, err, "flex deferred")
+	assert.Equal(t, new(big.Int).Add(execFee, blobFee), spec.TotalFee, "flex deferred TotalFee")
+	assert.Equal(t, new(big.Int).Add(execFee, blobFee), spec.BurntFee, "flex deferred BurntFee")
+	sanityCheckRewardSpec(t, spec, "flex deferred with blob")
 }

--- a/kaiax/reward/impl/init_test.go
+++ b/kaiax/reward/impl/init_test.go
@@ -208,6 +208,16 @@ func makeTestKaiaBlock(num int64) (*types.Header, []*types.Transaction, []*types
 		}
 }
 
+// makeTestOsakaBlock creates a Kaia block with one blob transaction.
+// execFee = 0.0376e18 (same as makeTestKaiaBlock)
+// blobFee = BlobTxBlobGasPerBlob * baseFee * BlobBaseFeeMultiplier = 131072 * 27e9 * 8 = 28311552000000000
+func makeTestOsakaBlock(num int64) (*types.Header, []*types.Transaction, []*types.Receipt) {
+	blobGasUsed := uint64(params.BlobTxBlobGasPerBlob)
+	header, txs, receipts := makeTestKaiaBlock(num)
+	header.BlobGasUsed = &blobGasUsed
+	return header, txs, receipts
+}
+
 func makeTestTx_type0(gasPrice, gasLimit int64) *types.Transaction {
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)


### PR DESCRIPTION
## Proposed changes

- Fix unreported blob fee burn: `getTotalFee` (renamed to `getExecFee`) only accounted for execution gas fees. Blob fees (`blobGasUsed * blobBaseFee`) are deducted from senders in `buyGas()` and burned per EIP-4844 spec, but were invisible to the reward/supply accounting module. `spec.TotalFee` and `spec.BurntFee` now include blob fees.
   - This change does not alter the block processing. Only affects the reported number by an informational API.
- (minor) Rename `totalFee` in local variables & parameters to `execFee` because it is for representing the "total tx execution fees" and the blob fee is not included. So for now it's `totalFee = execFee + blobFee`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
