### PR TITLE
Permissionless: move VRankEpoch to ChainConfig as single source of truth

### DIFF
--- a/blockchain/system/permissionless.go
+++ b/blockchain/system/permissionless.go
@@ -34,14 +34,12 @@ import (
 	cnstakingv4factory "github.com/kaiachain/kaia/contracts_permissionless/contracts/CnStaking/CnStakingV4Factory"
 	beaconcontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/Proxy/beacon"
 	pdcontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/PublicDelegation"
-	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 )
 
 // DefaultEpochBlockInterval is the default number of blocks per epoch for ABv2.
-// Uses valset.DefaultVRankEpoch as the single source of truth.
-const DefaultEpochBlockInterval = int64(valset.DefaultVRankEpoch)
+const DefaultEpochBlockInterval = int64(params.DefaultVRankEpoch)
 
 // AllocPermissionlessConfig holds parameters for genesis permissionless allocation.
 type AllocPermissionlessConfig struct {

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/kaiachain/kaia/blockchain/system"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/valset"
 )
@@ -126,6 +127,20 @@ func (v *ValsetModule) GetNodeByState(num uint64, states []valset.State) (valset
 	var nodes valset.NodeStateMap
 	if cached, ok := v.nodeStatesCache.Get(num); ok {
 		nodes = cached.(valset.NodeStateMap)
+	} else if num == 0 {
+		// Block 0 has no parent; read ABv2 directly from genesis state.
+		genesisHeader := v.Chain.GetHeaderByNumber(0)
+		if genesisHeader == nil {
+			return nil, errParentHeaderNotFound(num)
+		}
+		statedb, err := v.Chain.StateAt(genesisHeader.Root)
+		if err != nil {
+			return nil, err
+		}
+		nodes, _, _, _, _, err = system.ReadNodeStates(statedb, v.Chain, genesisHeader)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		parentHeader := v.Chain.GetHeaderByNumber(num - 1)
 		if parentHeader == nil {

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -76,8 +76,7 @@ type ValsetModule struct {
 	proposerListCache *lru.Cache // uint64 -> []common.Address
 	removeVotesCache  *lru.Cache // uint64 -> removeVoteList
 	councilCache      *lru.Cache // uint64 -> *valset.AddressSet
-	nodeStatesCache   *lru.Cache // uint64 -> valset.NodeStateMap (permissionless node states)
-	vrankEpoch        uint64     // blocks per VRank epoch; defaults to valset.DefaultVRankEpoch
+	nodeStatesCache *lru.Cache // uint64 -> valset.NodeStateMap (permissionless node states)
 
 	validatorVoteBlockNumsCache []uint64
 	lowestScannedVoteNumCache   *uint64
@@ -92,8 +91,7 @@ func NewValsetModule() *ValsetModule {
 		proposerListCache: pListCache,
 		removeVotesCache:  rVoteCache,
 		councilCache:      councilCache,
-		nodeStatesCache:   nodeStatesCache,
-		vrankEpoch:        valset.DefaultVRankEpoch,
+		nodeStatesCache: nodeStatesCache,
 	}
 }
 

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -76,7 +76,7 @@ type ValsetModule struct {
 	proposerListCache *lru.Cache // uint64 -> []common.Address
 	removeVotesCache  *lru.Cache // uint64 -> removeVoteList
 	councilCache      *lru.Cache // uint64 -> *valset.AddressSet
-	nodeStatesCache *lru.Cache // uint64 -> valset.NodeStateMap (permissionless node states)
+	nodeStatesCache   *lru.Cache // uint64 -> valset.NodeStateMap (permissionless node states)
 
 	validatorVoteBlockNumsCache []uint64
 	lowestScannedVoteNumCache   *uint64
@@ -91,7 +91,7 @@ func NewValsetModule() *ValsetModule {
 		proposerListCache: pListCache,
 		removeVotesCache:  rVoteCache,
 		councilCache:      councilCache,
-		nodeStatesCache: nodeStatesCache,
+		nodeStatesCache:   nodeStatesCache,
 	}
 }
 

--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -104,7 +104,7 @@ func (v *ValsetModule) isPassVrankTest() bool {
 }
 
 func (v *ValsetModule) isVrankEpoch(num uint64) bool {
-	return num%v.vrankEpoch == 0
+	return num%v.Chain.Config().VRankEpoch == 0
 }
 
 // WriteStatesToContract computes state transitions and writes updated validator states to ABv2 contract.

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -72,11 +72,13 @@ func newTestValsetModule(ctrl *gomock.Controller) *ValsetModule {
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
 		MinimumStake: new(big.Int).SetUint64(testMinStake),
 	}).AnyTimes()
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(&params.ChainConfig{VRankEpoch: testVRankEpoch}).AnyTimes()
 	return &ValsetModule{
 		InitOpts: InitOpts{
+			Chain:     mockChain,
 			GovModule: mockGov,
 		},
-		vrankEpoch: testVRankEpoch,
 	}
 }
 
@@ -306,7 +308,7 @@ func newTestApplyAllTransitions(ctrl *gomock.Controller) *ValsetModule {
 	mockChain := chain_mock.NewMockBlockChain(ctrl)
 	mockGov := gov_mock.NewMockGovModule(ctrl)
 
-	chainConfig := &params.ChainConfig{}
+	chainConfig := &params.ChainConfig{VRankEpoch: testVRankEpoch}
 	mockChain.EXPECT().Config().Return(chainConfig).AnyTimes()
 
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
@@ -318,7 +320,6 @@ func newTestApplyAllTransitions(ctrl *gomock.Controller) *ValsetModule {
 			Chain:     mockChain,
 			GovModule: mockGov,
 		},
-		vrankEpoch: testVRankEpoch,
 	}
 	return v
 }

--- a/kaiax/valset/impl/state_transition_test.go
+++ b/kaiax/valset/impl/state_transition_test.go
@@ -163,7 +163,7 @@ func TestGetOrComputeNodeStates(t *testing.T) {
 		v := NewValsetModule()
 		v.Chain = chain
 		v.GovModule = mockGov
-		v.vrankEpoch = testVRankEpoch
+		chain.Config().VRankEpoch = testVRankEpoch
 		return v
 	}
 

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -11,10 +11,6 @@ import (
 	"github.com/kaiachain/kaia/common"
 )
 
-// DefaultVRankEpoch is the default number of blocks per VRank epoch.
-// Shared across valset and vrank modules as the single source of truth.
-const DefaultVRankEpoch = 86400
-
 type State uint8
 
 const (

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -42,7 +42,7 @@ func (v *VRankModule) VerifyHeader(header *types.Header) error {
 		return nil
 	}
 
-	if number%vrank.Epoch == 0 && len(header.VRank) > 0 {
+	if number%v.vrankEpoch() == 0 && len(header.VRank) > 0 {
 		return vrank.ErrUnexpectedVRankAtEpochStart
 	}
 

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/kaiax/vrank"
+	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,14 +78,14 @@ func TestVerifyHeader(t *testing.T) {
 	t.Run("epoch-start: empty VRank passes", func(t *testing.T) {
 		vs := noCallValset(t)
 		_, module := newTestModule(t, vs, database.NewMemDB(), &testChain{headers: map[uint64]*types.Header{}})
-		h := &types.Header{Number: big.NewInt(int64(vrank.Epoch))}
+		h := &types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}
 		assert.NoError(t, module.VerifyHeader(h))
 	})
 
 	t.Run("epoch-start: non-empty VRank rejected", func(t *testing.T) {
 		vs := noCallValset(t)
 		_, module := newTestModule(t, vs, database.NewMemDB(), &testChain{headers: map[uint64]*types.Header{}})
-		assert.ErrorIs(t, module.VerifyHeader(makeVRankHeader(t, vrank.Epoch, []common.Address{C1})),
+		assert.ErrorIs(t, module.VerifyHeader(makeVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1})),
 			vrank.ErrUnexpectedVRankAtEpochStart)
 	})
 

--- a/kaiax/vrank/impl/execution.go
+++ b/kaiax/vrank/impl/execution.go
@@ -38,7 +38,7 @@ func (v *VRankModule) PostInsertBlock(block *types.Block) error {
 		return err
 	}
 
-	if blockNum%scoreCheckpointInterval == 0 {
+	if blockNum%v.scoreCheckpointInterval() == 0 {
 		// GetCFS populates cpMatrixCache, so fetch from there.
 		cpRaw, hasCPS := v.cpMatrixCache.Get(blockNum)
 		var cpMatrix vrank.CPMatrix
@@ -50,7 +50,7 @@ func (v *VRankModule) PostInsertBlock(block *types.Block) error {
 			if err != nil {
 				return err
 			}
-			cpMatrix, err = v.applyBlocksForCPMatrix(calcEpochStart(blockNum), blockNum, cpMatrix)
+			cpMatrix, err = v.applyBlocksForCPMatrix(calcEpochStart(blockNum, v.vrankEpoch()), blockNum, cpMatrix)
 			if err != nil {
 				return err
 			}

--- a/kaiax/vrank/impl/execution_test.go
+++ b/kaiax/vrank/impl/execution_test.go
@@ -32,10 +32,10 @@ import (
 
 // TestPostInsertBlock verifies the checkpoint-writing behaviour of PostInsertBlock.
 func TestPostInsertBlock(t *testing.T) {
-	cp := scoreCheckpointInterval
+	cp := testCheckpointInterval
 	P1, C1 := addrN(1), addrN(10)
 
-	// at_interval: block lands exactly on a scoreCheckpointInterval boundary →
+	// at_interval: block lands exactly on a testCheckpointInterval boundary →
 	// combined PFS+CFS checkpoint and lastCheckpoint pointer must be written.
 	t.Run("at_interval", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -87,7 +87,7 @@ func (v *VRankModule) TallyCfReport(blockNum, round uint64) ([]common.Address, e
 	}
 
 	// epoch header's VRank should be nil
-	if (blockNum+1)%vrankEpoch == 0 {
+	if (blockNum+1)%v.vrankEpoch() == 0 {
 		return []common.Address{}, nil
 	}
 	if round > maxRound {

--- a/kaiax/vrank/impl/getter_test.go
+++ b/kaiax/vrank/impl/getter_test.go
@@ -28,9 +28,12 @@ import (
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/kaiax/vrank"
+	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var testCheckpointInterval = params.DefaultVRankEpoch / 8
 
 type testChain struct {
 	headers map[uint64]*types.Header
@@ -357,14 +360,14 @@ func TestTallyCfReport_Errors(t *testing.T) {
 	t.Run("epoch header returns empty report", func(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
 		val := createCN(t, valset)
-		valset.EXPECT().GetCommittee(uint64(vrankEpoch-1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(vrankEpoch-1)).Return([]common.Address{candAddr}, nil).AnyTimes()
-		valset.EXPECT().GetProposer(uint64(vrankEpoch-1), uint64(0)).Return(val.Addr, nil).AnyTimes()
-		block := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(vrankEpoch - 1)})
-		view := &istanbul.View{Sequence: new(big.Int).SetUint64(vrankEpoch - 1), Round: common.Big0}
+		valset.EXPECT().GetCommittee(uint64(params.DefaultVRankEpoch-1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCandidates(uint64(params.DefaultVRankEpoch-1)).Return([]common.Address{candAddr}, nil).AnyTimes()
+		valset.EXPECT().GetProposer(uint64(params.DefaultVRankEpoch-1), uint64(0)).Return(val.Addr, nil).AnyTimes()
+		block := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(params.DefaultVRankEpoch - 1)})
+		view := &istanbul.View{Sequence: new(big.Int).SetUint64(params.DefaultVRankEpoch - 1), Round: common.Big0}
 		val.VRankModule.HandleIstanbulPreprepare(block, view)
 
-		report, err := val.VRankModule.TallyCfReport(vrankEpoch-1, 0)
+		report, err := val.VRankModule.TallyCfReport(params.DefaultVRankEpoch-1, 0)
 		require.NoError(t, err)
 		assert.Empty(t, report)
 	})

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -619,8 +619,8 @@ func TestHandleVRankCandidate(t *testing.T) {
 	t.Run("epoch boundary future messages should be stored until tally", func(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
 		val, cand := createCN(t, valset), createCN(t, valset)
-		blockNum := vrank.Epoch - 1
-		nextBlockNum := vrank.Epoch
+		blockNum := params.DefaultVRankEpoch - 1
+		nextBlockNum := params.DefaultVRankEpoch
 		block := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(blockNum)})
 		nextBlock := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(nextBlockNum)})
 		view := &istanbul.View{Sequence: new(big.Int).SetUint64(blockNum), Round: common.Big0}

--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -39,12 +39,10 @@ const (
 	vrankCandidateSigDomain  = "VRANK_CANDIDATE_V1"
 
 	broadcastChSize    = 2048
-	vrankEpoch         = vrank.Epoch
 	maxRound           = vrank.MaxRound
 	maxCollectorWindow = uint64(10) // max collection window [N-10, N+10]
 
-	scoreCacheSize          = 1024
-	scoreCheckpointInterval = uint64(vrankEpoch / 8) // 10,800 blocks
+	scoreCacheSize = 1024
 )
 
 var (
@@ -99,6 +97,16 @@ func NewVRankModule() *VRankModule {
 	}
 }
 
+func (v *VRankModule) vrankEpoch() uint64 {
+	return v.ChainConfig.VRankEpoch
+}
+
+// scoreCheckpointInterval returns the block interval at which PFS/CFS scores are persisted to disk.
+// Divides VRankEpoch into 8 segments so that cold-start replay covers at most 1/8 of an epoch.
+func (v *VRankModule) scoreCheckpointInterval() uint64 {
+	return v.ChainConfig.VRankEpoch / 8
+}
+
 func (v *VRankModule) Init(opts *InitOpts) error {
 	if opts == nil || opts.Valset == nil || opts.NodeKey == nil || opts.ChainConfig == nil || opts.ChainConfig.ChainID == nil || opts.Chain == nil || opts.ChainKv == nil {
 		return vrank.ErrInitUnexpectedNil
@@ -106,7 +114,7 @@ func (v *VRankModule) Init(opts *InitOpts) error {
 	v.InitOpts = *opts
 	v.nodeID = crypto.PubkeyToAddress(opts.NodeKey.PublicKey)
 	if err := v.catchUpScoreCaches(); err != nil {
-		return err
+		logger.Warn("Failed to catch up score caches, starting cold", "err", err)
 	}
 	return nil
 }
@@ -168,7 +176,7 @@ func (v *VRankModule) catchUpScoreCaches() error {
 }
 
 func (v *VRankModule) loadPFSCheckpointInEpoch(blockNum uint64) (uint64, map[common.Address]uint64, bool) {
-	cpNum := calcCheckpointBlock(blockNum)
+	cpNum := calcCheckpointBlock(blockNum, v.scoreCheckpointInterval())
 	pfs := ReadCheckpointPFS(v.ChainKv, cpNum)
 	if pfs == nil {
 		return 0, nil, false
@@ -177,7 +185,7 @@ func (v *VRankModule) loadPFSCheckpointInEpoch(blockNum uint64) (uint64, map[com
 }
 
 func (v *VRankModule) loadCPMatrixCheckpointInEpoch(blockNum uint64) (uint64, vrank.CPMatrix, bool) {
-	cpNum := calcCheckpointBlock(blockNum)
+	cpNum := calcCheckpointBlock(blockNum, v.scoreCheckpointInterval())
 	cpMatrix := ReadCheckpointCPMatrix(v.ChainKv, cpNum)
 	if cpMatrix == nil {
 		return 0, nil, false

--- a/kaiax/vrank/impl/init_test.go
+++ b/kaiax/vrank/impl/init_test.go
@@ -42,7 +42,7 @@ import (
 // Both caches are seeded from the checkpoint (P1:1 / C1:{P1:1}) so the assertions
 // confirm both the carry-over from the checkpoint AND the tail-block contribution.
 func TestInit_CatchUpFromCheckpoint(t *testing.T) {
-	var checkpoint = testCheckpointInterval // must be a testCheckpointInterval multiple
+	checkpoint := testCheckpointInterval // must be a testCheckpointInterval multiple
 	P1, P2, C1 := addrN(1), addrN(2), addrN(10)
 
 	// Only the two headers around the tail are needed: catchUp loads from the DB
@@ -99,7 +99,7 @@ func TestInit_CatchUpFromCheckpoint(t *testing.T) {
 }
 
 func TestCheckpointRoundTrip_PreservesZeroScores(t *testing.T) {
-	var checkpoint = testCheckpointInterval
+	checkpoint := testCheckpointInterval
 	P1, P2, C1, C2 := addrN(1), addrN(2), addrN(10), addrN(11)
 
 	db := database.NewMemDB()

--- a/kaiax/vrank/impl/init_test.go
+++ b/kaiax/vrank/impl/init_test.go
@@ -42,7 +42,7 @@ import (
 // Both caches are seeded from the checkpoint (P1:1 / C1:{P1:1}) so the assertions
 // confirm both the carry-over from the checkpoint AND the tail-block contribution.
 func TestInit_CatchUpFromCheckpoint(t *testing.T) {
-	const checkpoint = scoreCheckpointInterval // must be a scoreCheckpointInterval multiple
+	var checkpoint = testCheckpointInterval // must be a testCheckpointInterval multiple
 	P1, P2, C1 := addrN(1), addrN(2), addrN(10)
 
 	// Only the two headers around the tail are needed: catchUp loads from the DB
@@ -99,7 +99,7 @@ func TestInit_CatchUpFromCheckpoint(t *testing.T) {
 }
 
 func TestCheckpointRoundTrip_PreservesZeroScores(t *testing.T) {
-	const checkpoint = scoreCheckpointInterval
+	var checkpoint = testCheckpointInterval
 	P1, P2, C1, C2 := addrN(1), addrN(2), addrN(10), addrN(11)
 
 	db := database.NewMemDB()

--- a/kaiax/vrank/impl/rewind.go
+++ b/kaiax/vrank/impl/rewind.go
@@ -40,8 +40,9 @@ func (v *VRankModule) RewindDelete(hash common.Hash, num uint64) {
 		return
 	}
 
-	for cpNum := num; cpNum >= scoreCheckpointInterval; cpNum -= scoreCheckpointInterval {
-		prevCP := cpNum - scoreCheckpointInterval
+	cpInterval := v.scoreCheckpointInterval()
+	for cpNum := num; cpNum >= cpInterval; cpNum -= cpInterval {
+		prevCP := cpNum - cpInterval
 		prevPFS := ReadCheckpointPFS(v.ChainKv, prevCP)
 		if prevPFS != nil {
 			WriteLastCheckpoint(v.ChainKv, prevCP)

--- a/kaiax/vrank/impl/rewind_test.go
+++ b/kaiax/vrank/impl/rewind_test.go
@@ -39,25 +39,25 @@ func TestRewindTo_PurgesCache(t *testing.T) {
 
 	headers := map[uint64]*types.Header{
 		0:                           makeHeaderWithRound(0, 0),
-		scoreCheckpointInterval:     makeHeaderWithRound(scoreCheckpointInterval, 0),
-		scoreCheckpointInterval + 1: makeHeaderWithRound(scoreCheckpointInterval+1, 0),
+		testCheckpointInterval:     makeHeaderWithRound(testCheckpointInterval, 0),
+		testCheckpointInterval + 1: makeHeaderWithRound(testCheckpointInterval+1, 0),
 	}
 	v := newTestModuleWithHeaders(t, valset, db, headers)
 
 	v.pfsCache.Add(uint64(1), map[common.Address]uint64{addrN(0): 1})
-	v.pfsCache.Add(scoreCheckpointInterval+1, map[common.Address]uint64{addrN(0): 2})
+	v.pfsCache.Add(testCheckpointInterval+1, map[common.Address]uint64{addrN(0): 2})
 	v.cpMatrixCache.Add(uint64(1), vrank.CPMatrix{addrN(1): {addrN(2): 1}})
-	v.cpMatrixCache.Add(scoreCheckpointInterval+1, vrank.CPMatrix{addrN(1): {addrN(2): 2}})
+	v.cpMatrixCache.Add(testCheckpointInterval+1, vrank.CPMatrix{addrN(1): {addrN(2): 2}})
 
-	v.RewindTo(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(int64(scoreCheckpointInterval))}))
+	v.RewindTo(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(int64(testCheckpointInterval))}))
 
 	_, ok := v.pfsCache.Get(uint64(1))
 	assert.False(t, ok, "pfsCache entry below rewind point must be purged")
-	_, ok = v.pfsCache.Get(scoreCheckpointInterval + 1)
+	_, ok = v.pfsCache.Get(testCheckpointInterval + 1)
 	assert.False(t, ok, "pfsCache entry above rewind point must be purged")
 	_, ok = v.cpMatrixCache.Get(uint64(1))
 	assert.False(t, ok, "cpMatrixCache entry below rewind point must be purged")
-	_, ok = v.cpMatrixCache.Get(scoreCheckpointInterval + 1)
+	_, ok = v.cpMatrixCache.Get(testCheckpointInterval + 1)
 	assert.False(t, ok, "cpMatrixCache entry above rewind point must be purged")
 }
 
@@ -71,8 +71,8 @@ func TestRewindDelete_UpdatesLastCheckpoint(t *testing.T) {
 	_ = valset
 	db := database.NewMemDB()
 
-	cp1 := scoreCheckpointInterval
-	cp2 := 2 * scoreCheckpointInterval
+	cp1 := testCheckpointInterval
+	cp2 := 2 * testCheckpointInterval
 
 	headers := map[uint64]*types.Header{
 		0:   makeHeaderWithRound(0, 0),
@@ -118,9 +118,9 @@ func TestRewindDelete_MultiIntervalReorg(t *testing.T) {
 	_ = valset
 	db := database.NewMemDB()
 
-	cp1 := scoreCheckpointInterval
-	cp2 := 2 * scoreCheckpointInterval
-	cp3 := 3 * scoreCheckpointInterval
+	cp1 := testCheckpointInterval
+	cp2 := 2 * testCheckpointInterval
+	cp3 := 3 * testCheckpointInterval
 
 	headers := map[uint64]*types.Header{
 		0:   makeHeaderWithRound(0, 0),

--- a/kaiax/vrank/impl/schema.go
+++ b/kaiax/vrank/impl/schema.go
@@ -104,8 +104,8 @@ func DeleteCheckpoint(db database.Database, blockNum uint64) {
 	}
 }
 
-func calcCheckpointBlock(blockNum uint64) uint64 {
-	return blockNum - (blockNum % scoreCheckpointInterval)
+func calcCheckpointBlock(blockNum, checkpointInterval uint64) uint64 {
+	return blockNum - (blockNum % checkpointInterval)
 }
 
 // ReadLastCheckpoint returns the block number of the most recently written checkpoint and true,

--- a/kaiax/vrank/impl/schema_test.go
+++ b/kaiax/vrank/impl/schema_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestCheckpointRoundTrip_PreservesZeroFailureCandidates(t *testing.T) {
 	db := database.NewMemDB()
-	cp := scoreCheckpointInterval
+	cp := testCheckpointInterval
 	P1, C1, C2 := addrN(1), addrN(10), addrN(11)
 
 	WriteCheckpoint(db, cp,

--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -27,7 +27,7 @@ import (
 
 const scoreCacheProbeLookback = uint64(64)
 
-func calcEpochStart(blockNum uint64) uint64 {
+func calcEpochStart(blockNum, vrankEpoch uint64) uint64 {
 	return blockNum - (blockNum % vrankEpoch)
 }
 
@@ -100,7 +100,7 @@ func (v *VRankModule) lookupPFSSeed(blockNum uint64) (start uint64, seed map[com
 	if cpNum, pfs, ok := v.loadPFSCheckpointInEpoch(blockNum); ok {
 		return cpNum + 1, pfs
 	}
-	return calcEpochStart(blockNum), make(map[common.Address]uint64)
+	return calcEpochStart(blockNum, v.vrankEpoch()), make(map[common.Address]uint64)
 }
 
 // lookupCFSSeed returns (start, seed) where seed holds the CP matrix accumulated up to start-1.
@@ -116,7 +116,7 @@ func (v *VRankModule) lookupCFSSeed(blockNum uint64) (start uint64, seed vrank.C
 	if err != nil {
 		return 0, nil, err
 	}
-	return calcEpochStart(blockNum), cpMatrix, nil
+	return calcEpochStart(blockNum, v.vrankEpoch()), cpMatrix, nil
 }
 
 func (v *VRankModule) newCPMatrix(blockNum uint64) (vrank.CPMatrix, error) {
@@ -223,7 +223,7 @@ func cloneMap(src map[common.Address]uint64) map[common.Address]uint64 {
 }
 
 func (v *VRankModule) lookupPFSCache(blockNum uint64) (uint64, map[common.Address]uint64, bool) {
-	epochStart := calcEpochStart(blockNum)
+	epochStart := calcEpochStart(blockNum, v.vrankEpoch())
 	for i := uint64(0); i <= min(scoreCacheProbeLookback, blockNum-epochStart); i++ {
 		candidateNum := blockNum - i
 		if cached, ok := v.pfsCache.Get(candidateNum); ok {
@@ -234,7 +234,7 @@ func (v *VRankModule) lookupPFSCache(blockNum uint64) (uint64, map[common.Addres
 }
 
 func (v *VRankModule) lookupCPMatrixCache(blockNum uint64) (uint64, vrank.CPMatrix, bool) {
-	epochStart := calcEpochStart(blockNum)
+	epochStart := calcEpochStart(blockNum, v.vrankEpoch())
 	for i := uint64(0); i <= min(scoreCacheProbeLookback, blockNum-epochStart); i++ {
 		candidateNum := blockNum - i
 		if cached, ok := v.cpMatrixCache.Get(candidateNum); ok {

--- a/kaiax/vrank/impl/scoring_test.go
+++ b/kaiax/vrank/impl/scoring_test.go
@@ -128,7 +128,7 @@ func TestGetPFS(t *testing.T) {
 	var (
 		P0, P1, P2    = addrN(0), addrN(1), addrN(2)
 		proposerList  = []common.Address{P0, P1, P2}
-		epochStart    = uint64(vrankEpoch)
+		epochStart    = uint64(params.DefaultVRankEpoch)
 		proposerCount = uint64(len(proposerList))
 		round1Offset  = proposerCount     // keep (epochStart+round1Offset)%len(proposerList) == 0
 		round2Offset  = proposerCount * 2 // keep (epochStart+round2Offset)%len(proposerList) == 0
@@ -279,7 +279,7 @@ func TestGetPFS_DBCheckpointHit(t *testing.T) {
 	db := database.NewMemDB()
 
 	P0 := addrN(0)
-	cp := scoreCheckpointInterval
+	cp := testCheckpointInterval
 	headers := map[uint64]*types.Header{
 		cp:     makeHeaderWithRound(cp, 0),
 		cp + 1: makeHeaderWithRound(cp+1, 1), // round 1 → pfReport = [P0]
@@ -329,7 +329,7 @@ func TestGetPFS_EpochStart(t *testing.T) {
 	valset := mock_valset.NewMockValsetModule(ctrl)
 	db := database.NewMemDB()
 
-	epochStart := uint64(vrankEpoch)
+	epochStart := uint64(params.DefaultVRankEpoch)
 	v := newTestModuleWithHeaders(t, valset, db, map[uint64]*types.Header{
 		epochStart: makeHeaderWithRound(epochStart, 0),
 	})
@@ -351,7 +351,7 @@ func TestGetPFS_EpochBoundaryClamp(t *testing.T) {
 	valset := mock_valset.NewMockValsetModule(ctrl)
 	db := database.NewMemDB()
 
-	epochStart := uint64(vrankEpoch)
+	epochStart := uint64(params.DefaultVRankEpoch)
 	blockNum := epochStart + 5
 	headers := map[uint64]*types.Header{}
 	for i := epochStart; i <= blockNum; i++ {
@@ -472,15 +472,15 @@ func TestGetPFS_MissingHeader(t *testing.T) {
 func TestGetCFS(t *testing.T) {
 	t.Run("epoch boundary", func(t *testing.T) {
 		P1, C1 := addrN(1), addrN(10)
-		epochStart := uint64(vrankEpoch)
-		epochEnd := uint64(2*vrankEpoch - 1)
+		epochStart := uint64(params.DefaultVRankEpoch)
+		epochEnd := uint64(2*params.DefaultVRankEpoch - 1)
 
 		ctrl := gomock.NewController(t)
 		valset := mock_valset.NewMockValsetModule(ctrl)
 		v := createCN(t, valset).VRankModule
 
-		headers := make(map[uint64]*types.Header, vrankEpoch)
-		for i := uint64(0); i < vrankEpoch; i++ {
+		headers := make(map[uint64]*types.Header, params.DefaultVRankEpoch)
+		for i := uint64(0); i < params.DefaultVRankEpoch; i++ {
 			headers[epochStart+i] = makeHeaderWithRound(epochStart+i, 0)
 		}
 		headers[epochStart+1] = makeHeaderWithVRank(epochStart+1, 0, []common.Address{C1})
@@ -501,7 +501,7 @@ func TestGetCFS(t *testing.T) {
 	})
 
 	t.Run("multi-reporter epoch", func(t *testing.T) {
-		epochStart := uint64(vrankEpoch)
+		epochStart := uint64(params.DefaultVRankEpoch)
 		P1, P2, P3, P4 := addrN(30), addrN(31), addrN(32), addrN(33)
 		C1, C2, C3 := addrN(40), addrN(41), addrN(42)
 		candidates := []common.Address{C1, C2, C3}
@@ -654,7 +654,7 @@ func TestGetCFS_DBCheckpointHit(t *testing.T) {
 	db := database.NewMemDB()
 
 	P1, C1 := addrN(1), addrN(10)
-	cp := scoreCheckpointInterval
+	cp := testCheckpointInterval
 	headers := map[uint64]*types.Header{
 		cp:     makeHeaderWithRound(cp, 0),
 		cp + 1: makeHeaderWithVRank(cp+1, 0, []common.Address{C1}),
@@ -682,7 +682,7 @@ func TestGetCFS_DBCheckpointHit_PreservesZeroFailureCandidates(t *testing.T) {
 	db := database.NewMemDB()
 
 	P1, C1, C2 := addrN(1), addrN(10), addrN(11)
-	cp := scoreCheckpointInterval
+	cp := testCheckpointInterval
 	headers := map[uint64]*types.Header{
 		cp: makeHeaderWithRound(cp, 0),
 	}
@@ -745,7 +745,7 @@ func TestGetCFS_EpochStart(t *testing.T) {
 	valset := mock_valset.NewMockValsetModule(ctrl)
 	db := database.NewMemDB()
 
-	epochStart := uint64(vrankEpoch)
+	epochStart := uint64(params.DefaultVRankEpoch)
 	C1, C2, P1 := addrN(10), addrN(11), addrN(1)
 	headers := map[uint64]*types.Header{
 		epochStart: makeHeaderWithVRank(epochStart, 0, nil), // epoch start: VRank must be nil
@@ -775,7 +775,7 @@ func TestGetCFS_EpochBoundaryClamp(t *testing.T) {
 	valset := mock_valset.NewMockValsetModule(ctrl)
 	db := database.NewMemDB()
 
-	epochStart := uint64(vrankEpoch)
+	epochStart := uint64(params.DefaultVRankEpoch)
 	blockNum := epochStart + 3
 	C1, P1 := addrN(10), addrN(1)
 	headers := map[uint64]*types.Header{}
@@ -807,7 +807,7 @@ func TestGetCFS_NearbyProbe_SameEpoch(t *testing.T) {
 	valset := mock_valset.NewMockValsetModule(ctrl)
 	db := database.NewMemDB()
 
-	epochStart := uint64(vrankEpoch)
+	epochStart := uint64(params.DefaultVRankEpoch)
 	C1, P1 := addrN(10), addrN(1)
 
 	headers := map[uint64]*types.Header{

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -60,8 +60,6 @@ const (
 )
 
 const (
-	// Epoch is the number of blocks in one VRank scoring epoch.
-	Epoch = uint64(86400)
 	// MaxRound is the maximum allowed consensus round per block (range [0, MaxRound]).
 	MaxRound = 10
 )

--- a/params/config.go
+++ b/params/config.go
@@ -215,6 +215,7 @@ func TestKaiaConfig(maxHardfork string) *ChainConfig {
 		return chainConfig
 	}
 	chainConfig.PermissionlessCompatibleBlock = big.NewInt(0)
+	chainConfig.VRankEpoch = DefaultVRankEpoch
 	if maxHardfork == "permissionless" {
 		return chainConfig
 	}
@@ -243,7 +244,7 @@ const (
 	PasswordLength = 16
 
 	// DefaultVRankEpoch is the default number of blocks per VRank epoch.
-	DefaultVRankEpoch = 86400
+	DefaultVRankEpoch = uint64(86400)
 )
 
 var (

--- a/params/config.go
+++ b/params/config.go
@@ -288,7 +288,7 @@ type ChainConfig struct {
 	PragueCompatibleBlock         *big.Int `json:"pragueCompatibleBlock,omitempty"`         // PragueCompatible switch block (nil = no fork)
 	OsakaCompatibleBlock          *big.Int `json:"osakaCompatibleBlock,omitempty"`          // OsakaCompatible switch block (nil = no fork)
 	PermissionlessCompatibleBlock *big.Int `json:"permissionlessCompatibleBlock,omitempty"` // PermissionlessCompatible switch block (nil = no fork)
-	VRankEpoch                    uint64  `json:"vrankEpoch,omitempty"`                    // Blocks per VRank epoch; defaults to DefaultVRankEpoch (86400). No CLI flag by design; set via genesis.json only.
+	VRankEpoch                    uint64   `json:"vrankEpoch,omitempty"`                    // Blocks per VRank epoch; defaults to DefaultVRankEpoch (86400). No CLI flag by design; set via genesis.json only.
 
 	// Kip103 is a special purpose hardfork feature that can be executed only once
 	// Both Kip103CompatibleBlock and Kip103ContractAddress should be specified to enable KIP103

--- a/params/config.go
+++ b/params/config.go
@@ -241,6 +241,9 @@ const (
 
 const (
 	PasswordLength = 16
+
+	// DefaultVRankEpoch is the default number of blocks per VRank epoch.
+	DefaultVRankEpoch = 86400
 )
 
 var (
@@ -285,6 +288,7 @@ type ChainConfig struct {
 	PragueCompatibleBlock         *big.Int `json:"pragueCompatibleBlock,omitempty"`         // PragueCompatible switch block (nil = no fork)
 	OsakaCompatibleBlock          *big.Int `json:"osakaCompatibleBlock,omitempty"`          // OsakaCompatible switch block (nil = no fork)
 	PermissionlessCompatibleBlock *big.Int `json:"permissionlessCompatibleBlock,omitempty"` // PermissionlessCompatible switch block (nil = no fork)
+	VRankEpoch                    uint64  `json:"vrankEpoch,omitempty"`                    // Blocks per VRank epoch; defaults to DefaultVRankEpoch (86400). No CLI flag by design; set via genesis.json only.
 
 	// Kip103 is a special purpose hardfork feature that can be executed only once
 	// Both Kip103CompatibleBlock and Kip103ContractAddress should be specified to enable KIP103
@@ -743,6 +747,9 @@ func (c *ChainConfig) SetDefaults() {
 	}
 	if c.Governance.Reward.StakingRewardThreshold == nil {
 		c.Governance.Reward.StakingRewardThreshold = DefaultStakingRewardThreshold
+	}
+	if c.VRankEpoch == 0 {
+		c.VRankEpoch = DefaultVRankEpoch
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Move `VRankEpoch` from module-local variables to `ChainConfig`. Configurable via `genesis.json` only (no CLI flag by design). Defaults to 86400 in `SetDefaults()`.

- valset: remove `vrankEpoch` field, read from `chain.Config().VRankEpoch`
- vrank module update deferred until #794 is merged

To override the default, set `vrankEpoch` in genesis.json:
```json
{
  "config": {
    "vrankEpoch": 86400
  }
}
```

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 🟢 Lint and unit tests pass locally with my changes

## Related issues

- vrank module (#794) will be updated after merge

## Further comments