### PR TITLE
Permissionless: refactor ReadNodeStates to return struct

### DIFF
--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -127,21 +127,32 @@ func EncodeNodeStateUpdate(
 	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
+// NodeStatesResult holds the result of ReadNodeStates.
+type NodeStatesResult struct {
+	Validators        valset.NodeStateMap
+	PauseTimeout      time.Duration
+	IdleTimeout       time.Duration
+	MaxValCount       uint64
+	MaxReadyCandCount uint64
+	PfsThreshold      uint64
+	CfsThreshold      uint64
+}
+
 // ReadNodeStates reads all validator states, timeouts, max counts, and thresholds from ABv2 in a single MultiCall.
 func ReadNodeStates(
 	statedb *state.StateDB,
 	chain backends.BlockChainForCaller,
 	header *types.Header,
-) (valset.NodeStateMap, time.Duration, time.Duration, uint64, uint64, uint64, uint64, error) {
+) (*NodeStatesResult, error) {
 	caller, err := NewMultiCallContractCaller(statedb, chain, header)
 	if err != nil {
-		return nil, 0, 0, 0, 0, 0, 0, err
+		return nil, err
 	}
 	opts := &bind.CallOpts{BlockNumber: header.Number}
 
 	res, err := caller.MultiCallNodeStatesPermissionless(opts)
 	if err != nil {
-		return nil, 0, 0, 0, 0, 0, 0, err
+		return nil, err
 	}
 
 	validators := make(valset.NodeStateMap)
@@ -164,15 +175,15 @@ func ReadNodeStates(
 		validators[p.NodeId] = vs
 	}
 
-	var (
-		pauseTimeout      = time.Duration(res.PauseTimeout.Int64()) * time.Second
-		idleTimeout       = time.Duration(res.IdleTimeout.Int64()) * time.Second
-		maxValCount       = res.MaxValidatorCount.Uint64()
-		maxReadyCandCount = res.MaxReadyCandidateCount.Uint64()
-		pfsThreshold      = res.PfsThreshold.Uint64()
-		cfsThreshold      = res.CfsThreshold.Uint64()
-	)
-	return validators, pauseTimeout, idleTimeout, maxValCount, maxReadyCandCount, pfsThreshold, cfsThreshold, nil
+	return &NodeStatesResult{
+		Validators:        validators,
+		PauseTimeout:      time.Duration(res.PauseTimeout.Int64()) * time.Second,
+		IdleTimeout:       time.Duration(res.IdleTimeout.Int64()) * time.Second,
+		MaxValCount:       res.MaxValidatorCount.Uint64(),
+		MaxReadyCandCount: res.MaxReadyCandidateCount.Uint64(),
+		PfsThreshold:      res.PfsThreshold.Uint64(),
+		CfsThreshold:      res.CfsThreshold.Uint64(),
+	}, nil
 }
 
 // ReadAddressBookV2BlsAll reads BLS public key info for all nodes from AddressBookV2.

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -137,10 +137,11 @@ func (v *ValsetModule) GetNodeByState(num uint64, states []valset.State) (valset
 		if err != nil {
 			return nil, err
 		}
-		nodes, _, _, _, _, _, _, err = system.ReadNodeStates(statedb, v.Chain, genesisHeader)
+		res, err := system.ReadNodeStates(statedb, v.Chain, genesisHeader)
 		if err != nil {
 			return nil, err
 		}
+		nodes = res.Validators
 	} else {
 		parentHeader := v.Chain.GetHeaderByNumber(num - 1)
 		if parentHeader == nil {

--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -67,11 +67,11 @@ func (v *ValsetModule) getOrComputeNodeStates(num uint64, parentStatedb *state.S
 // computeNodeStates reads ABv2 validators, timeouts, and max counts in a single MultiCall,
 // then applies all transitions.
 func (v *ValsetModule) computeNodeStates(statedb *state.StateDB, header *types.Header) (valset.NodeStateMap, error) {
-	validators, pauseTimeout, idleTimeout, maxValCount, _, pfsThreshold, cfsThreshold, err := system.ReadNodeStates(statedb, v.Chain, header)
+	res, err := system.ReadNodeStates(statedb, v.Chain, header)
 	if err != nil {
 		return nil, err
 	}
-	return v.applyAllTransitions(validators, header, pauseTimeout, idleTimeout, maxValCount, pfsThreshold, cfsThreshold)
+	return v.applyAllTransitions(res.Validators, header, res.PauseTimeout, res.IdleTimeout, res.MaxValCount, res.PfsThreshold, res.CfsThreshold)
 }
 
 // applyAllTransitions computes applyTr(N-1) given ABv2(N-1) validators and block N-1 parameters.
@@ -172,11 +172,11 @@ func (v *ValsetModule) writeNodeStateUpdateToContract(
 	if parentHeader == nil {
 		return errParentHeaderNotFound(num)
 	}
-	parentNodes, _, _, _, _, _, _, err := system.ReadNodeStates(statedb, v.Chain, parentHeader)
+	parentRes, err := system.ReadNodeStates(statedb, v.Chain, parentHeader)
 	if err != nil {
 		return fmt.Errorf("failed to read ABv2(N-1): %w", err)
 	}
-	diff := diffNodeStates(parentNodes, currentNodes)
+	diff := diffNodeStates(parentRes.Validators, currentNodes)
 
 	// Skip call if no changes and not an epoch block (epoch blocks need epochValCount update)
 	if len(diff) == 0 && !v.isVrankEpoch(num) {

--- a/kaiax/valset/impl/state_transition_test.go
+++ b/kaiax/valset/impl/state_transition_test.go
@@ -150,9 +150,9 @@ func TestGetOrComputeNodeStates(t *testing.T) {
 	header1 := chain.GetHeaderByNumber(1)
 	statedb1, err := chain.StateAt(header1.Root)
 	require.NoError(t, err)
-	validators, _, _, _, _, _, _, err := system.ReadNodeStates(statedb1, chain, header1)
+	res, err := system.ReadNodeStates(statedb1, chain, header1)
 	require.NoError(t, err)
-	require.Equal(t, valset.ValPaused, validators[config.NodeIds[0]].State, "ABv2(1) should have ValPaused after pause tx")
+	require.Equal(t, valset.ValPaused, res.Validators[config.NodeIds[0]].State, "ABv2(1) should have ValPaused after pause tx")
 
 	newModule := func(t *testing.T) *ValsetModule {
 		ctrl := gomock.NewController(t)
@@ -237,8 +237,9 @@ func TestReadGetAllValidators(t *testing.T) {
 	require.NoError(t, err)
 
 	// Before transition(initial state): all validators are ValActive
-	validators, _, _, _, _, _, _, err := system.ReadNodeStates(statedb, chain, header)
+	res, err := system.ReadNodeStates(statedb, chain, header)
 	require.NoError(t, err)
+	validators := res.Validators
 	assert.Len(t, validators, 3)
 
 	for _, nodeId := range config.NodeIds {
@@ -276,8 +277,9 @@ func TestReadGetAllValidators(t *testing.T) {
 	require.NoError(t, err)
 
 	// After transition: config.NodeIds[0] should be ValPaused
-	validators, _, _, _, _, _, _, err = system.ReadNodeStates(statedb, chain, header)
+	res, err = system.ReadNodeStates(statedb, chain, header)
 	require.NoError(t, err)
+	validators = res.Validators
 	assert.Len(t, validators, 3)
 
 	vs0 := validators[config.NodeIds[0]]


### PR DESCRIPTION
## Proposed changes

- Replace 8 individual return values from `ReadNodeStates` with `NodeStatesResult` struct

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments