### PR TITLE
Permissionless: return copied ValidatorState in diffNodeStates

### DIFF
--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -183,7 +183,8 @@ func diffNodeStates(parent, current valset.NodeStateMap) valset.NodeStateMap {
 	for addr, cur := range current {
 		prev, exists := parent[addr]
 		if !exists || prev.State != cur.State || prev.IdleTimeout != cur.IdleTimeout || prev.PausedTimeout != cur.PausedTimeout {
-			diff[addr] = cur
+			copied := *cur
+			diff[addr] = &copied
 		}
 	}
 	return diff


### PR DESCRIPTION
## Proposed changes

`diffNodeStates` returns pointers from the input map directly. Copy each entry to prevent unintended mutation of the source map.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments