### PR TITLE
Permissionless: update mock and test for new multicall fields

### DIFF
--- a/contracts_permissionless/contracts/testing/AddressBookV2Mock.sol
+++ b/contracts_permissionless/contracts/testing/AddressBookV2Mock.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.18;
 
 import {Profile, State} from "../types/Node.sol";
+import {SlotMath} from "../libraries/SlotMath.sol";
 
 /// @title AddressBookV2Mock
-/// @notice Minimal mock for testing multiCallStakingInfoPermissionless
+/// @notice Minimal mock for testing multiCallStakingInfoPermissionless and multiCallNodeStatesPermissionless
 contract AddressBookV2Mock {
     Profile[] private profiles;
     address public kefAddress;
@@ -14,6 +15,9 @@ contract AddressBookV2Mock {
     uint256 public idleTimeout;
     uint256 public maxValidatorCount;
     uint256 public maxReadyCandidateCount;
+    uint256 public pfsThreshold;
+    uint256 public cfsThreshold;
+    uint256 public slotFactor;
 
     function addProfile(
         address nodeId,
@@ -55,5 +59,30 @@ contract AddressBookV2Mock {
 
     function getMaxCounts() external view returns (uint256, uint256) {
         return (maxValidatorCount, maxReadyCandidateCount);
+    }
+
+    function setThresholds(uint256 _pfsThreshold, uint256 _cfsThreshold) external {
+        pfsThreshold = _pfsThreshold;
+        cfsThreshold = _cfsThreshold;
+    }
+
+    function setSlotFactor(uint256 _slotFactor) external {
+        slotFactor = _slotFactor;
+    }
+
+    function getPfsThreshold() external view returns (uint256) {
+        return pfsThreshold;
+    }
+
+    function getCfsThreshold() external view returns (uint256) {
+        return cfsThreshold;
+    }
+
+    function getSlotFactor() external view returns (uint256) {
+        return slotFactor;
+    }
+
+    function getSlotLimits() external view returns (uint256 maxSlotAvailable, uint256 minActiveCount) {
+        return (SlotMath.maxSlotAvailable(slotFactor), SlotMath.minActiveCount(slotFactor));
     }
 }

--- a/contracts_permissionless/test/MultiCall/multicall.test.ts
+++ b/contracts_permissionless/test/MultiCall/multicall.test.ts
@@ -91,15 +91,24 @@ describe("Multicall permissionless", function () {
     expect(retKpf.toLowerCase()).to.equal("0x000000000000000000000000000000000000aaa3");
   });
 
-  it("multiCallNodeStatesPermissionless returns profiles, amounts, timeouts, maxCounts", async function () {
+  it("multiCallNodeStatesPermissionless returns profiles, amounts, timeouts, maxCounts, thresholds, slotFactor, slotLimits", async function () {
     const { abv2, multiCall, cnStakingAddrs, expectedAmounts } = await loadFixture(deployMulticallFixture);
 
-    // Set timeouts and max counts
+    // Set timeouts, max counts, thresholds, and slot factor
     await abv2.setTimeouts(28800, 2592000); // 8h, 30d in seconds
     await abv2.setMaxCounts(50, 100);
+    await abv2.setThresholds(2, 300); // pfsThreshold=2, cfsThreshold=300
+    await abv2.setSlotFactor(10); // slotFactor=10 → f(10)=3, maxSlot=1, minActive=8
 
     const result = await multiCall.multiCallNodeStatesPermissionless();
-    const [profiles, stakingAmounts, retPauseTimeout, retIdleTimeout, retMaxValCount, retMaxReadyCandCount] = result;
+    const [
+      profiles, stakingAmounts,
+      retPauseTimeout, retIdleTimeout,
+      retMaxValCount, retMaxReadyCandCount,
+      retPfsThreshold, retCfsThreshold,
+      retSlotFactor,
+      retMaxSlotAvailable, retMinActiveCount,
+    ] = result;
 
     expect(profiles.length).to.equal(3);
     for (let i = 0; i < 3; i++) {
@@ -111,5 +120,11 @@ describe("Multicall permissionless", function () {
     expect(retIdleTimeout).to.equal(2592000);
     expect(retMaxValCount).to.equal(50);
     expect(retMaxReadyCandCount).to.equal(100);
+    expect(retPfsThreshold).to.equal(2);
+    expect(retCfsThreshold).to.equal(300);
+    expect(retSlotFactor).to.equal(10);
+    // SlotMath for n=10: f(10)=3, maxSlotAvailable=max(1,3/2)=1, minActiveCount=max(7,8)=8
+    expect(retMaxSlotAvailable).to.equal(1);
+    expect(retMinActiveCount).to.equal(8);
   });
 });


### PR DESCRIPTION
## Proposed changes

Updates `AddressBookV2Mock` and the multicall test to cover new fields returned by `multiCallNodeStatesPermissionless`: `pfsThreshold`, `cfsThreshold`, `slotFactor`, and derived slot limits (`maxSlotAvailable`, `minActiveCount`).

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA`
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

No production code changes; mock and test only.