### PR TITLE
Permissionless: pre-deploy EIP-2935 history storage in genesis

### DIFF
--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -849,6 +849,15 @@ func Gen(ctx *cli.Context) error {
 	}
 	genesisJson.Config.BlobScheduleConfig = params.DefaultBlobSchedule
 
+	// EIP-2935: pre-deploy history storage contract when Prague is active from genesis
+	if pragueBlock := ctx.Int64(pragueCompatibleBlockNumberFlag.Name); pragueBlock == 0 {
+		genesisJson.Alloc[params.HistoryStorageAddress] = blockchain.GenesisAccount{
+			Nonce:   1,
+			Code:    params.HistoryStorageCode,
+			Balance: common.Big0,
+		}
+	}
+
 	genesisJsonBytes, _ = json.MarshalIndent(genesisJson, "", "    ")
 	genValidatorKeystore(privKeys)
 	lastIssuedPortNum = uint16(ctx.Int(p2pPortFlag.Name))


### PR DESCRIPTION
## Proposed changes

- Pre-deploy EIP-2935 history storage contract in genesis alloc when Prague fork is active from block 0
- Follows the same pattern as [go-ethereum](https://github.com/ethereum/go-ethereum/blob/master/core/genesis.go#L716)

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

EIP-2935 support was added in the Prague fork implementation but the genesis pre-deployment was missing. Previously required manual deployment via script.