### PR TITLE
permless: add homi flag --vrank-epoch

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -147,6 +147,7 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewInt64Flag(pragueCompatibleBlockNumberFlag),
 	altsrc.NewInt64Flag(osakaCompatibleBlockNumberFlag),
 	altsrc.NewInt64Flag(permissionlessCompatibleBlockNumberFlag),
+	altsrc.NewUint64Flag(vrankEpochFlag),
 	altsrc.NewStringFlag(kip113ProxyAddressFlag),
 	altsrc.NewStringFlag(kip113LogicAddressFlag),
 	altsrc.NewBoolFlag(kip113MockFlag),
@@ -584,10 +585,11 @@ func allocatePermissionless(ctx *cli.Context, genesisJson *blockchain.Genesis, v
 	}
 
 	config := &system.AllocPermissionlessConfig{
-		Owner:     owner,
-		NodeIds:   validatorAddrs,
-		NodeInfos: nodeInfos,
-		StakeAmts: stakeAmts,
+		Owner:              owner,
+		NodeIds:            validatorAddrs,
+		NodeInfos:          nodeInfos,
+		StakeAmts:          stakeAmts,
+		EpochBlockInterval: int64(ctx.Uint64(vrankEpochFlag.Name)),
 		DataConfig: addressbookv2contract.IABv2DataContractInitData{
 			InitialOwner:           owner,
 			PfsThreshold:           big.NewInt(defaultPfsThreshold),
@@ -842,6 +844,9 @@ func Gen(ctx *cli.Context) error {
 	genesisJson.Config.PragueCompatibleBlock = big.NewInt(ctx.Int64(pragueCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.OsakaCompatibleBlock = big.NewInt(ctx.Int64(osakaCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.PermissionlessCompatibleBlock = big.NewInt(ctx.Int64(permissionlessCompatibleBlockNumberFlag.Name))
+	if epoch := ctx.Uint64(vrankEpochFlag.Name); epoch != params.DefaultVRankEpoch {
+		genesisJson.Config.VRankEpoch = epoch
+	}
 	genesisJson.Config.BlobScheduleConfig = params.DefaultBlobSchedule
 
 	genesisJsonBytes, _ = json.MarshalIndent(genesisJson, "", "    ")

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -556,6 +556,13 @@ var (
 		Aliases: []string{"genesis.hardfork.permissionless-compatible-blocknumber"},
 	}
 
+	vrankEpochFlag = &cli.Uint64Flag{
+		Name:    "vrank-epoch",
+		Usage:   "VRank epoch block interval for permissionless mode (default: 86400)",
+		Value:   params.DefaultVRankEpoch,
+		Aliases: []string{"genesis.vrank-epoch"},
+	}
+
 	kip113ProxyAddressFlag = &cli.StringFlag{
 		Name:    "kip113-proxy-contract-address",
 		Usage:   "kip113 proxy contract address",


### PR DESCRIPTION
## Proposed changes

Add homi flag `--vrank-epoch`. In `genesis.json`, `vrankEpoch` is added.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
