### PR TITLE
Permissionless: define state group variables for permissionless consensus

### DIFF
--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -27,7 +27,7 @@ import (
 // GetCouncil returns the whole validator list for validating the block `num`.
 func (v *ValsetModule) GetCouncil(num uint64) ([]common.Address, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		nodes, err := v.GetNodeByState(num, []valset.State{valset.ValActive, valset.ValReady, valset.ValPaused})
+		nodes, err := v.GetNodeByState(num, valset.CouncilStates)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func (v *ValsetModule) GetDemotedValidators(num uint64) ([]common.Address, error
 func (v *ValsetModule) getQualifiedValidators(num uint64) (*valset.AddressSet, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
 		// qualified = council - demoted = ValActive
-		m, err := v.GetNodeByState(num, []valset.State{valset.ValActive})
+		m, err := v.GetNodeByState(num, valset.CommitteeStates)
 		if err != nil {
 			return nil, err
 		}
@@ -160,7 +160,7 @@ func (v *ValsetModule) GetNodeByState(num uint64, states []valset.State) (valset
 }
 
 func (v *ValsetModule) GetCandidates(num uint64) ([]common.Address, error) {
-	candTestings, err := v.GetNodeByState(num, []valset.State{valset.CandTesting})
+	candTestings, err := v.GetNodeByState(num, valset.CandidateStates)
 	if err != nil {
 		return nil, err
 	}

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -29,6 +29,18 @@ const (
 	ValExiting               // 8
 )
 
+// State groups for permissionless consensus.
+// Validator = ValActive + ValReady + ValPaused + ValExiting + ValInactive
+// Council = ValActive + ValReady + ValPaused
+// Committee = ValActive
+// Candidate = CandTesting
+var (
+	ValidatorStates = []State{ValActive, ValReady, ValPaused, ValExiting, ValInactive}
+	CouncilStates   = []State{ValActive, ValReady, ValPaused}
+	CommitteeStates = []State{ValActive}
+	CandidateStates = []State{CandTesting}
+)
+
 const (
 	RegisteredStr  = "Registered"
 	CandReadyStr   = "CandReady"


### PR DESCRIPTION
## Proposed changes

Define `CouncilStates`, `CommitteeStates`, `CandidateStates`, `ValidatorStates` as package-level variables in `valset/types.go` to replace scattered state literals across the codebase.

- Replaces `[]valset.State{valset.ValActive, valset.ValReady, valset.ValPaused}` → `valset.CouncilStates`
- Replaces `[]valset.State{valset.ValActive}` → `valset.CommitteeStates`
- Replaces `[]valset.State{valset.CandTesting}` → `valset.CandidateStates`
- Applied in `GetCouncil`, `getQualifiedValidators`, `GetCandidates`

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 🟢 Lint and unit tests pass locally with my changes

## Further comments

## Related issues

- Follows #811 (PR6: state transition engine)