### PR TITLE
vrank: skip catchup when head=zero

### DIFF
--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -157,6 +157,9 @@ func (v *VRankModule) catchUpScoreCaches() error {
 		return nil
 	}
 	headNum := head.Number.Uint64()
+	if headNum == 0 {
+		return nil
+	}
 
 	if _, err := v.GetPFS(headNum); err != nil {
 		return err

--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -120,6 +120,12 @@ func (v *VRankModule) lookupCFSSeed(blockNum uint64) (start uint64, seed vrank.C
 }
 
 func (v *VRankModule) newCPMatrix(blockNum uint64) (vrank.CPMatrix, error) {
+	if blockNum == 0 {
+		// Block 0 is genesis; there is no parent block, so GetCandidates(0) would
+		// underflow to GetHeaderByNumber(MaxUint64). Start with an empty matrix —
+		// the first epoch begins scoring from block 1 onward.
+		return vrank.NewCPMatrix(nil), nil
+	}
 	candidates, err := v.Valset.GetCandidates(blockNum)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Proposed changes

Skip catchup when head block number is zero.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
