### PR TITLE
Permissionless: fix VRank scoring failure at fork boundary

### DIFF
--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -31,6 +31,16 @@ func calcEpochStart(blockNum, vrankEpoch uint64) uint64 {
 	return blockNum - (blockNum % vrankEpoch)
 }
 
+// clampToForkStart returns max(start, forkBlock) so that scoring loops
+// never iterate over blocks before the permissionless fork.
+func (v *VRankModule) clampToForkStart(start uint64) uint64 {
+	forkBlock := v.ChainConfig.PermissionlessCompatibleBlock
+	if forkBlock != nil && start < forkBlock.Uint64() {
+		return forkBlock.Uint64()
+	}
+	return start
+}
+
 // GetPFS computes the running Proposal Failure Score up to blockNum.
 // pfs(N) -> map[proposerAddr]score for blocks [epochBegin(N), N].
 // Returns ErrNotPermissionless if blockNum is before the permissionless fork.
@@ -100,7 +110,7 @@ func (v *VRankModule) lookupPFSSeed(blockNum uint64) (start uint64, seed map[com
 	if cpNum, pfs, ok := v.loadPFSCheckpointInEpoch(blockNum); ok {
 		return cpNum + 1, pfs
 	}
-	return calcEpochStart(blockNum, v.vrankEpoch()), make(map[common.Address]uint64)
+	return v.clampToForkStart(calcEpochStart(blockNum, v.vrankEpoch())), make(map[common.Address]uint64)
 }
 
 // lookupCFSSeed returns (start, seed) where seed holds the CP matrix accumulated up to start-1.
@@ -116,7 +126,7 @@ func (v *VRankModule) lookupCFSSeed(blockNum uint64) (start uint64, seed vrank.C
 	if err != nil {
 		return 0, nil, err
 	}
-	return calcEpochStart(blockNum, v.vrankEpoch()), cpMatrix, nil
+	return v.clampToForkStart(calcEpochStart(blockNum, v.vrankEpoch())), cpMatrix, nil
 }
 
 func (v *VRankModule) newCPMatrix(blockNum uint64) (vrank.CPMatrix, error) {

--- a/kaiax/vrank/impl/scoring_test.go
+++ b/kaiax/vrank/impl/scoring_test.go
@@ -1125,3 +1125,65 @@ func TestByzantineFilter(t *testing.T) {
 		assert.Equal(t, uint64(116), cfs[candidates[4]], "C5")
 	})
 }
+
+// TestForkBoundaryClamping verifies that when the fork block is after epoch start,
+// scoring only covers blocks from the fork block onward (not from epoch start).
+func TestForkBoundaryClamping(t *testing.T) {
+	var (
+		forkBlock  = uint64(50)
+		queryBlock = uint64(60)
+		P0         = addrN(0)
+		C1         = addrN(10)
+	)
+
+	newForkClampedModule := func(t *testing.T, vs *mock_valset.MockValsetModule, headers map[uint64]*types.Header) *VRankModule {
+		t.Helper()
+		v := newTestModuleWithHeaders(t, vs, database.NewMemDB(), headers)
+		v.ChainConfig = params.TestKaiaConfig("permissionless")
+		v.ChainConfig.PermissionlessCompatibleBlock = new(big.Int).SetUint64(forkBlock)
+		v.Chain = &testChain{headers: headers}
+		return v
+	}
+
+	makeHeaders := func(overrides map[uint64]*types.Header) map[uint64]*types.Header {
+		headers := make(map[uint64]*types.Header)
+		for i := forkBlock; i <= queryBlock; i++ {
+			headers[i] = makeHeaderWithRound(i, 0)
+		}
+		for k, v := range overrides {
+			headers[k] = v
+		}
+		return headers
+	}
+
+	t.Run("PFS starts from fork block", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		vs := mock_valset.NewMockValsetModule(ctrl)
+		headers := makeHeaders(map[uint64]*types.Header{
+			forkBlock + 5: makeHeaderWithRound(forkBlock+5, 1),
+		})
+		v := newForkClampedModule(t, vs, headers)
+		vs.EXPECT().GetProposer(forkBlock+5, uint64(0)).Return(P0, nil).Times(1)
+
+		pfs, err := v.GetPFS(queryBlock)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), pfs[P0])
+		assert.Len(t, pfs, 1)
+	})
+
+	t.Run("CFS starts from fork block", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		vs := mock_valset.NewMockValsetModule(ctrl)
+		headers := makeHeaders(map[uint64]*types.Header{
+			forkBlock + 3: makeHeaderWithVRank(forkBlock+3, 0, []common.Address{C1}),
+		})
+		v := newForkClampedModule(t, vs, headers)
+		vs.EXPECT().GetCandidates(queryBlock).Return([]common.Address{C1}, nil).Times(1)
+		vs.EXPECT().GetProposer(forkBlock+3, uint64(0)).Return(P0, nil).Times(1)
+		vs.EXPECT().GetCommittee(queryBlock, uint64(0)).Return([]common.Address{P0}, nil).Times(1)
+
+		cfs, err := v.GetCFS(queryBlock)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), cfs[C1])
+	})
+}


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

- Fix `PostInsertBlock` failure when permissionless fork block is after epoch start
- When permissionless fork block is after epoch start (e.g. permissionless fork block=480, vrankEpoch=86400), scoring loops would start from epoch start (block 0), iterating pre-fork blocks and hitting `ErrNotPermissionless`
- Add `clampToForkStart` to ensure `lookupPFSSeed`/`lookupCFSSeed` never return a start before the permissionless fork block
- Add `TestForkBoundaryClamping` covering both PFS and CFS scenarios

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Without this fix, block production halts at the permissionless fork block because `PostInsertBlock` → `GetPFS` → `applyBlocksForPFS(0, forkBlock)` returns `ErrNotPermissionless` for pre-fork blocks.