### PR TITLE
Permissionless: add --override.permissionless flag and remove admin API

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -159,7 +159,8 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideOsaka *big.Int
+	OverrideOsaka          *big.Int
+	OverridePermissionless *big.Int
 }
 
 // apply applies the chain overrides on the supplied chain config.
@@ -169,6 +170,9 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 	}
 	if o.OverrideOsaka != nil {
 		cfg.OsakaCompatibleBlock = new(big.Int).Set(o.OverrideOsaka)
+	}
+	if o.OverridePermissionless != nil {
+		cfg.PermissionlessCompatibleBlock = new(big.Int).Set(o.OverridePermissionless)
 	}
 	return cfg.CheckConfigForkOrder()
 }

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -602,6 +602,10 @@ func (kCfg *KaiaConfig) SetKaiaConfig(ctx *cli.Context, stack *node.Node) {
 		v := ctx.Uint64(OverrideOsaka.Name)
 		overrides.OverrideOsaka = new(big.Int).SetUint64(v)
 	}
+	if ctx.IsSet(OverridePermissionless.Name) {
+		v := ctx.Uint64(OverridePermissionless.Name)
+		overrides.OverridePermissionless = new(big.Int).SetUint64(v)
+	}
 	cfg.Overrides = &overrides
 	cfg.StartBlockNumber = ctx.Uint64(StartBlockNumberFlag.Name)
 

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -51,6 +51,7 @@ var FlagGroups = []FlagGroup{
 			ExtraDataFlag,
 			ConfigFileFlag,
 			OverrideOsaka,
+			OverridePermissionless,
 			StartBlockNumberFlag,
 			BlockGenerationIntervalFlag,
 			BlockGenerationTimeLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -194,6 +194,11 @@ var (
 		Usage:    "Manually specify the Osaka fork block, overriding the bundled setting",
 		Category: "KAIA",
 	}
+	OverridePermissionless = &cli.Uint64Flag{
+		Name:     "override.permissionless",
+		Usage:    "Manually specify the permissionless hardfork block, overriding the bundled setting",
+		Category: "KAIA",
+	}
 	StartBlockNumberFlag = &cli.Uint64Flag{
 		Name:     "start-block-num",
 		Usage:    "Starts the node from the given block number. Starting from 0 is not supported.",

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -70,6 +70,7 @@ var (
 			utils.RocksDBMaxOpenFilesFlag,
 			utils.RocksDBCacheIndexAndFilterFlag,
 			utils.OverrideOsaka,
+			utils.OverridePermissionless,
 			utils.LivePruningFlag,
 			utils.FlatTrieFlag,
 		},
@@ -124,6 +125,10 @@ func initGenesis(ctx *cli.Context) error {
 	if ctx.IsSet(utils.OverrideOsaka.Name) {
 		v := ctx.Uint64(utils.OverrideOsaka.Name)
 		overrides.OverrideOsaka = new(big.Int).SetUint64(v)
+	}
+	if ctx.IsSet(utils.OverridePermissionless.Name) {
+		v := ctx.Uint64(utils.OverridePermissionless.Name)
+		overrides.OverridePermissionless = new(big.Int).SetUint64(v)
 	}
 
 	// Update undefined config with default values

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -177,6 +177,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewPathFlag(DataDirFlag),
 	altsrc.NewPathFlag(ChainDataDirFlag),
 	altsrc.NewUint64Flag(OverrideOsaka),
+	altsrc.NewUint64Flag(OverridePermissionless),
 	altsrc.NewUint64Flag(StartBlockNumberFlag),
 	altsrc.NewPathFlag(KeyStoreDirFlag),
 	altsrc.NewBoolFlag(TxPoolNoLocalsFlag),

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -544,12 +544,6 @@ web3._extend({
 		}),
 		// TODO-Permissionless: Testing only. Remove before production release.
 		new web3._extend.Method({
-			name: 'setPermissionlessForkBlock',
-			call: 'admin_setPermissionlessForkBlock',
-			params: 1,
-		}),
-		// TODO-Permissionless: Testing only. Remove before production release.
-		new web3._extend.Method({
 			name: 'setSkipPropose',
 			call: 'admin_setSkipPropose',
 			params: 1,

--- a/kaiax/vrank/TODO.md
+++ b/kaiax/vrank/TODO.md
@@ -2,9 +2,7 @@
 
 ## Go
 
-| # | File | Line | Description | Priority |
-|---|------|------|-------------|----------|
-| 1 | `kaiax/valset/impl/state_transition.go` | 102 | `isPassVrankTest()` — replace with KIP-227 CFS implementation (currently hardcoded `return true`). Blocked on cfsThreshold contract addition. | High |
+No pending items.
 
 ## Config
 
@@ -17,9 +15,10 @@
 
 | # | File | Description |
 |---|------|-------------|
-| 6 | `node/cn/api_admin_chain.go` | Remove `SetPermissionlessForkBlock` API |
-| 7 | `console/web3ext/web3ext.go` | Remove `admin.setPermissionlessForkBlock` web3 method |
 | 8 | `consensus/istanbul/backend/backend.go` | Remove `SetSkipPropose` and `skipPropose` flag |
 | 9 | `consensus/istanbul/backend/engine.go` | Remove `skipPropose` check in Seal |
 | 10 | `node/cn/api_admin_chain.go` | Remove `SetSkipPropose` API |
 | 11 | `console/web3ext/web3ext.go` | Remove `admin.setSkipPropose` web3 method |
+| 12 | `kaiax/vrank/impl/init.go` | Remove `SetSkipCandidate` and `skipCandidate` flag |
+| 13 | `node/cn/api_admin_chain.go` | Remove `SetSkipCandidate` API |
+| 14 | `console/web3ext/web3ext.go` | Remove `admin.setSkipCandidate` web3 method |

--- a/node/cn/api_admin_chain.go
+++ b/node/cn/api_admin_chain.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
 	"os"
 	"strings"
 
@@ -257,16 +256,6 @@ func (s *AdminChainCNAPI) NodeConfig(ctx context.Context) interface{} {
 	return *s.cn.config
 }
 
-// SetPermissionlessForkBlock overrides the permissionless hardfork block number
-// in the chain config and persists it to the chain database.
-// TODO-Permissionless: Testing only. Remove before production release.
-func (api *AdminChainCNAPI) SetPermissionlessForkBlock(blockNumber uint64) (uint64, error) {
-	cfg := api.cn.blockchain.Config()
-	cfg.PermissionlessCompatibleBlock = new(big.Int).SetUint64(blockNumber)
-	genesisHash := api.cn.blockchain.Genesis().Hash()
-	api.cn.chainDB.WriteChainConfig(genesisHash, cfg)
-	return blockNumber, nil
-}
 
 // SetSkipPropose enables or disables skipping block proposals.
 // When enabled, this node will not propose blocks even when it is the proposer,


### PR DESCRIPTION
## Proposed changes

- Add `--override.permissionless` CLI flag following the same pattern as `--override.osaka`
- Remove `admin.setPermissionlessForkBlock` runtime API (replaced by CLI flag)
- Update VRank TODO with completed and remaining cleanup items

## Types of changes

- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

The CLI flag approach is consistent with `--override.osaka` and avoids runtime chain config persistence. Nodes should set the flag in `kcnd.conf` ADDITIONAL and restart.