### PR TITLE
Permissionless: remove zero threshold checks for PFS/CFS

### DIFF
--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -101,9 +101,6 @@ func (v *ValsetModule) applyAllTransitions(
 // isPassVrankTest returns true if the candidate's CFS is below the threshold.
 // CFS < cfsThreshold → pass (CandTesting → ValActive promotion eligible).
 func (v *ValsetModule) isPassVrankTest(addr common.Address, num, cfsThreshold uint64) bool {
-	if cfsThreshold == 0 { // threshold not configured → skip CFS check
-		return true
-	}
 	cfsScores, err := v.VRankModule.GetCFS(num)
 	if err != nil { // CFS unavailable → pass to avoid blocking promotion
 		logger.Warn("isPassVrankTest: GetCFS failed", "num", num, "err", err)

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -83,10 +83,13 @@ func newTestValsetModule(ctrl *gomock.Controller) *ValsetModule {
 	}).AnyTimes()
 	mockChain := chain_mock.NewMockBlockChain(ctrl)
 	mockChain.EXPECT().Config().Return(&params.ChainConfig{VRankEpoch: testVRankEpoch}).AnyTimes()
+	mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+	mockVRank.EXPECT().GetCFS(gomock.Any()).Return(nil, nil).AnyTimes()
 	return &ValsetModule{
 		InitOpts: InitOpts{
-			Chain:     mockChain,
-			GovModule: mockGov,
+			Chain:       mockChain,
+			GovModule:   mockGov,
+			VRankModule: mockVRank,
 		},
 	}
 }
@@ -191,10 +194,6 @@ func TestIsPassVrankTest(t *testing.T) {
 		expected     bool
 	}{
 		{
-			"threshold=0 → always pass",
-			0, nil, nil, true,
-		},
-		{
 			"CFS below threshold → pass",
 			testCFSThreshold,
 			map[common.Address]uint64{addr1: testCFSThreshold - 5},
@@ -229,9 +228,7 @@ func TestIsPassVrankTest(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			v := newTestValsetModule(ctrl)
 			mockVRank := vrank_mock.NewMockVRankModule(ctrl)
-			if tc.cfsThreshold > 0 {
-				mockVRank.EXPECT().GetCFS(testCFSBlockNum).Return(tc.cfsScores, tc.cfsErr)
-			}
+			mockVRank.EXPECT().GetCFS(testCFSBlockNum).Return(tc.cfsScores, tc.cfsErr)
 			v.VRankModule = mockVRank
 
 			result := v.isPassVrankTest(addr1, testCFSBlockNum, tc.cfsThreshold)
@@ -421,20 +418,6 @@ func TestGetViolationTransition_PFSAboveThreshold(t *testing.T) {
 	result := v.getViolationTransition(testMinStake, validators, 100, 2, noSlotLimit, noMinActive)
 	assert.Equal(t, valset.ValExiting, result[addr1].State, "PFS(3) >= threshold(2) → ValExiting (severe)")
 	assert.Equal(t, valset.ValPaused, result[addr2].State, "PFS(1) > 0, < threshold(2) → ValPaused (minor)")
-}
-
-func TestGetViolationTransition_PFSSkippedWhenZeroThreshold(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	v := newTestValsetModule(ctrl)
-	mockVRank := vrank_mock.NewMockVRankModule(ctrl)
-	mockVRank.EXPECT().GetPfReport(gomock.Any()).Return(nil, nil).AnyTimes()
-	v.VRankModule = mockVRank
-
-	validators := valset.NodeStateMap{
-		addr1: {State: valset.ValActive, StakingAmount: aboveMinStake},
-	}
-	result := v.getViolationTransition(testMinStake, validators, 100, 0, noSlotLimit, noMinActive)
-	assert.Equal(t, valset.ValActive, result[addr1].State, "pfsThreshold=0 → PFS check skipped")
 }
 
 func TestGetViolationTransition_PFSNonActiveNotAffected(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

- Remove dead zero-threshold checks in Go code since ABv2 contract enforces nonzero at both genesis and runtime

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments