### PR TITLE
permless: make values configurable for testing

### DIFF
--- a/blockchain/system/kip113_test.go
+++ b/blockchain/system/kip113_test.go
@@ -27,6 +27,7 @@ import (
 	testcontracts "github.com/kaiachain/kaia/contracts/contracts/testing/system_contracts"
 	proxycontracts "github.com/kaiachain/kaia/contracts_permissionless/contracts/Proxy"
 	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/bls"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
@@ -180,5 +181,9 @@ func compareStorage(t *testing.T, backend *backends.SimulatedBackend, contractAd
 }
 
 func makeBlsKey() (priv, pub, pop []byte) {
-	return MakeTestBlsKey()
+	key, _ := crypto.GenerateKey()
+	sk, _ := bls.DeriveFromECDSA(key)
+	pk := sk.PublicKey()
+	sig := bls.PopProve(sk)
+	return sk.Marshal(), pk.Marshal(), sig.Marshal()
 }

--- a/blockchain/system/permissionless.go
+++ b/blockchain/system/permissionless.go
@@ -44,12 +44,12 @@ const DefaultEpochBlockInterval = int64(params.DefaultVRankEpoch)
 
 // AllocPermissionlessConfig holds parameters for genesis permissionless allocation.
 type AllocPermissionlessConfig struct {
-	Owner               common.Address                                  // Owner of beacons, Registry registrant
-	NodeIds             []common.Address                                // Validator node IDs
-	NodeInfos           []addressbookv2contract.NodeInfo                // Validator info — caller fills all fields except StakingContract (set after deployCnStaking)
-	StakeAmts           []*big.Int                                      // Stake amounts per validator
-	DataConfig          addressbookv2contract.IABv2DataContractInitData // ABv2DataContract constructor data
-	EpochBlockInterval  int64                                           // Blocks per epoch baked into ABv2 bytecode. 0 = use DefaultEpochBlockInterval.
+	Owner              common.Address                                  // Owner of beacons, Registry registrant
+	NodeIds            []common.Address                                // Validator node IDs
+	NodeInfos          []addressbookv2contract.NodeInfo                // Validator info — caller fills all fields except StakingContract (set after deployCnStaking)
+	StakeAmts          []*big.Int                                      // Stake amounts per validator
+	DataConfig         addressbookv2contract.IABv2DataContractInitData // ABv2DataContract constructor data
+	EpochBlockInterval int64                                           // Blocks per epoch baked into ABv2 bytecode. 0 = use DefaultEpochBlockInterval.
 }
 
 // allocPermissionlessResult holds intermediate deployed addresses passed between internal steps.

--- a/blockchain/system/permissionless.go
+++ b/blockchain/system/permissionless.go
@@ -304,11 +304,11 @@ func installAndInitABv2(cfg *runtime.Config, statedb *state.StateDB, implAddr co
 // for test scenarios (e.g., CandReady genesis) where a different starting state is desired.
 // It is a no-op if all nodes have ValActive state (the default).
 func applyInitialNodeStateOverrides(cfg *runtime.Config, config *AllocPermissionlessConfig) error {
-	valActiveState := valset.ValActive.ToUint8()
 	var (
-		nodeIds    []common.Address
-		newStates  []uint8
-		timeoutAts []*big.Int
+		valActiveState = valset.ValActive.ToUint8()
+		nodeIds        []common.Address
+		newStates      []uint8
+		timeoutAts     []*big.Int
 	)
 	for i, info := range config.NodeInfos {
 		if info.State != valActiveState {

--- a/blockchain/system/permissionless.go
+++ b/blockchain/system/permissionless.go
@@ -34,6 +34,7 @@ import (
 	cnstakingv4factory "github.com/kaiachain/kaia/contracts_permissionless/contracts/CnStaking/CnStakingV4Factory"
 	beaconcontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/Proxy/beacon"
 	pdcontract "github.com/kaiachain/kaia/contracts_permissionless/contracts/PublicDelegation"
+	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 )
@@ -43,11 +44,12 @@ const DefaultEpochBlockInterval = int64(params.DefaultVRankEpoch)
 
 // AllocPermissionlessConfig holds parameters for genesis permissionless allocation.
 type AllocPermissionlessConfig struct {
-	Owner      common.Address                                  // Owner of beacons, Registry registrant
-	NodeIds    []common.Address                                // Validator node IDs
-	NodeInfos  []addressbookv2contract.NodeInfo                // Validator info — caller fills all fields except StakingContract (set after deployCnStaking)
-	StakeAmts  []*big.Int                                      // Stake amounts per validator
-	DataConfig addressbookv2contract.IABv2DataContractInitData // ABv2DataContract constructor data
+	Owner               common.Address                                  // Owner of beacons, Registry registrant
+	NodeIds             []common.Address                                // Validator node IDs
+	NodeInfos           []addressbookv2contract.NodeInfo                // Validator info — caller fills all fields except StakingContract (set after deployCnStaking)
+	StakeAmts           []*big.Int                                      // Stake amounts per validator
+	DataConfig          addressbookv2contract.IABv2DataContractInitData // ABv2DataContract constructor data
+	EpochBlockInterval  int64                                           // Blocks per epoch baked into ABv2 bytecode. 0 = use DefaultEpochBlockInterval.
 }
 
 // allocPermissionlessResult holds intermediate deployed addresses passed between internal steps.
@@ -100,7 +102,7 @@ func AllocPermissionless(config *AllocPermissionlessConfig) (map[common.Address]
 	result := &allocPermissionlessResult{}
 
 	// Step 1: Deploy implementation contracts and their UpgradeableBeacons
-	if err := deployBeaconInfra(cfg, deployer, result); err != nil {
+	if err := deployBeaconInfra(cfg, deployer, config.EpochBlockInterval, result); err != nil {
 		return nil, err
 	}
 
@@ -125,6 +127,13 @@ func AllocPermissionless(config *AllocPermissionlessConfig) (map[common.Address]
 
 	// Step 5: Install ABv2 at 0x400 and call initialize()
 	if err := installAndInitABv2(cfg, statedb, result.abv2Impl); err != nil {
+		return nil, err
+	}
+
+	// Step 5b: Override initial states for nodes that are not ValActive.
+	// ABv2.initialize() always sets all nodes to ValActive; this step applies
+	// custom initial states for testing scenarios (e.g. CandReady, ValExiting).
+	if err := applyInitialNodeStateOverrides(cfg, config); err != nil {
 		return nil, err
 	}
 
@@ -158,7 +167,7 @@ func AllocPermissionless(config *AllocPermissionlessConfig) (map[common.Address]
 
 // deployBeaconInfra deploys CnStakingV4 and PublicDelegation implementations
 // along with their UpgradeableBeacons (step 1).
-func deployBeaconInfra(cfg *runtime.Config, owner common.Address, result *allocPermissionlessResult) error {
+func deployBeaconInfra(cfg *runtime.Config, owner common.Address, epochBlockInterval int64, result *allocPermissionlessResult) error {
 	// Deploy CnStakingV4 implementation
 	cnImplAddr, err := evmCreate(cfg, common.FromHex(cnstakingv4.CnStakingV4Bin))
 	if err != nil {
@@ -195,7 +204,10 @@ func deployBeaconInfra(cfg *runtime.Config, owner common.Address, result *allocP
 
 	// Deploy AddressBookV2 implementation (used by ABv2DataContract and proxy setup)
 	abv2ABI, _ := addressbookv2contract.AddressBookV2MetaData.GetAbi()
-	abv2ImplInput, err := packConstructor(abv2ABI, common.FromHex(addressbookv2contract.AddressBookV2Bin), big.NewInt(DefaultEpochBlockInterval))
+	if epochBlockInterval == 0 {
+		epochBlockInterval = DefaultEpochBlockInterval
+	}
+	abv2ImplInput, err := packConstructor(abv2ABI, common.FromHex(addressbookv2contract.AddressBookV2Bin), big.NewInt(epochBlockInterval))
 	if err != nil {
 		return fmt.Errorf("pack ABv2 impl constructor: %w", err)
 	}
@@ -284,6 +296,40 @@ func installAndInitABv2(cfg *runtime.Config, statedb *state.StateDB, implAddr co
 	}
 	// Set isActivated = true (storage slot 12) so legacy getter getAllAddress() returns data.
 	statedb.SetState(AddressBookAddr, common.BigToHash(big.NewInt(12)), common.BigToHash(big.NewInt(1)))
+	return nil
+}
+
+// applyInitialNodeStateOverrides calls processSystemTransition on ABv2 to set non-ValActive
+// initial states. ABv2.initialize() always resets all nodes to ValActive; this step is needed
+// for test scenarios (e.g., CandReady genesis) where a different starting state is desired.
+// It is a no-op if all nodes have ValActive state (the default).
+func applyInitialNodeStateOverrides(cfg *runtime.Config, config *AllocPermissionlessConfig) error {
+	valActiveState := valset.ValActive.ToUint8()
+	var (
+		nodeIds    []common.Address
+		newStates  []uint8
+		timeoutAts []*big.Int
+	)
+	for i, info := range config.NodeInfos {
+		if info.State != valActiveState {
+			nodeIds = append(nodeIds, config.NodeIds[i])
+			newStates = append(newStates, info.State)
+			timeoutAts = append(timeoutAts, new(big.Int)) // no timeout at genesis
+		}
+	}
+	if len(nodeIds) == 0 {
+		return nil // all ValActive, nothing to do
+	}
+
+	abv2ABI, _ := addressbookv2contract.AddressBookV2MetaData.GetAbi()
+	// Temporarily use SystemAddress as caller so OnlySystemTx passes.
+	origOrigin := cfg.Origin
+	cfg.Origin = params.SystemAddress
+	defer func() { cfg.Origin = origOrigin }()
+
+	if err := evmCallABI(cfg, AddressBookAddr, abv2ABI, "processSystemTransition", nodeIds, newStates, timeoutAts); err != nil {
+		return fmt.Errorf("applyInitialNodeStateOverrides: %w", err)
+	}
 	return nil
 }
 

--- a/blockchain/system/testing.go
+++ b/blockchain/system/testing.go
@@ -44,7 +44,11 @@ func MakeTestPermissionlessConfig(n int) (*AllocPermissionlessConfig, []*ecdsa.P
 		key, _ := crypto.GenerateKey()
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 		nodeKeys[i] = key
-		_, pub, pop := MakeTestBlsKey()
+		blsSk, _ := bls.DeriveFromECDSA(key)
+		blsPk := blsSk.PublicKey()
+		blsPop := bls.PopProve(blsSk)
+		pub := blsPk.Marshal()
+		pop := blsPop.Marshal()
 
 		nodeIds[i] = addr
 		stakeAmts[i] = new(big.Int).Set(stakeAmt)

--- a/blockchain/system/testing.go
+++ b/blockchain/system/testing.go
@@ -18,7 +18,6 @@ package system
 
 import (
 	"crypto/ecdsa"
-	"crypto/rand"
 	"math/big"
 
 	"github.com/kaiachain/kaia/common"
@@ -86,20 +85,3 @@ func MakeTestPermissionlessConfig(n int) (*AllocPermissionlessConfig, []*ecdsa.P
 	}, nodeKeys
 }
 
-// MakeTestBlsKey generates a random BLS key pair for testing.
-func MakeTestBlsKey() (priv, pub, pop []byte) {
-	ikm := make([]byte, 32)
-	rand.Read(ikm)
-
-	sk, _ := bls.GenerateKey(ikm)
-	pk := sk.PublicKey()
-	sig := bls.PopProve(sk)
-
-	priv = sk.Marshal()
-	pub = pk.Marshal()
-	pop = sig.Marshal()
-	if len(priv) != 32 || len(pub) != 48 || len(pop) != 96 {
-		panic("bad bls key")
-	}
-	return priv, pub, pop
-}

--- a/kaiax/valset/impl/state_transition_test.go
+++ b/kaiax/valset/impl/state_transition_test.go
@@ -293,3 +293,10 @@ func TestReadGetAllValidators(t *testing.T) {
 		assert.True(t, vs.PausedTimeout.IsZero())
 	}
 }
+
+// invalidateNodeStatesCache purges all cached node state entries.
+// Call this after injecting VRank data (pfReport/PFS/CFS) to ensure
+// getOrComputeNodeStates recomputes rather than returning a stale cache hit.
+func (v *ValsetModule) invalidateNodeStatesCache() {
+	v.nodeStatesCache.Purge()
+}

--- a/kaiax/valset/impl/state_transition_test.go
+++ b/kaiax/valset/impl/state_transition_test.go
@@ -294,9 +294,3 @@ func TestReadGetAllValidators(t *testing.T) {
 	}
 }
 
-// invalidateNodeStatesCache purges all cached node state entries.
-// Call this after injecting VRank data (pfReport/PFS/CFS) to ensure
-// getOrComputeNodeStates recomputes rather than returning a stale cache hit.
-func (v *ValsetModule) invalidateNodeStatesCache() {
-	v.nodeStatesCache.Purge()
-}

--- a/kaiax/valset/impl/state_transition_test.go
+++ b/kaiax/valset/impl/state_transition_test.go
@@ -293,4 +293,3 @@ func TestReadGetAllValidators(t *testing.T) {
 		assert.True(t, vs.PausedTimeout.IsZero())
 	}
 }
-


### PR DESCRIPTION
## Proposed changes

This PR adds three small but blocking primitives needed by the permissionless integration **_test suite_**.

### Changes

**`blockchain/system/permissionless.go`**
- Add `EpochBlockInterval int64` to `AllocPermissionlessConfig`. Tests need a short epoch (e.g. 10 blocks) baked into the ABv2 bytecode. Zero falls back to `DefaultEpochBlockInterval` — no breaking change for existing callers.
- Add `applyInitialNodeStateOverrides`: `ABv2.initialize()` unconditionally resets all nodes to `ValActive`. This post-init step calls `processSystemTransition` as `SystemAddress` to set nodes that should start in a non-`ValActive` state (e.g. `CandReady`, `CandTesting`, `ValExiting`). Production genesis never has non-`ValActive` states, so this is a no-op in prod.

**`blockchain/system/testing.go`**
- Fix `MakeTestPermissionlessConfig` to derive BLS keys from ECDSA keys via `bls.DeriveFromECDSA` instead of random generation. Previously, the BLS public key stored in ABv2 at genesis didn't match the key the engine uses for Randao, causing `invalid randao fields` on every mined block.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
