### PR TITLE
blockchain: Fix proposer reward distribution for non-deferred mode after Magma

### DIFF
--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -618,7 +618,11 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// DeferredTxFee has never been voted, so it's ok to use the genesis value instead of the latest value from governance.
 	if st.evm.ChainConfig().Governance == nil || !st.evm.ChainConfig().Governance.DeferredTxFee() {
 		if rules.IsMagma {
-			st.state.AddBalance(st.evm.Context.Rewardbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
+			// Since Magma, half the fee is burned and the other half goes to the proposer (Rewardbase).
+			fee := new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice)
+			burnt := new(big.Int).Div(fee, big.NewInt(2)) // fee / 2
+			distributed := new(big.Int).Sub(fee, burnt)
+			st.state.AddBalance(st.evm.Context.Rewardbase, distributed)
 		} else {
 			st.state.AddBalance(st.evm.Context.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 		}

--- a/blockchain/state_transition_test.go
+++ b/blockchain/state_transition_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/holiman/uint256"
 	mock_bc "github.com/kaiachain/kaia/blockchain/mocks"
+	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/blockchain/vm"
@@ -36,6 +37,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1088,4 +1090,54 @@ func TestStateTransition_EIP7623(t *testing.T) {
 	res, err = NewStateTransition(evm, tx).TransitionDb()
 	assert.NoError(t, err)
 	assert.Equal(t, gaslimit2, res.UsedGas)
+}
+
+// TestStateTransition_NonDeferredMagmaFeeBurn verifies that in non-deferred mode after Magma,
+// exactly half the transaction fee is credited to Rewardbase and the other half is burned
+// (i.e. not credited to anyone).
+func TestStateTransition_NonDeferredMagmaFeeBurn(t *testing.T) {
+	// TestKaiaConfig("magma") has Magma enabled and DeferredTxFee=false (the default).
+	config := params.TestKaiaConfig("magma")
+	fork.SetHardForkBlockNumberConfig(config)
+
+	var (
+		key, _     = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		sender     = crypto.PubkeyToAddress(key.PublicKey)
+		to         = common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+		rewardbase = common.HexToAddress("0x000000000000000000000000000000000000beef")
+		gasPrice   = big.NewInt(25 * params.Gkei)
+		gasLimit   = uint64(21000) // basic transfer, all gas consumed
+		signer     = types.LatestSignerForChainID(config.ChainID)
+	)
+
+	fee := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasLimit)))
+	halfFee := new(big.Int).Div(fee, big.NewInt(2))
+
+	// Fund the sender with enough balance to cover gas.
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	statedb.AddBalance(sender, new(big.Int).Mul(fee, big.NewInt(10)))
+
+	tx, err := types.SignTx(
+		types.NewTransaction(0, to, big.NewInt(0), gasLimit, gasPrice, nil),
+		signer, key,
+	)
+	require.NoError(t, err)
+	msg, err := tx.AsMessageWithAccountKeyPicker(signer, statedb, 0)
+	require.NoError(t, err)
+
+	header := &types.Header{
+		Number:     big.NewInt(0),
+		Time:       big.NewInt(0),
+		BlockScore: big.NewInt(0),
+		Rewardbase: rewardbase,
+	}
+	blockContext := NewEVMBlockContext(header, nil, &rewardbase)
+	txContext := NewEVMTxContext(msg, header, config)
+	evm := vm.NewEVM(blockContext, txContext, statedb, config, &vm.Config{})
+
+	_, err = NewStateTransition(evm, msg).TransitionDb()
+	require.NoError(t, err)
+
+	// Rewardbase should receive exactly F/2. The other half is burned (not credited to anyone).
+	assert.Equal(t, halfFee, statedb.GetBalance(rewardbase))
 }

--- a/tests/kaia_test_account_map_test.go
+++ b/tests/kaia_test_account_map_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax"
+	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/work/builder"
 )
 
@@ -39,14 +40,27 @@ type AccountInfo struct {
 	nonce   uint64
 }
 
+// txFeeInfo caches per-transaction fee data computed in Update(), so that
+// AdjustFeesByReceipts can reconcile with actual gas used from receipts.
+type txFeeInfo struct {
+	estimatedFee *big.Int
+	from         common.Address
+	feePayer     common.Address
+	feeRatio     types.FeeRatio
+	hasFeeRatio  bool
+}
+
 type AccountMap struct {
-	m          map[common.Address]*AccountInfo
-	rewardbase common.Address
+	m           map[common.Address]*AccountInfo
+	rewardbase  common.Address
+	chainConfig *params.ChainConfig
+	txFeeCache  map[common.Hash]*txFeeInfo // tx hash → fee info from Update()
 }
 
 func NewAccountMap() *AccountMap {
 	return &AccountMap{
-		m: make(map[common.Address]*AccountInfo),
+		m:          make(map[common.Address]*AccountInfo),
+		txFeeCache: make(map[common.Hash]*txFeeInfo),
 	}
 }
 
@@ -105,10 +119,13 @@ func (a *AccountMap) Initialize(bcdata *BCData) error {
 	}
 
 	a.rewardbase = *bcdata.addrs[0]
+	a.chainConfig = bcdata.bc.Config()
 
 	return nil
 }
 
+// Update simulates the balance and nonce changes for txs as if they were applied in the block
+// at currentBlockNumber. currentBlockNumber must be the mined block number, not the parent.
 func (a *AccountMap) Update(txs types.Transactions, txHashesExpectedFail []common.Hash, txBundlingModules []kaiax.TxBundlingModule, signer types.Signer, picker types.AccountKeyPicker, currentBlockNumber uint64) error {
 	modules := make([]builder.TxBundlingModule, len(txBundlingModules)) // TODO-Kaia: Remove this cast.
 	for i, module := range txBundlingModules {
@@ -162,8 +179,14 @@ func (a *AccountMap) Update(txs types.Transactions, txHashesExpectedFail []commo
 		intrinsicGas += gasFrom + gasFeePayer
 
 		fee := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(intrinsicGas))
-
 		feeRatio, ok := tx.FeeRatio()
+		a.txFeeCache[tx.Hash()] = &txFeeInfo{
+			estimatedFee: new(big.Int).Set(fee),
+			from:         from,
+			feePayer:     feePayer,
+			feeRatio:     feeRatio,
+			hasFeeRatio:  ok,
+		}
 		if ok {
 			feeByFeePayer, feeBySender := types.CalcFeeWithRatio(feeRatio, fee)
 			a.SubBalance(feePayer, feeByFeePayer)
@@ -172,7 +195,18 @@ func (a *AccountMap) Update(txs types.Transactions, txHashesExpectedFail []commo
 			a.SubBalance(feePayer, fee)
 		}
 
-		a.AddBalance(a.rewardbase, fee)
+		// In non-deferred Magma mode, only half the fee is distributed to the rewardbase;
+		// the other half is burned. Mirror that logic here.
+		// currentBlockNumber is the mined block number (invariant upheld by all callers).
+		rewardFee := new(big.Int).Set(fee)
+		if a.chainConfig != nil {
+			rules := a.chainConfig.Rules(new(big.Int).SetUint64(currentBlockNumber))
+			isNonDeferred := a.chainConfig.Governance == nil || !a.chainConfig.Governance.DeferredTxFee()
+			if rules.IsMagma && isNonDeferred {
+				rewardFee.Div(rewardFee, big.NewInt(2))
+			}
+		}
+		a.AddBalance(a.rewardbase, rewardFee)
 
 		a.IncNonce(from)
 
@@ -183,6 +217,55 @@ func (a *AccountMap) Update(txs types.Transactions, txHashesExpectedFail []commo
 		if tx.Type() == types.TxTypeSmartContractDeploy || tx.Type() == types.TxTypeFeeDelegatedSmartContractDeploy || tx.Type() == types.TxTypeFeeDelegatedSmartContractDeployWithRatio {
 			a.IncNonce(*to)
 		}
+	}
+
+	return nil
+}
+
+// AdjustFeesByReceipts corrects the accountMap after mining by reconciling the estimated
+// intrinsic gas fee (used in Update) against the actual gas used recorded in receipts.
+// This is necessary because Update() uses IntrinsicGas as an approximation, which excludes
+// execution overhead (e.g., constructor gas, code storage cost for contract deployments).
+// txs must be b.Transactions() and receipts must be the corresponding block receipts.
+func (a *AccountMap) AdjustFeesByReceipts(txs types.Transactions, receipts types.Receipts, blockNum uint64) error {
+	if a.chainConfig == nil || len(a.txFeeCache) == 0 {
+		return nil
+	}
+
+	blockNumBig := new(big.Int).SetUint64(blockNum)
+	rules := a.chainConfig.Rules(blockNumBig)
+	isNonDeferred := a.chainConfig.Governance == nil || !a.chainConfig.Governance.DeferredTxFee()
+
+	for i, tx := range txs {
+		cached, ok := a.txFeeCache[tx.Hash()]
+		if !ok {
+			continue // tx was skipped in Update (txHashesExpectedFail) or not tracked
+		}
+
+		actualFee := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(receipts[i].GasUsed))
+		delta := new(big.Int).Sub(actualFee, cached.estimatedFee)
+		if delta.Sign() == 0 {
+			continue
+		}
+
+		// delta > 0: actual > estimated (e.g. constructor or execution gas not in IntrinsicGas)
+		//   → deduct delta from payer, add delta/2 to rewardbase
+		// delta < 0: actual < estimated (e.g. EIP-7702 authorization refund > execution gas)
+		//   → refund |delta| to payer, subtract |delta|/2 from rewardbase
+		// SubBalance with a negative value adds to balance; AddBalance with negative subtracts.
+		if cached.hasFeeRatio {
+			deltaByFeePayer, deltaBySender := types.CalcFeeWithRatio(cached.feeRatio, delta)
+			a.SubBalance(cached.feePayer, deltaByFeePayer)
+			a.SubBalance(cached.from, deltaBySender)
+		} else {
+			a.SubBalance(cached.feePayer, delta)
+		}
+
+		rewardDelta := new(big.Int).Set(delta)
+		if rules.IsMagma && isNonDeferred {
+			rewardDelta.Div(rewardDelta, big.NewInt(2))
+		}
+		a.AddBalance(a.rewardbase, rewardDelta)
 	}
 
 	return nil

--- a/tests/kaia_test_blockchain_test.go
+++ b/tests/kaia_test_blockchain_test.go
@@ -419,6 +419,14 @@ func (bcdata *BCData) GenABlockWithTxpool(accountMap *AccountMap, txpool *blockc
 	}
 	prof.Profile("main_apply_reward", time.Now().Sub(start))
 
+	// Adjust accountMap for actual gas used vs. the intrinsic gas estimate in Update().
+	// Execution overhead (e.g. constructor gas, code storage cost) is not captured by
+	// IntrinsicGas, causing a mismatch in Magma non-deferred mode where only half the
+	// fee reaches the rewardbase.
+	if err := accountMap.AdjustFeesByReceipts(b.Transactions(), receipts, b.NumberU64()); err != nil {
+		return err
+	}
+
 	// Verification with accountMap
 	start = time.Now()
 	statedbNew, err := bcdata.bc.State()
@@ -455,9 +463,10 @@ func (bcdata *BCData) genABlockWithTransactionsWithBundle(accountMap *AccountMap
 		return err
 	}
 
-	// Update accountMap
+	// Update accountMap. Update() requires the mined block number. Since mining
+	// hasn't happened yet, derive it as CurrentBlock (parent) + 1.
 	start := time.Now()
-	if err := accountMap.Update(transactions, txHashesExpectedFail, txBundlingModules, signer, statedb, bcdata.bc.CurrentBlock().NumberU64()); err != nil {
+	if err := accountMap.Update(transactions, txHashesExpectedFail, txBundlingModules, signer, statedb, bcdata.bc.CurrentBlock().NumberU64()+1); err != nil {
 		return err
 	}
 	prof.Profile("main_update_accountMap", time.Now().Sub(start))
@@ -522,6 +531,14 @@ func (bcdata *BCData) genABlockWithTransactionsWithBundle(accountMap *AccountMap
 		}
 	}
 	prof.Profile("main_apply_reward", time.Now().Sub(start))
+
+	// Adjust accountMap for actual gas used vs. the intrinsic gas estimate in Update().
+	// Execution overhead (e.g. constructor gas, code storage cost) is not captured by
+	// IntrinsicGas, causing a mismatch in Magma non-deferred mode where only half the
+	// fee reaches the rewardbase.
+	if err := accountMap.AdjustFeesByReceipts(b.Transactions(), receipts, b.NumberU64()); err != nil {
+		return err
+	}
 
 	// Verification with accountMap
 	start = time.Now()


### PR DESCRIPTION
## Proposed changes

- Fix actual burn in non-deferred mode after Magma: In non-deferred mode with Magma enabled, we are crediting the full transaction fee to `Rewardbase` instead of half (`F/2`). Now our code matches the description in the `kaiax/reward` module [README](https://github.com/kaiachain/kaia/tree/dev/kaiax/reward/README.md).
   - This change is not relevant to our Mainnet/Kairos.
- Fix AccountMap test helper to correctly simulate Magma non-deferred fee burn: credit only half the tx fee to rewardbase in `Update()`, and add `AdjustFeesByReceipts()` to reconcile the intrinsic gas estimate against actual gas used from receipts.
## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
