### PR TITLE
Permissionless: fix noisy cfReport error log and rename node write functions

### DIFF
--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -85,8 +85,8 @@ func EncodeInitializeABv2(rules params.Rules) (common.Address, *types.Transactio
 	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
-// EncodeWriteNodes encodes the processSystemTransition call with the given validator state changes.
-func EncodeWriteNodes(
+// EncodeNodeStateUpdate encodes the processSystemTransition call with the given validator state changes.
+func EncodeNodeStateUpdate(
 	rules params.Rules,
 	validators valset.NodeStateMap,
 ) (common.Address, *types.Transaction, error) {

--- a/blockchain/system/addressbook_v2_test.go
+++ b/blockchain/system/addressbook_v2_test.go
@@ -53,7 +53,7 @@ func TestInstallAddressBookV2(t *testing.T) {
 	assert.Equal(t, lpad32(logicAddr), implSlot)
 }
 
-func TestEncodeWriteNodes(t *testing.T) {
+func TestEncodeNodeStateUpdate(t *testing.T) {
 	rules := params.Rules{IsPrague: true} // enable intrinsic gas calculation
 
 	tests := []struct {
@@ -148,7 +148,7 @@ func TestEncodeWriteNodes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			from, msg, err := EncodeWriteNodes(rules, tc.validators)
+			from, msg, err := EncodeNodeStateUpdate(rules, tc.validators)
 			require.NoError(t, err)
 
 			// from is always SystemAddress

--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -116,7 +116,7 @@ func (v *ValsetModule) WriteStatesToContract(
 	config := v.Chain.Config()
 
 	if config.IsPermissionlessForkEnabled(header.Number) {
-		if err := v.writeNodesToContract(vmenv, header, state); err != nil {
+		if err := v.writeNodeStateUpdateToContract(vmenv, header, state); err != nil {
 			return err
 		}
 	}
@@ -136,10 +136,10 @@ func (v *ValsetModule) InstallABv2(
 	return nil
 }
 
-// writeNodesToContract computes the diff between parent(N-1) and current(N) node states,
+// writeNodeStateUpdateToContract computes the diff between parent(N-1) and current(N) node states,
 // and writes only the changed nodes to the AddressBookV2 contract via processSystemTransition.
 // At epoch blocks, the call is always made (even with empty diff) to update epochValCount.
-func (v *ValsetModule) writeNodesToContract(
+func (v *ValsetModule) writeNodeStateUpdateToContract(
 	vmenv *vm.EVM,
 	header *types.Header,
 	statedb *state.StateDB,
@@ -167,7 +167,7 @@ func (v *ValsetModule) writeNodesToContract(
 	}
 
 	config := v.Chain.Config()
-	msg, from, err := prepareNodeWrite(config, header.Number, diff)
+	msg, from, err := prepareNodeStateUpdate(config, header.Number, diff)
 	if err != nil {
 		return err
 	}
@@ -231,13 +231,13 @@ func (v *ValsetModule) installAndInitializeABv2(
 	return nil
 }
 
-// prepareNodeWrite builds the ABI-encoded input for writing changed validator states to ABv2.
-func prepareNodeWrite(
+// prepareNodeStateUpdate builds the ABI-encoded input for writing changed validator states to ABv2.
+func prepareNodeStateUpdate(
 	config *params.ChainConfig,
 	num *big.Int,
 	nodes valset.NodeStateMap,
 ) (*types.Transaction, common.Address, error) {
-	from, msg, err := system.EncodeWriteNodes(
+	from, msg, err := system.EncodeNodeStateUpdate(
 		config.Rules(num),
 		nodes,
 	)

--- a/kaiax/valset/impl/state_transition_test.go
+++ b/kaiax/valset/impl/state_transition_test.go
@@ -250,7 +250,7 @@ func TestReadGetAllValidators(t *testing.T) {
 		assert.True(t, vs.PausedTimeout.IsZero())
 	}
 
-	// Apply a state transition via writeNodesToContract (core path):
+	// Apply a state transition via writeNodeStateUpdateToContract (core path):
 	// Seed cache with parent(block 0) = current validators, current(block 1) = modified validators
 	v := NewValsetModule()
 	v.Chain = chain
@@ -272,7 +272,7 @@ func TestReadGetAllValidators(t *testing.T) {
 	}
 	blockCtx := blockchain.NewEVMBlockContext(hfHeader, chain, nil)
 	vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, chain.Config(), &vm.Config{})
-	err = v.writeNodesToContract(vmenv, hfHeader, statedb)
+	err = v.writeNodeStateUpdateToContract(vmenv, hfHeader, statedb)
 	require.NoError(t, err)
 
 	// After transition: config.NodeIds[0] should be ValPaused

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -107,9 +107,12 @@ func (v *VRankModule) TallyCfReport(blockNum, round uint64) ([]common.Address, e
 		return []common.Address{}, nil
 	}
 	candidates, err := v.Valset.GetCandidates(blockNum)
-	if err != nil || candidates == nil {
-		logger.Error("GetCandidates failed", "blockNum", blockNum)
+	if err != nil {
+		logger.Error("GetCandidates failed", "blockNum", blockNum, "err", err)
 		return nil, vrank.ErrGetCandidateFailed
+	}
+	if len(candidates) == 0 {
+		return []common.Address{}, nil
 	}
 	var cfReport []common.Address
 	for _, addr := range candidates {

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -211,8 +211,11 @@ func (v *VRankModule) vrankCandidateSigHash(blockNum uint64, round uint8, blockH
 func (v *VRankModule) BroadcastVRankPreprepare(vrankPreprepare *vrank.VRankPreprepare) {
 	block := vrankPreprepare.Block
 	candidates, err := v.Valset.GetCandidates(block.NumberU64())
-	if err != nil || candidates == nil {
-		logger.Error("GetCandidates failed", "blockNum", block.NumberU64())
+	if err != nil {
+		logger.Error("GetCandidates failed", "blockNum", block.NumberU64(), "err", err)
+		return
+	}
+	if len(candidates) == 0 {
 		return
 	}
 	sigHash := v.vrankPreprepareSigHash(block.NumberU64(), uint8(vrankPreprepare.View.Round.Uint64()), block.Hash())
@@ -258,8 +261,8 @@ func (v *VRankModule) isProposer(blockNum, round uint64) bool {
 
 func (v *VRankModule) isCandidate(blockNum uint64) bool {
 	candidates, err := v.Valset.GetCandidates(blockNum)
-	if err != nil || candidates == nil {
-		logger.Error("GetCandidates failed", "blockNum", blockNum)
+	if err != nil {
+		logger.Error("GetCandidates failed", "blockNum", blockNum, "err", err)
 		return false
 	}
 


### PR DESCRIPTION
## Proposed changes

- Fix `"Failed to tally cfReport"` error log spamming every block when no candidates are registered
  - Split `err != nil || candidates == nil` into separate error and empty-length checks in `TallyCfReport`, `BroadcastVRankPreprepare`, and `isCandidate`
  - Return empty cfReport instead of error when candidates list is empty
- Rename node write functions for better alignment with state transition semantics
  - `EncodeWriteNodes` → `EncodeNodeStateUpdate`
  - `prepareNodeWrite` → `prepareNodeStateUpdate`
  - `writeNodesToContract` → `writeNodeStateUpdateToContract`

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)