### PR TITLE
consensus: add sealer abstraction and bft sealer facade

### DIFF
--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -99,9 +99,21 @@ type headerMarshaling struct {
 	ExcessBlobGas *hexutil.Uint64
 }
 
+// HeaderHashFn is an optional override for Header.Hash. When set, it replaces
+// the default logic. Intended to be initialized by the consensus sealer.
+var HeaderHashFn func(h *Header) common.Hash // replaces Header.Hash
+
+// SetHeaderHashFn sets an optional override for Header.Hash.
+func SetHeaderHashFn(hashFn func(h *Header) common.Hash) {
+	HeaderHashFn = hashFn
+}
+
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
 // RLP encoding.
 func (h *Header) Hash() common.Hash {
+	if fn := HeaderHashFn; fn != nil {
+		return fn(h)
+	}
 	// If the mix digest is equivalent to the predefined Istanbul digest, use Istanbul
 	// specific hash calculation.
 	if EngineType == Engine_IBFT {

--- a/cmd/utils/nodecmd/run_test.go
+++ b/cmd/utils/nodecmd/run_test.go
@@ -143,6 +143,7 @@ func TestMain(m *testing.M) {
 func runKaia(t *testing.T, name string, args ...string) *testKaia {
 	tt := &testKaia{}
 	tt.TestCmd = utils.NewTestCmd(t, tt)
+	hasNtpFlag := false
 	for i, arg := range args {
 		switch {
 		case arg == "-datadir" || arg == "--datadir":
@@ -153,6 +154,8 @@ func runKaia(t *testing.T, name string, args ...string) *testKaia {
 			if i < len(args)-1 {
 				tt.Rewardbase = args[i+1]
 			}
+		case arg == "--ntp.disable" || arg == "--ntp.server":
+			hasNtpFlag = true
 		}
 	}
 	if tt.Datadir == "" {
@@ -165,6 +168,9 @@ func runKaia(t *testing.T, name string, args ...string) *testKaia {
 				tt.Cleanup()
 			}
 		}()
+	}
+	if !hasNtpFlag {
+		args = append([]string{"--ntp.disable"}, args...)
 	}
 
 	// Boot "Kaia". This actually runs the test binary but the TestMain

--- a/consensus/bft/sealer.go
+++ b/consensus/bft/sealer.go
@@ -11,6 +11,8 @@ import (
 	"github.com/kaiachain/kaia/params"
 )
 
+var _ consensus.Sealer = (*dynamicSealer)(nil)
+
 func newSealerImpl(privateKey *ecdsa.PrivateKey) consensus.Sealer {
 	return istanbul.NewSealerImpl(privateKey)
 }
@@ -30,7 +32,7 @@ func NewSealer(chainConfig *params.ChainConfig, privateKey *ecdsa.PrivateKey) co
 		s.address = crypto.PubkeyToAddress(privateKey.PublicKey)
 	}
 	s.sealer = newSealerImpl(privateKey)
-	types.SetHeaderHashFn(s.headerHash)
+	types.SetHeaderHashFn(s.HeaderHash)
 	return s
 }
 
@@ -42,12 +44,20 @@ func (s *dynamicSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) 
 	if header == nil || header.Number == nil {
 		return nil, consensus.ErrUnknownBlock
 	}
+	// If it's genesis block, return empty seal
+	if header.Number.Sign() == 0 {
+		return []byte{}, nil
+	}
 	return s.implAt(header.Number.Uint64()).MakeCommittedSeal(header)
 }
 
 func (s *dynamicSealer) MakeAuthorSeal(header *types.Header) ([]byte, error) {
 	if header == nil || header.Number == nil {
 		return nil, consensus.ErrUnknownBlock
+	}
+	// If it's genesis block, return empty seal
+	if header.Number.Sign() == 0 {
+		return []byte{}, nil
 	}
 	return s.implAt(header.Number.Uint64()).MakeAuthorSeal(header)
 }
@@ -112,11 +122,19 @@ func (s *dynamicSealer) WriteAuthorSeal(header *types.Header, seal []byte) error
 	if header == nil || header.Number == nil {
 		return consensus.ErrUnknownBlock
 	}
+	// It shoudn't support writing author seal for the genesis block
+	if header.Number.Sign() == 0 {
+		return consensus.ErrUnknownBlock
+	}
 	return s.implAt(header.Number.Uint64()).WriteAuthorSeal(header, seal)
 }
 
 func (s *dynamicSealer) WriteCommittedSeals(header *types.Header, committedSeals [][]byte) error {
 	if header == nil || header.Number == nil {
+		return consensus.ErrUnknownBlock
+	}
+	// It shouldn't support writing committed seals for the genesis block
+	if header.Number.Sign() == 0 {
 		return consensus.ErrUnknownBlock
 	}
 	return s.implAt(header.Number.Uint64()).WriteCommittedSeals(header, committedSeals)
@@ -134,20 +152,10 @@ func (s *dynamicSealer) SigHash(header *types.Header) common.Hash {
 	if header == nil || header.Number == nil {
 		return common.Hash{}
 	}
-	hasher, ok := s.implAt(header.Number.Uint64()).(interface {
-		SigHash(header *types.Header) common.Hash
-	})
-	if !ok {
-		return common.Hash{}
-	}
-	return hasher.SigHash(header)
+	return s.implAt(header.Number.Uint64()).SigHash(header)
 }
 
 func (s *dynamicSealer) HeaderHash(header *types.Header) common.Hash {
-	return s.headerHash(header)
-}
-
-func (s *dynamicSealer) headerHash(header *types.Header) common.Hash {
 	if header == nil || header.Number == nil {
 		return istanbul.RLPHash(header)
 	}
@@ -157,11 +165,4 @@ func (s *dynamicSealer) headerHash(header *types.Header) common.Hash {
 func (s *dynamicSealer) implAt(number uint64) consensus.Sealer {
 	_ = number
 	return s.sealer
-}
-
-func (s *dynamicSealer) ChainConfig() *params.ChainConfig {
-	if s.chainConfig != nil {
-		return s.chainConfig
-	}
-	return params.TestChainConfig
 }

--- a/consensus/bft/sealer.go
+++ b/consensus/bft/sealer.go
@@ -1,0 +1,167 @@
+package bft
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/params"
+)
+
+func newSealerImpl(privateKey *ecdsa.PrivateKey) consensus.Sealer {
+	return istanbul.NewSealerImpl(privateKey)
+}
+
+type dynamicSealer struct {
+	chainConfig *params.ChainConfig
+	address     common.Address
+
+	sealer consensus.Sealer
+}
+
+func NewSealer(chainConfig *params.ChainConfig, privateKey *ecdsa.PrivateKey) consensus.Sealer {
+	s := &dynamicSealer{
+		chainConfig: chainConfig,
+	}
+	if privateKey != nil {
+		s.address = crypto.PubkeyToAddress(privateKey.PublicKey)
+	}
+	s.sealer = newSealerImpl(privateKey)
+	types.SetHeaderHashFn(s.headerHash)
+	return s
+}
+
+func (s *dynamicSealer) Address() common.Address {
+	return s.address
+}
+
+func (s *dynamicSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).MakeCommittedSeal(header)
+}
+
+func (s *dynamicSealer) MakeAuthorSeal(header *types.Header) ([]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).MakeAuthorSeal(header)
+}
+
+func (s *dynamicSealer) Author(header *types.Header) (common.Address, error) {
+	if header == nil || header.Number == nil {
+		return common.Address{}, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).Author(header)
+}
+
+func (s *dynamicSealer) Committers(header *types.Header) ([]common.Address, error) {
+	if header == nil || header.Number == nil {
+		return nil, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).Committers(header)
+}
+
+func (s *dynamicSealer) Vanity(header *types.Header) ([]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).Vanity(header)
+}
+
+func (s *dynamicSealer) Validators(header *types.Header) ([]common.Address, error) {
+	if header == nil || header.Number == nil {
+		return nil, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).Validators(header)
+}
+
+func (s *dynamicSealer) Round(header *types.Header) (byte, error) {
+	if header == nil || header.Number == nil {
+		return 0, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).Round(header)
+}
+
+func (s *dynamicSealer) RawSeals(header *types.Header) ([]byte, [][]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, nil, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).RawSeals(header)
+}
+
+func (s *dynamicSealer) WriteRound(header *types.Header, round int64) {
+	if header == nil || header.Number == nil {
+		return
+	}
+	s.implAt(header.Number.Uint64()).WriteRound(header, round)
+}
+
+func (s *dynamicSealer) WriteValidators(header *types.Header, validators []common.Address) error {
+	if header == nil || header.Number == nil {
+		return consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).WriteValidators(header, validators)
+}
+
+func (s *dynamicSealer) WriteAuthorSeal(header *types.Header, seal []byte) error {
+	if header == nil || header.Number == nil {
+		return consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).WriteAuthorSeal(header, seal)
+}
+
+func (s *dynamicSealer) WriteCommittedSeals(header *types.Header, committedSeals [][]byte) error {
+	if header == nil || header.Number == nil {
+		return consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).WriteCommittedSeals(header, committedSeals)
+}
+
+func (s *dynamicSealer) F(blockNum uint64, qualifiedlen, committeesize int) int {
+	return s.implAt(blockNum).F(blockNum, qualifiedlen, committeesize)
+}
+
+func (s *dynamicSealer) Quorum(blockNum uint64, qualifiedlen, committeesize int) int {
+	return s.implAt(blockNum).Quorum(blockNum, qualifiedlen, committeesize)
+}
+
+func (s *dynamicSealer) SigHash(header *types.Header) common.Hash {
+	if header == nil || header.Number == nil {
+		return common.Hash{}
+	}
+	hasher, ok := s.implAt(header.Number.Uint64()).(interface {
+		SigHash(header *types.Header) common.Hash
+	})
+	if !ok {
+		return common.Hash{}
+	}
+	return hasher.SigHash(header)
+}
+
+func (s *dynamicSealer) HeaderHash(header *types.Header) common.Hash {
+	return s.headerHash(header)
+}
+
+func (s *dynamicSealer) headerHash(header *types.Header) common.Hash {
+	if header == nil || header.Number == nil {
+		return istanbul.RLPHash(header)
+	}
+	return s.implAt(header.Number.Uint64()).HeaderHash(header)
+}
+
+func (s *dynamicSealer) implAt(number uint64) consensus.Sealer {
+	_ = number
+	return s.sealer
+}
+
+func (s *dynamicSealer) ChainConfig() *params.ChainConfig {
+	if s.chainConfig != nil {
+		return s.chainConfig
+	}
+	return params.TestChainConfig
+}

--- a/consensus/bft/sealer_test.go
+++ b/consensus/bft/sealer_test.go
@@ -1,0 +1,77 @@
+package bft
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/rlp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockHash(t *testing.T) {
+	cases := []struct {
+		name         string
+		encoded      string
+		expectedHash common.Hash
+	}{
+		{
+			name:         "kairos-144654443", // Kairos 144654443
+			encoded:      "f904f1f903c1a046f5775da65a7c9e9a12d2ee4d010285df656ebd64c97cad2669c42c4aa39d8b94f90675a56a03f836204d66c0f923e00500ddc90aa0cec442b90b1d21e465474f7e5c233c3461e950bf383b39227917ad8a608653dfa004de211f466c3543bb2e3db8c976e9d046c214bc33c982d664b7e494d0c2c88aa0390d7c4c79e1e594bcc3236742112d9a7358652e66b1c97dea1c490e69276617b90100000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000002000000000000000000800000000000000000000010000020000000000000010000000000000000000000000000000000000006000000000000000000000004000000000000001240004000000000000000000000000000000000000004800000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000002000000000000000000000000000000000000000400000a00000000000000000000000000000000000000000000184089f406b8302c7158465b315d945b90187d883010c00846b6c617988676f312e32302e36856c696e757800000000000000f90164f85494571e53df607be97431a5bbefca1dffe5aef56f4d945cb1a7dccbd0dc446e3640898ede8820368554c89499fb17d324fa0e07f23b49d09028ac0919414db694b74ff9dea397fe9e231df545eb53fe2adf776cb2b841dc7dca1dc15d06e83a0a39217052ad7915d3b0f0a68f49d4b53498130a1212327b9dd5514362eb3e5f0ebb277e7d38baecad9cd045d3627d3a1f322422eeee8a01f8c9b8410a3fb9227632261c8520f1ee859c503f017701fdb92c2e39f532e190779888a63cf112cf2e530f656153ab64103558c26fb9ca43d5cf31425e62569f891e1eca00b8414a32097b87c481f145ae75ded4e8ec2ea4230c7b2feb3f3afcd2d22ea0b7d4596f4354e185d4f1f93b4d758ddb97e9203e1d306413ad0db1f4a779156879baa300b841fde66a2abb916bf314c82a2dfcd82ed356af829a98573d7cdb4a74cccb6ceecc22358750332ad31dccd9a890dbde7e0d4e21f173515011656f6c222169ba94620080808505d21dba00b860a027d1591d784686d063234bc000a8b9f829da534c41b555c867329b2b4abc5ef8f36245546adcc35c31dbc7c16b084a0d48487817b0eb191ac5b9aa8f3c908d413f19a1e784c3920fc0c0ef9180582902dc30ee8b70859e493af467bc227403a047f8b901fe5f4a3387cb6ccd5c14a00f7649247d2d2d315a652c378f328c1970f9012a31f90126830a596a850ba43b740083061a8094a317038414a275365ed4a085b786e83e761d20a580944dd5fa43054709155d5e68fadd3aeb3f853f34b0b844202ee0ed00000000000000000000000000000000000000000000000000000000000a596a0000000000000000000000000000000000000000000000000000000000000377f847f8458207f5a085d89c94a1e010f90b8e825e5321b1fff91ea748f50424448e17d5f1658498bda053936941c152ce9721447711a80c39b07fb36d42c8a8b6a258d8b071ab3b6c96945e6b99bca5a21818d40d12c56194674989146fc8f847f8458207f5a0c40d29e71cdd4f07051398fa35d41a25cc2f5db165d3ad8aa8b5eff20cc81996a01ea154d91320586165b139870e688a0ab4837137c5208a2da60cbdc60d7c7d81",
+			expectedHash: common.HexToHash("0x4d0a7bafd8a88c983431031270df6bfc0e9a0909b126f2a3f1ac5b3c03392eb7"),
+		},
+	}
+
+	s := NewSealer(params.KairosChainConfig, nil)
+	defer types.SetHeaderHashFn(nil)
+	for _, tc := range cases {
+		var block types.Block
+		require.NoError(t, rlp.DecodeBytes(common.FromHex(tc.encoded), &block), tc.name)
+
+		assert.Equal(t, tc.expectedHash, block.Hash(), tc.name)
+		assert.Equal(t, tc.expectedHash, block.Header().Hash(), tc.name)
+		assert.Equal(t, tc.expectedHash, s.HeaderHash(block.Header()), tc.name)
+	}
+}
+
+func TestBlockHash_PreIstanbulCompatibleBlockUsesIstanbulHeaderHash(t *testing.T) {
+	header := &types.Header{
+		ParentHash:  common.HexToHash("0x1"),
+		Rewardbase:  common.HexToAddress("0x2"),
+		Root:        common.HexToHash("0x3"),
+		TxHash:      common.HexToHash("0x4"),
+		ReceiptHash: common.HexToHash("0x5"),
+		BlockScore:  big.NewInt(1),
+		Number:      big.NewInt(6145),
+		GasUsed:     21000,
+		Time:        big.NewInt(1711959900),
+		Governance:  []byte{0x01},
+		Vote:        []byte{0x02},
+	}
+
+	istanbulSealer := istanbul.NewSealerImpl(nil)
+	require.NoError(t, istanbulSealer.WriteValidators(header, []common.Address{
+		common.HexToAddress("0x44add0ec310f115a0e603b2d7db9f067778eaf8a"),
+		common.HexToAddress("0x294fc7e8f22b3bcdcf955dd7ff3ba2ed833f8212"),
+	}))
+	istanbulSealer.WriteRound(header, 3)
+	require.NoError(t, istanbulSealer.WriteAuthorSeal(header, bytes.Repeat([]byte{0x07}, istanbul.IstanbulExtraSeal)))
+	require.NoError(t, istanbulSealer.WriteCommittedSeals(header, [][]byte{bytes.Repeat([]byte{0x09}, istanbul.IstanbulExtraSeal)}))
+
+	plainHash := istanbul.RLPHash(header)
+	expectedHash := istanbulSealer.HeaderHash(header)
+	require.NotEqual(t, plainHash, expectedHash)
+
+	s := NewSealer(params.KairosChainConfig, nil)
+	defer types.SetHeaderHashFn(nil)
+
+	assert.Equal(t, expectedHash, s.HeaderHash(header))
+	assert.Equal(t, expectedHash, header.Hash())
+	assert.Equal(t, uint64(75373312), params.KairosChainConfig.IstanbulCompatibleBlock.Uint64())
+	assert.Less(t, header.Number.Uint64(), params.KairosChainConfig.IstanbulCompatibleBlock.Uint64())
+}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -79,6 +79,38 @@ type ChainContext interface {
 		header *types.Header, tx *types.Transaction, usedGas *uint64, cfg *vm.Config) (*types.Receipt, *vm.InternalTxTrace, error)
 }
 
+type ChainReaderWithSealer interface {
+	ChainReader
+	Sealer() Sealer
+}
+
+// Sealer handles seal-related logic independent from consensus networking/runtime.
+type Sealer interface {
+	// Read information from header.Extra.
+	Author(header *types.Header) (common.Address, error)
+	Committers(header *types.Header) ([]common.Address, error)
+	Vanity(header *types.Header) ([]byte, error)
+	RawSeals(header *types.Header) ([]byte, [][]byte, error)
+	Round(header *types.Header) (byte, error)
+	Validators(header *types.Header) ([]common.Address, error)
+
+	// Write information to header.Extra.
+	WriteAuthorSeal(header *types.Header, seal []byte) error
+	WriteCommittedSeals(header *types.Header, committedSeals [][]byte) error
+	WriteRound(header *types.Header, round int64)
+	WriteValidators(header *types.Header, validators []common.Address) error
+
+	// Create seal bytes
+	MakeAuthorSeal(header *types.Header) ([]byte, error)
+	MakeCommittedSeal(header *types.Header) ([]byte, error)
+	HeaderHash(header *types.Header) common.Hash
+	SigHash(header *types.Header) common.Hash
+
+	// Verify seals and derive consensus metadata.
+	F(blockNum uint64, qualifiedlen, committeeSize int) int
+	Quorum(blockNum uint64, qualifiedlen, committeeSize int) int
+}
+
 // Engine is an algorithm agnostic consensus engine.
 //
 //go:generate mockgen -destination=./mocks/engine_mock.go -package=mocks github.com/kaiachain/kaia/consensus Engine
@@ -91,6 +123,9 @@ type Engine interface {
 	// Engines that do not use committed seals may return (nil, nil).
 	Committers(header *types.Header) ([]common.Address, error)
 
+	// RegisterKaiaxModules wires kaiax modules to the consensus engine.
+	RegisterKaiaxModules(mGov gov.GovModule, mValset valset.ValsetModule)
+
 	// Start starts any consensus-specific background lifecycle.
 	// Engines without a background runtime should implement this as a no-op.
 	Start(chain ChainReader, currentBlock func() *types.Block, hasBadBlock func(hash common.Hash) bool, executor Executor) error
@@ -98,10 +133,6 @@ type Engine interface {
 	// Stop stops any consensus-specific background lifecycle.
 	// Engines without a background runtime should implement this as a no-op.
 	Stop() error
-
-	// RegisterKaiaxModules wires kaiax modules needed by the engine.
-	// Engines that do not use these modules should implement this as a no-op.
-	RegisterKaiaxModules(mGov gov.GovModule, mValset valset.ValsetModule)
 
 	// PrepareExtra builds consensus-specific header.Extra content.
 	PrepareExtra(header *types.Header, parent *types.Header) ([]byte, error)
@@ -112,13 +143,13 @@ type Engine interface {
 	// This allows the caller to update pending block state for APIs.
 	SubmitTransactions(txs *types.TransactionsByPriceAndNonce, state *state.StateDB, header *types.Header, mux *event.TypeMux, onPrepared func(*ExecutionResult)) (finalizeCh <-chan *ExecutionResult)
 
-	// VerifySeals checks consensus-specific seals for the given header.
-	VerifySeals(header *types.Header) error
-
 	// APIs returns the RPC APIs this consensus engine provides.
 	APIs(chain ChainReader) []rpc.API
 
-	// Protocol returns the protocol for this consensus
+	// VerifySeals checks consensus-specific seals for the given header.
+	VerifySeals(header *types.Header) error
+
+	// Protocol returns the protocol for this consensus.
 	Protocol() Protocol
 
 	// GetConsensusInfo returns consensus information regarding the given block number.

--- a/consensus/istanbul/README.md
+++ b/consensus/istanbul/README.md
@@ -1,0 +1,318 @@
+# consensus/istanbul
+
+This package is responsible for implementing Kaia's Istanbul BFT consensus runtime.
+
+## Concepts
+
+### Overview
+
+The implementation is split into three layers.
+
+- Top-level `consensus/istanbul`
+  - Shared protocol types such as `View`, `Preprepare`, `Subject`, and `ConsensusMsg`
+  - Shared events such as `RequestEvent`, `MessageEvent`, `ChainHeadEvent`, and `NewSequenceEvent`
+  - Shared `IstanbulSealer` implementation for header encoding, hashing, and signatures
+- `consensus/istanbul/core`
+  - Consensus state machine for `PREPREPARE`, `PREPARE`, `COMMIT`, and round change
+- `consensus/istanbul/backend`
+  - Integration layer between the state machine and the node, blockchain, executor, and p2p stack
+
+The package is normally constructed through [consensus/bft](../bft/README.md), which exposes the generic `consensus.Engine` interface used by the rest of the node.
+
+### View
+
+Consensus progresses on a `View`, which is a pair of:
+
+- `Sequence`: the block number being finalized
+- `Round`: the retry number for that block number
+
+For each new sequence, consensus starts from round `0`. When the proposer fails to finalize a block in time or the proposal becomes invalid, validators move to a higher round.
+
+### Consensus phases
+
+Istanbul uses three voting phases.
+
+1. `PREPREPARE`
+   - The proposer broadcasts a block proposal for the current `(sequence, round)`.
+2. `PREPARE`
+   - Committee members vote for the proposal digest and parent hash.
+3. `COMMIT`
+   - Committee members attach committed seals for the proposal hash.
+
+When enough `COMMIT` messages are collected, the core asks the backend to commit the proposal. If progress stalls, the core sends `ROUND CHANGE` messages and starts a higher round.
+
+### Quorum and fault tolerance
+
+For a given sequence and round, the core derives:
+
+- `qualifiedLen`: the number of qualified validators
+- `committeeSize`: the effective committee size from governance
+- `f`: the maximum number of faulty validators tolerated by the round
+- `requiredMsgCnt`: the quorum size needed to move consensus forward
+
+The effective committee size is `min(qualifiedLen, committeeSize)`.
+
+- If the effective size is less than `4`, quorum is the effective size itself.
+- Otherwise, quorum is `ceil(2 * effectiveSize / 3)`.
+- Fault tolerance is `ceil(effectiveSize / 3) - 1`.
+
+This means the round state is not driven by the whole council directly. It is driven by the qualified validators and the governance-selected committee size for that block.
+
+### Header extra-data
+
+Consensus metadata is stored in `header.Extra` in Istanbul format.
+
+- First 32 bytes: vanity area
+- Last byte of the vanity area: round number
+- Remaining RLP payload:
+  - `Validators []common.Address`
+  - `Seal []byte`
+  - `CommittedSeal [][]byte`
+
+`IstanbulSealer` is responsible for:
+
+- parsing and caching `IstanbulExtra`
+- reading validators, author, committers, and round from a header
+- writing validators, proposer seal, and committed seals into a header
+- computing `SigHash` and consensus-aware `HeaderHash`
+- creating proposer and committed signatures
+
+### Signature and hash basis
+
+Istanbul uses different hash inputs for different signatures.
+
+- Proposer seal
+  - Signed over `SigHash(header)`
+  - The hash is calculated from the header with proposer seal removed and committed seals removed
+- Committed seal
+  - Signed over `Keccak256(prepareCommittedSeal(HeaderHash(header)))`
+  - `prepareCommittedSeal` appends the commit message code marker to the proposal hash
+- Block hash
+  - `HeaderHash(header)` is the consensus-aware block hash
+  - It keeps the proposer seal but removes committed seals before hashing
+
+This distinction is important because:
+
+- proposer identity is recovered from the proposer seal over `SigHash`
+- committers are recovered from committed seals over `HeaderHash`
+- the block hash used by the chain is not the same thing as the proposer-signing preimage
+
+### kaiax integration
+
+Istanbul depends on kaiax modules for validator and governance logic.
+
+- `kaiax/valset`
+  - Provides council, qualified validators, committee, and proposer for a given block and round
+- `kaiax/gov`
+  - Provides committee size and other governance-driven parameters used by consensus
+
+`backend.RegisterKaiaxModules(mGov, mValset)` wires those modules into both the backend and the core. Without them, proposal preparation and validation cannot proceed.
+
+### Networking
+
+The backend exposes an Istanbul subprotocol.
+
+- Protocol name: `istanbul`
+- Consensus message code: `0x11`
+
+Network messages are carried as `ConsensusMsg{PrevHash, Payload}` where `Payload` is an RLP-encoded core message.
+
+To reduce redundant gossip, the backend keeps:
+
+- `recentMessages`: messages recently seen from each peer
+- `knownMessages`: messages already seen locally
+
+`GossipSubPeer` narrows broadcast targets to the union of the current-round and next-round committees.
+
+## Persistent schema
+
+This package does not define its own persistent schema.
+
+Blocks, headers, receipts, and governance state are persisted by other components.
+
+## In-memory structures
+
+### `IstanbulSealer`
+
+`IstanbulSealer` stores:
+
+- the local private key used to create proposer and committed seals
+- an LRU cache of parsed `IstanbulExtra`
+
+### `backend.backend`
+
+The backend keeps the node-facing runtime state:
+
+- `istanbulEventMux`: shared event bus between worker, backend, and core
+- `commitCh`, `proposedBlockHash`, `sealSkippedNum`: coordination state for the blocking `Seal()` path
+- `recentMessages`, `knownMessages`: duplicate-suppression caches
+- `currentView`: latest view published by the core
+- `candidates`: local validator authorization proposals exposed through RPC
+- references to kaiax modules, broadcaster, chain accessors, and executor
+
+### `core.core`
+
+The core keeps the consensus-facing runtime state:
+
+- current `roundState`
+- pending requests and backlog queues for future messages
+- round-change tracking and timers
+- committee, quorum, and proposer metadata for the active view
+- observability metrics and consensus timestamps
+
+## Lifecycle
+
+### Construction
+
+`backend.New(opts)` creates:
+
+- the local sealer and node address
+- the event mux
+- the message caches
+- the Istanbul core instance
+
+### Start and stop
+
+`backend.Start(...)`:
+
+- injects chain access, current-block callback, bad-block callback, and executor
+- resets transient seal state
+- starts the core event loop
+
+`backend.Stop()`:
+
+- closes any pending `commitCh`
+- stops the core event loop
+
+`core.Start()` subscribes to the event mux, starts from the latest sequence plus one, and launches the handler goroutine.
+
+`core.Stop()` unsubscribes from all event streams, stops timers, and waits for the handler goroutine to exit.
+
+## Block processing
+
+### Consensus
+
+#### SubmitTransactions
+
+`backend.SubmitTransactions(...)` bridges execution and consensus.
+
+Its flow is:
+
+1. Read the qualified validators for the new block from `kaiax/valset`.
+2. Write validators into the header using the sealer.
+3. Reset the executor with the current state and header.
+4. Execute transactions.
+5. Finalize block state.
+6. Notify the caller that the block is prepared.
+7. Call `Seal()` to run Istanbul consensus.
+
+If the local node is not the winning proposer, `Seal()` may return `nil` and the block will instead arrive through normal block import.
+
+#### Seal
+
+`backend.Seal(...)`:
+
+- writes the proposer seal into the block header
+- initializes the seal coordination state
+- posts a `RequestEvent` into the event mux
+- waits for `backend.Commit(...)` to deliver the finalized block through `commitCh`
+
+#### Verify
+
+`backend.Verify(...)` validates:
+
+- block proposal type
+- bad-block blacklist state
+- transaction root and blob sidecar consistency
+- header validity through `chain.ValidateHeader`
+
+#### Commit
+
+When the core gathers quorum `COMMIT` messages:
+
+- it collects committed seals
+- it calls `backend.Commit(proposal, seals)`
+- the backend writes round and committed seals into the header
+- if the local node proposed the block, the sealed block is sent back to `Seal()`
+- otherwise the block is enqueued for normal import
+
+#### New sequence
+
+When a new sequence starts, the core posts `NewSequenceEvent` so the worker can prepare the next block.
+
+## APIs
+
+The backend exposes the public `istanbul` RPC namespace.
+
+### `istanbul_getValidators`
+
+Returns the qualified validators for the given block number.
+
+- Parameters
+  - `number`: block number, `latest`, or `pending`
+- Returns
+  - `[]common.Address`
+
+### `istanbul_getDemotedValidators`
+
+Returns the demoted validators for the given block number.
+
+- Parameters
+  - `number`: block number, `latest`, or `pending`
+- Returns
+  - `[]common.Address`
+
+### `istanbul_getValidatorsAtHash`
+
+Returns the qualified validators for the given block hash.
+
+- Parameters
+  - `hash`: block hash
+- Returns
+  - `[]common.Address`
+
+### `istanbul_getDemotedValidatorsAtHash`
+
+Returns the demoted validators for the given block hash.
+
+- Parameters
+  - `hash`: block hash
+- Returns
+  - `[]common.Address`
+
+### `istanbul_candidates`
+
+Returns the local candidate map currently tracked by the backend.
+
+- Parameters
+  - none
+- Returns
+  - `map[common.Address]bool`
+
+### `istanbul_propose`
+
+Adds or updates a local authorization candidate.
+
+- Parameters
+  - `address`: candidate validator address
+  - `auth`: whether the node votes to authorize or deauthorize the address
+- Returns
+  - none
+
+### `istanbul_discard`
+
+Removes a local authorization candidate.
+
+- Parameters
+  - `address`: candidate validator address
+- Returns
+  - none
+
+### `istanbul_getTimeout`
+
+Returns the default Istanbul timeout value exposed by the API implementation.
+
+- Parameters
+  - none
+- Returns
+  - `uint64`

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -37,6 +37,9 @@ type Backend interface {
 	// Address returns the owner's address
 	Address() common.Address
 
+	// Sealer returns the seal handler used by this backend.
+	Sealer() *IstanbulSealer
+
 	// EventMux returns the event mux in backend
 	EventMux() *event.TypeMux
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -76,6 +76,7 @@ func New(opts *BackendOpts) consensus.Engine {
 		recentMessages:   recentMessages,
 		knownMessages:    knownMessages,
 		govModule:        opts.GovModule,
+		sealer:           istanbul.NewSealerImpl(opts.PrivateKey),
 		nodetype:         opts.NodeType,
 	}
 
@@ -122,12 +123,17 @@ type backend struct {
 	// Reference to the kaiax modules
 	govModule    gov.GovModule
 	valsetModule valset.ValsetModule
+	sealer       *istanbul.IstanbulSealer
 
 	// Node type
 	nodetype common.ConnType
 
 	// Executor for transaction execution
 	executor consensus.Executor
+}
+
+func (sb *backend) Sealer() *istanbul.IstanbulSealer {
+	return sb.sealer
 }
 
 func (sb *backend) NodeType() common.ConnType {
@@ -297,12 +303,12 @@ func (sb *backend) Commit(proposal istanbul.Proposal, seals [][]byte) error {
 		sb.logger.Error("Invalid proposal, %v", proposal)
 		return istanbul.ErrInvalidProposal
 	}
+	proposalHash := proposal.Hash()
 	h := block.Header()
 	round := sb.currentView.Load().(*istanbul.View).Round.Int64()
-	h = types.SetRoundToHeader(h, round)
+	sb.sealer.WriteRound(h, round)
 	// Append seals into extra-data
-	err := writeCommittedSeals(h, seals)
-	if err != nil {
+	if err := sb.sealer.WriteCommittedSeals(h, seals); err != nil {
 		return err
 	}
 	// update block's header
@@ -317,7 +323,7 @@ func (sb *backend) Commit(proposal istanbul.Proposal, seals [][]byte) error {
 	// -- otherwise, a error will be returned and a round change event will be fired.
 
 	sb.sealMu.Lock()
-	if sb.proposedBlockHash == block.Hash() {
+	if sb.proposedBlockHash == proposalHash {
 		// Proposer: feed block hash to Seal() and wait the Seal() result
 		if sb.commitCh != nil {
 			sb.commitCh <- &types.Result{Block: block, Round: round}
@@ -404,7 +410,6 @@ func (sb *backend) CheckSignature(data []byte, address common.Address, sig []byt
 		logger.Error("Failed to get signer address", "err", err)
 		return err
 	}
-	// Compare derived addresses
 	if signer != address {
 		return istanbul.ErrInvalidSignature
 	}
@@ -422,7 +427,7 @@ func (sb *backend) LastProposal() (istanbul.Proposal, common.Address) {
 	var proposer common.Address
 	if block.Number().Cmp(common.Big0) > 0 {
 		var err error
-		proposer, err = sb.Author(block.Header())
+		proposer, err = sb.sealer.Author(block.Header())
 		if err != nil {
 			sb.logger.Error("Failed to get block proposer", "err", err)
 			return nil, common.Address{}
@@ -455,6 +460,16 @@ func (sb *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, st
 				resultCh <- nil
 			}
 		}()
+
+		validators, err := sb.valsetModule.GetQualifiedValidators(header.Number.Uint64())
+		if err != nil {
+			resultCh <- nil
+			return
+		}
+		if err := sb.sealer.WriteValidators(header, validators); err != nil {
+			resultCh <- nil
+			return
+		}
 
 		// Reset executor with current state and header
 		if err := sb.executor.ResetWithState(statedb, header); err != nil {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	mock_istanbul "github.com/kaiachain/kaia/consensus/istanbul/mocks"
 	"github.com/kaiachain/kaia/crypto"
-	"github.com/kaiachain/kaia/crypto/sha3"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/kaiax/gov"
@@ -52,7 +51,7 @@ import (
 func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanbul.MockBackend, *gomock.Controller, *valset_mock.MockValsetModule, *mock_gov.MockGovModule) {
 	committeeSize := uint64(len(validatorAddrs) / 3)
 
-	istExtra := &types.IstanbulExtra{
+	istExtra := &istanbul.IstanbulExtra{
 		Validators:    validatorAddrs,
 		Seal:          []byte{},
 		CommittedSeal: [][]byte{},
@@ -66,7 +65,7 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 		ParentHash: common.Hash{},
 		Number:     common.Big0,
 		GasUsed:    0,
-		Extra:      append(make([]byte, types.IstanbulExtraVanity), extra...),
+		Extra:      append(make([]byte, istanbul.IstanbulExtraVanity), extra...),
 		Time:       new(big.Int).SetUint64(1234),
 		BlockScore: common.Big0,
 	})
@@ -95,6 +94,9 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 
 	// Consider the last proposal is "initBlock" and the owner of mockBackend is validatorAddrs[0]
 	mockBackend.EXPECT().Address().Return(validatorAddrs[0]).AnyTimes()
+	sealerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	mockBackend.EXPECT().Sealer().Return(istanbul.NewSealerImpl(sealerKey)).AnyTimes()
 	mockBackend.EXPECT().LastProposal().Return(initBlock, validatorAddrs[0]).AnyTimes()
 	mockBackend.EXPECT().NodeType().Return(common.CONSENSUSNODE).AnyTimes()
 
@@ -145,31 +147,16 @@ func genValidators(n int) ([]common.Address, map[common.Address]*ecdsa.PrivateKe
 
 // signBlock signs the given block with the given private key
 func signBlock(block *types.Block, privateKey *ecdsa.PrivateKey) (*types.Block, error) {
-	var hash common.Hash
 	header := block.Header()
-	hasher := sha3.NewKeccak256()
 
-	// Clean seal is required for calculating proposer seal
-	rlp.Encode(hasher, types.IstanbulFilteredHeader(header, false))
-	hasher.Sum(hash[:0])
-
-	seal, err := crypto.Sign(crypto.Keccak256([]byte(hash.Bytes())), privateKey)
+	testSealer := istanbul.NewSealerImpl(privateKey)
+	authorSeal, err := testSealer.MakeAuthorSeal(header)
 	if err != nil {
 		return nil, err
 	}
-
-	istanbulExtra, err := types.ExtractIstanbulExtra(header)
-	if err != nil {
+	if err := testSealer.WriteAuthorSeal(header, authorSeal); err != nil {
 		return nil, err
 	}
-	istanbulExtra.Seal = seal
-
-	payload, err := rlp.EncodeToBytes(&istanbulExtra)
-	if err != nil {
-		return nil, err
-	}
-
-	header.Extra = append(header.Extra[:types.IstanbulExtraVanity], payload...)
 	return block.WithSeal(header), nil
 }
 

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -25,7 +25,6 @@ package core
 import (
 	"time"
 
-	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/istanbul"
@@ -34,7 +33,8 @@ import (
 func (c *core) sendPreprepare(request *istanbul.Request) {
 	logger := c.logger.NewWith("state", c.state)
 
-	header := types.SetRoundToHeader(request.Proposal.Header(), c.currentView().Round.Int64())
+	header := request.Proposal.Header()
+	c.backend.Sealer().WriteRound(header, c.currentView().Round.Int64())
 	request.Proposal = request.Proposal.WithSeal(header)
 
 	// If I'm the proposer and I have the same sequence with the proposal
@@ -118,7 +118,8 @@ func (c *core) handlePreprepare(msg *message, src common.Address) error {
 	if c.state == StateAcceptRequest {
 		// Send ROUND CHANGE if the locked proposal and the received proposal are different
 		if c.current.IsHashLocked() {
-			header := types.SetRoundToHeader(c.current.Preprepare.Proposal.Header(), c.currentView().Round.Int64())
+			header := c.current.Preprepare.Proposal.Header()
+			c.backend.Sealer().WriteRound(header, c.currentView().Round.Int64())
 			c.current.Preprepare.Proposal = c.current.Preprepare.Proposal.WithSeal(header)
 
 			if preprepare.Proposal.Hash() == c.current.GetLockedHash() {

--- a/consensus/istanbul/errors.go
+++ b/consensus/istanbul/errors.go
@@ -16,7 +16,9 @@
 
 package istanbul
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrUnauthorizedAddress is returned when given address cannot be found in
@@ -35,13 +37,15 @@ var (
 	ErrNoValidator = errors.New("no validator")
 	// errNoEssentialModule is returned when essential module is not registered.
 	ErrNoEssentialModule = errors.New("no essential module")
-	// errUnauthorized is returned if a header is signed by a non authorized entity.
+	// ErrUnauthorized is returned if a header is signed by a non authorized entity.
 	ErrUnauthorized = errors.New("unauthorized")
 	// errInvalidExtraDataFormat is returned when the extra data format is incorrect
 	ErrInvalidExtraDataFormat = errors.New("invalid extra data format")
 	// errInvalidVotingChain is returned if an authorization list is attempted to
 	// be modified via out-of-range or non-contiguous headers.
 	ErrInvalidVotingChain = errors.New("invalid voting chain")
+	// ErrUnknownBlock is returned when a required block/header context is missing.
+	ErrUnknownBlock = errors.New("unknown block")
 	// errInvalidCommittedSeals is returned if the committed seal is not signed by any of parent validators.
 	ErrInvalidCommittedSeals = errors.New("invalid committed seals")
 	// errEmptyCommittedSeals is returned if the field of committed seals is zero.

--- a/consensus/istanbul/mocks/backend_mock.go
+++ b/consensus/istanbul/mocks/backend_mock.go
@@ -52,6 +52,20 @@ func (mr *MockBackendMockRecorder) Address() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockBackend)(nil).Address))
 }
 
+// Sealer mocks base method.
+func (m *MockBackend) Sealer() *istanbul.IstanbulSealer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sealer")
+	ret0, _ := ret[0].(*istanbul.IstanbulSealer)
+	return ret0
+}
+
+// Sealer indicates an expected call of Sealer.
+func (mr *MockBackendMockRecorder) Sealer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sealer", reflect.TypeOf((*MockBackend)(nil).Sealer))
+}
+
 // Broadcast mocks base method.
 func (m *MockBackend) Broadcast(arg0 common.Hash, arg1 []byte) error {
 	m.ctrl.T.Helper()

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -11,11 +11,13 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/sha3"
 	"github.com/kaiachain/kaia/rlp"
 )
 
+var _ consensus.Sealer = (*IstanbulSealer)(nil)
 var (
 	inmemoryBlocks             = 2048
 	inmemoryValidatorsPerBlock = 30
@@ -73,9 +75,6 @@ func (ist *IstanbulExtra) DecodeRLP(s *rlp.Stream) error {
 }
 
 func (ist *IstanbulExtra) Copy() *IstanbulExtra {
-	if ist == nil {
-		return &IstanbulExtra{}
-	}
 	out := &IstanbulExtra{
 		Validators: make([]common.Address, len(ist.Validators)),
 		Seal:       append([]byte(nil), ist.Seal...),
@@ -152,9 +151,6 @@ func prepareCommittedSeal(hash common.Hash) []byte {
 }
 
 func (m *IstanbulSealer) Author(header *types.Header) (common.Address, error) {
-	if header == nil || header.Number == nil {
-		return common.Address{}, ErrUnknownBlock
-	}
 	extra, err := m.parseIstanbulExtra(header.Extra)
 	if err != nil {
 		return common.Address{}, err
@@ -170,9 +166,6 @@ func (m *IstanbulSealer) Author(header *types.Header) (common.Address, error) {
 }
 
 func (m *IstanbulSealer) Committers(header *types.Header) ([]common.Address, error) {
-	if header == nil || header.Number == nil {
-		return nil, ErrUnknownBlock
-	}
 	extra, err := m.parseIstanbulExtra(header.Extra)
 	if err != nil {
 		return nil, err
@@ -194,9 +187,6 @@ func (m *IstanbulSealer) Committers(header *types.Header) ([]common.Address, err
 }
 
 func (m *IstanbulSealer) Vanity(header *types.Header) ([]byte, error) {
-	if header == nil || header.Number == nil {
-		return nil, ErrUnknownBlock
-	}
 	if _, err := m.parseIstanbulExtra(header.Extra); err != nil {
 		return nil, err
 	}
@@ -206,9 +196,6 @@ func (m *IstanbulSealer) Vanity(header *types.Header) ([]byte, error) {
 }
 
 func (m *IstanbulSealer) Validators(header *types.Header) ([]common.Address, error) {
-	if header == nil || header.Number == nil {
-		return nil, ErrUnknownBlock
-	}
 	extra, err := m.parseIstanbulExtra(header.Extra)
 	if err != nil {
 		return nil, err
@@ -219,9 +206,6 @@ func (m *IstanbulSealer) Validators(header *types.Header) ([]common.Address, err
 }
 
 func (m *IstanbulSealer) Round(header *types.Header) (byte, error) {
-	if header == nil || header.Number == nil {
-		return 0, ErrUnknownBlock
-	}
 	if _, err := m.parseIstanbulExtra(header.Extra); err != nil {
 		return 0, err
 	}
@@ -229,9 +213,6 @@ func (m *IstanbulSealer) Round(header *types.Header) (byte, error) {
 }
 
 func (m *IstanbulSealer) RawSeals(header *types.Header) ([]byte, [][]byte, error) {
-	if header == nil || header.Number == nil {
-		return nil, nil, ErrUnknownBlock
-	}
 	extra, err := m.parseIstanbulExtra(header.Extra)
 	if err != nil {
 		return nil, nil, err
@@ -245,9 +226,6 @@ func (m *IstanbulSealer) RawSeals(header *types.Header) ([]byte, [][]byte, error
 }
 
 func (m *IstanbulSealer) writeExtra(header *types.Header, mutator func(*IstanbulExtra) error) error {
-	if header == nil {
-		return ErrUnknownBlock
-	}
 	header.Extra = ensureIstanbulVanityBytes(header.Extra)
 
 	extra, err := m.parseIstanbulExtra(header.Extra)
@@ -284,9 +262,6 @@ func (m *IstanbulSealer) WriteValidators(header *types.Header, validators []comm
 }
 
 func (m *IstanbulSealer) WriteAuthorSeal(header *types.Header, seal []byte) error {
-	if header == nil || header.Number == nil || header.Number.Sign() == 0 {
-		return ErrUnknownBlock
-	}
 	if len(seal) != IstanbulExtraSeal {
 		return ErrInvalidSignature
 	}
@@ -297,9 +272,6 @@ func (m *IstanbulSealer) WriteAuthorSeal(header *types.Header, seal []byte) erro
 }
 
 func (m *IstanbulSealer) WriteCommittedSeals(header *types.Header, committedSeals [][]byte) error {
-	if header == nil || header.Number == nil || header.Number.Sign() == 0 {
-		return ErrUnknownBlock
-	}
 	if len(committedSeals) == 0 {
 		return ErrInvalidCommittedSeals
 	}
@@ -341,19 +313,10 @@ func (m *IstanbulSealer) Quorum(blockNum uint64, qualifiedlen, committeeSize int
 }
 
 func (m *IstanbulSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) {
-	if header == nil || header.Number == nil {
-		return nil, ErrUnknownBlock
-	}
-	if header.Number.Sign() == 0 {
-		return []byte{}, nil
-	}
 	return crypto.Sign(crypto.Keccak256(prepareCommittedSeal(m.HeaderHash(header))), m.privateKey)
 }
 
 func (m *IstanbulSealer) MakeAuthorSeal(header *types.Header) ([]byte, error) {
-	if header == nil || header.Number == nil {
-		return nil, ErrUnknownBlock
-	}
 	if header.Number.Sign() == 0 {
 		return []byte{}, nil
 	}

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -18,6 +18,7 @@ import (
 )
 
 var _ consensus.Sealer = (*IstanbulSealer)(nil)
+
 var (
 	inmemoryBlocks             = 2048
 	inmemoryValidatorsPerBlock = 30

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -1,0 +1,378 @@
+package istanbul
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"errors"
+	"io"
+	"math"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/sha3"
+	"github.com/kaiachain/kaia/rlp"
+)
+
+var (
+	inmemoryBlocks             = 2048
+	inmemoryValidatorsPerBlock = 30
+	signatureAddresses, _      = lru.NewARC(inmemoryBlocks * inmemoryValidatorsPerBlock)
+
+	// IstanbulDigest represents a hash of "Istanbul practical byzantine fault tolerance"
+	// to identify whether the block is from Istanbul consensus engine.
+	IstanbulDigest = common.HexToHash("0x63746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365")
+
+	IstanbulExtraVanity = 32 // Fixed number of extra-data bytes reserved for validator vanity
+	IstanbulExtraSeal   = 65 // Fixed number of extra-data bytes reserved for validator seal
+
+	// ErrInvalidIstanbulHeaderExtra is returned if the length of extra-data is less than 32 bytes.
+	ErrInvalidIstanbulHeaderExtra = errors.New("invalid istanbul header extra-data")
+)
+
+type IstanbulSealer struct {
+	privateKey *ecdsa.PrivateKey
+
+	parsedExtraCache *lru.ARCCache
+}
+
+func NewSealerImpl(privateKey *ecdsa.PrivateKey) *IstanbulSealer {
+	parsedExtraCache, _ := lru.NewARC(inmemoryBlocks)
+	return &IstanbulSealer{privateKey: privateKey, parsedExtraCache: parsedExtraCache}
+}
+
+type IstanbulExtra struct {
+	Validators    []common.Address
+	Seal          []byte
+	CommittedSeal [][]byte
+}
+
+// EncodeRLP serializes the istanbul fields into the Kaia RLP format.
+func (ist *IstanbulExtra) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{
+		ist.Validators,
+		ist.Seal,
+		ist.CommittedSeal,
+	})
+}
+
+// DecodeRLP implements rlp.Decoder and loads the istanbul fields from a RLP stream.
+func (ist *IstanbulExtra) DecodeRLP(s *rlp.Stream) error {
+	var istanbulExtra struct {
+		Validators    []common.Address
+		Seal          []byte
+		CommittedSeal [][]byte
+	}
+	if err := s.Decode(&istanbulExtra); err != nil {
+		return err
+	}
+	ist.Validators, ist.Seal, ist.CommittedSeal = istanbulExtra.Validators, istanbulExtra.Seal, istanbulExtra.CommittedSeal
+	return nil
+}
+
+func (ist *IstanbulExtra) Copy() *IstanbulExtra {
+	if ist == nil {
+		return &IstanbulExtra{}
+	}
+	out := &IstanbulExtra{
+		Validators: make([]common.Address, len(ist.Validators)),
+		Seal:       append([]byte(nil), ist.Seal...),
+	}
+	copy(out.Validators, ist.Validators)
+	out.CommittedSeal = make([][]byte, len(ist.CommittedSeal))
+	for i, seal := range ist.CommittedSeal {
+		out.CommittedSeal[i] = append([]byte(nil), seal...)
+	}
+	return out
+}
+
+func ensureIstanbulVanityBytes(extra []byte) []byte {
+	if len(extra) >= IstanbulExtraVanity {
+		return append([]byte(nil), extra...)
+	}
+	out := append([]byte(nil), extra...)
+	out = append(out, bytes.Repeat([]byte{0x00}, IstanbulExtraVanity-len(out))...)
+	return out
+}
+
+func (m *IstanbulSealer) parseIstanbulExtra(extraBytes []byte) (*IstanbulExtra, error) {
+	if len(extraBytes) < IstanbulExtraVanity {
+		return nil, ErrInvalidIstanbulHeaderExtra
+	}
+
+	if m.parsedExtraCache != nil {
+		key := crypto.Keccak256Hash(extraBytes)
+		if cached, ok := m.parsedExtraCache.Get(key); ok {
+			return cached.(*IstanbulExtra).Copy(), nil
+		}
+	}
+
+	var extra *IstanbulExtra
+	if err := rlp.DecodeBytes(extraBytes[IstanbulExtraVanity:], &extra); err != nil {
+		return nil, err
+	}
+	if m.parsedExtraCache != nil {
+		m.parsedExtraCache.Add(crypto.Keccak256Hash(extraBytes), extra.Copy())
+	}
+	return extra, nil
+}
+
+func istanbulFilteredHeader(h *types.Header, keepSeal bool) *types.Header {
+	newHeader := types.CopyHeader(h)
+	if len(newHeader.Extra) < IstanbulExtraVanity {
+		return nil
+	}
+	var istanbulExtra *IstanbulExtra
+	err := rlp.DecodeBytes(newHeader.Extra[IstanbulExtraVanity:], &istanbulExtra)
+	if err != nil {
+		return nil
+	}
+
+	if !keepSeal {
+		istanbulExtra.Seal = []byte{}
+	}
+	istanbulExtra.CommittedSeal = [][]byte{}
+
+	payload, err := rlp.EncodeToBytes(istanbulExtra)
+	if err != nil {
+		return nil
+	}
+	newHeader.Extra[IstanbulExtraVanity-1] = 0
+	newHeader.Extra = append(newHeader.Extra[:IstanbulExtraVanity], payload...)
+	return newHeader
+}
+
+func prepareCommittedSeal(hash common.Hash) []byte {
+	var buf bytes.Buffer
+	buf.Write(hash.Bytes())
+	buf.Write([]byte{byte(2)}) // keep in sync with consensus/istanbul/core.msgCommit
+	return buf.Bytes()
+}
+
+func (m *IstanbulSealer) Author(header *types.Header) (common.Address, error) {
+	if header == nil || header.Number == nil {
+		return common.Address{}, ErrUnknownBlock
+	}
+	extra, err := m.parseIstanbulExtra(header.Extra)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if len(extra.Seal) == 0 {
+		return common.Address{}, ErrInvalidSignature
+	}
+	addr, err := cacheSignatureAddress(m.SigHash(header).Bytes(), extra.Seal)
+	if err != nil {
+		return common.Address{}, ErrInvalidSignature
+	}
+	return addr, nil
+}
+
+func (m *IstanbulSealer) Committers(header *types.Header) ([]common.Address, error) {
+	if header == nil || header.Number == nil {
+		return nil, ErrUnknownBlock
+	}
+	extra, err := m.parseIstanbulExtra(header.Extra)
+	if err != nil {
+		return nil, err
+	}
+	if len(extra.CommittedSeal) == 0 {
+		return []common.Address{}, nil
+	}
+
+	proposalSeal := prepareCommittedSeal(m.HeaderHash(header)) // msgCommit
+	committers := make([]common.Address, 0, len(extra.CommittedSeal))
+	for _, seal := range extra.CommittedSeal {
+		addr, err := cacheSignatureAddress(proposalSeal, seal)
+		if err != nil {
+			return nil, ErrInvalidSignature
+		}
+		committers = append(committers, addr)
+	}
+	return committers, nil
+}
+
+func (m *IstanbulSealer) Vanity(header *types.Header) ([]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, ErrUnknownBlock
+	}
+	if _, err := m.parseIstanbulExtra(header.Extra); err != nil {
+		return nil, err
+	}
+	vanity := make([]byte, IstanbulExtraVanity)
+	copy(vanity, header.Extra[:IstanbulExtraVanity])
+	return vanity, nil
+}
+
+func (m *IstanbulSealer) Validators(header *types.Header) ([]common.Address, error) {
+	if header == nil || header.Number == nil {
+		return nil, ErrUnknownBlock
+	}
+	extra, err := m.parseIstanbulExtra(header.Extra)
+	if err != nil {
+		return nil, err
+	}
+	validators := make([]common.Address, len(extra.Validators))
+	copy(validators, extra.Validators)
+	return validators, nil
+}
+
+func (m *IstanbulSealer) Round(header *types.Header) (byte, error) {
+	if header == nil || header.Number == nil {
+		return 0, ErrUnknownBlock
+	}
+	if _, err := m.parseIstanbulExtra(header.Extra); err != nil {
+		return 0, err
+	}
+	return header.Extra[IstanbulExtraVanity-1], nil
+}
+
+func (m *IstanbulSealer) RawSeals(header *types.Header) ([]byte, [][]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, nil, ErrUnknownBlock
+	}
+	extra, err := m.parseIstanbulExtra(header.Extra)
+	if err != nil {
+		return nil, nil, err
+	}
+	authorSeal := append([]byte(nil), extra.Seal...)
+	committedSeals := make([][]byte, len(extra.CommittedSeal))
+	for i, seal := range extra.CommittedSeal {
+		committedSeals[i] = append([]byte(nil), seal...)
+	}
+	return authorSeal, committedSeals, nil
+}
+
+func (m *IstanbulSealer) writeExtra(header *types.Header, mutator func(*IstanbulExtra) error) error {
+	if header == nil {
+		return ErrUnknownBlock
+	}
+	header.Extra = ensureIstanbulVanityBytes(header.Extra)
+
+	extra, err := m.parseIstanbulExtra(header.Extra)
+	if err != nil {
+		extra = &IstanbulExtra{}
+	}
+
+	if err := mutator(extra); err != nil {
+		return err
+	}
+
+	payload, err := rlp.EncodeToBytes(extra)
+	if err != nil {
+		return err
+	}
+	header.Extra = append(header.Extra[:IstanbulExtraVanity], payload...)
+	return nil
+}
+
+func (m *IstanbulSealer) WriteRound(header *types.Header, round int64) {
+	header.Extra = ensureIstanbulVanityBytes(header.Extra)
+	header.Extra[IstanbulExtraVanity-1] = byte(round)
+}
+
+func (m *IstanbulSealer) WriteValidators(header *types.Header, validators []common.Address) error {
+	return m.writeExtra(header, func(extra *IstanbulExtra) error {
+		extra.Validators = append([]common.Address(nil), validators...)
+		// Validators are written when preparing a new proposal header.
+		// Any inherited proposer/committed seals from a parent header must be cleared.
+		extra.Seal = nil
+		extra.CommittedSeal = nil
+		return nil
+	})
+}
+
+func (m *IstanbulSealer) WriteAuthorSeal(header *types.Header, seal []byte) error {
+	if header == nil || header.Number == nil || header.Number.Sign() == 0 {
+		return ErrUnknownBlock
+	}
+	if len(seal) != IstanbulExtraSeal {
+		return ErrInvalidSignature
+	}
+	return m.writeExtra(header, func(extra *IstanbulExtra) error {
+		extra.Seal = append([]byte(nil), seal...)
+		return nil
+	})
+}
+
+func (m *IstanbulSealer) WriteCommittedSeals(header *types.Header, committedSeals [][]byte) error {
+	if header == nil || header.Number == nil || header.Number.Sign() == 0 {
+		return ErrUnknownBlock
+	}
+	if len(committedSeals) == 0 {
+		return ErrInvalidCommittedSeals
+	}
+	return m.writeExtra(header, func(extra *IstanbulExtra) error {
+		extra.CommittedSeal = make([][]byte, len(committedSeals))
+		for i, seal := range committedSeals {
+			if len(seal) != IstanbulExtraSeal {
+				return ErrInvalidCommittedSeals
+			}
+			extra.CommittedSeal[i] = append([]byte(nil), seal...)
+		}
+		return nil
+	})
+}
+
+func (m *IstanbulSealer) HeaderHash(header *types.Header) common.Hash {
+	if filtered := istanbulFilteredHeader(header, true); filtered != nil {
+		return RLPHash(filtered)
+	}
+	return RLPHash(header)
+}
+
+func (m *IstanbulSealer) SigHash(header *types.Header) (hash common.Hash) {
+	hasher := sha3.NewKeccak256()
+	rlp.Encode(hasher, istanbulFilteredHeader(header, false))
+	hasher.Sum(hash[:0])
+	return hash
+}
+
+func (m *IstanbulSealer) F(_ uint64, qualifiedLen, committeeSize int) int {
+	if qualifiedLen > int(committeeSize) {
+		return int(math.Ceil(float64(committeeSize)/3)) - 1
+	}
+	return int(math.Ceil(float64(qualifiedLen)/3)) - 1
+}
+
+func (m *IstanbulSealer) Quorum(blockNum uint64, qualifiedlen, committeeSize int) int {
+	return 2*m.F(blockNum, qualifiedlen, committeeSize) + 1
+}
+
+func (m *IstanbulSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, ErrUnknownBlock
+	}
+	if header.Number.Sign() == 0 {
+		return []byte{}, nil
+	}
+	return crypto.Sign(crypto.Keccak256(prepareCommittedSeal(m.HeaderHash(header))), m.privateKey)
+}
+
+func (m *IstanbulSealer) MakeAuthorSeal(header *types.Header) ([]byte, error) {
+	if header == nil || header.Number == nil {
+		return nil, ErrUnknownBlock
+	}
+	if header.Number.Sign() == 0 {
+		return []byte{}, nil
+	}
+	canonicalHeader := types.CopyHeader(header)
+	if err := m.writeExtra(canonicalHeader, func(*IstanbulExtra) error { return nil }); err != nil {
+		return nil, err
+	}
+	return crypto.Sign(crypto.Keccak256(m.SigHash(canonicalHeader).Bytes()), m.privateKey)
+}
+
+func cacheSignatureAddress(data []byte, sig []byte) (common.Address, error) {
+	sigHex := hex.EncodeToString(sig)
+	if addr, ok := signatureAddresses.Get(sigHex); ok {
+		return addr.(common.Address), nil
+	}
+	addr, err := GetSignatureAddress(data, sig)
+	if err != nil {
+		return common.Address{}, err
+	}
+	signatureAddresses.Add(sigHex, addr)
+	return addr, nil
+}

--- a/consensus/istanbul/sealer_test.go
+++ b/consensus/istanbul/sealer_test.go
@@ -1,0 +1,164 @@
+package istanbul
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/rlp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitters(t *testing.T) {
+	// Kairos debug.getBlockRlp(144654443)
+	var (
+		kairosBlockRLP144654443 = "f904f1f903c1a046f5775da65a7c9e9a12d2ee4d010285df656ebd64c97cad2669c42c4aa39d8b94f90675a56a03f836204d66c0f923e00500ddc90aa0cec442b90b1d21e465474f7e5c233c3461e950bf383b39227917ad8a608653dfa004de211f466c3543bb2e3db8c976e9d046c214bc33c982d664b7e494d0c2c88aa0390d7c4c79e1e594bcc3236742112d9a7358652e66b1c97dea1c490e69276617b90100000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000002000000000000000000800000000000000000000010000020000000000000010000000000000000000000000000000000000006000000000000000000000004000000000000001240004000000000000000000000000000000000000004800000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000002000000000000000000000000000000000000000400000a00000000000000000000000000000000000000000000184089f406b8302c7158465b315d945b90187d883010c00846b6c617988676f312e32302e36856c696e757800000000000000f90164f85494571e53df607be97431a5bbefca1dffe5aef56f4d945cb1a7dccbd0dc446e3640898ede8820368554c89499fb17d324fa0e07f23b49d09028ac0919414db694b74ff9dea397fe9e231df545eb53fe2adf776cb2b841dc7dca1dc15d06e83a0a39217052ad7915d3b0f0a68f49d4b53498130a1212327b9dd5514362eb3e5f0ebb277e7d38baecad9cd045d3627d3a1f322422eeee8a01f8c9b8410a3fb9227632261c8520f1ee859c503f017701fdb92c2e39f532e190779888a63cf112cf2e530f656153ab64103558c26fb9ca43d5cf31425e62569f891e1eca00b8414a32097b87c481f145ae75ded4e8ec2ea4230c7b2feb3f3afcd2d22ea0b7d4596f4354e185d4f1f93b4d758ddb97e9203e1d306413ad0db1f4a779156879baa300b841fde66a2abb916bf314c82a2dfcd82ed356af829a98573d7cdb4a74cccb6ceecc22358750332ad31dccd9a890dbde7e0d4e21f173515011656f6c222169ba94620080808505d21dba00b860a027d1591d784686d063234bc000a8b9f829da534c41b555c867329b2b4abc5ef8f36245546adcc35c31dbc7c16b084a0d48487817b0eb191ac5b9aa8f3c908d413f19a1e784c3920fc0c0ef9180582902dc30ee8b70859e493af467bc227403a047f8b901fe5f4a3387cb6ccd5c14a00f7649247d2d2d315a652c378f328c1970f9012a31f90126830a596a850ba43b740083061a8094a317038414a275365ed4a085b786e83e761d20a580944dd5fa43054709155d5e68fadd3aeb3f853f34b0b844202ee0ed00000000000000000000000000000000000000000000000000000000000a596a0000000000000000000000000000000000000000000000000000000000000377f847f8458207f5a085d89c94a1e010f90b8e825e5321b1fff91ea748f50424448e17d5f1658498bda053936941c152ce9721447711a80c39b07fb36d42c8a8b6a258d8b071ab3b6c96945e6b99bca5a21818d40d12c56194674989146fc8f847f8458207f5a0c40d29e71cdd4f07051398fa35d41a25cc2f5db165d3ad8aa8b5eff20cc81996a01ea154d91320586165b139870e688a0ab4837137c5208a2da60cbdc60d7c7d81"
+		expectedProposer        = common.HexToAddress("0x5cb1a7dccbd0dc446e3640898ede8820368554c8")
+		// Committers from consensus info of this block.
+		expectedCommitters = []common.Address{
+			common.HexToAddress("0x99fb17d324fa0e07f23b49d09028ac0919414db6"),
+			common.HexToAddress("0x571e53df607be97431a5bbefca1dffe5aef56f4d"),
+			common.HexToAddress("0x5cb1a7dccbd0dc446e3640898ede8820368554c8"),
+		}
+	)
+
+	var block *types.Block
+	assert.Nil(t, rlp.DecodeBytes(common.FromHex(kairosBlockRLP144654443), &block))
+
+	sealer := NewSealerImpl(nil)
+	authorSeal, committedSeals, err := sealer.RawSeals(block.Header())
+	assert.Nil(t, err)
+	author, err := sealer.Author(block.Header())
+	assert.Nil(t, err)
+	assert.Equal(t, author, expectedProposer)
+	committers, err := sealer.Committers(block.Header())
+	assert.Nil(t, err)
+	assert.ElementsMatch(t, expectedCommitters, committers)
+	assert.NotEmpty(t, authorSeal)
+	assert.NotEmpty(t, committedSeals)
+}
+
+func TestWriteValidators(t *testing.T) {
+	var (
+		validators = []common.Address{
+			common.HexToAddress("0x44add0ec310f115a0e603b2d7db9f067778eaf8a"),
+			common.HexToAddress("0x294fc7e8f22b3bcdcf955dd7ff3ba2ed833f8212"),
+			common.HexToAddress("0x6beaaed781d2d2ab6350f5c4566a2c6eaac407a6"),
+			common.HexToAddress("0x8be76812f765c24641ec63dc2852b378aba2b440"),
+		}
+		s = NewSealerImpl(nil)
+		h = &types.Header{Number: big.NewInt(1)}
+	)
+
+	err := s.WriteValidators(h, validators)
+	require.NoError(t, err)
+
+	gotValidators, err := s.Validators(h)
+	require.NoError(t, err)
+	authorSeal, committedSeals, err := s.RawSeals(h)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, validators, gotValidators)
+	assert.Empty(t, authorSeal)
+	assert.Empty(t, committedSeals)
+}
+
+func TestWriteValidators_ClearsExistingSeals(t *testing.T) {
+	s := NewSealerImpl(nil)
+	h := &types.Header{Number: big.NewInt(1)}
+
+	require.NoError(t, s.WriteAuthorSeal(h, bytes.Repeat([]byte{0x01}, IstanbulExtraSeal)))
+	require.NoError(t, s.WriteCommittedSeals(h, [][]byte{bytes.Repeat([]byte{0x02}, IstanbulExtraSeal)}))
+
+	require.NoError(t, s.WriteValidators(h, []common.Address{common.HexToAddress("0x1")}))
+
+	authorSeal, committedSeals, err := s.RawSeals(h)
+	require.NoError(t, err)
+	assert.Empty(t, authorSeal)
+	assert.Empty(t, committedSeals)
+}
+
+func TestWriteAuthorSeal(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	authorizedAddr := crypto.PubkeyToAddress(key.PublicKey)
+
+	s := NewSealerImpl(key)
+	h := &types.Header{Number: big.NewInt(1)}
+
+	seal, err := s.MakeAuthorSeal(h)
+	require.NoError(t, err)
+	require.NoError(t, s.WriteAuthorSeal(h, seal))
+
+	authorSeal, _, err := s.RawSeals(h)
+	require.NoError(t, err)
+	assert.Equal(t, authorSeal, seal)
+	author, err := s.Author(h)
+	require.NoError(t, err)
+	assert.Equal(t, author, authorizedAddr)
+}
+
+func TestWriteAuthorSeal_GenesisNotHandled(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	s := NewSealerImpl(key)
+	h := &types.Header{Number: big.NewInt(0)}
+	err = s.WriteAuthorSeal(h, make([]byte, IstanbulExtraSeal))
+	require.ErrorIs(t, err, ErrUnknownBlock)
+}
+
+func TestWriteCommittedSeals(t *testing.T) {
+	vanity := bytes.Repeat([]byte{0x00}, IstanbulExtraVanity)
+	istRawData := hexutil.MustDecode("0xf858f8549444add0ec310f115a0e603b2d7db9f067778eaf8a94294fc7e8f22b3bcdcf955dd7ff3ba2ed833f8212946beaaed781d2d2ab6350f5c4566a2c6eaac407a6948be76812f765c24641ec63dc2852b378aba2b44080c0")
+	expectedCommittedSeal := append([]byte{1, 2, 3}, bytes.Repeat([]byte{0x00}, IstanbulExtraSeal-3)...)
+	s := NewSealerImpl(nil)
+	h := &types.Header{
+		Number: big.NewInt(1),
+		Extra:  append(vanity, istRawData...),
+	}
+
+	err := s.WriteCommittedSeals(h, [][]byte{expectedCommittedSeal})
+	require.NoError(t, err)
+	validators, err := s.Validators(h)
+	require.NoError(t, err)
+	_, committedSeals, err := s.RawSeals(h)
+	require.NoError(t, err)
+	assert.Equal(t, []common.Address{
+		common.BytesToAddress(hexutil.MustDecode("0x44add0ec310f115a0e603b2d7db9f067778eaf8a")),
+		common.BytesToAddress(hexutil.MustDecode("0x294fc7e8f22b3bcdcf955dd7ff3ba2ed833f8212")),
+		common.BytesToAddress(hexutil.MustDecode("0x6beaaed781d2d2ab6350f5c4566a2c6eaac407a6")),
+		common.BytesToAddress(hexutil.MustDecode("0x8be76812f765c24641ec63dc2852b378aba2b440")),
+	}, validators)
+	assert.Equal(t, [][]byte{expectedCommittedSeal}, committedSeals)
+
+	unexpectedCommittedSeal := append(expectedCommittedSeal, make([]byte, 1)...)
+	err = s.WriteCommittedSeals(h, [][]byte{unexpectedCommittedSeal})
+	assert.ErrorIs(t, err, ErrInvalidCommittedSeals)
+}
+
+func TestWriteCommittedSeals_GenesisNotHandled(t *testing.T) {
+	s := NewSealerImpl(nil)
+	err := s.WriteCommittedSeals(&types.Header{Number: big.NewInt(0)}, [][]byte{make([]byte, IstanbulExtraSeal)})
+	require.ErrorIs(t, err, ErrUnknownBlock)
+}
+
+func TestMakeSeals_GenesisHandled(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	s := NewSealerImpl(key)
+	h := &types.Header{Number: big.NewInt(0)}
+
+	authorSeal, err := s.MakeAuthorSeal(h)
+	require.NoError(t, err)
+	assert.Empty(t, authorSeal)
+
+	committedSeal, err := s.MakeCommittedSeal(h)
+	require.NoError(t, err)
+	assert.Empty(t, committedSeal)
+}

--- a/consensus/istanbul/sealer_test.go
+++ b/consensus/istanbul/sealer_test.go
@@ -102,14 +102,19 @@ func TestWriteAuthorSeal(t *testing.T) {
 	assert.Equal(t, author, authorizedAddr)
 }
 
-func TestWriteAuthorSeal_GenesisNotHandled(t *testing.T) {
+func TestWriteAuthorSeal_GenesisHandled(t *testing.T) {
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
 	s := NewSealerImpl(key)
 	h := &types.Header{Number: big.NewInt(0)}
-	err = s.WriteAuthorSeal(h, make([]byte, IstanbulExtraSeal))
-	require.ErrorIs(t, err, ErrUnknownBlock)
+	seal := make([]byte, IstanbulExtraSeal)
+
+	require.NoError(t, s.WriteAuthorSeal(h, seal))
+
+	authorSeal, _, err := s.RawSeals(h)
+	require.NoError(t, err)
+	assert.Equal(t, seal, authorSeal)
 }
 
 func TestWriteCommittedSeals(t *testing.T) {
@@ -141,10 +146,16 @@ func TestWriteCommittedSeals(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidCommittedSeals)
 }
 
-func TestWriteCommittedSeals_GenesisNotHandled(t *testing.T) {
+func TestWriteCommittedSeals_GenesisHandled(t *testing.T) {
 	s := NewSealerImpl(nil)
-	err := s.WriteCommittedSeals(&types.Header{Number: big.NewInt(0)}, [][]byte{make([]byte, IstanbulExtraSeal)})
-	require.ErrorIs(t, err, ErrUnknownBlock)
+	h := &types.Header{Number: big.NewInt(0)}
+	seal := make([]byte, IstanbulExtraSeal)
+
+	require.NoError(t, s.WriteCommittedSeals(h, [][]byte{seal}))
+
+	_, committedSeals, err := s.RawSeals(h)
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{seal}, committedSeals)
 }
 
 func TestMakeSeals_GenesisHandled(t *testing.T) {
@@ -160,5 +171,8 @@ func TestMakeSeals_GenesisHandled(t *testing.T) {
 
 	committedSeal, err := s.MakeCommittedSeal(h)
 	require.NoError(t, err)
-	assert.Empty(t, committedSeal)
+	assert.Len(t, committedSeal, IstanbulExtraSeal)
+	addr, err := GetSignatureAddress(prepareCommittedSeal(s.HeaderHash(h)), committedSeal)
+	require.NoError(t, err)
+	assert.Equal(t, crypto.PubkeyToAddress(key.PublicKey), addr)
 }


### PR DESCRIPTION
## Proposed changes

This PR is the first in a three-PR series for the sealer refactor.

The planned series is:
1. introduce a standalone sealer abstraction
2. migrate seal-related consumers to the new abstraction
3. route the CN runtime through the BFT facade and remove legacy engine paths

Why a separate sealer is needed is that `consensus.Engine` and seal-related logic have different responsibilities. `consensus.Engine` is responsible for live consensus execution around the current chain head. By contrast, seal-related logic is also required outside the live runtime path, including:
- parsing and writing Istanbul extra-data
- computing consensus-specific header hashes and signature hashes
- interpreting historical blocks correctly

Changes
- add `consensus.Sealer`
- add the Istanbul sealer implementation
- add the BFT sealer facade
- wire Istanbul backend/core to use the sealer abstraction internally
- add sealer-focused tests and Istanbul documentation

Note that this PR does not yet migrate all seal consumers, and it does not yet switch CN runtime construction to the BFT engine facade. Those changes are handled in the follow-up PRs.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
