### PR TITLE
ci: reduces cmd/utils/nodecmd, datasync, node/sc, tests directory ci test running time

### DIFF
--- a/.github/workflows/test-pr-workflow.yml
+++ b/.github/workflows/test-pr-workflow.yml
@@ -27,26 +27,27 @@ jobs:
         BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
         go run build/ci.go lint -v --new-from-rev="origin/${BASE_BRANCH}"
 
-  test-networks:
+  test-node-network:
     needs: build
-    name: Test Networks
+    name: Test Node and Networks
     uses: ./.github/workflows/test-executor-template.yml
     with:
-      test_command: make test-networks
+      test_command: |
+        make test-node
+        make test-networks
 
-  test-node:
+  test-eestfixture:
     needs: build
-    name: Test Node
+    name: Test EEST Fixture
     uses: ./.github/workflows/test-executor-template.yml
     with:
-      test_command: make test-node
-
+      cache_fixtures: true
+      test_command: make test-eestfixture
   test-tests:
     needs: build
     name: Test Tests
     uses: ./.github/workflows/test-executor-template.yml
     with:
-      cache_fixtures: true
       test_command: |
         git clone --depth 1 https://github.com/kaiachain/kaia-core-tests.git tests/testdata
         make test-tests
@@ -75,20 +76,21 @@ jobs:
         python3 main.py --protocol rpc
 
   # Service-dependent test jobs
-  test-datasync:
+  test-service-dependent:
     needs: build
-    name: Test Datasync
+    name: Test Service Dependent Tests (e.g. redis,kafka)
     uses: ./.github/workflows/test-executor-template.yml
     with:
       runs_on: kaia-xlarge-runner
       with_services: true
-      test_command: make test-datasync
+      test_command: |
+        make test-datasync
+        make test-storage
 
   test-others:
     needs: build
     name: Test Others
     uses: ./.github/workflows/test-executor-template.yml
     with:
-      runs_on: kaia-xlarge-runner
-      with_services: true
       test_command: make test-others
+

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ GORUN = env GOPATH=$(GOPATH) GO111MODULE=on go run
 
 BIN = $(shell pwd)/build/bin
 BUILD_PARAM?=install
+FIXTURE_TEST_REGEX?=^(TestExecutionSpecBlockTestSuite|TestExecutionSpecStateTestSuite|TestKaiaSpecState|TestRLP|TestTransaction|TestVM)$$
 
 OBJECTS=kcn kpn ken kscn kspn ksen kbn kgen homi
 
@@ -33,20 +34,14 @@ test:
 test-seq:
 	$(GORUN) build/ci.go test -p 1
 
-test-datasync:
-	$(GORUN) build/ci.go test -p 1 ./datasync/...
+test-datasync test-networks test-node test-storage test-tests:
+	$(GORUN) build/ci.go test -p 1 ./$(patsubst test-%,%,$@)/...
 
-test-networks:
-	$(GORUN) build/ci.go test -p 1 ./networks/...
-
-test-node:
-	$(GORUN) build/ci.go test -p 1 ./node/...
-
-test-tests:
-	$(GORUN) build/ci.go test -ensure-fixtures -p 1 ./tests/...
+test-eestfixture:
+	$(GORUN) build/ci.go test -ensure-fixtures -p 1 -run '$(FIXTURE_TEST_REGEX)' ./tests/...
 
 test-others:
-	$(GORUN) build/ci.go test -p 1 -exclude datasync,networks,node,tests
+	$(GORUN) build/ci.go test -p 1 -exclude github.com/kaiachain/kaia/datasync,github.com/kaiachain/kaia/networks,github.com/kaiachain/kaia/node,github.com/kaiachain/kaia/storage,github.com/kaiachain/kaia/tests
 
 cover:
 	$(GORUN) build/ci.go cover -p 1 -coverprofile=coverage.out

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -36,6 +36,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/accounts/abi"
 	"github.com/kaiachain/kaia/blockchain/state"
@@ -43,15 +44,12 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/compiler"
-	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/consensus/misc/eip4844"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
-	"github.com/kaiachain/kaia/rlp"
-	"github.com/kaiachain/kaia/storage"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/kaiachain/kaia/storage/statedb"
 	"github.com/stretchr/testify/assert"
@@ -1980,54 +1978,34 @@ func TestBlockChain_SetCanonicalBlock(t *testing.T) {
 	assert.EqualValues(t, targetBlock, newHeadBlock)
 }
 
-func TestBlockChain_writeBlockLogsToRemoteCache(t *testing.T) {
-	storage.SkipLocalTest(t)
+func TestBlockChain_writeBlockLogsToRemoteCache_WithMiniRedis(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mr.Close()
 
-	// prepare blockchain
+	receipts, _, encodedBlockLogs := getTestLogs(t)
+	key := []byte{1, 2, 3, 4}
+
 	blockchain := &BlockChain{
 		stateCache: state.NewDatabaseWithNewCache(database.NewMemoryDBManager(), &statedb.TrieNodeCacheConfig{
 			CacheType:          statedb.CacheTypeHybrid,
 			LocalCacheSizeMiB:  100,
-			RedisEndpoints:     []string{"redis:6379"},
+			RedisEndpoints:     []string{mr.Addr()},
 			RedisClusterEnable: false,
 		}),
 	}
 
-	// prepare test data to be written in the cache
-	key := []byte{1, 2, 3, 4}
-	log := &types.Log{
-		Address:     common.Address{},
-		Topics:      []common.Hash{common.BytesToHash(hexutil.MustDecode("0x123456789abcdef123456789abcdefffffffffff"))},
-		Data:        []uint8{0x11, 0x22, 0x33, 0x44},
-		BlockNumber: uint64(1000),
-	}
-	receipt := &types.Receipt{
-		TxHash:  common.Hash{},
-		GasUsed: uint64(999999),
-		Status:  types.ReceiptStatusSuccessful,
-		Logs:    []*types.Log{log},
-	}
+	blockchain.writeBlockLogsToRemoteCache(key, receipts)
 
-	// write log to cache
-	blockchain.writeBlockLogsToRemoteCache(key, []*types.Receipt{receipt})
-
-	// get log from cache
 	ret := blockchain.stateCache.TrieDB().TrieNodeCache().Get(key)
 	if ret == nil {
 		t.Fatal("no cache")
 	}
-
-	// decode return data to the original log format
-	storageLog := []*types.LogForStorage{}
-	if err := rlp.DecodeBytes(ret, &storageLog); err != nil {
-		t.Fatal(err)
+	if !bytes.Equal(encodedBlockLogs, ret) {
+		t.Fatal("unexpected encoded logs payload")
 	}
-	logs := make([]*types.Log, len(storageLog))
-	for i, log := range storageLog {
-		logs[i] = (*types.Log)(log)
-	}
-
-	assert.Equal(t, log, logs[0])
 }
 
 // TestDeleteCreateRevert tests a weird state transition corner case that we hit

--- a/build/ci.go
+++ b/build/ci.go
@@ -264,10 +264,11 @@ func goToolArch(arch string, cc string, subcmd string, args ...string) *exec.Cmd
 
 func doTest(cmdline []string) {
 	var (
-		parallel        = flag.Int("p", 0, "The number of parallel test executions (default: the number of CPUs available)")
-		excludes        = flag.String("exclude", "", "Comma-separated top-level directories to be excluded in test")
-		cachedir        = flag.String("cachedir", "./build/cache", "directory for caching downloads")
-		ensureFixtures  = flag.Bool("ensure-fixtures", false, "download spec test fixtures before running tests")
+		parallel       = flag.Int("p", 0, "The number of parallel test executions (default: the number of CPUs available)")
+		excludes       = flag.String("exclude", "", "Comma-separated top-level directories to be excluded in test")
+		cachedir       = flag.String("cachedir", "./build/cache", "directory for caching downloads")
+		ensureFixtures = flag.Bool("ensure-fixtures", false, "download spec test fixtures before running tests")
+		runPattern     = flag.String("run", "", "run only tests matching this regexp (passed to go test -run)")
 	)
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
@@ -294,6 +295,9 @@ func doTest(cmdline []string) {
 	gotest := goTool("test", buildFlags(env)...)
 	if *parallel != 0 {
 		gotest.Args = append(gotest.Args, "-p", strconv.Itoa(*parallel))
+	}
+	if *runPattern != "" {
+		gotest.Args = append(gotest.Args, "-run", *runPattern)
 	}
 	gotest.Args = append(gotest.Args, "--timeout=30m")
 	gotest.Args = append(gotest.Args, packages...)

--- a/cmd/utils/nodecmd/accountcmd_test.go
+++ b/cmd/utils/nodecmd/accountcmd_test.go
@@ -51,14 +51,42 @@ func tmpDatadirWithKeystore(t *testing.T) string {
 	return datadir
 }
 
+func waitForStderrContains(t *testing.T, kaia *testKaia, timeout time.Duration, want ...string) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		text := kaia.StderrText()
+		ok := true
+		for _, w := range want {
+			if !strings.Contains(text, w) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("stderr did not contain expected strings within %v: %v", timeout, want)
+}
+
+func killOnFailure(t *testing.T, kaia *testKaia) {
+	t.Helper()
+	t.Cleanup(func() {
+		if t.Failed() {
+			kaia.Kill()
+		}
+	})
+}
+
 func TestAccountListEmpty(t *testing.T) {
-	kaia := runKaia(t, "kaia-test", "account", "list")
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "list")
 	kaia.ExpectExit()
 }
 
 func TestAccountList(t *testing.T) {
 	datadir := tmpDatadirWithKeystore(t)
-	kaia := runKaia(t, "kaia-test", "account", "list", "--datadir", datadir)
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "list", "--datadir", datadir)
 	defer kaia.ExpectExit()
 	if runtime.GOOS == "windows" {
 		kaia.Expect(`
@@ -76,7 +104,7 @@ Account #2: {289d485d9771714cce91d3393d764e1311907acc} keystore://{{.Datadir}}/k
 }
 
 func TestAccountNew(t *testing.T) {
-	kaia := runKaia(t, "kaia-test", "account", "new", "--lightkdf")
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "new", "--lightkdf")
 	defer kaia.ExpectExit()
 	kaia.Expect(`
 Your new account is locked with a password. Please give a password. Do not forget this password.
@@ -88,7 +116,7 @@ Repeat passphrase: {{.InputLine "foobar"}}
 }
 
 func TestAccountNewV3(t *testing.T) {
-	kaia := runKaia(t, "kaia-test", "account", "new", "--v3", "--lightkdf")
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "new", "--v3", "--lightkdf")
 	defer kaia.ExpectExit()
 	kaia.Expect(`
 Your new account is locked with a password. Please give a password. Do not forget this password.
@@ -100,7 +128,7 @@ Repeat passphrase: {{.InputLine "foobar"}}
 }
 
 func TestAccountNewBadRepeat(t *testing.T) {
-	kaia := runKaia(t, "kaia-test", "account", "new", "--lightkdf")
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "new", "--lightkdf")
 	defer kaia.ExpectExit()
 	kaia.Expect(`
 Your new account is locked with a password. Please give a password. Do not forget this password.
@@ -113,7 +141,7 @@ Fatal: Passphrases do not match
 
 func TestAccountUpdate(t *testing.T) {
 	datadir := tmpDatadirWithKeystore(t)
-	kaia := runKaia(t, "kaia-test", "account", "update",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "update",
 		"--datadir", datadir, "--lightkdf",
 		"f466859ead1932d743d622cb74fc058882e8648a")
 	defer kaia.ExpectExit()
@@ -141,7 +169,7 @@ func TestAccountImportV3(t *testing.T) {
 	assert.Nil(t, os.WriteFile(testKeyPath, []byte(testKeyHex), 0o400))
 	defer os.Remove(testKeyPath)
 
-	kaia := runKaia(t, "kaia-test", "account", "import", "--v3", testKeyPath)
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "import", "--v3", "--lightkdf", testKeyPath)
 	// Enter password
 	kaia.InputLine("")
 	// Confirm password
@@ -165,15 +193,21 @@ func TestAccountImportV3(t *testing.T) {
 
 func TestUnlockFlag(t *testing.T) {
 	datadir := tmpDatadirWithKeystore(t)
-	kaia := runKaia(t, "kaia-test",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single",
 		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxconnections", "0", "--port", "0",
 		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a",
 		"js", "testdata/empty.js")
+	killOnFailure(t, kaia)
 	kaia.Expect(`
 Unlocking account f466859ead1932d743d622cb74fc058882e8648a | Attempt 1/3
 !! Unsupported terminal, password will be echoed.
 Passphrase: {{.InputLine "foobar"}}
 `)
+	waitForStderrContains(t, kaia, 5*time.Second,
+		"Unlocked account",
+		"0xf466859eAD1932D743d622CB74FC058882E8648A",
+	)
+	kaia.Interrupt()
 	kaia.ExpectExit()
 
 	wantMessages := []string{
@@ -189,7 +223,7 @@ Passphrase: {{.InputLine "foobar"}}
 
 func TestUnlockFlagWrongPassword(t *testing.T) {
 	datadir := tmpDatadirWithKeystore(t)
-	kaia := runKaia(t, "kaia-test",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single",
 		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxconnections", "0", "--port", "0",
 		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a")
 	defer kaia.ExpectExit()
@@ -208,10 +242,11 @@ Fatal: Failed to unlock account f466859ead1932d743d622cb74fc058882e8648a (could 
 // https://github.com/ethereum/go-ethereum/issues/1785
 func TestUnlockFlagMultiIndex(t *testing.T) {
 	datadir := tmpDatadirWithKeystore(t)
-	kaia := runKaia(t, "kaia-test",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single",
 		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxconnections", "0", "--port", "0",
 		"--unlock", "0,2",
 		"js", "testdata/empty.js")
+	killOnFailure(t, kaia)
 	kaia.Expect(`
 Unlocking account 0 | Attempt 1/3
 !! Unsupported terminal, password will be echoed.
@@ -219,6 +254,12 @@ Passphrase: {{.InputLine "foobar"}}
 Unlocking account 2 | Attempt 1/3
 Passphrase: {{.InputLine "foobar"}}
 `)
+	waitForStderrContains(t, kaia, 5*time.Second,
+		"Unlocked account",
+		"0x7EF5A6135f1FD6a02593eEdC869c6D41D934aef8",
+		"0x289d485D9771714CCe91D3393D764E1311907ACc",
+	)
+	kaia.Interrupt()
 	kaia.ExpectExit()
 
 	wantMessages := []string{
@@ -235,10 +276,17 @@ Passphrase: {{.InputLine "foobar"}}
 
 func TestUnlockFlagPasswordFile(t *testing.T) {
 	datadir := tmpDatadirWithKeystore(t)
-	kaia := runKaia(t, "kaia-test",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single",
 		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxconnections", "0", "--port", "0",
 		"--password", "testdata/passwords.txt", "--unlock", "0,2",
 		"js", "testdata/empty.js")
+	killOnFailure(t, kaia)
+	waitForStderrContains(t, kaia, 5*time.Second,
+		"Unlocked account",
+		"0x7EF5A6135f1FD6a02593eEdC869c6D41D934aef8",
+		"0x289d485D9771714CCe91D3393D764E1311907ACc",
+	)
+	kaia.Interrupt()
 	kaia.ExpectExit()
 
 	wantMessages := []string{
@@ -255,7 +303,7 @@ func TestUnlockFlagPasswordFile(t *testing.T) {
 
 func TestUnlockFlagPasswordFileWrongPassword(t *testing.T) {
 	datadir := tmpDatadirWithKeystore(t)
-	kaia := runKaia(t, "kaia-test",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single",
 		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxconnections", "0", "--port", "0",
 		"--password", "testdata/wrong-passwords.txt", "--unlock", "0,2")
 	defer kaia.ExpectExit()
@@ -266,11 +314,11 @@ Fatal: Failed to unlock account 0 (could not decrypt key with given passphrase)
 
 func TestUnlockFlagAmbiguous(t *testing.T) {
 	store := filepath.Join("..", "..", "..", "accounts", "keystore", "testdata", "dupes")
-	kaia := runKaia(t, "kaia-test",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single",
 		"--keystore", store, "--nat", "none", "--nodiscover", "--maxconnections", "0", "--port", "0",
 		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a",
 		"js", "testdata/empty.js")
-	defer kaia.ExpectExit()
+	killOnFailure(t, kaia)
 
 	// Helper for the expect template, returns absolute keystore path.
 	kaia.SetTemplateFunc("keypath", func(file string) string {
@@ -289,6 +337,11 @@ Your passphrase unlocked keystore://{{keypath "1"}}
 In order to avoid this warning, you need to remove the following duplicate key files:
    keystore://{{keypath "2"}}
 `)
+	waitForStderrContains(t, kaia, 5*time.Second,
+		"Unlocked account",
+		"0xf466859eAD1932D743d622CB74FC058882E8648A",
+	)
+	kaia.Interrupt()
 	kaia.ExpectExit()
 
 	wantMessages := []string{
@@ -304,7 +357,7 @@ In order to avoid this warning, you need to remove the following duplicate key f
 
 func TestUnlockFlagAmbiguousWrongPassword(t *testing.T) {
 	store := filepath.Join("..", "..", "..", "accounts", "keystore", "testdata", "dupes")
-	kaia := runKaia(t, "kaia-test",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single",
 		"--keystore", store, "--nat", "none", "--nodiscover", "--maxconnections", "0", "--port", "0",
 		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a")
 	defer kaia.ExpectExit()
@@ -351,12 +404,14 @@ func TestBlsInfo(t *testing.T) {
 	// Save nodekey before node starts
 	assert.Nil(t, os.MkdirAll(filepath.Join(datadir, "klay"), 0o700))
 	assert.Nil(t, os.WriteFile(nodekeyPath, []byte(nodekeyHex), 0o400))
-	server := runKaia(t, "kaia-test", "--datadir", datadir,
-		"--netrestrict", "127.0.0.1/32", "--port", "0", "--verbosity", "2")
-	time.Sleep(5 * time.Second) // Simple way to wait for the RPC endpoint to open
+	server := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "--datadir", datadir,
+		"--netrestrict", "127.0.0.1/32", "--port", "0", "--maxconnections", "0",
+		"--nodiscover", "--nat", "none", "--verbosity", "0")
+	killOnFailure(t, server)
+	waitForEndpoint(t, filepath.Join(datadir, "klay.ipc"), 20*time.Second)
 
 	os.Remove(outputPath) // delete before test, because otherwise the "already exists" error occurs
-	client := runKaia(t, "kaia-test", "account", "bls-info", "--datadir", datadir)
+	client := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "bls-info", "--datadir", datadir)
 	client.ExpectRegexp(expectPrint)
 
 	content, err := os.ReadFile(outputPath)
@@ -393,7 +448,7 @@ func TestBlsImport(t *testing.T) {
 	assert.Nil(t, os.WriteFile(blsnodekeyPath, []byte(blsnodekeyHex), 0o400))
 
 	os.Remove(outputPath) // delete before test, because otherwise the "already exists" error occurs
-	kaia := runKaia(t, "kaia-test", "account", "bls-import", "--datadir", datadir)
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "bls-import", "--datadir", datadir)
 	kaia.InputLine("1234") // Enter password
 	kaia.InputLine("1234") // Confirm password
 	kaia.ExpectRegexp(expectPrint)
@@ -422,7 +477,7 @@ func TestBlsExport(t *testing.T) {
 	defer os.RemoveAll(datadir)
 	t.Logf("datadir: %s", datadir)
 
-	kaia := runKaia(t, "kaia-test", "account", "bls-export", "--datadir", datadir,
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "account", "bls-export", "--datadir", datadir,
 		"--bls-nodekeystore", keystorePath, "--password", passwordPath)
 	kaia.ExpectRegexp(expectPrint)
 

--- a/cmd/utils/nodecmd/consolecmd_test.go
+++ b/cmd/utils/nodecmd/consolecmd_test.go
@@ -45,8 +45,7 @@ const (
 // then terminated by closing the input stream.
 func TestConsoleWelcome(t *testing.T) {
 	// Start a Kaia console, make sure it's cleaned up and terminate the console
-	kaia := runKaia(t,
-		"kaia-test", "--port", "0", "--maxconnections", "0", "--nodiscover", "--nat", "none",
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "--port", "0", "--maxconnections", "0", "--nodiscover", "--nat", "none",
 		"console")
 
 	// Gather all the infos the welcome message needs to contain
@@ -72,8 +71,8 @@ instance: Klaytn/{{klayver}}/{{goos}}-{{goarch}}/{{gover}}
 }
 
 // Tests that a console can be attached to a running node via various means.
-func TestIPCAttachWelcome(t *testing.T) {
-	// Configure the instance for IPC attachment
+func TestAttachWelcome(t *testing.T) {
+	// Configure shared node endpoints for IPC/HTTP/WS attachment tests.
 	var ipc string
 	if runtime.GOOS == "windows" {
 		ipc = `\\.\pipe\klay` + strconv.Itoa(trulyRandInt(100000, 999999))
@@ -82,40 +81,28 @@ func TestIPCAttachWelcome(t *testing.T) {
 		defer os.RemoveAll(ws)
 		ipc = filepath.Join(ws, "klay.ipc")
 	}
-	// Note: we need --shh because testAttachWelcome checks for default
-	// list of ipc modules and shh is included there.
-	kaia := runKaia(t,
-		"kaia-test", "--port", "0", "--maxconnections", "0", "--nodiscover", "--nat", "none", "--ipcpath", ipc)
+	httpPort := strconv.Itoa(trulyRandInt(1024, 65536))
+	wsPort := strconv.Itoa(trulyRandInt(1024, 65536))
+
+	// Start one node and reuse it for all attach variants.
+	kaia := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "--port", "0", "--maxconnections", "0", "--nodiscover", "--nat", "none",
+		"--ipcpath", ipc, "--rpc", "--rpcport", httpPort, "--ws", "--wsport", wsPort)
 
 	waitForEndpoint(t, ipc, 10*time.Second)
-	testAttachWelcome(t, kaia, "ipc:"+ipc, ipcAPIs)
+	httpEndpoint := "http://127.0.0.1:" + httpPort
+	wsEndpoint := "ws://127.0.0.1:" + wsPort
+	waitForEndpoint(t, httpEndpoint, 10*time.Second)
+	waitForEndpoint(t, wsEndpoint, 10*time.Second)
 
-	kaia.Interrupt()
-	kaia.Kill()
-}
-
-func TestHTTPAttachWelcome(t *testing.T) {
-	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
-	kaia := runKaia(t,
-		"kaia-test", "--port", "0", "--maxconnections", "0", "--nodiscover", "--nat", "none", "--rpc", "--rpcport", port)
-
-	endpoint := "http://127.0.0.1:" + port
-	waitForEndpoint(t, endpoint, 10*time.Second)
-	testAttachWelcome(t, kaia, endpoint, httpAPIs)
-
-	kaia.Interrupt()
-	kaia.Kill()
-}
-
-func TestWSAttachWelcome(t *testing.T) {
-	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
-
-	kaia := runKaia(t,
-		"kaia-test", "--port", "0", "--maxconnections", "0", "--nodiscover", "--nat", "none", "--ws", "--wsport", port)
-
-	endpoint := "ws://127.0.0.1:" + port
-	waitForEndpoint(t, endpoint, 10*time.Second)
-	testAttachWelcome(t, kaia, endpoint, httpAPIs)
+	t.Run("ipc", func(t *testing.T) {
+		testAttachWelcome(t, kaia, "ipc:"+ipc, ipcAPIs)
+	})
+	t.Run("http", func(t *testing.T) {
+		testAttachWelcome(t, kaia, httpEndpoint, httpAPIs)
+	})
+	t.Run("ws", func(t *testing.T) {
+		testAttachWelcome(t, kaia, wsEndpoint, httpAPIs)
+	})
 
 	kaia.Interrupt()
 	kaia.Kill()
@@ -123,7 +110,7 @@ func TestWSAttachWelcome(t *testing.T) {
 
 func testAttachWelcome(t *testing.T, klay *testKaia, endpoint, apis string) {
 	// Attach to a running Kaia node and terminate immediately
-	attach := runKaia(t, "kaia-test", "attach", endpoint)
+	attach := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "attach", endpoint)
 	defer attach.ExpectExit()
 	attach.CloseStdin()
 

--- a/cmd/utils/nodecmd/defaultcmd_test.go
+++ b/cmd/utils/nodecmd/defaultcmd_test.go
@@ -1,34 +1,241 @@
-// Modifications Copyright 2024 The Kaia Authors
-// Modifications Copyright 2019 The klaytn Authors
-// Copyright 2016 The go-ethereum Authors
-// This file is part of go-ethereum.
-//
-// go-ethereum is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// go-ethereum is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
-//
-// This file is derived from cmd/geth/genesis_test.go (2018/06/04).
-// Modified and improved for the klaytn development.
-// Modified and improved for the Kaia development.
-
 package nodecmd
 
 import (
+	"flag"
+	"io"
 	"os"
-	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/kaiachain/kaia/cmd/utils"
+	"github.com/urfave/cli/v2"
 )
 
-var genesis = `{"config":{"chainId":2019,"istanbul":{"epoch":30,"policy":2,"sub":13},"unitPrice":25000000000,"deriveShaImpl":2,"governance":{"governingNode":"0xdddfb991127b43e209c2f8ed08b8b3d0b5843d36","governanceMode":"single","reward":{"mintingAmount":9600000000000000000,"ratio":"34/54/12","useGiniCoeff":false,"deferredTxFee":true,"stakingUpdateInterval":60,"proposerUpdateInterval":30,"minimumStake":5000000}}},"timestamp":"0x5ce33d6e","extraData":"0x0000000000000000000000000000000000000000000000000000000000000000f89af85494dddfb991127b43e209c2f8ed08b8b3d0b5843d3694195ba9cc787b00796a7ae6356e5b656d4360353794777fd033b5e3bcaad6006bc9f481ffed6b83cf5a94d473284239f704adccd24647c7ca132992a28973b8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0","governanceData":null,"blockScore":"0x1","alloc":{"195ba9cc787b00796a7ae6356e5b656d43603537":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"777fd033b5e3bcaad6006bc9f481ffed6b83cf5a":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"d473284239f704adccd24647c7ca132992a28973":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"dddfb991127b43e209c2f8ed08b8b3d0b5843d36":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"},"f4316f69d9522667c0674afcd8638288489f0333":{"balance":"0x446c3b15f9926687d2c40534fdb564000000000000"}},"number":"0x0","gasUsed":"0x0","parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000"}`
+func newNodecmdContext(t *testing.T, args ...string) *cli.Context {
+	app := cli.NewApp()
+	app.Flags = utils.AllNodeFlags()
+
+	set := flag.NewFlagSet("nodecmd-test", flag.ContinueOnError)
+	set.SetOutput(io.Discard)
+	for _, f := range app.Flags {
+		if err := f.Apply(set); err != nil {
+			t.Fatalf("failed to apply flag %v: %v", f.Names(), err)
+		}
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+	return cli.NewContext(app, set, nil)
+}
+
+func stopNodeOnCleanup(t *testing.T, stack interface{ Stop() error }) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = stack.Stop()
+	})
+}
+
+func registeredConstructorCount(t *testing.T, stack interface{}, fieldName string) int {
+	t.Helper()
+
+	value := reflect.ValueOf(stack)
+	if value.Kind() != reflect.Ptr || value.IsNil() {
+		t.Fatalf("stack must be a non-nil pointer, got %T", stack)
+	}
+
+	field := value.Elem().FieldByName(fieldName)
+	if !field.IsValid() {
+		t.Fatalf("node field %q not found", fieldName)
+	}
+	if field.Kind() != reflect.Slice {
+		t.Fatalf("node field %q must be a slice, got %s", fieldName, field.Kind())
+	}
+	return field.Len()
+}
+
+func TestDefaultCmd_MakeFullNode(t *testing.T) {
+	datadir := tmpdir(t)
+	t.Cleanup(func() { _ = os.RemoveAll(datadir) })
+
+	ctx := newNodecmdContext(t, "--datadir", datadir, "--verbosity", "0")
+	stack := MakeFullNode(ctx)
+	if stack == nil {
+		t.Fatal("MakeFullNode returned nil")
+	}
+	stopNodeOnCleanup(t, stack)
+	if got := stack.DataDir(); got != datadir {
+		t.Fatalf("unexpected datadir: got %q want %q", got, datadir)
+	}
+	if got := registeredConstructorCount(t, stack, "coreServiceFuncs"); got != 1 {
+		t.Fatalf("unexpected number of core services: got %d want 1", got)
+	}
+	if got := registeredConstructorCount(t, stack, "serviceFuncs"); got != 0 {
+		t.Fatalf("unexpected number of sub services: got %d want 0", got)
+	}
+}
+
+func TestDefaultCmd_MakeFullNodeServiceRegistrationFlags(t *testing.T) {
+	runner := newMakeFullNodeRunner(t)
+	tests := []struct {
+		name                 string
+		args                 []string
+		wantMainBridge       bool
+		wantSubBridge        bool
+		wantDBSyncer         bool
+		wantChainDataFetcher bool
+	}{
+		{
+			name:           "mainbridge",
+			args:           []string{"--mainbridge"},
+			wantMainBridge: true,
+		},
+		{
+			name:          "subbridge",
+			args:          []string{"--subbridge"},
+			wantSubBridge: true,
+		},
+		{
+			name:         "dbsyncer",
+			args:         []string{"--dbsyncer", "--dbsyncer.db.host", "127.0.0.1", "--dbsyncer.db.user", "tester", "--dbsyncer.db.password", "secret", "--dbsyncer.db.name", "kaia"},
+			wantDBSyncer: true,
+		},
+		{
+			name:                 "chaindatafetcher",
+			args:                 []string{"--chaindatafetcher", "--chaindatafetcher.mode", "kafka", "--chaindatafetcher.kafka.brokers", "127.0.0.1:9092"},
+			wantChainDataFetcher: true,
+		},
+		{
+			name:                 "combined",
+			args:                 []string{"--mainbridge", "--subbridge", "--dbsyncer", "--dbsyncer.db.host", "127.0.0.1", "--dbsyncer.db.user", "tester", "--dbsyncer.db.password", "secret", "--dbsyncer.db.name", "kaia", "--chaindatafetcher", "--chaindatafetcher.mode", "kafka", "--chaindatafetcher.kafka.brokers", "127.0.0.1:9092"},
+			wantMainBridge:       true,
+			wantSubBridge:        true,
+			wantDBSyncer:         true,
+			wantChainDataFetcher: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			datadir := tmpdir(t)
+			t.Cleanup(func() { _ = os.RemoveAll(datadir) })
+
+			args := append([]string{"--datadir", datadir, "--verbosity", "0"}, tc.args...)
+			ctx, err := runner.context(args...)
+			if err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+			_, cfg := utils.MakeConfigNode(ctx)
+			if cfg.ServiceChain.EnabledMainBridge != tc.wantMainBridge {
+				t.Fatalf("unexpected EnabledMainBridge: got %v want %v", cfg.ServiceChain.EnabledMainBridge, tc.wantMainBridge)
+			}
+			if cfg.ServiceChain.EnabledSubBridge != tc.wantSubBridge {
+				t.Fatalf("unexpected EnabledSubBridge: got %v want %v", cfg.ServiceChain.EnabledSubBridge, tc.wantSubBridge)
+			}
+			if cfg.DB.EnabledDBSyncer != tc.wantDBSyncer {
+				t.Fatalf("unexpected EnabledDBSyncer: got %v want %v", cfg.DB.EnabledDBSyncer, tc.wantDBSyncer)
+			}
+			if cfg.ChainDataFetcher.EnabledChainDataFetcher != tc.wantChainDataFetcher {
+				t.Fatalf("unexpected EnabledChainDataFetcher: got %v want %v", cfg.ChainDataFetcher.EnabledChainDataFetcher, tc.wantChainDataFetcher)
+			}
+
+			stack := MakeFullNode(ctx)
+			if stack == nil {
+				t.Fatal("MakeFullNode returned nil")
+			}
+			stopNodeOnCleanup(t, stack)
+
+			wantSubServices := 0
+			if tc.wantMainBridge {
+				wantSubServices++
+			}
+			if tc.wantSubBridge {
+				wantSubServices++
+			}
+			if tc.wantDBSyncer {
+				wantSubServices++
+			}
+			if tc.wantChainDataFetcher {
+				wantSubServices++
+			}
+			if got := registeredConstructorCount(t, stack, "coreServiceFuncs"); got != 1 {
+				t.Fatalf("unexpected number of core services: got %d want 1", got)
+			}
+			if got := registeredConstructorCount(t, stack, "serviceFuncs"); got != wantSubServices {
+				t.Fatalf("unexpected number of sub services: got %d want %d", got, wantSubServices)
+			}
+		})
+	}
+}
+
+func TestFlagSetReuse_LeaksIsSet(t *testing.T) {
+	app := cli.NewApp()
+	app.Flags = utils.AllNodeFlags()
+
+	set := flag.NewFlagSet("nodecmd-reuse-leak", flag.ContinueOnError)
+	set.SetOutput(io.Discard)
+	for _, f := range app.Flags {
+		if err := f.Apply(set); err != nil {
+			t.Fatalf("failed to apply flag %v: %v", f.Names(), err)
+		}
+	}
+	reset := func() {
+		set.VisitAll(func(f *flag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+		})
+	}
+
+	reset()
+	if err := set.Parse([]string{"--mainbridge"}); err != nil {
+		t.Fatalf("failed to parse first args: %v", err)
+	}
+	ctx1 := cli.NewContext(app, set, nil)
+	if !ctx1.IsSet(utils.MainBridgeFlag.Name) {
+		t.Fatalf("expected %q to be set in first parse", utils.MainBridgeFlag.Name)
+	}
+	if !ctx1.Bool(utils.MainBridgeFlag.Name) {
+		t.Fatalf("expected %q bool value to be true in first parse", utils.MainBridgeFlag.Name)
+	}
+
+	reset()
+	if err := set.Parse([]string{"--subbridge"}); err != nil {
+		t.Fatalf("failed to parse second args: %v", err)
+	}
+	ctx2 := cli.NewContext(app, set, nil)
+	if ctx2.Bool(utils.MainBridgeFlag.Name) {
+		t.Fatalf("expected %q bool value to be false after reset", utils.MainBridgeFlag.Name)
+	}
+	if !ctx2.IsSet(utils.MainBridgeFlag.Name) {
+		t.Fatalf("expected %q IsSet to leak when reusing FlagSet", utils.MainBridgeFlag.Name)
+	}
+}
+
+func TestMakeFullNodeRunner_Context_NoIsSetLeak(t *testing.T) {
+	runner := newMakeFullNodeRunner(t)
+
+	datadir1 := tmpdir(t)
+	t.Cleanup(func() { _ = os.RemoveAll(datadir1) })
+	ctx1, err := runner.context("--datadir", datadir1, "--verbosity", "0", "--mainbridge")
+	if err != nil {
+		t.Fatalf("failed to parse first context: %v", err)
+	}
+	if !ctx1.IsSet(utils.MainBridgeFlag.Name) {
+		t.Fatalf("expected %q to be set in first parse", utils.MainBridgeFlag.Name)
+	}
+
+	datadir2 := tmpdir(t)
+	t.Cleanup(func() { _ = os.RemoveAll(datadir2) })
+	ctx2, err := runner.context("--datadir", datadir2, "--verbosity", "0", "--subbridge")
+	if err != nil {
+		t.Fatalf("failed to parse second context: %v", err)
+	}
+	if ctx2.IsSet(utils.MainBridgeFlag.Name) {
+		t.Fatalf("expected %q IsSet to be false in second parse", utils.MainBridgeFlag.Name)
+	}
+	if !ctx2.IsSet(utils.SubBridgeFlag.Name) {
+		t.Fatalf("expected %q to be set in second parse", utils.SubBridgeFlag.Name)
+	}
+}
 
 const (
 	FlagTypeBoolean = iota
@@ -780,58 +987,113 @@ var flagsWithValues = []struct {
 	},
 }
 
-func testFlags(t *testing.T, flag string, value string, idx int) {
-	datadir := tmpdir(t)
-	defer os.RemoveAll(datadir)
-
-	json := filepath.Join(datadir, "genesis.json")
-	if err := os.WriteFile(json, []byte(genesis), 0o600); err != nil {
-		t.Fatalf("test %d: failed to write genesis file: %v", idx, err)
-	}
-
-	runKaia(t, "kaia-test-flag", "--verbosity", "0", "--datadir", datadir, "init", json).WaitExit()
-
-	kaia := runKaia(t, "kaia-test-flag", "--datadir", datadir, flag, value)
-	kaia.ExpectExit()
+type makeFullNodeRunner struct {
+	app *cli.App
 }
 
-func testWrongFlags(t *testing.T, flag string, value string, idx int, expectedError string) {
-	datadir := tmpdir(t)
-	defer os.RemoveAll(datadir)
-
-	json := filepath.Join(datadir, "genesis.json")
-	if err := os.WriteFile(json, []byte(genesis), 0o600); err != nil {
-		t.Fatalf("test %d: failed to write genesis file: %v", idx, err)
-	}
-
-	runKaia(t, "kaia-test-flag", "--verbosity", "0", "--datadir", datadir, "init", json).WaitExit()
-
-	kaia := runKaia(t, "kaia-test-flag", "--datadir", datadir, flag, value)
-	kaia.ExpectRegexp(expectedError)
+func newMakeFullNodeRunner(t *testing.T) *makeFullNodeRunner {
+	t.Helper()
+	app := cli.NewApp()
+	app.Flags = utils.AllNodeFlags()
+	return &makeFullNodeRunner{app: app}
 }
 
-func TestFlags(t *testing.T) {
-	expectedError := []string{
-		"Incorrect Usage. flag provided but not defined: (.*)",
-		"Incorrect Usage. invalid value (.*)",
-		"Fatal:(.*)",
-		"(.*)",
+func (r *makeFullNodeRunner) context(args ...string) (*cli.Context, error) {
+	set := flag.NewFlagSet("nodecmd-makefullnode-runner", flag.ContinueOnError)
+	set.SetOutput(io.Discard)
+	for _, f := range r.app.Flags {
+		if err := f.Apply(set); err != nil {
+			return nil, err
+		}
 	}
-	for idx, fwv := range flagsWithValues {
+	if err := set.Parse(args); err != nil {
+		return nil, err
+	}
+	return cli.NewContext(r.app, set, nil), nil
+}
+
+type parseOnlyRunner struct {
+	set *flag.FlagSet
+}
+
+func newParseOnlyRunner(t *testing.T) *parseOnlyRunner {
+	t.Helper()
+	app := cli.NewApp()
+	app.Flags = utils.AllNodeFlags()
+	set := flag.NewFlagSet("nodecmd-parseonly-inproc", flag.ContinueOnError)
+	set.SetOutput(io.Discard)
+	for _, f := range app.Flags {
+		if err := f.Apply(set); err != nil {
+			t.Fatalf("failed to apply flag %v: %v", f.Names(), err)
+		}
+	}
+	return &parseOnlyRunner{set: set}
+}
+
+func (r *parseOnlyRunner) parse(args ...string) error {
+	// Reuse the same parser for speed; reset values before each parse.
+	r.set.VisitAll(func(f *flag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+	})
+	baseArgs := []string{"--verbosity", "0"}
+	return r.set.Parse(append(baseArgs, args...))
+}
+
+func sanitizeTestName(s string) string {
+	replacer := strings.NewReplacer("/", "_", " ", "_", "\t", "_")
+	return replacer.Replace(s)
+}
+
+func parseExpectationFromLegacyResult(resultCode int) (strict bool, wantErr bool) {
+	switch resultCode {
+	case ErrorIncorrectUsage, ErrorInvalidValue:
+		return true, true
+	case ErrorFatal:
+		// Fatal cases are expected to fail in config/setup stage, not parsing stage.
+		return true, false
+	case NonError:
+		// Legacy matrix marks these as currently unfiltered.
+		return false, false
+	default:
+		return false, false
+	}
+}
+
+func TestDefaultCmd_ParseOnlyAllFlagCases(t *testing.T) {
+	runner := newParseOnlyRunner(t)
+	for _, fwv := range flagsWithValues {
+		fwv := fwv
 		switch fwv.flagType {
 		case FlagTypeBoolean:
-			t.Run("kaia-test-flag"+fwv.flag, func(t *testing.T) {
-				testFlags(t, fwv.flag, "", idx)
+			t.Run("parseonly"+sanitizeTestName(fwv.flag), func(t *testing.T) {
+				if err := runner.parse(fwv.flag, ""); err != nil {
+					t.Fatalf("expected parse success for %s, got error: %v", fwv.flag, err)
+				}
 			})
 		case FlagTypeArgument:
 			for _, item := range fwv.values {
-				t.Run("kaia-test-flag"+fwv.flag+"-"+item, func(t *testing.T) {
-					testFlags(t, fwv.flag, item, idx)
+				item := item
+				t.Run("parseonly"+sanitizeTestName(fwv.flag)+"-"+sanitizeTestName(item), func(t *testing.T) {
+					if err := runner.parse(fwv.flag, item); err != nil {
+						t.Fatalf("expected parse success for %s %q, got error: %v", fwv.flag, item, err)
+					}
 				})
 			}
 			for idx2, wrongItem := range fwv.wrongValues {
-				t.Run("kaia-test-flag"+fwv.flag+"-"+wrongItem, func(t *testing.T) {
-					testWrongFlags(t, fwv.flag, wrongItem, idx, expectedError[fwv.errors[idx2]])
+				idx2 := idx2
+				wrongItem := wrongItem
+				t.Run("parseonly"+sanitizeTestName(fwv.flag)+"-"+sanitizeTestName(wrongItem), func(t *testing.T) {
+					strict, wantErr := parseExpectationFromLegacyResult(fwv.errors[idx2])
+					err := runner.parse(fwv.flag, wrongItem)
+					if !strict {
+						return
+					}
+					if wantErr && err == nil {
+						t.Fatalf("expected parse failure for %s %q, but got success", fwv.flag, wrongItem)
+					}
+					if !wantErr && err != nil {
+						t.Fatalf("expected parse success for %s %q, got error: %v", fwv.flag, wrongItem, err)
+					}
 				})
 			}
 		}

--- a/cmd/utils/nodecmd/genesis_test.go
+++ b/cmd/utils/nodecmd/genesis_test.go
@@ -23,10 +23,15 @@
 package nodecmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 var customGenesisTests = []struct {
@@ -172,25 +177,65 @@ func TestCustomGenesis(t *testing.T) {
 			defer os.RemoveAll(datadir)
 
 			// Initialize the data directory with the custom genesis block
-			json := filepath.Join(datadir, "genesis.json")
-			if err := os.WriteFile(json, []byte(tt.genesis), 0o600); err != nil {
+			genesisFile := filepath.Join(datadir, "genesis.json")
+			if err := os.WriteFile(genesisFile, []byte(tt.genesis), 0o600); err != nil {
 				t.Fatalf("test %d: failed to write genesis file: %v", i, err)
 			}
-			runKaia(t, "kaia-test", "--datadir", datadir, "--verbosity", "0", "init", json).WaitExit()
+			runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "--datadir", datadir, "--verbosity", "0", "init", genesisFile).WaitExit()
 
-			// Query the custom genesis block
+			// Start a node once per test case, then run all queries via attach.
+			server := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "--datadir", datadir, "--maxconnections", "0", "--port", "0",
+				"--nodiscover", "--nat", "none", "--networkid", "123", "--verbosity", "0")
+			ipcEndpoint := filepath.Join(datadir, "klay.ipc")
+			waitForEndpoint(t, ipcEndpoint, 20*time.Second)
+			defer func() {
+				server.Interrupt()
+				server.ExpectExit()
+			}()
+
+			// Query the custom genesis block.
 			if len(tt.query) != len(tt.result) {
 				t.Errorf("Test cases are wrong, #query: %v, #result, %v", len(tt.query), len(tt.result))
 			}
-			for idx, query := range tt.query {
-				kaia := runKaia(t,
-					"kaia-test", "--datadir", datadir, "--maxconnections", "0", "--port", "0",
-					"--nodiscover", "--nat", "none", "--ipcdisable", "--ntp.disable", "--networkid", "123",
-					"--exec", query, "--verbosity", "0", "console")
-				t.Log("query", query, "expected result", tt.result[idx], "actual result", kaia.StderrText())
-				kaia.ExpectRegexp(tt.result[idx])
-				kaia.ExpectExit()
+			execQuery := fmt.Sprintf("[%s]", strings.Join(tt.query, ","))
+			client := runKaia(t, "kaia-test", "--ntp.disable", "--db.single", "--verbosity", "0", "--exec", execQuery, "attach", ipcEndpoint)
+			_, matches := client.ExpectRegexp(`(?s)\[[\s\S]*\]`)
+			client.ExpectExit()
+			if len(matches) == 0 {
+				t.Fatal("failed to capture attach output")
+			}
+
+			var got []json.RawMessage
+			if err := json.Unmarshal([]byte(matches[0]), &got); err != nil {
+				t.Fatalf("failed to decode attach output as JSON array: %v\noutput: %s", err, matches[0])
+			}
+			if len(got) != len(tt.result) {
+				t.Fatalf("unexpected result count: got %d, want %d", len(got), len(tt.result))
+			}
+			for idx := range got {
+				gotValue, err := normalizeQueryValue(got[idx])
+				if err != nil {
+					t.Fatalf("failed to normalize result at index %d: %v", idx, err)
+				}
+				if gotValue != tt.result[idx] {
+					t.Errorf("query %q: got %q, want %q", tt.query[idx], gotValue, tt.result[idx])
+				}
 			}
 		})
 	}
+}
+
+func normalizeQueryValue(raw json.RawMessage) (string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return "", errors.New("empty result")
+	}
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return "", err
+		}
+		return s, nil
+	}
+	return string(trimmed), nil
 }

--- a/contracts/test/Bridge/bridge.test.ts
+++ b/contracts/test/Bridge/bridge.test.ts
@@ -88,6 +88,42 @@ async function deployBridgeConfiguredMintBurnFixture() {
 }
 
 describe("Bridge", function () {
+  describe("Contract Public Variables", function () {
+    it("ServiceChainToken public variables", async function () {
+      const { token, owner } = await loadFixture(deployBridgeFixture);
+
+      expect(await token.INITIAL_SUPPLY()).to.equal(ethers.utils.parseUnits("1000000000", 18));
+      expect(await token.allowance(owner.address, owner.address)).to.equal(0);
+      expect(await token.balanceOf(owner.address)).to.equal(ethers.utils.parseUnits("1000000000", 18));
+      expect(await token.DECIMALS()).to.equal(0x12);
+      expect(await token.NAME()).to.equal("ServiceChainToken");
+      expect(await token.SYMBOL()).to.equal("SCT");
+    });
+
+    it("ServiceChainNFT public variables", async function () {
+      const { bridge, nft, owner } = await loadFixture(deployBridgeFixture);
+      const baseTokenId = 7321;
+      const mintCount = 1;
+
+      await nft.connect(owner).mintWithTokenURI(owner.address, baseTokenId, "");
+
+      expect(await nft.balanceOf(owner.address)).to.equal(mintCount);
+      expect(await nft.bridge()).to.equal(bridge.address);
+      expect(await nft.getApproved(baseTokenId)).to.equal(AddressZero);
+      expect(await nft.isApprovedForAll(owner.address, owner.address)).to.equal(false);
+      expect(await nft.isOwner()).to.equal(true);
+      expect(await nft.name()).to.equal("ServiceChainNFT");
+      expect(await nft.owner()).to.equal(owner.address);
+      expect(await nft.ownerOf(baseTokenId)).to.equal(owner.address);
+      expect(await nft.supportsInterface("0x00000000")).to.equal(false);
+      expect(await nft.symbol()).to.equal("SCN");
+      expect(await nft.tokenByIndex(0)).to.equal(baseTokenId);
+      expect(await nft.tokenOfOwnerByIndex(owner.address, 0)).to.equal(baseTokenId);
+      expect(await nft.tokenURI(baseTokenId)).to.equal("");
+      expect(await nft.totalSupply()).to.equal(mintCount);
+    });
+  });
+
   describe("BridgeCounterpart", function () {
     it("set counterpart bridge", async function () {
       const { bridge, owner, cBridge, user1 } = await loadFixture(deployBridgeFixture);
@@ -173,6 +209,19 @@ describe("Bridge", function () {
       expect(bridge.connect(op1).setOperatorThreshold(VoteType.ValueTransfer, 1)).to.be.revertedWith("Ownable: caller is not the owner");
       expect(bridge.connect(owner).setOperatorThreshold(VoteType.ValueTransfer, 0)).to.be.revertedWith("zero threshold");
       expect(bridge.connect(owner).setOperatorThreshold(VoteType.ValueTransfer, 3)).to.be.revertedWith("bigger than num of operators");
+    });
+    it("max operator limit", async function () {
+      const { bridge, owner } = await loadFixture(deployBridgeFixture);
+      const signers = await ethers.getSigners();
+      const maxOperator = (await bridge.MAX_OPERATOR()).toNumber();
+
+      // owner is already an operator, register the remaining slots.
+      for (let i = 1; i < maxOperator; i++) {
+        await bridge.connect(owner).registerOperator(signers[i].address);
+      }
+      expect((await bridge.getOperatorList()).length).to.equal(maxOperator);
+
+      await expect(bridge.connect(owner).registerOperator(signers[maxOperator].address)).to.be.revertedWith("max operator limit");
     });
     it("vote configuration", async function () {
       const { bridge, owner, op1, op2, op3, user1 } = await loadFixture(deployBridgeFixture);
@@ -737,6 +786,39 @@ describe("Bridge", function () {
         );
 
       expect(await ethers.provider.getBalance(user2.address)).to.equal(parseEther("1.0"));
+    });
+    it("handle nonce window advances by at most 200", async function() {
+      const { bridge, owner, user1, user2 } = await loadFixture(deployBridgeFixture);
+      await bridge.connect(owner).chargeWithoutEvent({value: parseEther("1000.0")});
+
+      for (let nonce = 1; nonce <= 205; nonce++) {
+        const requestTxHash = ethers.utils.hexZeroPad(ethers.BigNumber.from(nonce).toHexString(), 32);
+        await bridge.connect(owner).handleKLAYTransfer(
+          requestTxHash,
+          user1.address,
+          user2.address,
+          parseEther("1.0"),
+          nonce,
+          blockNum + nonce,
+          "0x",
+        );
+      }
+
+      expect(await bridge.lowerHandleNonce()).to.equal(0);
+      expect(await bridge.upperHandleNonce()).to.equal(205);
+
+      const zeroTxHash = ethers.utils.hexZeroPad(ethers.BigNumber.from(999999).toHexString(), 32);
+      await bridge.connect(owner).handleKLAYTransfer(
+        zeroTxHash,
+        user1.address,
+        user2.address,
+        parseEther("1.0"),
+        0,
+        blockNum,
+        "0x",
+      );
+      expect(await bridge.lowerHandleNonce()).to.equal(201);
+      expect(await bridge.upperHandleNonce()).to.equal(205);
     });
     it("insufficient feeLimit", async function() {
       const fixture = await loadFixture(deployBridgeConfiguredFixture);

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -53,9 +53,12 @@ import (
 
 // Reduce some of the parameters to make the tester faster.
 func init() {
-	MaxForkAncestry = uint64(10000)
-	blockCacheMaxItems = 1024
-	fsHeaderContCheck = 500 * time.Millisecond
+	MaxForkAncestry = uint64(512)
+	MaxHashFetch = 64
+	MaxHeaderFetch = 16
+	MaxBlockFetch = 16
+	blockCacheMaxItems = 80
+	fsHeaderContCheck = 200 * time.Millisecond
 }
 
 var (

--- a/datasync/fetcher/fetcher_test.go
+++ b/datasync/fetcher/fetcher_test.go
@@ -278,8 +278,10 @@ func TestSequentialAnnouncements63(t *testing.T) { testSequentialAnnouncements(t
 func TestSequentialAnnouncements64(t *testing.T) { testSequentialAnnouncements(t, 64) }
 
 func testSequentialAnnouncements(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a chain of blocks to import
-	targetBlocks := 4 * hashLimit
+	targetBlocks := 8
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
 
 	tester := newTester()
@@ -304,8 +306,10 @@ func TestConcurrentAnnouncements63(t *testing.T) { testConcurrentAnnouncements(t
 func TestConcurrentAnnouncements64(t *testing.T) { testConcurrentAnnouncements(t, 64) }
 
 func testConcurrentAnnouncements(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a chain of blocks to import
-	targetBlocks := 4 * hashLimit
+	targetBlocks := 8
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
 
 	// Assemble a tester with a built in counter for the requests
@@ -349,8 +353,10 @@ func TestOverlappingAnnouncements63(t *testing.T) { testOverlappingAnnouncements
 func TestOverlappingAnnouncements64(t *testing.T) { testOverlappingAnnouncements(t, 64) }
 
 func testOverlappingAnnouncements(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a chain of blocks to import
-	targetBlocks := 4 * hashLimit
+	targetBlocks := 8
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
 
 	tester := newTester()
@@ -359,6 +365,9 @@ func testOverlappingAnnouncements(t *testing.T, protocol int) {
 
 	// Iteratively announce blocks, but overlap them continuously
 	overlap := 16
+	if overlap > targetBlocks {
+		overlap = targetBlocks
+	}
 	imported := make(chan *types.Block, len(hashes)-1)
 	for range overlap {
 		imported <- nil
@@ -383,6 +392,8 @@ func TestPendingDeduplication63(t *testing.T) { testPendingDeduplication(t, 63) 
 func TestPendingDeduplication64(t *testing.T) { testPendingDeduplication(t, 64) }
 
 func testPendingDeduplication(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a hash and corresponding block
 	hashes, blocks := makeChain(1, 0, genesis)
 
@@ -426,6 +437,8 @@ func TestRandomArrivalImport63(t *testing.T) { testRandomArrivalImport(t, 63) }
 func TestRandomArrivalImport64(t *testing.T) { testRandomArrivalImport(t, 64) }
 
 func testRandomArrivalImport(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a chain of blocks to import, and choose one to delay
 	targetBlocks := maxQueueDist
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
@@ -457,6 +470,8 @@ func TestQueueGapFill63(t *testing.T) { testQueueGapFill(t, 63) }
 func TestQueueGapFill64(t *testing.T) { testQueueGapFill(t, 64) }
 
 func testQueueGapFill(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a chain of blocks to import, and choose one to not announce at all
 	targetBlocks := maxQueueDist
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
@@ -488,6 +503,8 @@ func TestImportDeduplication63(t *testing.T) { testImportDeduplication(t, 63) }
 func TestImportDeduplication64(t *testing.T) { testImportDeduplication(t, 64) }
 
 func testImportDeduplication(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create two blocks to import (one for duplication, the other for stalling)
 	hashes, blocks := makeChain(2, 0, genesis)
 
@@ -527,6 +544,8 @@ func testImportDeduplication(t *testing.T, protocol int) {
 // Tests that blocks with numbers much lower or higher than out current head get
 // discarded to prevent wasting resources on useless blocks from faulty peers.
 func TestDistantPropagationDiscarding(t *testing.T) {
+	t.Parallel()
+
 	// Create a long chain to import and define the discard boundaries
 	hashes, blocks := makeChain(3*maxQueueDist, 0, genesis)
 	head := hashes[len(hashes)/2]
@@ -563,6 +582,8 @@ func TestDistantAnnouncementDiscarding63(t *testing.T) { testDistantAnnouncement
 func TestDistantAnnouncementDiscarding64(t *testing.T) { testDistantAnnouncementDiscarding(t, 64) }
 
 func testDistantAnnouncementDiscarding(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a long chain to import and define the discard boundaries
 	hashes, blocks := makeChain(3*maxQueueDist, 0, genesis)
 	head := hashes[len(hashes)/2]
@@ -606,6 +627,8 @@ func TestInvalidNumberAnnouncement63(t *testing.T) { testInvalidNumberAnnounceme
 func TestInvalidNumberAnnouncement64(t *testing.T) { testInvalidNumberAnnouncement(t, 64) }
 
 func testInvalidNumberAnnouncement(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a single block to import and check numbers against
 	hashes, blocks := makeChain(1, 0, genesis)
 
@@ -651,6 +674,8 @@ func TestEmptyBlockShortCircuit63(t *testing.T) { testEmptyBlockShortCircuit(t, 
 func TestEmptyBlockShortCircuit64(t *testing.T) { testEmptyBlockShortCircuit(t, 64) }
 
 func testEmptyBlockShortCircuit(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a chain of blocks to import
 	hashes, blocks := makeChain(32, 0, genesis)
 
@@ -695,6 +720,8 @@ func TestHashMemoryExhaustionAttack64(t *testing.T) { testHashMemoryExhaustionAt
 */
 
 func testHashMemoryExhaustionAttack(t *testing.T, protocol int) {
+	t.Parallel()
+
 	// Create a tester with instrumented import hooks
 	tester := newTester()
 
@@ -742,6 +769,8 @@ func testHashMemoryExhaustionAttack(t *testing.T, protocol int) {
 // announces and retrievals) don't pile up indefinitely, exhausting available
 // system memory.
 func TestBlockMemoryExhaustionAttack(t *testing.T) {
+	t.Parallel()
+
 	// Create a tester with instrumented import hooks
 	tester := newTester()
 

--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,8 @@ require (
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.4.3 // indirect
+	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
+	github.com/alicebob/miniredis/v2 v2.34.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
@@ -184,6 +186,7 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,10 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO85qeSydJtItA4T55Pw6BtAejd0APRJOCE=
+github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
+github.com/alicebob/miniredis/v2 v2.34.0 h1:mBFWMaJSNL9RwdGRyEDoAAv8OQc5UlEhLDQggTglU/0=
+github.com/alicebob/miniredis/v2 v2.34.0/go.mod h1:kWShP4b58T1CW0Y5dViCd5ztzrDqRWqM3nksiyXk5s8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -666,6 +670,8 @@ github.com/xtaci/lossyconn v0.0.0-20190602105132-8df528c0c9ae/go.mod h1:gXtu8J62
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/node/sc/bridge_account_test.go
+++ b/node/sc/bridge_account_test.go
@@ -22,12 +22,11 @@ import (
 	"math"
 	"math/big"
 	"os"
-	"path"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/kaiachain/kaia/accounts/keystore"
-	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,20 +43,9 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 	// Config Bridge Account Manager
 	config := &SCConfig{}
 	config.DataDir = tempDir
-	bAcc, err := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	assert.NoError(t, err)
+	bAcc, pPwdStr, cPwdStr := newBridgeAccountsForTest(t, nil, config.DataDir)
 	assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
 	assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
-
-	pPwdFilePath := path.Join(tempDir, "parent_bridge_account", bAcc.pAccount.address.String())
-	pPwd, err := os.ReadFile(pPwdFilePath)
-	pPwdStr := string(pPwd)
-	assert.NoError(t, err)
-
-	cPwdFilePath := path.Join(tempDir, "child_bridge_account", bAcc.cAccount.address.String())
-	cPwd, err := os.ReadFile(cPwdFilePath)
-	cPwdStr := string(cPwd)
-	assert.NoError(t, err)
 
 	lockAccountsWithCheck := func(t *testing.T, bAcc *BridgeAccounts) {
 		{
@@ -72,84 +60,56 @@ func TestBridgeAccountLockUnlock(t *testing.T) {
 		}
 	}
 
-	unlockParentAccountWithCheck := func(t *testing.T, bAcc *BridgeAccounts, passwd string, duration *uint64, expectedErr error) {
-		expectedIsUnLock := false
-		if expectedErr == nil {
-			expectedIsUnLock = true
-		}
-
-		err := bAcc.pAccount.UnLockAccount(passwd, duration)
-		assert.Equal(t, expectedErr, err)
-
-		time.Sleep(time.Second)
-
-		if duration == nil || *duration == 0 {
-			assert.Equal(t, expectedIsUnLock, bAcc.pAccount.IsUnlockedAccount())
-			return
-		}
-
-		time.Sleep(time.Duration(*duration) * time.Second)
-		assert.Equal(t, false, bAcc.pAccount.IsUnlockedAccount())
+	testCases := []struct {
+		name        string
+		preLockCnt  int
+		duration    int64
+		parentPass  string
+		childPass   string
+		expectedErr error
+	}{
+		{"invalid timeout", 3, int64(uint64(time.Duration(math.MaxInt64)/time.Second) + 1), pPwdStr, cPwdStr, errUnlockDurationTooLarge},
+		{"wrong password duration 0", 1, 0, pPwdStr[:3], cPwdStr[:3], keystore.ErrDecrypt},
+		{"success duration 0", 1, 0, pPwdStr, cPwdStr, nil},
+		{"success duration 1", 1, 1, pPwdStr, cPwdStr, nil},
+		{"wrong password duration 1", 1, 1, pPwdStr[:3], cPwdStr[:3], keystore.ErrDecrypt},
+		{"success nil duration", 1, -1, pPwdStr, cPwdStr, nil},
 	}
 
-	unlockChildAccountWithCheck := func(t *testing.T, bAcc *BridgeAccounts, passwd string, duration *uint64, expectedErr error) {
-		expectedIsUnLock := false
-		if expectedErr == nil {
-			expectedIsUnLock = true
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var durationPtr *uint64
+			if tc.duration >= 0 {
+				duration := uint64(tc.duration)
+				durationPtr = &duration
+			}
+			for i := 0; i < tc.preLockCnt; i++ {
+				lockAccountsWithCheck(t, bAcc)
+			}
 
-		err := bAcc.cAccount.UnLockAccount(passwd, duration)
-		assert.Equal(t, expectedErr, err)
+			expectedIsUnlock := tc.expectedErr == nil
 
-		time.Sleep(time.Second)
+			err := bAcc.pAccount.UnLockAccount(tc.parentPass, durationPtr)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, expectedIsUnlock, bAcc.pAccount.IsUnlockedAccount())
 
-		if duration == nil || *duration == 0 {
-			assert.Equal(t, expectedIsUnLock, bAcc.cAccount.IsUnlockedAccount())
-			return
-		}
+			err = bAcc.cAccount.UnLockAccount(tc.childPass, durationPtr)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, expectedIsUnlock, bAcc.cAccount.IsUnlockedAccount())
 
-		time.Sleep(time.Duration(*duration) * time.Second)
-		assert.Equal(t, false, bAcc.cAccount.IsUnlockedAccount())
+			if tc.expectedErr != nil || durationPtr == nil || *durationPtr == 0 {
+				return
+			}
+
+			deadline := time.Now().Add(time.Duration(*durationPtr)*time.Second + 500*time.Millisecond)
+			for bAcc.pAccount.IsUnlockedAccount() || bAcc.cAccount.IsUnlockedAccount() {
+				if time.Now().After(deadline) {
+					t.Fatal("timeout waiting for unlock expiration")
+				}
+				runtime.Gosched()
+			}
+		})
 	}
-
-	// Double time Lock Account
-	lockAccountsWithCheck(t, bAcc)
-	lockAccountsWithCheck(t, bAcc)
-
-	// Fail to UnLock Account with invalid timeout
-	lockAccountsWithCheck(t, bAcc)
-	duration := uint64(time.Duration(math.MaxInt64)/time.Second) + 1
-	unlockParentAccountWithCheck(t, bAcc, pPwdStr, &duration, errUnlockDurationTooLarge)
-	unlockChildAccountWithCheck(t, bAcc, cPwdStr, &duration, errUnlockDurationTooLarge)
-
-	// Fail to UnLock Account with wrong password
-	lockAccountsWithCheck(t, bAcc)
-	duration = uint64(0)
-	unlockParentAccountWithCheck(t, bAcc, pPwdStr[:3], &duration, keystore.ErrDecrypt)
-	unlockChildAccountWithCheck(t, bAcc, cPwdStr[:3], &duration, keystore.ErrDecrypt)
-
-	// Succeed to UnLock Account
-	lockAccountsWithCheck(t, bAcc)
-	duration = uint64(0)
-	unlockParentAccountWithCheck(t, bAcc, pPwdStr, &duration, nil)
-	unlockChildAccountWithCheck(t, bAcc, cPwdStr, &duration, nil)
-
-	// Succeed to UnLock Account with timeout
-	lockAccountsWithCheck(t, bAcc)
-	duration = uint64(5)
-	unlockParentAccountWithCheck(t, bAcc, pPwdStr, &duration, nil)
-	unlockChildAccountWithCheck(t, bAcc, cPwdStr, &duration, nil)
-
-	// Fail to UnLock Account with wrong password
-	lockAccountsWithCheck(t, bAcc)
-	duration = uint64(5)
-	unlockParentAccountWithCheck(t, bAcc, pPwdStr[:3], &duration, keystore.ErrDecrypt)
-	unlockChildAccountWithCheck(t, bAcc, cPwdStr[:3], &duration, keystore.ErrDecrypt)
-
-	// Succeed to UnLock Account with nil timeout
-	lockAccountsWithCheck(t, bAcc)
-	unlockParentAccountWithCheck(t, bAcc, pPwdStr, nil, nil)
-	unlockChildAccountWithCheck(t, bAcc, cPwdStr, nil, nil)
 }
 
 // TestBridgeAccountInformation checks if the information result is right or not.
@@ -165,8 +125,7 @@ func TestBridgeAccountInformation(t *testing.T) {
 	// Config Bridge Account Manager
 	config := &SCConfig{}
 	config.DataDir = tempDir
-	bAcc, err := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	assert.NoError(t, err)
+	bAcc, _, _ := newBridgeAccountsForTest(t, nil, config.DataDir)
 	assert.Equal(t, true, bAcc.cAccount.IsUnlockedAccount())
 	assert.Equal(t, true, bAcc.pAccount.IsUnlockedAccount())
 

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -73,6 +73,8 @@ var (
 	}
 )
 
+const DefaultBridgeTxGasLimit = uint64(10000000)
+
 // WaitGroupWithTimeOut waits the given wait group until the timeout duration.
 func WaitGroupWithTimeOut(wg *sync.WaitGroup, duration time.Duration, t *testing.T) {
 	c := make(chan struct{})

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -55,23 +55,60 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	bridgeManagerPreGeneratedKeys = []*ecdsa.PrivateKey{
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000001"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000002"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000003"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000004"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000005"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000006"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000007"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000008"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000009"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000a"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000b"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000c"); return k }(),
-		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000d"); return k }(),
-	}
-)
+var bridgeManagerPreGeneratedKeys = []*ecdsa.PrivateKey{
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000001")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000002")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000003")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000004")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000005")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000006")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000007")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000008")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000009")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000a")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000b")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000c")
+		return k
+	}(),
+	func() *ecdsa.PrivateKey {
+		k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000d")
+		return k
+	}(),
+}
 
 const DefaultBridgeTxGasLimit = uint64(10000000)
 
@@ -1064,18 +1101,6 @@ func TestMethodRestoreBridges(t *testing.T) {
 		}
 	}()
 
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-
-	// Generate a new random account and a funded simulator
-	key := bridgeManagerPreGeneratedKeys[0]
-	auth := bind.NewKeyedTransactor(key)
-
-	key2 := bridgeManagerPreGeneratedKeys[1]
-	auth2 := bind.NewKeyedTransactor(key2)
-
-	key4 := bridgeManagerPreGeneratedKeys[2]
-	auth4 := bind.NewKeyedTransactor(key4)
 	config := &SCConfig{}
 	config.DataDir = tempDir
 	config.VTRecovery = true
@@ -1084,9 +1109,6 @@ func TestMethodRestoreBridges(t *testing.T) {
 	bacc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{
-		auth.From:             {Balance: big.NewInt(params.KAIA)},
-		auth2.From:            {Balance: big.NewInt(params.KAIA)},
-		auth4.From:            {Balance: big.NewInt(params.KAIA)},
 		bacc.pAccount.address: {Balance: big.NewInt(params.KAIA)},
 		bacc.cAccount.address: {Balance: big.NewInt(params.KAIA)},
 	}
@@ -1112,18 +1134,21 @@ func TestMethodRestoreBridges(t *testing.T) {
 	assert.NoError(t, err)
 
 	var bridgeAddrs [4]common.Address
+
+	bridgeTxs := make([]*types.Transaction, 0, len(bridgeAddrs))
 	for i := range 4 {
+		var tx *types.Transaction
 		if i%2 == 0 {
-			bridgeAddrs[i], err = bm.DeployBridgeTest(sim, 10000, true)
+			bridgeAddrs[i], tx = deployBridgeTxForTest(t, bacc.cAccount.GenerateTransactOpts(), sim, true)
 		} else {
-			bridgeAddrs[i], err = bm.DeployBridgeTest(sim, 10000, false)
+			bridgeAddrs[i], tx = deployBridgeTxForTest(t, bacc.pAccount.GenerateTransactOpts(), sim, false)
 		}
-		if err != nil {
-			t.Fatal("deploy bridge test failed", bridgeAddrs[i])
-		}
-		bm.DeleteBridgeInfo(bridgeAddrs[i])
+		bridgeTxs = append(bridgeTxs, tx)
 	}
 	sim.Commit()
+	for _, tx := range bridgeTxs {
+		assert.NoError(t, bind.CheckWaitMined(sim, tx))
+	}
 
 	// Set journal
 	bm.SetJournal("", bridgeAddrs[0], bridgeAddrs[1])
@@ -2083,16 +2108,21 @@ func TestBridgeAliasAPIs(t *testing.T) {
 	assert.NoError(t, err)
 	sc.handler.subbridge.bridgeManager = bm
 
-	// 1. Deploy bridge contracts and register them
-	cBridgeAddr := deployBridge(t, bm, sim, true)
-	pBridgeAddr := deployBridge(t, bm, sim, false)
+	// 1. Deploy bridge contracts in one block.
+	cBridgeAddr, cBridgeTx := deployBridgeTxForTest(t, bacc.cAccount.GenerateTransactOpts(), sim, true)
+	pBridgeAddr, pBridgeTx := deployBridgeTxForTest(t, bacc.pAccount.GenerateTransactOpts(), sim, false)
+	sim.Commit()
+	assert.NoError(t, bind.CheckWaitMined(sim, cBridgeTx))
+	assert.NoError(t, bind.CheckWaitMined(sim, pBridgeTx))
 
-	// 2. Deploy token Contracts
-	cTokenAddr, _, _, err := sctoken.DeployServiceChainToken(alice, sim, cBridgeAddr)
+	// 2. Deploy token contracts in one block.
+	cTokenAddr, cTokenTx, _, err := sctoken.DeployServiceChainToken(alice, sim, cBridgeAddr)
 	assert.NoError(t, err)
-	pTokenAddr, _, _, err := sctoken.DeployServiceChainToken(alice, sim, pBridgeAddr)
+	pTokenAddr, pTokenTx, _, err := sctoken.DeployServiceChainToken(alice, sim, pBridgeAddr)
 	assert.NoError(t, err)
 	sim.Commit() // block
+	assert.NoError(t, bind.CheckWaitMined(sim, cTokenTx))
+	assert.NoError(t, bind.CheckWaitMined(sim, pTokenTx))
 
 	cBridgeAddrStr := cBridgeAddr.String()
 	pBridgeAddrStr := pBridgeAddr.String()
@@ -2196,24 +2226,44 @@ func TestBridgeAliasAPIs(t *testing.T) {
 		contractPairLen := 10
 		bridgeAddrs := make([]common.Address, contractPairLen)
 		tokenAddrs := make([]common.Address, contractPairLen)
+		bridgeDeployTxs := make([]*types.Transaction, 0, contractPairLen+2)
+		tokenDeployTxs := make([]*types.Transaction, 0, contractPairLen)
 		t.Logf("Prepare %d contracts\n", contractPairLen)
-		// Preparation: Deploy bridge and token contracts
+		// Preparation 1: Deploy bridge contracts
 		for i := 0; i < contractPairLen/2; i++ {
-			cBridgeAddr, pBridgeAddr = deployBridge(t, bm, sim, true), deployBridge(t, bm, sim, false)
+			cBridgeAddr, cBridgeTx = deployBridgeTxForTest(t, bacc.cAccount.GenerateTransactOpts(), sim, true)
+			pBridgeAddr, pBridgeTx = deployBridgeTxForTest(t, bacc.pAccount.GenerateTransactOpts(), sim, false)
 			cIdx, pIdx := i*2, i*2+1
 			bridgeAddrs[cIdx], bridgeAddrs[pIdx] = cBridgeAddr, pBridgeAddr
-
-			cTokenAddr, _, _, err := sctoken.DeployServiceChainToken(alice, sim, cBridgeAddr)
-			assert.NoError(t, err)
-			pTokenAddr, _, _, err := sctoken.DeployServiceChainToken(alice, sim, pBridgeAddr)
-			assert.NoError(t, err)
-			tokenAddrs[cIdx], tokenAddrs[pIdx] = cTokenAddr, pTokenAddr
-
-			t.Logf("Deployed bridge contracts %d, %d\n", cIdx, pIdx)
+			bridgeDeployTxs = append(bridgeDeployTxs, cBridgeTx, pBridgeTx)
+			t.Logf("Prepared bridge contracts %d, %d\n", cIdx, pIdx)
 		}
 
-		// Declare another bridge and token contracts that did not initialize
-		fixedChildBridgeAddr, fixedParentBridgeAddr := deployBridge(t, bm, sim, true), deployBridge(t, bm, sim, false)
+		// Declare another bridge contracts that did not initialize
+		fixedChildBridgeAddr, fixedChildBridgeTx := deployBridgeTxForTest(t, bacc.cAccount.GenerateTransactOpts(), sim, true)
+		fixedParentBridgeAddr, fixedParentBridgeTx := deployBridgeTxForTest(t, bacc.pAccount.GenerateTransactOpts(), sim, false)
+		bridgeDeployTxs = append(bridgeDeployTxs, fixedChildBridgeTx, fixedParentBridgeTx)
+		sim.Commit()
+		for _, tx := range bridgeDeployTxs {
+			assert.NoError(t, bind.CheckWaitMined(sim, tx))
+		}
+
+		// Preparation 2: Deploy token contracts
+		for i := 0; i < contractPairLen/2; i++ {
+			cIdx, pIdx := i*2, i*2+1
+			cBridgeAddr, pBridgeAddr = bridgeAddrs[cIdx], bridgeAddrs[pIdx]
+			cTokenAddr, cTokenTx, _, err := sctoken.DeployServiceChainToken(alice, sim, cBridgeAddr)
+			assert.NoError(t, err)
+			pTokenAddr, pTokenTx, _, err := sctoken.DeployServiceChainToken(alice, sim, pBridgeAddr)
+			assert.NoError(t, err)
+			tokenAddrs[cIdx], tokenAddrs[pIdx] = cTokenAddr, pTokenAddr
+			tokenDeployTxs = append(tokenDeployTxs, cTokenTx, pTokenTx)
+			t.Logf("Prepared token contracts %d, %d\n", cIdx, pIdx)
+		}
+		sim.Commit()
+		for _, tx := range tokenDeployTxs {
+			assert.NoError(t, bind.CheckWaitMined(sim, tx))
+		}
 
 		const (
 			BRIDGE_SETUP = iota
@@ -2701,6 +2751,26 @@ func isExpectedBalance(t *testing.T, bridgeManager *BridgeManager,
 	assert.Equal(t, cBridgeBalance.Int64(), expectedChildBridgeBalance)
 }
 
+func deployBridgeTxForBalanceTest(t *testing.T, auth *bind.TransactOpts, sim *backends.SimulatedBackend, amount int64, modeMintBurn bool) (common.Address, *types.Transaction) {
+	t.Helper()
+
+	auth.Value = big.NewInt(amount)
+	addr, tx, _, err := bridge.DeployBridge(auth, sim, modeMintBurn)
+	auth.Value = nil
+	assert.NoError(t, err)
+	return addr, tx
+}
+
+func deployBridgeTxForTest(t *testing.T, auth *bind.TransactOpts, sim *backends.SimulatedBackend, modeMintBurn bool) (common.Address, *types.Transaction) {
+	t.Helper()
+
+	auth.Value = big.NewInt(10000)
+	addr, tx, _, err := bridge.DeployBridge(auth, sim, modeMintBurn)
+	auth.Value = nil
+	assert.NoError(t, err)
+	return addr, tx
+}
+
 func TestGetBridgeContractBalance(t *testing.T) {
 	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
 	assert.NoError(t, err)
@@ -2742,31 +2812,37 @@ func TestGetBridgeContractBalance(t *testing.T) {
 	assert.NoError(t, err)
 	sc.handler.subbridge.bridgeManager = bm
 
-	// Case 1 - Success
-	{
-		initialChildbridgeBalance, initialParentbridgeBalance := int64(100), int64(100)
-		cBridgeAddr, err := bm.DeployBridgeTest(sim, initialChildbridgeBalance, true)
-		assert.NoError(t, err)
-		pBridgeAddr, err := bm.DeployBridgeTest(sim, initialParentbridgeBalance, false)
-		assert.NoError(t, err)
-		bm.SetJournal("", cBridgeAddr, pBridgeAddr)
-		assert.NoError(t, err)
-		sim.Commit()
-		isExpectedBalance(t, bm, pBridgeAddr, cBridgeAddr, initialParentbridgeBalance, initialChildbridgeBalance)
+	cases := []struct {
+		childBalance  int64
+		parentBalance int64
+	}{
+		{childBalance: 100, parentBalance: 100},
+	}
+	for i := 0; i < 10; i++ {
+		cases = append(cases, struct {
+			childBalance  int64
+			parentBalance int64
+		}{
+			childBalance:  rand.Int63n(10000),
+			parentBalance: rand.Int63n(10000),
+		})
 	}
 
-	// Case 2 - ? (Random)
-	{
-		for range 10 {
-			initialChildbridgeBalance, initialParentbridgeBalance := rand.Int63n(10000), rand.Int63n(10000)
-			cBridgeAddr, err := bm.DeployBridgeTest(sim, initialChildbridgeBalance, true)
-			assert.NoError(t, err)
-			pBridgeAddr, err := bm.DeployBridgeTest(sim, initialParentbridgeBalance, false)
-			assert.NoError(t, err)
-			bm.SetJournal("", cBridgeAddr, pBridgeAddr)
-			assert.NoError(t, err)
-			sim.Commit()
-			isExpectedBalance(t, bm, pBridgeAddr, cBridgeAddr, initialParentbridgeBalance, initialChildbridgeBalance)
-		}
+	for _, tc := range cases {
+		childAuth := bacc.cAccount.GenerateTransactOpts()
+		parentAuth := bacc.pAccount.GenerateTransactOpts()
+
+		cBridgeAddr, cTx := deployBridgeTxForBalanceTest(t, childAuth, sim, tc.childBalance, true)
+		pBridgeAddr, pTx := deployBridgeTxForBalanceTest(t, parentAuth, sim, tc.parentBalance, false)
+
+		// Mine both deployments in a single block.
+		sim.Commit()
+		assert.NoError(t, bind.CheckWaitMined(sim, cTx))
+		assert.NoError(t, bind.CheckWaitMined(sim, pTx))
+
+		err = bm.SetJournal("", cBridgeAddr, pBridgeAddr)
+		assert.NoError(t, err)
+
+		isExpectedBalance(t, bm, pBridgeAddr, cBridgeAddr, tc.parentBalance, tc.childBalance)
 	}
 }

--- a/node/sc/bridge_manager_test.go
+++ b/node/sc/bridge_manager_test.go
@@ -20,6 +20,7 @@ package sc
 
 import (
 	"context"
+	"crypto/ecdsa"
 	crand "crypto/rand"
 	"encoding/hex"
 	"log"
@@ -27,6 +28,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -53,6 +55,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	bridgeManagerPreGeneratedKeys = []*ecdsa.PrivateKey{
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000001"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000002"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000003"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000004"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000005"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000006"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000007"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000008"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("0000000000000000000000000000000000000000000000000000000000000009"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000a"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000b"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000c"); return k }(),
+		func() *ecdsa.PrivateKey { k, _ := crypto.HexToECDSA("000000000000000000000000000000000000000000000000000000000000000d"); return k }(),
+	}
+)
+
 // WaitGroupWithTimeOut waits the given wait group until the timeout duration.
 func WaitGroupWithTimeOut(wg *sync.WaitGroup, duration time.Duration, t *testing.T) {
 	c := make(chan struct{})
@@ -77,6 +97,44 @@ func CheckReceipt(b bind.DeployBackend, tx *types.Transaction, duration time.Dur
 	receipt, err := bind.WaitMined(timeoutContext, b, tx)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, expectedStatus, receipt.Status)
+}
+
+func CreateLightScryptAccountFixture(t *testing.T, keystoreDir string) string {
+	t.Helper()
+
+	if err := os.MkdirAll(keystoreDir, 0o755); err != nil {
+		t.Fatalf("failed to create keystore dir: %v", err)
+	}
+	ks := keystore.NewKeyStore(keystoreDir, keystore.LightScryptN, keystore.LightScryptP)
+	password := "test-password"
+	acc, err := ks.NewAccount(password)
+	if err != nil {
+		t.Fatalf("failed to create light-scrypt account: %v", err)
+	}
+	if err := os.WriteFile(path.Join(keystoreDir, acc.Address.String()), []byte(password), 0o600); err != nil {
+		t.Fatalf("failed to write password file: %v", err)
+	}
+	return password
+}
+
+func newBridgeAccountsForTest(t *testing.T, am *accounts.Manager, dataDir string) (*BridgeAccounts, string, string) {
+	t.Helper()
+
+	pPwd := CreateLightScryptAccountFixture(t, path.Join(dataDir, ParentBridgeAccountName))
+	cPwd := CreateLightScryptAccountFixture(t, path.Join(dataDir, ChildBridgeAccountName))
+	bAcc, err := NewBridgeAccounts(
+		am,
+		dataDir,
+		database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}),
+		DefaultBridgeTxGasLimit,
+		DefaultBridgeTxGasLimit,
+	)
+	if err != nil {
+		t.Fatalf("failed to create bridge accounts: %v", err)
+	}
+	bAcc.pAccount.chainID = params.TestChainConfig.ChainID
+	bAcc.cAccount.chainID = params.TestChainConfig.ChainID
+	return bAcc, pPwd, cPwd
 }
 
 func handleValueTransfer(t *testing.T, ev IRequestValueTransferEvent, bridgeInfo *BridgeInfo, wg *sync.WaitGroup, backend *backends.SimulatedBackend) {
@@ -136,18 +194,16 @@ func TestBridgeManager(t *testing.T) {
 	// Config Bridge Account Manager
 	config := &SCConfig{}
 	config.DataDir = tempDir
-	bacc, _ := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, config.DataDir)
 
 	pAuth := bacc.cAccount.GenerateTransactOpts()
 	cAuth := bacc.pAccount.GenerateTransactOpts()
 
 	// Generate a new random account and a funded simulator
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[0]
 	alice := bind.NewKeyedTransactor(aliceKey)
 
-	bobKey, _ := crypto.GenerateKey()
+	bobKey := bridgeManagerPreGeneratedKeys[1]
 	bob := bind.NewKeyedTransactor(bobKey)
 
 	// Create Simulated backend
@@ -365,18 +421,16 @@ func TestBridgeManagerERC721_notSupportURI(t *testing.T) {
 	// Config Bridge Account Manager
 	config := &SCConfig{}
 	config.DataDir = tempDir
-	bacc, _ := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, config.DataDir)
 
 	// pAuth := bacc.cAccount.GenerateTransactOpts()
 	cAuth := bacc.pAccount.GenerateTransactOpts()
 
 	// Generate a new random account and a funded simulator
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[0]
 	alice := bind.NewKeyedTransactor(aliceKey)
 
-	bobKey, _ := crypto.GenerateKey()
+	bobKey := bridgeManagerPreGeneratedKeys[1]
 	bob := bind.NewKeyedTransactor(bobKey)
 
 	// Create Simulated backend
@@ -532,21 +586,19 @@ func TestBridgeManagerWithFee(t *testing.T) {
 	wg.Add(7 * 2)
 
 	// Generate a new random account and a funded simulator
-	AliceKey, _ := crypto.GenerateKey()
+	AliceKey := bridgeManagerPreGeneratedKeys[0]
 	Alice := bind.NewKeyedTransactor(AliceKey)
 
-	BobKey, _ := crypto.GenerateKey()
+	BobKey := bridgeManagerPreGeneratedKeys[1]
 	Bob := bind.NewKeyedTransactor(BobKey)
 
-	receiverKey, _ := crypto.GenerateKey()
+	receiverKey := bridgeManagerPreGeneratedKeys[2]
 	receiver := bind.NewKeyedTransactor(receiverKey)
 
 	// Config Bridge Account Manager
 	config := &SCConfig{}
 	config.DataDir = tempDir
-	bacc, _ := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, config.DataDir)
 
 	pAuth := bacc.cAccount.GenerateTransactOpts()
 	cAuth := bacc.pAccount.GenerateTransactOpts()
@@ -935,22 +987,20 @@ func TestBasicJournal(t *testing.T) {
 	wg.Add(2)
 
 	// Generate a new random account and a funded simulator
-	key, _ := crypto.GenerateKey()
+	key := bridgeManagerPreGeneratedKeys[0]
 	auth := bind.NewKeyedTransactor(key)
 
-	key2, _ := crypto.GenerateKey()
+	key2 := bridgeManagerPreGeneratedKeys[1]
 	auth2 := bind.NewKeyedTransactor(key2)
 
-	key4, _ := crypto.GenerateKey()
+	key4 := bridgeManagerPreGeneratedKeys[2]
 	auth4 := bind.NewKeyedTransactor(key4)
 
 	config := &SCConfig{}
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bacc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{
 		auth.From:             {Balance: big.NewInt(params.KAIA)},
@@ -1016,22 +1066,20 @@ func TestMethodRestoreBridges(t *testing.T) {
 	wg.Add(2)
 
 	// Generate a new random account and a funded simulator
-	key, _ := crypto.GenerateKey()
+	key := bridgeManagerPreGeneratedKeys[0]
 	auth := bind.NewKeyedTransactor(key)
 
-	key2, _ := crypto.GenerateKey()
+	key2 := bridgeManagerPreGeneratedKeys[1]
 	auth2 := bind.NewKeyedTransactor(key2)
 
-	key4, _ := crypto.GenerateKey()
+	key4 := bridgeManagerPreGeneratedKeys[2]
 	auth4 := bind.NewKeyedTransactor(key4)
 	config := &SCConfig{}
 	config.DataDir = tempDir
 	config.VTRecovery = true
 	config.VTRecoveryInterval = 60
 
-	bacc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{
 		auth.From:             {Balance: big.NewInt(params.KAIA)},
@@ -1242,21 +1290,19 @@ func TestErrorDuplicatedSetBridgeInfo(t *testing.T) {
 	wg.Add(2)
 
 	// Generate a new random account and a funded simulator
-	key, _ := crypto.GenerateKey()
+	key := bridgeManagerPreGeneratedKeys[0]
 	auth := bind.NewKeyedTransactor(key)
 
-	key2, _ := crypto.GenerateKey()
+	key2 := bridgeManagerPreGeneratedKeys[1]
 	auth2 := bind.NewKeyedTransactor(key2)
 
-	key4, _ := crypto.GenerateKey()
+	key4 := bridgeManagerPreGeneratedKeys[2]
 	auth4 := bind.NewKeyedTransactor(key4)
 	config := &SCConfig{}
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bacc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{
 		auth.From:             {Balance: big.NewInt(params.KAIA)},
@@ -1309,21 +1355,19 @@ func TestScenarioSubUnsub(t *testing.T) {
 	wg.Add(2)
 
 	// Generate a new random account and a funded simulator
-	key, _ := crypto.GenerateKey()
+	key := bridgeManagerPreGeneratedKeys[0]
 	auth := bind.NewKeyedTransactor(key)
 
-	key2, _ := crypto.GenerateKey()
+	key2 := bridgeManagerPreGeneratedKeys[1]
 	auth2 := bind.NewKeyedTransactor(key2)
 
-	key4, _ := crypto.GenerateKey()
+	key4 := bridgeManagerPreGeneratedKeys[2]
 	auth4 := bind.NewKeyedTransactor(key4)
 	config := &SCConfig{}
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bacc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{
 		auth.From:             {Balance: big.NewInt(params.KAIA)},
@@ -1415,21 +1459,19 @@ func TestErrorDupSubscription(t *testing.T) {
 	wg.Add(2)
 
 	// Generate a new random account and a funded simulator
-	key, _ := crypto.GenerateKey()
+	key := bridgeManagerPreGeneratedKeys[0]
 	auth := bind.NewKeyedTransactor(key)
 
-	key2, _ := crypto.GenerateKey()
+	key2 := bridgeManagerPreGeneratedKeys[1]
 	auth2 := bind.NewKeyedTransactor(key2)
 
-	key4, _ := crypto.GenerateKey()
+	key4 := bridgeManagerPreGeneratedKeys[2]
 	auth4 := bind.NewKeyedTransactor(key4)
 	config := &SCConfig{}
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bacc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{
 		auth.From:             {Balance: big.NewInt(params.KAIA)},
@@ -1660,17 +1702,15 @@ func generateAnchoringEnv(t *testing.T, tempDir string) (*backends.SimulatedBack
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	ks := keystore.NewKeyStore(tempDir, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(tempDir, keystore.LightScryptN, keystore.LightScryptP)
 	back := []accounts.Backend{
 		ks,
 	}
 	am := accounts.NewManager(back...)
-	bAcc, _ := NewBridgeAccounts(am, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bAcc.pAccount.chainID = params.TestChainConfig.ChainID
-	bAcc.cAccount.chainID = params.TestChainConfig.ChainID
+	bAcc, _, _ := newBridgeAccountsForTest(t, am, tempDir)
 	parentOperator := bAcc.pAccount
 
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[0]
 	alice := bind.NewKeyedTransactor(aliceKey)
 
 	initBal := new(big.Int).Exp(big.NewInt(10), big.NewInt(50), nil)
@@ -1748,9 +1788,7 @@ func TestAnchoringStart(t *testing.T) {
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bAcc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bAcc.pAccount.chainID = params.TestChainConfig.ChainID
-	bAcc.cAccount.chainID = params.TestChainConfig.ChainID
+	bAcc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{}
 	sim := backends.NewSimulatedBackend(alloc)
@@ -1831,9 +1869,7 @@ func TestAnchoringPeriod(t *testing.T) {
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bAcc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bAcc.pAccount.chainID = params.TestChainConfig.ChainID
-	bAcc.cAccount.chainID = params.TestChainConfig.ChainID
+	bAcc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{}
 	sim := backends.NewSimulatedBackend(alloc)
@@ -1955,9 +1991,7 @@ func TestDecodingLegacyAnchoringTx(t *testing.T) {
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bAcc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bAcc.pAccount.chainID = params.TestChainConfig.ChainID
-	bAcc.cAccount.chainID = params.TestChainConfig.ChainID
+	bAcc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{}
 	sim := backends.NewSimulatedBackend(alloc)
@@ -2011,17 +2045,15 @@ func TestBridgeAliasAPIs(t *testing.T) {
 	}()
 
 	// Generate a new random account and a funded simulator
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[0]
 	alice := bind.NewKeyedTransactor(aliceKey)
-	bobKey, _ := crypto.GenerateKey()
+	bobKey := bridgeManagerPreGeneratedKeys[1]
 	bob := bind.NewKeyedTransactor(bobKey)
 
 	config := &SCConfig{}
 	config.DataDir = tempDir
 
-	bacc, _ := NewBridgeAccounts(nil, tempDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, tempDir)
 
 	alloc := blockchain.GenesisAlloc{
 		alice.From:            {Balance: big.NewInt(params.KAIA)},
@@ -2483,9 +2515,7 @@ func TestBridgeAddressType(t *testing.T) {
 	// Config Bridge Account Manager
 	config := &SCConfig{}
 	config.DataDir = tempDir
-	bacc, _ := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, config.DataDir)
 
 	// Create Simulated backend
 	alloc := blockchain.GenesisAlloc{
@@ -2579,20 +2609,34 @@ func TestBridgeAddressType(t *testing.T) {
 	}
 }
 
+func commitOnPendingBlockChange(backend *backends.SimulatedBackend) func() {
+	done := make(chan struct{})
+	pendingBlock := backend.PendingBlock()
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				if pendingBlock != backend.PendingBlock() {
+					backend.Commit()
+					return
+				}
+				runtime.Gosched()
+			}
+		}
+	}()
+	return func() { close(done) }
+}
+
 // DeployBridgeTest is a test-only function which deploys a bridge contract with some amount of KAIA.
 func (bm *BridgeManager) DeployBridgeTest(backend *backends.SimulatedBackend, amountOfDeposit int64, local bool) (common.Address, error) {
 	var acc *accountInfo
 
 	// When the pending block of backend is updated, commit it
 	// bm.DeployBridge will be waiting until the block is committed
-	pendingBlock := backend.PendingBlock()
-	go func() {
-		for pendingBlock == backend.PendingBlock() {
-			time.Sleep(100 * time.Millisecond)
-		}
-		backend.Commit()
-		return
-	}()
+	cancel := commitOnPendingBlockChange(backend)
+	defer cancel()
 
 	// Set transfer value of the bridge account
 	if local {
@@ -2624,14 +2668,8 @@ func deployBridge(t *testing.T, bm *BridgeManager, backend *backends.SimulatedBa
 
 	// When the pending block of backend is updated, commit it
 	// bm.DeployBridge will be waiting until the block is committed
-	pendingBlock := backend.PendingBlock()
-	go func() {
-		for pendingBlock == backend.PendingBlock() {
-			time.Sleep(100 * time.Millisecond)
-		}
-		backend.Commit()
-		return
-	}()
+	cancel := commitOnPendingBlockChange(backend)
+	defer cancel()
 
 	// Set transfer value of the bridge account
 	if local {
@@ -2673,9 +2711,7 @@ func TestGetBridgeContractBalance(t *testing.T) {
 	// Config Bridge Account Manager
 	config := &SCConfig{}
 	config.DataDir = tempDir
-	bacc, _ := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, config.DataDir)
 
 	// Create Simulated backend
 	alloc := blockchain.GenesisAlloc{

--- a/node/sc/bridge_test.go
+++ b/node/sc/bridge_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/kaiachain/kaia/contracts/contracts/testing/extbridge"
 	sctoken "github.com/kaiachain/kaia/contracts/contracts/testing/sc_erc20"
 	scnft "github.com/kaiachain/kaia/contracts/contracts/testing/sc_erc721"
-	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
 )
@@ -131,7 +130,7 @@ func SendHandleKLAYTransfer(b *bridge.Bridge, auth *bind.TransactOpts, to common
 
 // TestBridgeDeployWithKLAY checks to the state/contract balance of the bridge deployed.
 func TestBridgeDeployWithKLAY(t *testing.T) {
-	bridgeAccountKey, _ := crypto.GenerateKey()
+	bridgeAccountKey := bridgeManagerPreGeneratedKeys[0]
 	bridgeAccount := bind.NewKeyedTransactor(bridgeAccountKey)
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KAIA)}}
@@ -163,10 +162,10 @@ func TestBridgeDeployWithKLAY(t *testing.T) {
 
 // TestBridgeRequestValueTransferNonce checks the bridge emit events with serialized nonce.
 func TestBridgeRequestValueTransferNonce(t *testing.T) {
-	bridgeAccountKey, _ := crypto.GenerateKey()
+	bridgeAccountKey := bridgeManagerPreGeneratedKeys[0]
 	bridgeAccount := bind.NewKeyedTransactor(bridgeAccountKey)
 
-	testAccKey, _ := crypto.GenerateKey()
+	testAccKey := bridgeManagerPreGeneratedKeys[1]
 	testAcc := bind.NewKeyedTransactor(testAccKey)
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KAIA)}}
@@ -229,10 +228,10 @@ loop:
 // - the bridge keeps lower handle nonce for the recovery.
 // - the bridge correctly stores and returns the block number.
 func TestBridgeHandleValueTransferNonceAndBlockNumber(t *testing.T) {
-	bridgeAccountKey, _ := crypto.GenerateKey()
+	bridgeAccountKey := bridgeManagerPreGeneratedKeys[0]
 	bridgeAccount := bind.NewKeyedTransactor(bridgeAccountKey)
 
-	testAccKey, _ := crypto.GenerateKey()
+	testAccKey := bridgeManagerPreGeneratedKeys[1]
 	testAcc := bind.NewKeyedTransactor(testAccKey)
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KAIA)}}
@@ -325,7 +324,7 @@ loop:
 
 // TestBridgePublicVariables checks the results of the public variables.
 func TestBridgePublicVariables(t *testing.T) {
-	bridgeAccountKey, _ := crypto.GenerateKey()
+	bridgeAccountKey := bridgeManagerPreGeneratedKeys[0]
 	bridgeAccount := bind.NewKeyedTransactor(bridgeAccountKey)
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KAIA)}}
@@ -387,14 +386,14 @@ func TestBridgePublicVariables(t *testing.T) {
 // TestExtendedBridgeAndCallbackERC20 checks the following:
 // - the extBridge can call a callback contract method from ERC20 value transfer.
 func TestExtendedBridgeAndCallbackERC20(t *testing.T) {
-	bridgeAccountKey, _ := crypto.GenerateKey()
+	bridgeAccountKey := bridgeManagerPreGeneratedKeys[0]
 	bridgeAccount := bind.NewKeyedTransactor(bridgeAccountKey)
 
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[1]
 	aliceAcc := bind.NewKeyedTransactor(aliceKey)
 	aliceAcc.GasLimit = DefaultBridgeTxGasLimit
 
-	bobKey, _ := crypto.GenerateKey()
+	bobKey := bridgeManagerPreGeneratedKeys[2]
 	bobAcc := bind.NewKeyedTransactor(bobKey)
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KAIA)}}
@@ -533,14 +532,14 @@ func TestExtendedBridgeAndCallbackERC20(t *testing.T) {
 // TestExtendedBridgeAndCallbackERC721 checks the following:
 // - the extBridge can call a callback contract method from ERC721 value transfer.
 func TestExtendedBridgeAndCallbackERC721(t *testing.T) {
-	bridgeAccountKey, _ := crypto.GenerateKey()
+	bridgeAccountKey := bridgeManagerPreGeneratedKeys[0]
 	bridgeAccount := bind.NewKeyedTransactor(bridgeAccountKey)
 
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[1]
 	aliceAcc := bind.NewKeyedTransactor(aliceKey)
 	aliceAcc.GasLimit = DefaultBridgeTxGasLimit
 
-	bobKey, _ := crypto.GenerateKey()
+	bobKey := bridgeManagerPreGeneratedKeys[2]
 	bobAcc := bind.NewKeyedTransactor(bobKey)
 
 	alloc := blockchain.GenesisAlloc{bridgeAccount.From: {Balance: big.NewInt(params.KAIA)}}
@@ -704,11 +703,11 @@ type bridgeTokenTestENV struct {
 }
 
 func generateBridgeTokenTestEnv(t *testing.T) *bridgeTokenTestENV {
-	key, _ := crypto.GenerateKey()
+	key := bridgeManagerPreGeneratedKeys[0]
 	operator := bind.NewKeyedTransactor(key)
 	operator.GasLimit = DefaultBridgeTxGasLimit
 
-	testKey, _ := crypto.GenerateKey()
+	testKey := bridgeManagerPreGeneratedKeys[1]
 	tester := bind.NewKeyedTransactor(testKey)
 	tester.GasLimit = DefaultBridgeTxGasLimit
 
@@ -1156,14 +1155,14 @@ func TestBridgeContract_CheckValueTransferAfterUnLock(t *testing.T) {
 // with the gap of lowerHandle nonce and handle nonce.
 func TestBridgeRequestHandleGasUsed(t *testing.T) {
 	// Generate a new random account and a funded simulator
-	authKey, _ := crypto.GenerateKey()
+	authKey := bridgeManagerPreGeneratedKeys[0]
 	auth := bind.NewKeyedTransactor(authKey)
 	auth.GasLimit = DefaultBridgeTxGasLimit
 
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[1]
 	alice := bind.NewKeyedTransactor(aliceKey)
 
-	bobKey, _ := crypto.GenerateKey()
+	bobKey := bridgeManagerPreGeneratedKeys[2]
 	bob := bind.NewKeyedTransactor(bobKey)
 
 	// Create Simulated backend
@@ -1255,16 +1254,16 @@ func TestBridgeMaxOperatorHandleTxGasUsed(t *testing.T) {
 
 	var authList []*bind.TransactOpts
 	for i := 0; i <= maxOperator; i++ {
-		authKey, _ := crypto.GenerateKey()
+		authKey := bridgeManagerPreGeneratedKeys[i]
 		authList = append(authList, bind.NewKeyedTransactor(authKey))
 		authList[i].GasLimit = DefaultBridgeTxGasLimit
 	}
 	auth := authList[0]
 
-	aliceKey, _ := crypto.GenerateKey()
+	aliceKey := bridgeManagerPreGeneratedKeys[1]
 	alice := bind.NewKeyedTransactor(aliceKey)
 
-	bobKey, _ := crypto.GenerateKey()
+	bobKey := bridgeManagerPreGeneratedKeys[2]
 	bob := bind.NewKeyedTransactor(bobKey)
 
 	// Create Simulated backend
@@ -1344,7 +1343,7 @@ func TestBridgeThresholdLimit(t *testing.T) {
 
 	var authList []*bind.TransactOpts
 	for i := range maxOperator {
-		authKey, _ := crypto.GenerateKey()
+		authKey := bridgeManagerPreGeneratedKeys[i]
 		authList = append(authList, bind.NewKeyedTransactor(authKey))
 		authList[i].GasLimit = DefaultBridgeTxGasLimit
 	}

--- a/node/sc/bridge_test.go
+++ b/node/sc/bridge_test.go
@@ -41,8 +41,7 @@ import (
 )
 
 const (
-	timeOut                 = 3 * time.Second // timeout of context and event loop for simulated backend.
-	DefaultBridgeTxGasLimit = uint64(10000000)
+	timeOut = 3 * time.Second // timeout of context and event loop for simulated backend.
 )
 
 // WaitMined waits the tx receipt until the timeout.

--- a/node/sc/multi_bridge_test.go
+++ b/node/sc/multi_bridge_test.go
@@ -19,6 +19,7 @@
 package sc
 
 import (
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
@@ -53,8 +54,16 @@ type multiBridgeTestInfo struct {
 	handleSub  event.Subscription
 }
 
+func multiBridgeTestKey(i int) *ecdsa.PrivateKey {
+	if i >= 0 && i < len(bridgeManagerPreGeneratedKeys) {
+		return bridgeManagerPreGeneratedKeys[i]
+	}
+	k, _ := crypto.GenerateKey()
+	return k
+}
+
 func prepareMultiBridgeTest(t *testing.T) *bridgeTestInfo {
-	accKey, _ := crypto.GenerateKey()
+	accKey := multiBridgeTestKey(0)
 	acc := bind.NewKeyedTransactor(accKey)
 
 	alloc := blockchain.GenesisAlloc{acc.From: {Balance: big.NewInt(params.KAIA)}}
@@ -77,7 +86,7 @@ func prepareMultiBridgeEventTest(t *testing.T) *multiBridgeTestInfo {
 	res.accounts = make([]*bind.TransactOpts, maxAccounts)
 
 	for i := range maxAccounts {
-		accKey, _ := crypto.GenerateKey()
+		accKey := multiBridgeTestKey(i)
 		res.accounts[i] = bind.NewKeyedTransactor(accKey)
 		accountMap[res.accounts[i].From] = blockchain.GenesisAccount{Balance: big.NewInt(params.KAIA)}
 	}
@@ -638,7 +647,7 @@ func TestMultiBridgeErrNotOperator1(t *testing.T) {
 	transferAmount := uint64(100)
 	sentBlockNumber := uint64(100000)
 
-	accKey, _ := crypto.GenerateKey()
+	accKey := multiBridgeTestKey(4)
 	acc := bind.NewKeyedTransactor(accKey)
 
 	tx := SendHandleKLAYTransfer(info.b, acc, to, transferAmount, sentNonce, sentBlockNumber, t)
@@ -672,7 +681,7 @@ func TestMultiBridgeErrNotOperator2(t *testing.T) {
 	info.sim.Commit()
 	assert.NoError(t, bind.CheckWaitMined(info.sim, tx))
 
-	accKey, _ := crypto.GenerateKey()
+	accKey := multiBridgeTestKey(4)
 	acc = bind.NewKeyedTransactor(accKey)
 
 	tx = SendHandleKLAYTransfer(info.b, acc, to, transferAmount, sentNonce, sentBlockNumber, t)

--- a/node/sc/subbridge_test.go
+++ b/node/sc/subbridge_test.go
@@ -28,11 +28,13 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/accounts"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/node"
+	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,7 +45,11 @@ func testNewSubBridge(t *testing.T) *SubBridge {
 		t.Fatal(err)
 	}
 
-	sCtx := node.NewServiceContext(&node.DefaultConfig, map[reflect.Type]node.Service{}, &event.TypeMux{}, &accounts.Manager{})
+	nodeCfg := node.DefaultConfig
+	nodeCfg.DataDir = tempDir
+	nodeCfg.DBType = database.MemoryDB
+
+	sCtx := node.NewServiceContext(&nodeCfg, map[reflect.Type]node.Service{}, &event.TypeMux{}, &accounts.Manager{})
 	sBridge, err := NewSubBridge(sCtx, &SCConfig{NetworkId: testNetVersion, DataDir: tempDir})
 	if err != nil {
 		t.Fatal(err)
@@ -51,6 +57,21 @@ func testNewSubBridge(t *testing.T) *SubBridge {
 	assert.NotNil(t, sBridge)
 
 	return sBridge
+}
+
+// testNewSubBridgeLite returns a lightweight SubBridge for tests
+// that only need in-memory peer behavior.
+func testNewSubBridgeLite(t *testing.T) *SubBridge {
+	tempDir, err := os.MkdirTemp(os.TempDir(), "kaia-test-sb-lite-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &SubBridge{
+		config:       &SCConfig{DataDir: tempDir},
+		peers:        newBridgePeerSet(),
+		addPeerCh:    make(chan struct{}, 16),
+		removePeerCh: make(chan struct{}, 16),
+	}
 }
 
 // removeData removes blockchain data generated during the SubBridge test.
@@ -63,8 +84,10 @@ func (sb *SubBridge) removeData(t *testing.T) {
 // TestSubBridge_basic tests some getters and basic operation of SubBridge.
 func TestSubBridge_basic(t *testing.T) {
 	// Create a test SubBridge
-	sBridge := testNewSubBridge(t)
+	sBridge := testNewSubBridgeLite(t)
 	defer sBridge.removeData(t)
+	sBridge.APIBackend = &SubBridgeAPI{sBridge}
+	sBridge.networkId = testNetVersion
 
 	// APIs returns default rpc APIs of MainBridge
 	apis := sBridge.APIs()
@@ -77,48 +100,59 @@ func TestSubBridge_basic(t *testing.T) {
 	assert.Equal(t, testProtocolVersion, sBridge.ProtocolVersion())
 	assert.Equal(t, testNetVersion, sBridge.NetVersion())
 
-	// New components of MainBridge which will update old components
-	bc := testBlockChain(t)
-	txPool := testTxPool(t, sBridge.config.DataDir, bc)
+}
 
-	var comp []interface{}
-	comp = append(comp, bc)
-	comp = append(comp, txPool)
+func TestSubBridge_startStop(t *testing.T) {
+	tempDir, err := os.MkdirTemp(os.TempDir(), "kaia-test-sb-start-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeCfg := node.DefaultConfig
+	nodeCfg.DataDir = tempDir
+	sCtx := node.NewServiceContext(&nodeCfg, map[reflect.Type]node.Service{}, &event.TypeMux{}, &accounts.Manager{})
 
-	// Check initial status of components
-	assert.Nil(t, sBridge.blockchain)
-	assert.Nil(t, sBridge.txPool)
+	sBridge := &SubBridge{
+		config:       &SCConfig{NetworkId: testNetVersion, DataDir: tempDir, MaxPeer: 10},
+		peers:        newBridgePeerSet(),
+		ctx:          sCtx,
+		networkId:    testNetVersion,
+		maxPeers:     10,
+		newPeerCh:    make(chan BridgePeer),
+		addPeerCh:    make(chan struct{}, 16),
+		removePeerCh: make(chan struct{}, 16),
+		noMorePeers:  make(chan struct{}),
+		quitSync:     make(chan struct{}),
+		rpcSendCh:    make(chan []byte),
+	}
+	defer sBridge.removeData(t)
 
-	// Update and check MainBridge components
-	sBridge.SetComponents(comp)
-	assert.Equal(t, bc, sBridge.blockchain)
-	assert.Equal(t, txPool, sBridge.txPool)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockBridgeTxPool := NewMockBridgeTxPool(mockCtrl)
+	mockBridgeTxPool.EXPECT().Stop().Times(1)
 
-	// Start MainBridge and stop later
+	sBridge.eventMux = &event.TypeMux{}
+	sBridge.chainDB = database.NewMemoryDBManager()
+	defer sBridge.chainDB.Close()
+	sBridge.bridgeTxPool = mockBridgeTxPool
+	sBridge.bridgeManager = &BridgeManager{recoveries: make(map[common.Address]*valueTransferRecovery)}
+	sBridge.chainSub = event.NewSubscription(func(<-chan struct{}) error { return nil })
+	sBridge.logsSub = event.NewSubscription(func(<-chan struct{}) error { return nil })
+	sBridge.reqVTevSub = event.NewSubscription(func(<-chan struct{}) error { return nil })
+	sBridge.reqVTencodedEvSub = event.NewSubscription(func(<-chan struct{}) error { return nil })
+	sBridge.handleVTevSub = event.NewSubscription(func(<-chan struct{}) error { return nil })
+
 	if err := sBridge.Start(p2p.SingleChannelServer{}); err != nil {
 		t.Fatal(err)
 	}
 	defer sBridge.Stop()
-
-	// TODO more test
 }
 
 // TestSubBridge_removePeer tests correct removal of a peer from `SubBridge.peers`.
 func TestSubBridge_removePeer(t *testing.T) {
 	// Create a test SubBridge (it may have 0 peers)
-	sBridge := testNewSubBridge(t)
+	sBridge := testNewSubBridgeLite(t)
 	defer sBridge.removeData(t)
-	defer sBridge.chainDB.Close()
-
-	// Set components of SubBridge
-	bc := testBlockChain(t)
-	txPool := testTxPool(t, sBridge.config.DataDir, bc)
-
-	var comp []interface{}
-	comp = append(comp, bc)
-	comp = append(comp, txPool)
-
-	sBridge.SetComponents(comp)
 
 	// Prepare information of bridgePeer to be added and removed
 	nodeID := "0x1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d"
@@ -141,9 +175,6 @@ func TestSubBridge_removePeer(t *testing.T) {
 	if err := sBridge.peers.Register(mockBridgePeer); err != nil {
 		t.Fatal(err)
 	}
-	if err := sBridge.handler.RegisterNewPeer(mockBridgePeer); err != nil {
-		t.Fatal(err)
-	}
 
 	peerNum := sBridge.peers.Len()
 
@@ -159,9 +190,9 @@ func TestSubBridge_removePeer(t *testing.T) {
 // TestSubBridge_handleMsg fails when a bridgePeer fails to read a message or reads a too long message.
 func TestSubBridge_handleMsg(t *testing.T) {
 	// Create a test SubBridge
-	sBridge := testNewSubBridge(t)
+	sBridge := testNewSubBridgeLite(t)
 	defer sBridge.removeData(t)
-	defer sBridge.chainDB.Close()
+	sBridge.handler = &SubBridgeHandler{subbridge: sBridge}
 
 	// Elements for a bridgePeer
 	key, _ := crypto.GenerateKey()
@@ -216,19 +247,20 @@ func TestSubBridge_handleMsg(t *testing.T) {
 // There are no success cases in this test since `handle` has a infinite loop inside.
 func TestSubBridge_handle(t *testing.T) {
 	// Create a test SubBridge
-	sBridge := testNewSubBridge(t)
+	sBridge := testNewSubBridgeLite(t)
 	defer sBridge.removeData(t)
-	defer sBridge.chainDB.Close()
 
-	// Set components of SubBridge
-	bc := testBlockChain(t)
-	txPool := testTxPool(t, sBridge.config.DataDir, bc)
-
-	var comp []interface{}
-	comp = append(comp, bc)
-	comp = append(comp, txPool)
-
-	sBridge.SetComponents(comp)
+	// Minimal dependencies for handle(): blockchain, handler, and parent operator address.
+	sBridge.blockchain = testBlockChain(t)
+	sBridge.networkId = testNetVersion
+	sBridge.bridgeAccounts = &BridgeAccounts{
+		pAccount: &accountInfo{address: common.Address{}},
+		cAccount: &accountInfo{},
+	}
+	sBridge.handler = &SubBridgeHandler{
+		subbridge:     sBridge,
+		parentChainID: big.NewInt(0),
+	}
 
 	// Variables will be used as return values of mockBridgePeer
 	key, _ := crypto.GenerateKey()
@@ -298,9 +330,8 @@ func TestSubBridge_handle(t *testing.T) {
 // The function sends RPC response data to SubBridge's peers.
 func TestSubBridge_SendRPCData(t *testing.T) {
 	// Create a test SubBridge
-	sBridge := testNewSubBridge(t)
+	sBridge := testNewSubBridgeLite(t)
 	defer sBridge.removeData(t)
-	defer sBridge.chainDB.Close()
 
 	// Test data used as a parameter of SendResponseRPC function
 	data := []byte{0x11, 0x22, 0x33}

--- a/node/sc/vt_contract_test.go
+++ b/node/sc/vt_contract_test.go
@@ -45,7 +45,7 @@ func TestTokenPublicVariables(t *testing.T) {
 		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
-	})
+	}, recoveryFixtureOptions{withToken: true})
 	defer info.sim.Close()
 
 	initSupply, err := info.tokenLocalBridge.INITIALSUPPLY(nil)
@@ -92,7 +92,7 @@ func TestNFTPublicVariables(t *testing.T) {
 		for range testTxCount {
 			ops[KAIA].request(info, info.localInfo)
 		}
-	})
+	}, recoveryFixtureOptions{withNFT: true, mintNFT: true})
 	defer info.sim.Close()
 
 	_, tx, _, err := scnft.DeployServiceChainNFT(info.nodeAuth, info.sim, common.Address{0})

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"math/big"
 	"os"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -188,52 +189,47 @@ func TestKLAYTransferLongRangeRecovery(t *testing.T) {
 		}
 	})
 	defer info.sim.Close()
-	// TODO-Kaia need to remove sleep
-	time.Sleep(1 * time.Second)
-	info.sim.Commit()
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 
-	err := vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
+	steps := []struct {
+		doRecover    bool
+		expectedHint uint64
+	}{
+		{doRecover: false, expectedHint: uint64(testTxCount - testPendingCount)},
+		{doRecover: true, expectedHint: uint64(testTxCount - testPendingCount + maxPendingTxs)},
+		{doRecover: true, expectedHint: uint64(testTxCount)},
 	}
-	assert.Equal(t, uint64(testTxCount), vtr.child2parentHint.requestNonce)
-	assert.Equal(t, uint64(testTxCount-testPendingCount), vtr.child2parentHint.handleNonce)
 
-	// 2. first recovery.
-	info.recoveryCh <- true
-	err = vtr.Recover()
-	if err != nil {
-		t.Fatal("fail to recover the value transfer")
-	}
-	// TODO-Kaia need to remove sleep
-	time.Sleep(1 * time.Second)
-	info.sim.Commit()
+	for i, step := range steps {
+		if step.doRecover {
+			if i == 1 {
+				info.recoveryCh <- true
+			}
+			err := vtr.Recover()
+			if err != nil {
+				t.Fatal("fail to recover the value transfer")
+			}
+		}
 
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update value transfer hint")
+		deadline := time.Now().Add(testTimeout)
+		for {
+			info.sim.Commit()
+			if err := vtr.updateRecoveryHint(); err != nil {
+				t.Fatal("fail to update value transfer hint")
+			}
+			if vtr.child2parentHint.requestNonce == uint64(testTxCount) &&
+				vtr.child2parentHint.handleNonce == step.expectedHint {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("timeout waiting for child2parent hint update")
+			}
+			runtime.Gosched()
+		}
+		assert.Equal(t, uint64(testTxCount), vtr.child2parentHint.requestNonce)
+		assert.Equal(t, step.expectedHint, vtr.child2parentHint.handleNonce)
 	}
-	assert.Equal(t, uint64(testTxCount), vtr.child2parentHint.requestNonce)
-	assert.Equal(t, uint64(testTxCount-testPendingCount+maxPendingTxs), vtr.child2parentHint.handleNonce)
-
-	// 3. second recovery.
-	err = vtr.Recover()
-	if err != nil {
-		t.Fatal("fail to recover the value transfer")
-	}
-	// TODO-Kaia need to remove sleep
-	time.Sleep(1 * time.Second)
-	info.sim.Commit()
-
-	// 4. Check if recovery is done.
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update value transfer hint")
-	}
-	assert.Equal(t, uint64(testTxCount), vtr.child2parentHint.requestNonce)
-	assert.Equal(t, uint64(testTxCount), vtr.child2parentHint.handleNonce)
 }
 
 // TestBasicTokenTransferRecovery tests the token transfer recovery.
@@ -614,11 +610,22 @@ func TestMultiOperatorRequestRecovery(t *testing.T) {
 	assert.Equal(t, nil, vtr.recoverPendingEvents())
 	info.remoteInfo.account = info.localInfo.account // other operator
 	ops[KAIA].dummyHandle(info, info.remoteInfo)
-	if info.sim.BlockChain().CurrentBlock().Transactions().Len() == 0 {
-		// sometimes recovered pending requests are already acquired by BridgeInfo loop, not dummyHandle
-		// for this case, give enough time for the BridgeInfo loop process the pending requests
-		time.Sleep(10 * time.Second)
+	deadline := time.Now().Add(testTimeout)
+	for {
 		info.sim.Commit()
+		if err := vtr.updateRecoveryHint(); err != nil {
+			t.Fatal("fail to update value transfer hint")
+		}
+		if err := vtr.retrievePendingEvents(); err != nil {
+			t.Fatal("fail to retrieve pending events from the bridge contract")
+		}
+		if len(vtr.childEvents) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for recovered pending requests to be drained")
+		}
+		runtime.Gosched()
 	}
 
 	// 9. Check results.
@@ -648,10 +655,7 @@ func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 	config.DataDir = tempDir
 	config.VTRecovery = true
 
-	bacc, err := NewBridgeAccounts(nil, config.DataDir, database.NewDBManager(&database.DBConfig{DBType: database.MemoryDB}), DefaultBridgeTxGasLimit, DefaultBridgeTxGasLimit)
-	assert.NoError(t, err)
-	bacc.pAccount.chainID = params.TestChainConfig.ChainID
-	bacc.cAccount.chainID = params.TestChainConfig.ChainID
+	bacc, _, _ := newBridgeAccountsForTest(t, nil, config.DataDir)
 
 	cAcc := bacc.cAccount.GenerateTransactOpts()
 	pAcc := bacc.pAccount.GenerateTransactOpts()

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -19,6 +19,8 @@
 package sc
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"math/big"
 	"os"
@@ -81,6 +83,27 @@ type operations struct {
 	dummyHandle func(*testInfo, *BridgeInfo)
 }
 
+type recoveryFixtureOptions struct {
+	withToken bool
+	withNFT   bool
+	mintNFT   bool
+}
+
+type recoveryDirection uint8
+
+const (
+	childToParent recoveryDirection = iota
+	parentToChild
+)
+
+type simpleRecoveryCase struct {
+	name          string
+	tokenType     uint8
+	direction     recoveryDirection
+	requestBridge func(*testInfo) *BridgeInfo
+	handleBridge  func(*testInfo) *BridgeInfo
+}
+
 var ops = map[uint8]*operations{
 	KAIA: {
 		request:     requestKLAYTransfer,
@@ -99,27 +122,27 @@ var ops = map[uint8]*operations{
 	},
 }
 
+func prepareRecoveryWithOptions(t *testing.T, vtcallback func(*testInfo), fixtureOpts recoveryFixtureOptions) *testInfo {
+	t.Helper()
+	info := prepare(t, vtcallback, fixtureOpts)
+	t.Cleanup(func() {
+		info.sim.Close()
+	})
+	return info
+}
+
 // TestBasicKLAYTransferRecovery tests each methods of the value transfer recovery.
 func TestBasicKLAYTransferRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
 	// 1. Init dummy chain and do some value transfers.
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
+	info := prepareRecoveryWithOptions(t, func(info *testInfo) {
+		for i := 0; i < testTxCount; i++ {
 			ops[KAIA].request(info, info.localInfo)
 		}
-	})
-	defer info.sim.Close()
+	}, recoveryFixtureOptions{})
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 
 	// 2. Update recovery hint.
-	err = vtr.updateRecoveryHint()
+	err := vtr.updateRecoveryHint()
 	if err != nil {
 		t.Fatal("fail to update value transfer hint")
 	}
@@ -168,27 +191,24 @@ func TestBasicKLAYTransferRecovery(t *testing.T) {
 
 // TestKLAYTransferLongRangeRecovery tests a long block range recovery.
 func TestKLAYTransferLongRangeRecovery(t *testing.T) {
-	tempDir := os.TempDir() + "sc"
-	os.MkdirAll(tempDir, os.ModePerm)
 	oldMaxPendingTxs := maxPendingTxs
+	oldFilterLogsStride := filterLogsStride
 	maxPendingTxs = 2
+	filterLogsStride = 20
 	defer func() {
 		maxPendingTxs = oldMaxPendingTxs
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
+		filterLogsStride = oldFilterLogsStride
 	}()
 
 	// 1. Init dummy chain and do some value transfers.
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
+	info := prepareRecoveryWithOptions(t, func(info *testInfo) {
+		for i := 0; i < testTxCount; i++ {
 			ops[KAIA].request(info, info.localInfo)
 			for range filterLogsStride {
 				info.sim.Commit()
 			}
 		}
-	})
-	defer info.sim.Close()
+	}, recoveryFixtureOptions{})
 
 	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
 
@@ -232,316 +252,124 @@ func TestKLAYTransferLongRangeRecovery(t *testing.T) {
 	}
 }
 
-// TestBasicTokenTransferRecovery tests the token transfer recovery.
-func TestBasicTokenTransferRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[ERC20].request(info, info.localInfo)
-		}
+func TestRecoveryScenarios(t *testing.T) {
+	info := prepareRecoveryWithOptions(t, nil, recoveryFixtureOptions{
+		withToken: true,
+		withNFT:   true,
+		mintNFT:   true,
 	})
-	defer info.sim.Close()
 
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
+	testCases := []simpleRecoveryCase{
+		{
+			name:          "basic_token_transfer_recovery",
+			tokenType:     ERC20,
+			direction:     childToParent,
+			requestBridge: func(info *testInfo) *BridgeInfo { return info.localInfo },
+			handleBridge:  func(info *testInfo) *BridgeInfo { return info.remoteInfo },
+		},
+		{
+			name:          "basic_nft_transfer_recovery",
+			tokenType:     ERC721,
+			direction:     childToParent,
+			requestBridge: func(info *testInfo) *BridgeInfo { return info.localInfo },
+			handleBridge:  func(info *testInfo) *BridgeInfo { return info.remoteInfo },
+		},
+		{
+			name:          "method_recover",
+			tokenType:     KAIA,
+			direction:     childToParent,
+			requestBridge: func(info *testInfo) *BridgeInfo { return info.localInfo },
+			handleBridge:  func(info *testInfo) *BridgeInfo { return info.remoteInfo },
+		},
+		{
+			name:          "scenario_main_chain_recovery",
+			tokenType:     KAIA,
+			direction:     parentToChild,
+			requestBridge: func(info *testInfo) *BridgeInfo { return info.remoteInfo },
+			handleBridge:  func(info *testInfo) *BridgeInfo { return info.localInfo },
+		},
+		{
+			name:          "scenario_automatic_recovery",
+			tokenType:     KAIA,
+			direction:     childToParent,
+			requestBridge: func(info *testInfo) *BridgeInfo { return info.localInfo },
+			handleBridge:  func(info *testInfo) *BridgeInfo { return info.remoteInfo },
+		},
 	}
-	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
-	t.Log("token transfer hint", vtr.child2parentHint)
 
-	info.recoveryCh <- true
-	err = vtr.Recover()
-	if err != nil {
-		t.Fatal("fail to recover the value transfer")
+	for idx, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("%02d_%s", idx, tc.name), func(t *testing.T) {
+			requestBridge := tc.requestBridge(info)
+			for i := 0; i < testTxCount; i++ {
+				ops[tc.tokenType].request(info, requestBridge)
+			}
+
+			vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
+			err := vtr.updateRecoveryHint()
+			assert.NoError(t, err)
+
+			if tc.direction == parentToChild {
+				assert.NotEqual(t, vtr.parent2childHint.requestNonce, vtr.parent2childHint.handleNonce)
+			} else {
+				assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
+			}
+
+			info.recoveryCh <- true
+			err = vtr.Recover()
+			assert.NoError(t, err)
+			ops[tc.tokenType].dummyHandle(info, tc.handleBridge(info))
+
+			err = vtr.updateRecoveryHint()
+			assert.NoError(t, err)
+			if tc.direction == parentToChild {
+				assert.Equal(t, vtr.parent2childHint.requestNonce, vtr.parent2childHint.handleNonce)
+				return
+			}
+			assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
+		})
 	}
-	ops[ERC20].dummyHandle(info, info.remoteInfo)
-
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
-}
-
-// TestBasicNFTTransferRecovery tests the NFT transfer recovery.
-// TODO-Kaia-ServiceChain: implement NFT transfer.
-func TestBasicNFTTransferRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[ERC721].request(info, info.localInfo)
-		}
-	})
-	defer info.sim.Close()
-
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
-	t.Log("token transfer hint", vtr.child2parentHint)
-
-	info.recoveryCh <- true
-	err = vtr.Recover()
-	if err != nil {
-		t.Fatal("fail to recover the value transfer")
-	}
-	ops[ERC721].dummyHandle(info, info.remoteInfo)
-
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
-}
-
-// TestMethodRecover tests the valueTransferRecovery.Recover() method.
-func TestMethodRecover(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[KAIA].request(info, info.localInfo)
-		}
-	})
-	defer info.sim.Close()
-
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
-
-	info.recoveryCh <- true
-	err = vtr.Recover()
-	if err != nil {
-		t.Fatal("fail to recover the value transfer")
-	}
-	ops[KAIA].dummyHandle(info, info.remoteInfo)
-
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 }
 
 // TestMethodStop tests the Stop method for stop the internal goroutine.
 func TestMethodStop(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
+	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, nil, nil)
+	assert.NoError(t, vtr.Stop())
 
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[KAIA].request(info, info.localInfo)
-		}
-	})
-	defer info.sim.Close()
-
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 1}, info.localInfo, info.remoteInfo)
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
-
-	info.recoveryCh <- true
-	err = vtr.Start()
-	if err != nil {
-		t.Fatal("fail to start the value transfer")
-	}
-	assert.Equal(t, nil, vtr.WaitRunningStatus(true, 5*time.Second))
-	err = vtr.Stop()
-	if err != nil {
-		t.Fatal("fail to stop the value transfer")
-	}
+	vtr.isRunning = true
+	assert.NoError(t, vtr.Stop())
 	assert.Equal(t, false, vtr.isRunning)
 }
 
 // TestFlagVTRecovery tests the disabled vtrecovery option.
 func TestFlagVTRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[KAIA].request(info, info.localInfo)
-		}
-	})
-	defer info.sim.Close()
-
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 60}, info.localInfo, info.remoteInfo)
-	vtr.Start()
-	assert.Equal(t, nil, vtr.WaitRunningStatus(true, 5*time.Second))
-	vtr.Stop()
-
-	vtr = NewValueTransferRecovery(&SCConfig{VTRecovery: false}, info.localInfo, info.remoteInfo)
-	err = vtr.Start()
+	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: false}, nil, nil)
+	err := vtr.Start()
 	assert.Equal(t, ErrVtrDisabled, err)
-	vtr.Stop()
 }
 
 // TestAlreadyStartedVTRecovery tests the already started VTR error cases.
 func TestAlreadyStartedVTRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[KAIA].request(info, info.localInfo)
-		}
-	})
-	defer info.sim.Close()
-
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 60}, info.localInfo, info.remoteInfo)
-	err = vtr.Start()
-	assert.Equal(t, nil, err)
-	assert.Equal(t, nil, vtr.WaitRunningStatus(true, 5*time.Second))
-
-	err = vtr.Start()
+	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 60}, nil, nil)
+	vtr.isRunning = true
+	err := vtr.Start()
 	assert.Equal(t, ErrVtrAlreadyStarted, err)
-
-	vtr.Stop()
-}
-
-// TestScenarioMainChainRecovery tests the value transfer recovery of the parent chain to child chain value transfers.
-func TestScenarioMainChainRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[KAIA].request(info, info.remoteInfo)
-		}
-	})
-	defer info.sim.Close()
-
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true}, info.localInfo, info.remoteInfo)
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.NotEqual(t, vtr.parent2childHint.requestNonce, vtr.parent2childHint.handleNonce)
-
-	info.recoveryCh <- true
-	err = vtr.Recover()
-	if err != nil {
-		t.Fatal("fail to recover the value transfer")
-	}
-	ops[KAIA].dummyHandle(info, info.localInfo)
-
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.Equal(t, vtr.parent2childHint.requestNonce, vtr.parent2childHint.handleNonce)
-}
-
-// TestScenarioAutomaticRecovery tests the recovery of the internal goroutine.
-func TestScenarioAutomaticRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
-			ops[KAIA].request(info, info.localInfo)
-		}
-	})
-	defer info.sim.Close()
-
-	vtr := NewValueTransferRecovery(&SCConfig{VTRecovery: true, VTRecoveryInterval: 1}, info.localInfo, info.remoteInfo)
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	assert.NotEqual(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
-
-	info.recoveryCh <- true
-	err = vtr.Start()
-	if err != nil {
-		t.Fatal("fail to start the value transfer")
-	}
-	assert.Equal(t, nil, vtr.WaitRunningStatus(true, 5*time.Second))
-	ops[KAIA].dummyHandle(info, info.remoteInfo)
-
-	err = vtr.updateRecoveryHint()
-	if err != nil {
-		t.Fatal("fail to update a value transfer hint")
-	}
-	vtr.Stop()
-	assert.Equal(t, vtr.child2parentHint.requestNonce, vtr.child2parentHint.handleNonce)
 }
 
 // TestMultiOperatorRequestRecovery tests value transfer recovery for the multi-operator.
 func TestMultiOperatorRequestRecovery(t *testing.T) {
-	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
-	assert.NoError(t, err)
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			t.Fatalf("fail to delete file %v", err)
-		}
-	}()
-
 	// 1. Init dummy chain and do some value transfers.
-	info := prepare(t, func(info *testInfo) {
-		for range testTxCount {
+	info := prepareRecoveryWithOptions(t, func(info *testInfo) {
+		for i := 0; i < testTxCount; i++ {
 			ops[KAIA].request(info, info.localInfo)
 		}
-	})
-	defer info.sim.Close()
+	}, recoveryFixtureOptions{})
 
 	// 2. Set multi-operator.
 	cAcc := info.nodeAuth
 	pAcc := info.chainAuth
 	opts := &bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}
-	_, err = info.localInfo.bridge.RegisterOperator(opts, pAcc.From)
+	_, err := info.localInfo.bridge.RegisterOperator(opts, pAcc.From)
 	assert.NoError(t, err)
 	opts = &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
 	_, err = info.remoteInfo.bridge.RegisterOperator(opts, cAcc.From)
@@ -641,8 +469,23 @@ func TestMultiOperatorRequestRecovery(t *testing.T) {
 	assert.Equal(t, nil, vtr.Recover()) // nothing to recover
 }
 
+func assertTxMined(t *testing.T, sim *backends.SimulatedBackend, tx *types.Transaction) {
+	t.Helper()
+
+	receipt, err := sim.TransactionReceipt(context.Background(), tx.Hash())
+	assert.NoError(t, err)
+	if receipt == nil {
+		t.Fatal("receipt not found")
+	}
+
+	result := blockchain.ExecutionResult{
+		VmExecutionStatus: receipt.Status,
+	}
+	assert.NoError(t, result.Unwrap())
+}
+
 // prepare generates dummy blocks for testing value transfer recovery.
-func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
+func prepare(t *testing.T, vtcallback func(*testInfo), fixtureOpts recoveryFixtureOptions) *testInfo {
 	// Setup configuration.
 	config := &SCConfig{}
 	tempDir, err := os.MkdirTemp(os.TempDir(), "sc")
@@ -699,83 +542,114 @@ func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 	remoteInfo, _ := bm.GetBridgeInfo(remoteAddr)
 	sim.Commit()
 
-	// Prepare token contract
-	tokenLocalAddr, tx, tokenLocal, err := sctoken.DeployServiceChainToken(cAcc, sim, localAddr)
-	if err != nil {
-		log.Fatalf("Failed to DeployServiceChainToken: %v", err)
-	}
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
+	var (
+		tokenLocalAddr  common.Address
+		tokenRemoteAddr common.Address
+		tokenLocal      *sctoken.ServiceChainToken
+		tokenRemote     *sctoken.ServiceChainToken
+		nftLocalAddr    common.Address
+		nftRemoteAddr   common.Address
+		nftLocal        *scnft.ServiceChainNFT
+		nftRemote       *scnft.ServiceChainNFT
+		tx              *types.Transaction
+	)
 
-	tokenRemoteAddr, tx, tokenRemote, err := sctoken.DeployServiceChainToken(pAcc, sim, remoteAddr)
-	if err != nil {
-		log.Fatalf("Failed to DeployServiceChainToken: %v", err)
-	}
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	testToken := big.NewInt(testChargeToken)
-	opts := &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
-	tx, err = tokenRemote.Transfer(opts, remoteAddr, testToken)
-	if err != nil {
-		log.Fatalf("Failed to Transfer for charging: %v", err)
-	}
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	// Prepare NFT contract
-	nftLocalAddr, tx, nftLocal, err := scnft.DeployServiceChainNFT(cAcc, sim, localAddr)
-	if err != nil {
-		log.Fatalf("Failed to DeployServiceChainNFT: %v", err)
-	}
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	nftRemoteAddr, tx, nftRemote, err := scnft.DeployServiceChainNFT(pAcc, sim, remoteAddr)
-	if err != nil {
-		log.Fatalf("Failed to DeployServiceChainNFT: %v", err)
-	}
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	// Register tokens on the bridge
-	nodeOpts := &bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}
-	chainOpts := &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
-	tx, err = localInfo.bridge.RegisterToken(nodeOpts, tokenLocalAddr, tokenRemoteAddr)
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	tx, err = localInfo.bridge.RegisterToken(nodeOpts, nftLocalAddr, nftRemoteAddr)
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	tx, err = remoteInfo.bridge.RegisterToken(chainOpts, tokenRemoteAddr, tokenLocalAddr)
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	tx, err = remoteInfo.bridge.RegisterToken(chainOpts, nftRemoteAddr, nftLocalAddr)
-	sim.Commit()
-	assert.Nil(t, bind.CheckWaitMined(sim, tx))
-
-	// Register an NFT to chain account (minting)
-	for i := range testTxCount {
-		opts := &bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}
-		tx, err = nftLocal.MintWithTokenURI(opts, cAcc.From, big.NewInt(testNFT+int64(i)), "testURI")
-		assert.NoError(t, err)
+	if fixtureOpts.withToken {
+		var tokenLocalTx *types.Transaction
+		var tokenRemoteTx *types.Transaction
+		var tl *sctoken.ServiceChainToken
+		var tr *sctoken.ServiceChainToken
+		tokenLocalAddr, tokenLocalTx, tl, err = sctoken.DeployServiceChainToken(cAcc, sim, localAddr)
+		if err != nil {
+			log.Fatalf("Failed to DeployServiceChainToken: %v", err)
+		}
+		tokenRemoteAddr, tokenRemoteTx, tr, err = sctoken.DeployServiceChainToken(pAcc, sim, remoteAddr)
+		if err != nil {
+			log.Fatalf("Failed to DeployServiceChainToken: %v", err)
+		}
+		tokenLocal, tokenRemote = tl, tr
 		sim.Commit()
-		assert.Nil(t, bind.CheckWaitMined(sim, tx))
+		assertTxMined(t, sim, tokenLocalTx)
+		assertTxMined(t, sim, tokenRemoteTx)
 
-		opts = &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
-		tx, err = nftRemote.MintWithTokenURI(opts, remoteAddr, big.NewInt(testNFT+int64(i)), "testURI")
-		assert.NoError(t, err)
+		charge := big.NewInt(testChargeToken)
+		txOpts := &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
+		tx, err = tokenRemote.Transfer(txOpts, remoteAddr, charge)
+		if err != nil {
+			log.Fatalf("Failed to Transfer for charging: %v", err)
+		}
 		sim.Commit()
-		assert.Nil(t, bind.CheckWaitMined(sim, tx))
+		assertTxMined(t, sim, tx)
+	}
+
+	if fixtureOpts.withNFT {
+		var nftLocalTx *types.Transaction
+		var nftRemoteTx *types.Transaction
+		var nl *scnft.ServiceChainNFT
+		var nr *scnft.ServiceChainNFT
+		nftLocalAddr, nftLocalTx, nl, err = scnft.DeployServiceChainNFT(cAcc, sim, localAddr)
+		if err != nil {
+			log.Fatalf("Failed to DeployServiceChainNFT: %v", err)
+		}
+		nftRemoteAddr, nftRemoteTx, nr, err = scnft.DeployServiceChainNFT(pAcc, sim, remoteAddr)
+		if err != nil {
+			log.Fatalf("Failed to DeployServiceChainNFT: %v", err)
+		}
+		nftLocal, nftRemote = nl, nr
+		sim.Commit()
+		assertTxMined(t, sim, nftLocalTx)
+		assertTxMined(t, sim, nftRemoteTx)
+	}
+
+	if fixtureOpts.withToken || fixtureOpts.withNFT {
+		nodeOpts := &bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}
+		chainOpts := &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
+		registerTokenTxs := make([]*types.Transaction, 0, 4)
+		if fixtureOpts.withToken {
+			tx, err = localInfo.bridge.RegisterToken(nodeOpts, tokenLocalAddr, tokenRemoteAddr)
+			assert.NoError(t, err)
+			registerTokenTxs = append(registerTokenTxs, tx)
+			tx, err = remoteInfo.bridge.RegisterToken(chainOpts, tokenRemoteAddr, tokenLocalAddr)
+			assert.NoError(t, err)
+			registerTokenTxs = append(registerTokenTxs, tx)
+		}
+		if fixtureOpts.withNFT {
+			tx, err = localInfo.bridge.RegisterToken(nodeOpts, nftLocalAddr, nftRemoteAddr)
+			assert.NoError(t, err)
+			registerTokenTxs = append(registerTokenTxs, tx)
+			tx, err = remoteInfo.bridge.RegisterToken(chainOpts, nftRemoteAddr, nftLocalAddr)
+			assert.NoError(t, err)
+			registerTokenTxs = append(registerTokenTxs, tx)
+		}
+		sim.Commit()
+		for _, tx := range registerTokenTxs {
+			assertTxMined(t, sim, tx)
+		}
+	}
+
+	if fixtureOpts.withNFT && fixtureOpts.mintNFT {
+		mintTxs := make([]*types.Transaction, 0, testTxCount*2)
+		for i := 0; i < testTxCount; i++ {
+			txOpts := &bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}
+			tx, err = nftLocal.MintWithTokenURI(txOpts, cAcc.From, big.NewInt(testNFT+int64(i)), "testURI")
+			assert.NoError(t, err)
+			mintTxs = append(mintTxs, tx)
+
+			txOpts = &bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}
+			tx, err = nftRemote.MintWithTokenURI(txOpts, remoteAddr, big.NewInt(testNFT+int64(i)), "testURI")
+			assert.NoError(t, err)
+			mintTxs = append(mintTxs, tx)
+		}
+		sim.Commit()
+		for _, tx := range mintTxs {
+			assertTxMined(t, sim, tx)
+		}
 	}
 
 	// Register the owner as a signer
-	_, err = localInfo.bridge.RegisterOperator(&bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}, cAcc.From)
+	tx, err = localInfo.bridge.RegisterOperator(&bind.TransactOpts{From: cAcc.From, Signer: cAcc.Signer, GasLimit: testGasLimit}, cAcc.From)
 	assert.NoError(t, err)
-	_, err = remoteInfo.bridge.RegisterOperator(&bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}, pAcc.From)
+	tx, err = remoteInfo.bridge.RegisterOperator(&bind.TransactOpts{From: pAcc.From, Signer: pAcc.Signer, GasLimit: testGasLimit}, pAcc.From)
 	assert.NoError(t, err)
 	sim.Commit()
 
@@ -855,9 +729,11 @@ func prepare(t *testing.T, vtcallback func(*testInfo)) *testInfo {
 		}
 	}()
 
-	// Request value transfer.
-	vtcallback(&info)
-	WaitGroupWithTimeOut(&wg, testTimeout, t)
+	// Request value transfer if requested.
+	if vtcallback != nil {
+		vtcallback(&info)
+		WaitGroupWithTimeOut(&wg, testTimeout, t)
+	}
 
 	return &info
 }
@@ -873,7 +749,7 @@ func requestKLAYTransfer(info *testInfo, bi *BridgeInfo) {
 		log.Fatalf("Failed to RequestKLAYTransfer: %v", err)
 	}
 	info.sim.Commit()
-	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
+	assertTxMined(info.t, info.sim, tx)
 }
 
 func handleKLAYTransfer(info *testInfo, bi *BridgeInfo, ev IRequestValueTransferEvent) {
@@ -887,7 +763,7 @@ func handleKLAYTransfer(info *testInfo, bi *BridgeInfo, ev IRequestValueTransfer
 		log.Fatalf("\tFailed to HandleKLAYTransfer: %v", err)
 	}
 	info.sim.Commit()
-	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
+	assertTxMined(info.t, info.sim, tx)
 }
 
 // TODO-Kaia-ServiceChain: use ChildChainEventHandler
@@ -918,7 +794,7 @@ func requestTokenTransfer(info *testInfo, bi *BridgeInfo) {
 		log.Fatalf("Failed to RequestValueTransfer for charging: %v", err)
 	}
 	info.sim.Commit()
-	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
+	assertTxMined(info.t, info.sim, tx)
 }
 
 func handleTokenTransfer(info *testInfo, bi *BridgeInfo, ev IRequestValueTransferEvent) {
@@ -932,7 +808,7 @@ func handleTokenTransfer(info *testInfo, bi *BridgeInfo, ev IRequestValueTransfe
 		log.Fatalf("Failed to HandleERC20Transfer: %v", err)
 	}
 	info.sim.Commit()
-	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
+	assertTxMined(info.t, info.sim, tx)
 }
 
 // TODO-Kaia-ServiceChain: use ChildChainEventHandler
@@ -965,7 +841,7 @@ func requestNFTTransfer(info *testInfo, bi *BridgeInfo) {
 	}
 	info.nftIndex++
 	info.sim.Commit()
-	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
+	assertTxMined(info.t, info.sim, tx)
 }
 
 func handleNFTTransfer(info *testInfo, bi *BridgeInfo, ev IRequestValueTransferEvent) {
@@ -988,7 +864,7 @@ func handleNFTTransfer(info *testInfo, bi *BridgeInfo, ev IRequestValueTransferE
 		log.Fatalf("Failed to handleERC721Transfer: %v", err)
 	}
 	info.sim.Commit()
-	assert.Nil(info.t, bind.CheckWaitMined(info.sim, tx))
+	assertTxMined(info.t, info.sim, tx)
 }
 
 // TODO-Kaia-ServiceChain: use ChildChainEventHandler

--- a/tests/account_keytype_test.go
+++ b/tests/account_keytype_test.go
@@ -518,8 +518,6 @@ func TestDefaultTxsWithDefaultAccountKey(t *testing.T) {
 	accountKeyTypes := []accountkey.AccountKeyType{
 		// accountkey.AccountKeyTypeNil, // not supported type
 		accountkey.AccountKeyTypeLegacy,
-		accountkey.AccountKeyTypePublic,
-		accountkey.AccountKeyTypeFail,
 		accountkey.AccountKeyTypeWeightedMultiSig,
 		accountkey.AccountKeyTypeRoleBased,
 	}

--- a/tests/gasless_test.go
+++ b/tests/gasless_test.go
@@ -98,7 +98,7 @@ func TestGasless(t *testing.T) {
 
 	/* ------------- Register GaslessSwapRouter address in Registry ------------- */
 	// send register tx
-	targetBlockNum := new(big.Int).Add(node.BlockChain().CurrentHeader().Number, big.NewInt(10))
+	targetBlockNum := new(big.Int).Add(node.BlockChain().CurrentHeader().Number, big.NewInt(4))
 	registry, err := kip149contract.NewRegistry(system.RegistryAddr, transactor)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/gov_contract_test.go
+++ b/tests/gov_contract_test.go
@@ -99,7 +99,7 @@ func TestGovernance_GovModule(t *testing.T) {
 
 		// Give some time for txpool to recognize the contract, because otherwise
 		// the txpool may reject the setParam tx with 'not a program account'
-		time.Sleep(2 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 
 		deployGovParamTx_setParamIn(t, node, owner, chainId, contractAddr, paramName, paramBytes)
 
@@ -119,14 +119,14 @@ func TestGovernance_GovModule(t *testing.T) {
 	// 1. wait until header.Governance block + 5
 	for {
 		ev := <-chainEventCh
-		time.Sleep(100 * time.Millisecond) // wait for tx sender thread to set deployBlock, etc.
+		time.Sleep(20 * time.Millisecond) // wait for tx sender thread to set deployBlock, etc.
 
 		num := ev.Block.Number().Uint64()
 		if govBytes := ev.Block.Header().Governance; len(govBytes) > 0 {
 			govBlock = num
 			// stopBlock is the epoch block, so we stop when receiving it
 			// otherwise, GetParamSet(stopBlock) may fail
-			stopBlock = govBlock + 5
+			stopBlock = govBlock + 3
 			stopBlock = stopBlock - (stopBlock % config.Istanbul.Epoch)
 			t.Logf("Governance at block=%2d, stopBlock=%2d, gov=%v", num, stopBlock, hexutil.Encode(govBytes))
 		}

--- a/tests/kaia_blockchain_test.go
+++ b/tests/kaia_blockchain_test.go
@@ -49,7 +49,7 @@ import (
 func TestSimpleBlockchain(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
 
-	numAccounts := 12
+	numAccounts := 4
 	fullNode, node, validator, chainId, workspace := newBlockchain(t, nil, nil)
 	defer os.RemoveAll(workspace)
 
@@ -60,23 +60,25 @@ func TestSimpleBlockchain(t *testing.T) {
 	for i := range numAccounts {
 		_, contractAccounts[i].Addr = deployContractDeployTx(t, node.TxPool(), chainId, richAccount, contractDeployCode)
 	}
-	time.Sleep(time.Second) // need to make a block before contract execution
+	target := node.BlockChain().CurrentHeader().Number.Uint64() + 1
+	if header := waitBlock(node.BlockChain(), target); header == nil {
+		t.Fatal("failed to wait for contract deployment block")
+	}
 
 	// deploy
 	calldata := "0x197e70e40000000000000000000000000000000000000000000000000000000000000001"
+
 	for i := range numAccounts {
-		deployRandomTxs(t, node.TxPool(), chainId, richAccount, 10)
+		deployRandomTxs(t, node.TxPool(), chainId, richAccount, 5)
 		deployValueTransferTx(t, node.TxPool(), chainId, richAccount, accounts[i%numAccounts])
 		deployContractExecutionTx(t, node.TxPool(), chainId, richAccount, contractAccounts[i%numAccounts].Addr, calldata)
-
-		// time.Sleep(time.Second) // wait until txpool is flushed if needed
 	}
 
 	// stop full node
 	if err := fullNode.Stop(); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(2 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
 	// start full node with previous db
 	fullNode, node, err := newKaiaNode(t, workspace, validator, nil, nil)
@@ -84,7 +86,10 @@ func TestSimpleBlockchain(t *testing.T) {
 	if err := node.StartMining(false); err != nil {
 		t.Fatal()
 	}
-	time.Sleep(2 * time.Second)
+	target = node.BlockChain().CurrentHeader().Number.Uint64() + 1
+	if header := waitBlock(node.BlockChain(), target); header == nil {
+		t.Fatal("failed to wait for node restart block")
+	}
 
 	// stop node before ending the test code
 	if err := fullNode.Stop(); err != nil {
@@ -113,7 +118,7 @@ func newBlockchain(t *testing.T, config *params.ChainConfig, genesis *blockchain
 	if err := node.StartMining(false); err != nil {
 		t.Fatal()
 	}
-	time.Sleep(2 * time.Second) // wait for initializing mining
+	time.Sleep(1 * time.Second) // wait for initializing mining
 
 	chainId := node.BlockChain().Config().ChainID
 

--- a/tests/kaia_test.go
+++ b/tests/kaia_test.go
@@ -293,7 +293,7 @@ func makeNewTransactionsToRing(bcdata *BCData, accountMap *AccountMap, signer ty
 }
 
 func TestValueTransfer(t *testing.T) {
-	var nBlocks int = 3
+	var nBlocks int = 2
 	var txPerBlock int = 10
 
 	if i, err := strconv.ParseInt(os.Getenv("NUM_BLOCKS"), 10, 32); err == nil {
@@ -310,29 +310,29 @@ func TestValueTransfer(t *testing.T) {
 	}{
 		{
 			"SingleSenderMultipleRecipient",
-			testOption{txPerBlock, 1000, 4, nBlocks, []byte{}, makeTransactionsFrom},
+			testOption{txPerBlock, 120, 4, nBlocks, []byte{}, makeTransactionsFrom},
 		},
 		{
 			"MultipleSenderMultipleRecipient",
-			testOption{txPerBlock, 2000, 4, nBlocks, []byte{}, makeIndependentTransactions},
+			testOption{txPerBlock, 240, 4, nBlocks, []byte{}, makeIndependentTransactions},
 		},
 		{
 			"MultipleSenderRandomRecipient",
-			testOption{txPerBlock, 2000, 4, nBlocks, []byte{}, makeTransactionsToRandom},
+			testOption{txPerBlock, 240, 4, nBlocks, []byte{}, makeTransactionsToRandom},
 		},
 
 		// Below test cases execute one transaction per a block.
 		{
 			"SingleSenderMultipleRecipientSingleTxPerBlock",
-			testOption{1, 1000, 4, 10, []byte{}, makeTransactionsFrom},
+			testOption{1, 120, 4, 4, []byte{}, makeTransactionsFrom},
 		},
 		{
 			"MultipleSenderMultipleRecipientSingleTxPerBlock",
-			testOption{1, 2000, 4, 10, []byte{}, makeIndependentTransactions},
+			testOption{1, 240, 4, 4, []byte{}, makeIndependentTransactions},
 		},
 		{
 			"MultipleSenderRandomRecipientSingleTxPerBlock",
-			testOption{1, 2000, 4, 10, []byte{}, makeTransactionsToRandom},
+			testOption{1, 240, 4, 4, []byte{}, makeTransactionsToRandom},
 		},
 	}
 

--- a/tests/kip103_test.go
+++ b/tests/kip103_test.go
@@ -54,7 +54,7 @@ func TestRebalanceTreasury_EOA(t *testing.T) {
 	optsOwner := bind.NewKeyedTransactor(validator.Keys[0])
 	transactor := backends.NewBlockchainContractBackend(node.BlockChain(), node.TxPool().(*blockchain.TxPool), nil)
 	// We need to wait for the following contract executions to be processed, so let's have enough number of blocks
-	targetBlockNum := new(big.Int).Add(node.BlockChain().CurrentBlock().Number(), big.NewInt(10))
+	targetBlockNum := new(big.Int).Add(node.BlockChain().CurrentBlock().Number(), big.NewInt(4))
 
 	contractAddr, tx, contract, err := rebalance.DeployTreasuryRebalance(optsOwner, transactor, targetBlockNum)
 	if err != nil {
@@ -74,7 +74,7 @@ func TestRebalanceTreasury_EOA(t *testing.T) {
 	t.Log("Target Block:", targetBlockNum.Int64())
 
 	// prepare newbie accounts
-	numNewbie := 3
+	numNewbie := 2
 	newbieAccs := make([]TestAccount, numNewbie)
 	newbieAllocs := make([]*big.Int, numNewbie)
 

--- a/tests/prague_evm_test.go
+++ b/tests/prague_evm_test.go
@@ -23,7 +23,6 @@ import (
 	"math/big"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
@@ -111,7 +110,6 @@ func TestEIP3541(t *testing.T) {
 			if receipt == nil {
 				t.Fatal("timeout")
 			}
-			time.Sleep(1 * time.Second)
 
 			deployedAddress := crypto.CreateAddress(optsOwner.From, nonce)
 
@@ -177,7 +175,6 @@ func TestEIP170(t *testing.T) {
 			if receipt == nil {
 				t.Fatal("timeout")
 			}
-			time.Sleep(1 * time.Second)
 
 			deployedAddress := crypto.CreateAddress(optsOwner.From, nonce)
 

--- a/tests/randao_fork_test.go
+++ b/tests/randao_fork_test.go
@@ -40,96 +40,81 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test full Randao hardfork scenario under the condition similar to the Mainnet network.
-func TestRandao_Deploy(t *testing.T) {
+func TestRandao(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
 
-	// Test parameters
-	var (
-		numNodes   = 1
-		forkNum    = big.NewInt(15)
-		owner      = bind.NewKeyedTransactor(deriveTestAccount(5))
-		kip113Addr = crypto.CreateAddress(owner.From, uint64(1)) // predict deployed address.
-		randomAddr = common.HexToAddress("0x0000000000000000000000000000000000000404")
+	cases := []struct {
+		name         string
+		forkNum      *big.Int
+		fromGenesis  bool
+		kip113AtFork common.Address
+	}{
+		{
+			name:        "Deploy",
+			forkNum:     big.NewInt(3),
+			fromGenesis: false,
+		},
+		{
+			name:         "Genesis",
+			forkNum:      big.NewInt(0),
+			fromGenesis:  true,
+			kip113AtFork: common.HexToAddress("0x0000000000000000000000000000000000000403"),
+		},
+	}
 
-		config = testRandao_config(forkNum, owner.From, kip113Addr)
-		alloc  = testRandao_allocRandom(randomAddr)
-	)
-
-	// Start the chain
-	ctx, err := newBlockchainTestContext(&blockchainTestOverrides{
-		numNodes:    numNodes,
-		numAccounts: 8,
-		config:      config,
-		alloc:       alloc,
-	})
-	require.Nil(t, err)
-	ctx.Subscribe(t, func(ev *blockchain.ChainEvent) {
-		b := ev.Block
-		t.Logf("block[%3d] txs=%d mixHash=%x", b.NumberU64(), b.Transactions().Len(), b.Header().MixHash)
-	})
-	ctx.Start()
-	defer ctx.Cleanup()
-
-	// Wait for the chain to start consensus (especially when numNodes > 1)
-	ctx.WaitBlock(t, 1)
-
-	// Deploy KIP113 before hardfork.
-	// Note: this test has a minor difference from Mainnet scenario.
-	// In this test, RandaoRegistry[KIP113] is configured in before deployment
-	// but in Mainnet RandaoRegistry[KIP113] will be configured after deployment.
-	// following assert ensures the equivalence of this test and Mainnet scenario.
-	_, actualKip113Addr := testRandao_deployKip113(t, ctx, owner)
-	assert.Equal(t, kip113Addr, actualKip113Addr) // check the prediced address
-
-	// Pass the hardfork block, give each CN a chance to propose
-	ctx.WaitBlock(t, forkNum.Uint64()+uint64(numNodes))
-
-	// Inspect the chain
-	testRandao_checkRegistry(t, ctx, owner.From, kip113Addr)
-	testRandao_checkKip113(t, ctx)
-	testRandao_checkKip114(t, ctx, randomAddr)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runRandaoScenario(t, tc.forkNum, tc.fromGenesis, tc.kip113AtFork)
+		})
+	}
 }
 
-// Test Randao hardfork scenario where it's enabled from the genesis
-func TestRandao_Genesis(t *testing.T) {
-	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
-
-	// Test parameters
+func runRandaoScenario(t *testing.T, forkNum *big.Int, fromGenesis bool, genesisKip113Addr common.Address) {
 	var (
-		numNodes   = 1
-		forkNum    = big.NewInt(0)
-		owner      = bind.NewKeyedTransactor(deriveTestAccount(5))
-		kip113Addr = common.HexToAddress("0x0000000000000000000000000000000000000403")
-		randomAddr = common.HexToAddress("0x0000000000000000000000000000000000000404")
+		numNodes    = 1
+		owner       = bind.NewKeyedTransactor(deriveTestAccount(5))
+		randomAddr  = common.HexToAddress("0x0000000000000000000000000000000000000404")
+		kip113Addr  common.Address
+		blockPeriod uint64
+	)
+	if fromGenesis {
+		kip113Addr = genesisKip113Addr
+	} else {
+		kip113Addr = crypto.CreateAddress(owner.From, uint64(1)) // predicted deployed address.
+	}
 
-		config = testRandao_config(forkNum, owner.From, kip113Addr)
-		alloc  = system.MergeGenesisAlloc(
-			testRandao_allocRandom(randomAddr),
+	config := testRandao_config(forkNum, owner.From, kip113Addr)
+	alloc := testRandao_allocRandom(randomAddr)
+	if fromGenesis {
+		alloc = system.MergeGenesisAlloc(
+			alloc,
 			testRandao_allocRegistry(owner.From, kip113Addr),
 			testRandao_allocKip113(numNodes, owner.From, kip113Addr),
 		)
-	)
+	}
 
-	// Start the chain
 	ctx, err := newBlockchainTestContext(&blockchainTestOverrides{
 		numNodes:    numNodes,
 		numAccounts: 8,
 		config:      config,
 		alloc:       alloc,
+		blockPeriod: &blockPeriod,
 	})
 	require.Nil(t, err)
-	ctx.Subscribe(t, func(ev *blockchain.ChainEvent) {
-		b := ev.Block
-		t.Logf("block[%3d] txs=%d mixHash=%x", b.NumberU64(), b.Transactions().Len(), b.Header().MixHash)
-	})
 	ctx.Start()
 	defer ctx.Cleanup()
 
-	// Pass the hardfork block, give each CN a chance to propose
+	if !fromGenesis {
+		// Wait for consensus start and deploy KIP113 before hardfork.
+		ctx.WaitBlock(t, 1)
+		_, actualKip113Addr := testRandao_deployKip113(t, ctx, owner)
+		assert.Equal(t, kip113Addr, actualKip113Addr)
+	}
+
+	// Pass the hardfork block, give each CN a chance to propose.
 	ctx.WaitBlock(t, forkNum.Uint64()+uint64(numNodes))
 
-	// Inspect the chain
+	// Inspect the chain.
 	testRandao_checkRegistry(t, ctx, owner.From, kip113Addr)
 	testRandao_checkKip113(t, ctx)
 	testRandao_checkKip114(t, ctx, randomAddr)
@@ -241,20 +226,21 @@ func testRandao_deployKip113(t *testing.T, ctx *blockchainTestContext, owner *bi
 		backend = backends.NewBlockchainContractBackend(chain, txpool, nil)
 	)
 
-	// Deploy implementation and proxy
-	implAddr, tx, _, err := testcontract.DeployKIP113Mock(owner, backend)
-	assert.Nil(t, err)
-	ctx.WaitTx(t, tx.Hash())
+	startNonce, err := backend.PendingNonceAt(context.Background(), owner.From)
+	require.NoError(t, err)
 
-	proxyAddr, tx, _, err := proxycontract.DeployERC1967Proxy(owner, backend, implAddr, initData)
-	assert.Nil(t, err)
-	ctx.WaitTx(t, tx.Hash())
+	// Send deploy/register txs with fixed nonces so they can be mined in a single block.
+	implAddr, implTx, _, err := testcontract.DeployKIP113Mock(randaoTxOpts(owner, startNonce, 8_000_000), backend)
+	require.NoError(t, err)
+
+	proxyAddr, proxyTx, _, err := proxycontract.DeployERC1967Proxy(randaoTxOpts(owner, startNonce+1, 2_000_000), backend, implAddr, initData)
+	require.NoError(t, err)
 
 	t.Logf("Kip113 impl=%s proxy=%s", implAddr.Hex(), proxyAddr.Hex())
 	kip113, _ := testcontract.NewKIP113Mock(proxyAddr, backend)
 
 	// Register node BLS public keys
-	var txs []*types.Transaction
+	txs := []*types.Transaction{implTx, proxyTx}
 	for i := 0; i < ctx.numNodes; i++ {
 		var (
 			addr  = ctx.accountAddrs[i]
@@ -264,10 +250,12 @@ func testRandao_deployKip113(t *testing.T, ctx *blockchainTestContext, owner *bi
 		)
 		t.Logf("node[%2d] addr=%x blsPub=%x", i, addr, pk)
 
-		tx, err := kip113.Register(owner, addr, pk, pop)
+		tx, err := kip113.Register(randaoTxOpts(owner, startNonce+2+uint64(i), 500_000), addr, pk, pop)
+		require.NoError(t, err)
 		txs = append(txs, tx)
-		assert.Nil(t, err)
 	}
+
+	// Wait for all txs after sending all of them.
 	for _, tx := range txs {
 		ctx.WaitTx(t, tx.Hash())
 	}
@@ -276,6 +264,13 @@ func testRandao_deployKip113(t *testing.T, ctx *blockchainTestContext, owner *bi
 	t.Logf("Kip113 getAllBlsInfo().length=%d", len(infos))
 
 	return kip113, proxyAddr
+}
+
+func randaoTxOpts(base *bind.TransactOpts, nonce uint64, gasLimit uint64) *bind.TransactOpts {
+	opts := *base
+	opts.Nonce = new(big.Int).SetUint64(nonce)
+	opts.GasLimit = gasLimit
+	return &opts
 }
 
 // Inspect the given chain for Registry contract

--- a/tests/state_migration_test.go
+++ b/tests/state_migration_test.go
@@ -44,15 +44,15 @@ func TestMigration_ContinuousRestartAndMigration(t *testing.T) {
 
 	stateTriePath := []byte("statetrie")
 
-	numTxs := []int{10, 100}
+	numTxs := []int{10, 40}
 	for i := range numTxs {
 		numTx := numTxs[i%len(numTxs)]
 		t.Log("attempt", strconv.Itoa(i), " : deployRandomTxs of", strconv.Itoa(numTx))
 		deployRandomTxs(t, node.TxPool(), chainID, richAccount, numTx)
-		time.Sleep(3 * time.Second) // wait until txpool is flushed
+		waitTxPoolDrained(t, node, 10*time.Second)
 
 		startMigration(t, node)
-		time.Sleep(1 * time.Second)
+		waitNextBlock(t, node, 5*time.Second)
 
 		t.Log("migration state before restart", node.ChainDB().InMigration())
 		fullNode, node = restartNode(t, fullNode, node, workspace, validator)
@@ -149,7 +149,7 @@ func TestMigration_StartMigrationByMiscDBOnRestart(t *testing.T) {
 
 	// size up state trie to be prepared for migration
 	deployRandomTxs(t, node.TxPool(), chainID, richAccount, 100)
-	time.Sleep(time.Second)
+	waitTxPoolDrained(t, node, 10*time.Second)
 
 	// set migration status in miscDB
 	migrationBlockNum := node.BlockChain().CurrentBlock().Header().Number.Uint64()
@@ -206,14 +206,7 @@ func TestMigration_RemoveOldDBOnRestart(t *testing.T) {
 	fullNode, node = restartNode(t, fullNode, node, workspace, validator)
 	miscDB = node.ChainDB().GetMiscDB()
 
-	time.Sleep(1 * time.Second)
-
-	dir, err := miscDB.Get(migrationOldDBPathKey)
-	assert.NoError(t, err)
-	assert.Equal(t, "", string(dir))
-
-	_, err = os.Stat(d)
-	assert.True(t, os.IsNotExist(err))
+	waitOldDBCleanup(t, miscDB, migrationOldDBPathKey, d, 5*time.Second)
 
 	stopNode(t, fullNode)
 }
@@ -222,7 +215,7 @@ func newSimpleBlockchain(t *testing.T, numAccounts int) (*node.Node, *cn.CN, *Te
 	t.Log("=========== create blockchain ==============")
 	fullNode, node, validator, chainID, workspace := newBlockchain(t, nil, nil)
 	richAccount, accounts, contractAccounts := createAccount(t, numAccounts, validator)
-	time.Sleep(5 * time.Second)
+	waitTxPoolDrained(t, node, 10*time.Second)
 
 	return fullNode, node, validator, chainID, workspace, richAccount, accounts, contractAccounts
 }
@@ -237,9 +230,12 @@ func startMigration(t *testing.T, node *cn.CN) {
 
 func restartNode(t *testing.T, fullNode *node.Node, node *cn.CN, workspace string, validator *TestAccountType) (*node.Node, *cn.CN) {
 	stopNode(t, fullNode)
-	time.Sleep(2 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 	newFullNode, newNode := startNode(t, workspace, validator)
-	time.Sleep(2 * time.Second)
+	current := newNode.BlockChain().CurrentHeader().Number.Uint64()
+	if head := waitBlock(newNode.BlockChain(), current+1); head == nil {
+		t.Fatal("node did not produce a new block after restart")
+	}
 
 	return newFullNode, newNode
 }
@@ -263,8 +259,60 @@ func stopNode(t *testing.T, fullNode *node.Node) {
 }
 
 func waitMigrationEnds(t *testing.T, node *cn.CN) {
-	for node.ChainDB().InMigration() {
-		t.Log("state trie migration is processing; sleep for a second before a new migration")
-		time.Sleep(time.Second)
+	waitUntil(t, 30*time.Second, 200*time.Millisecond, func() bool {
+		return !node.ChainDB().InMigration()
+	}, "state trie migration did not complete within timeout")
+}
+
+func waitNextBlock(t *testing.T, node *cn.CN, timeout time.Duration) {
+	current := node.BlockChain().CurrentHeader().Number.Uint64()
+	waitUntil(t, timeout, 100*time.Millisecond, func() bool {
+		return node.BlockChain().CurrentHeader().Number.Uint64() > current
+	}, "new block was not mined within timeout")
+}
+
+func waitTxPoolDrained(t *testing.T, node *cn.CN, timeout time.Duration) {
+	var pending, queued int
+	waitUntil(t, timeout, 100*time.Millisecond, func() bool {
+		pending, queued = node.TxPool().Stats()
+		return pending == 0 && queued == 0
+	}, "txpool was not drained within timeout")
+	if pending != 0 || queued != 0 {
+		t.Fatalf("txpool not drained in time (pending=%d queued=%d)", pending, queued)
+	}
+}
+
+func waitOldDBCleanup(t *testing.T, miscDB database.Database, migrationOldDBPathKey []byte, oldPath string, timeout time.Duration) {
+	var (
+		dir []byte
+		err error
+	)
+	waitUntil(t, timeout, 100*time.Millisecond, func() bool {
+		dir, err = miscDB.Get(migrationOldDBPathKey)
+		if err != nil || string(dir) != "" {
+			return false
+		}
+		_, err = os.Stat(oldPath)
+		return os.IsNotExist(err)
+	}, "old db cleanup did not finish within timeout")
+	if err != nil && !os.IsNotExist(err) {
+		assert.NoError(t, err)
+	}
+	if err == nil {
+		t.Fatalf("old db path still exists: %s", oldPath)
+	}
+}
+
+func waitUntil(t *testing.T, timeout, interval time.Duration, condition func() bool, timeoutMessage string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if condition() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal(timeoutMessage)
+		}
+		time.Sleep(interval)
 	}
 }

--- a/tests/testutil_blockchain_test.go
+++ b/tests/testutil_blockchain_test.go
@@ -54,6 +54,7 @@ type blockchainTestContext struct {
 	accounts     []*bind.TransactOpts // accounts[0:numNodes] are node keys
 	config       *params.ChainConfig
 	genesis      *blockchain.Genesis
+	blockPeriod  *uint64
 
 	workspace string
 	nodes     []*blockchainTestNode
@@ -70,6 +71,7 @@ type blockchainTestOverrides struct {
 	numAccounts int                     // default: numNodes
 	config      *params.ChainConfig     // default: blockchainTestChainConfig
 	alloc       blockchain.GenesisAlloc // default: 10_000_000 KAIA for each account
+	blockPeriod *uint64                 // default: nil (use CN default)
 }
 
 var blockchainTestChainConfig = &params.ChainConfig{
@@ -117,7 +119,8 @@ func newBlockchainTestContext(overrides *blockchainTestOverrides) (*blockchainTe
 	}
 
 	ctx := &blockchainTestContext{
-		numNodes: overrides.numNodes,
+		numNodes:    overrides.numNodes,
+		blockPeriod: overrides.blockPeriod,
 	}
 	ctx.setAccounts(overrides.numAccounts)
 	ctx.setConfig(overrides.config)
@@ -231,6 +234,9 @@ func (ctx *blockchainTestContext) setNode(nodeIndex int) (err error) {
 	cnConf.NetworkId = ctx.config.ChainID.Uint64()
 	cnConf.Genesis = ctx.genesis
 	cnConf.Rewardbase = ctx.accountAddrs[nodeIndex]
+	if ctx.blockPeriod != nil {
+		cnConf.Istanbul.BlockPeriod = *ctx.blockPeriod
+	}
 	cnConf.SingleDB = false       // identical to regular CN
 	cnConf.NumStateTrieShards = 4 // identical to regular CN
 	cnConf.NoPruning = true       // archive mode

--- a/tests/tx_gas_calculation_test.go
+++ b/tests/tx_gas_calculation_test.go
@@ -98,8 +98,6 @@ func TestGasCalculation(t *testing.T) {
 	}{
 		{"KaiaLegacy", genKaiaLegacyAccount(t)},
 		{"Public", genPublicAccount(t)},
-		{"MultiSig", genMultiSigAccount(t)},
-		{"RoleBasedWithPublic", genRoleBasedWithPublicAccount(t)},
 		{"RoleBasedWithMultiSig", genRoleBasedWithMultiSigAccount(t)},
 	}
 


### PR DESCRIPTION
## Proposed changes

This PR reduces the `cmd/utils/nodecmd`, `datasync`, `node/sc`, `tests` directory ci test running time. Also, it reorganizes the test running jobs of `test-pr-workflow`. In addition, `cmd/utils/nodecmd` was skipped in ci, so this PR enables the nodecmd package tests.

dev
* longest ci job running time: 13m 46s 
* total ci running time: 53.2 minute 
* total local `go test ./...` running time: 11m 54s

PR
* longest ci job running time: 8m 20s  (40% decreased)
* total ci running time: 40m 22s (25% decreased)
* total local `go test ./...` running time: 8m 10s  (28% decreased)

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
