### PR TITLE
permless: fallback when `len(ValActive)` becomes zero

### DIFF
--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -18,9 +18,7 @@ package impl
 
 import (
 	"fmt"
-	"maps"
 	"math/big"
-	"slices"
 	"time"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
@@ -96,16 +94,6 @@ func (v *ValsetModule) applyAllTransitions(
 	newValidators = v.getTimeoutTransition(newValidators, idleTimeout, pauseTimeout, blockTime)
 	if v.isVrankEpoch(num) {
 		newValidators = v.getEpochTransition(minStake, newValidators, idleTimeout, int(maxValCount), blockTime, header.Number.Uint64(), cfsThreshold, slotFactor)
-
-		hasActive := slices.ContainsFunc(slices.Collect(maps.Values(newValidators)), func(val *valset.ValidatorState) bool {
-			return val != nil && val.State == valset.ValActive
-		})
-		if !hasActive {
-			// Fallback: epoch transition produced no ValActive (e.g. all validators dropped below minStake).
-			// Use epoch-1 staking competition group as the committee, regardless of stake.
-			logger.Warn("Epoch transition produced no ValActive; falling back to epoch-1 committee", "num", num)
-			newValidators = v.getFallbackTransition(validators, blockTime, idleTimeout, num, cfsThreshold, slotFactor, int(maxValCount))
-		}
 	}
 	return newValidators, nil
 }

--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -104,7 +104,7 @@ func (v *ValsetModule) applyAllTransitions(
 			// Fallback: epoch transition produced no ValActive (e.g. all validators dropped below minStake).
 			// Use epoch-1 staking competition group as the committee, regardless of stake.
 			logger.Warn("Epoch transition produced no ValActive; falling back to epoch-1 committee", "num", num)
-			newValidators = v.getFallbackTransition(validators, num, cfsThreshold, slotFactor)
+			newValidators = v.getFallbackTransition(validators, num, cfsThreshold, slotFactor, int(maxValCount))
 		}
 	}
 	return newValidators, nil

--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -104,7 +104,7 @@ func (v *ValsetModule) applyAllTransitions(
 			// Fallback: epoch transition produced no ValActive (e.g. all validators dropped below minStake).
 			// Use epoch-1 staking competition group as the committee, regardless of stake.
 			logger.Warn("Epoch transition produced no ValActive; falling back to epoch-1 committee", "num", num)
-			newValidators = v.getFallbackTransition(validators, num, cfsThreshold, slotFactor, int(maxValCount))
+			newValidators = v.getFallbackTransition(validators, blockTime, idleTimeout, num, cfsThreshold, slotFactor, int(maxValCount))
 		}
 	}
 	return newValidators, nil

--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -18,7 +18,9 @@ package impl
 
 import (
 	"fmt"
+	"maps"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
@@ -94,6 +96,16 @@ func (v *ValsetModule) applyAllTransitions(
 	newValidators = v.getTimeoutTransition(newValidators, idleTimeout, pauseTimeout, blockTime)
 	if v.isVrankEpoch(num) {
 		newValidators = v.getEpochTransition(minStake, newValidators, idleTimeout, int(maxValCount), blockTime, header.Number.Uint64(), cfsThreshold, slotFactor)
+
+		hasActive := slices.ContainsFunc(slices.Collect(maps.Values(newValidators)), func(val *valset.ValidatorState) bool {
+			return val != nil && val.State == valset.ValActive
+		})
+		if !hasActive {
+			// Fallback: epoch transition produced no ValActive (e.g. all validators dropped below minStake).
+			// Use epoch-1 staking competition group as the committee, regardless of stake.
+			logger.Warn("Epoch transition produced no ValActive; falling back to epoch-1 committee", "num", num)
+			newValidators = v.getFallbackTransition(validators, num, cfsThreshold, slotFactor)
+		}
 	}
 	return newValidators, nil
 }

--- a/kaiax/valset/impl/state_transition_getter.go
+++ b/kaiax/valset/impl/state_transition_getter.go
@@ -93,24 +93,26 @@ func (v *ValsetModule) getEpochTransition(
 			potentialActiveVal.IdleTimeout = now.Add(idleTimeout)
 		}
 	}
+	return newValidators
+}
 
-	// Fallback: if no validator ended up ValActive (e.g., all top competitors were ValPaused),
-	// promote the entire staking-competition group to ValActive to preserve len(ValActive)>0.
-	// The group is guaranteed non-empty because intra-epoch checks ensure len(ValActive)>=1 at epoch-1.
-	hasActive := slices.ContainsFunc(activeValCompetitors, func(sv sortableValidator) bool {
-		// Optimization: check `activeValCompetitors` instead of `newValidators` — after the loop above,
-		// any ValActive in `newValidators` must have come through `activeValCompetitors`.
-		return sv.State == valset.ValActive
-	})
-	if !hasActive {
-		logger.Warn("All top competitors are ValPaused; force-promoting to ValActive", "count", min(maxValidatorCount, len(activeValCompetitors)))
-		for idx, sv := range activeValCompetitors {
-			if idx >= maxValidatorCount {
-				break
+// getFallbackTransition is the last-resort committee fallback when getEpochTransition produces no ValActive.
+// It promotes epoch-1's staking competition group members (CandTesting/ValReady/ValActive/ValPaused)
+// to ValActive regardless of stake. CandTesting validators are still subject to the vrank test.
+func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, num, cfsThreshold, slotFactor uint64) valset.NodeStateMap {
+	newValidators := validators.Copy()
+	for addr, val := range newValidators {
+		switch val.State {
+		case valset.CandTesting:
+			if v.isPassVrankTest(addr, num, cfsThreshold, slotFactor) {
+				val.State = valset.ValActive
+				val.IdleTimeout = time.Time{}
+				val.PausedTimeout = time.Time{}
 			}
-			sv.State = valset.ValActive
-			sv.IdleTimeout = time.Time{}
-			sv.PausedTimeout = time.Time{}
+		case valset.ValReady, valset.ValActive, valset.ValPaused:
+			val.State = valset.ValActive
+			val.IdleTimeout = time.Time{}
+			val.PausedTimeout = time.Time{}
 		}
 	}
 	return newValidators

--- a/kaiax/valset/impl/state_transition_getter.go
+++ b/kaiax/valset/impl/state_transition_getter.go
@@ -54,6 +54,29 @@ func (v *ValsetModule) getEpochTransition(
 	now time.Time,
 	num, cfsThreshold, slotFactor uint64,
 ) valset.NodeStateMap {
+	result := v.doEpochTransition(validators, minStake, idleTimeout, maxValidatorCount, now, num, cfsThreshold, slotFactor, false)
+	for _, val := range result {
+		if val != nil && val.State == valset.ValActive {
+			return result
+		}
+	}
+
+	logger.Warn("Epoch transition produced no ValActive; retrying with staking filter lifted", "num", num)
+	return v.doEpochTransition(validators, minStake, idleTimeout, maxValidatorCount, now, num, cfsThreshold, slotFactor, true)
+}
+
+// doEpochTransition applies all epoch state transitions (T1–T4) and the staking competition cap.
+// When fallback is true, the minStake guard (T3b) is skipped so all competition-group
+// members are eligible regardless of stake.
+func (v *ValsetModule) doEpochTransition(
+	validators valset.NodeStateMap,
+	minStake uint64,
+	idleTimeout time.Duration,
+	maxValidatorCount int,
+	now time.Time,
+	num, cfsThreshold, slotFactor uint64,
+	fallback bool, // when true, collect `activeValCompetitors` regardless of stake amount
+) valset.NodeStateMap {
 	var (
 		newValidators        = validators.Copy()
 		activeValCompetitors []sortableValidator
@@ -71,7 +94,7 @@ func (v *ValsetModule) getEpochTransition(
 			}
 		case valset.CandTesting:
 			if v.isPassVrankTest(addr, num, cfsThreshold, slotFactor) {
-				if val.StakingAmount >= minStake {
+				if fallback || val.StakingAmount >= minStake {
 					activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val}) // T3a
 				} else {
 					val.State = valset.ValInactive // T3b
@@ -81,7 +104,7 @@ func (v *ValsetModule) getEpochTransition(
 				val.State = valset.Registered // T2
 			}
 		case valset.ValReady, valset.ValActive, valset.ValPaused:
-			if val.StakingAmount >= minStake {
+			if fallback || val.StakingAmount >= minStake {
 				activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val}) // T3a
 			} else {
 				val.State = valset.ValInactive // T3b
@@ -97,37 +120,6 @@ func (v *ValsetModule) getEpochTransition(
 				potentialActiveVal.IdleTimeout = time.Time{}
 				potentialActiveVal.PausedTimeout = time.Time{}
 			}
-		} else {
-			potentialActiveVal.State = valset.ValInactive
-			potentialActiveVal.IdleTimeout = now.Add(idleTimeout)
-		}
-	}
-	return newValidators
-}
-
-// getFallbackTransition is the last-resort committee fallback when getEpochTransition produces no ValActive.
-// It promotes the top maxValidatorCount epoch-1 competition group members (sorted by stake desc, address asc)
-// to ValActive regardless of stake. CandTesting validators are still subject to the vrank test.
-func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, now time.Time, idleTimeout time.Duration, num, cfsThreshold, slotFactor uint64, maxValidatorCount int) valset.NodeStateMap {
-	newValidators := validators.Copy()
-
-	var activeValCompetitors []sortableValidator
-	for addr, val := range newValidators {
-		switch val.State {
-		case valset.CandTesting:
-			if v.isPassVrankTest(addr, num, cfsThreshold, slotFactor) {
-				activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val})
-			}
-		case valset.ValReady, valset.ValActive, valset.ValPaused:
-			activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val})
-		}
-	}
-	sortValidatorsByRank(activeValCompetitors)
-	for idx, potentialActiveVal := range activeValCompetitors {
-		if idx < maxValidatorCount {
-			potentialActiveVal.State = valset.ValActive
-			potentialActiveVal.IdleTimeout = time.Time{}
-			potentialActiveVal.PausedTimeout = time.Time{}
 		} else {
 			potentialActiveVal.State = valset.ValInactive
 			potentialActiveVal.IdleTimeout = now.Add(idleTimeout)

--- a/kaiax/valset/impl/state_transition_getter.go
+++ b/kaiax/valset/impl/state_transition_getter.go
@@ -93,6 +93,26 @@ func (v *ValsetModule) getEpochTransition(
 			potentialActiveVal.IdleTimeout = now.Add(idleTimeout)
 		}
 	}
+
+	// Fallback: if no validator ended up ValActive (e.g., all top competitors were ValPaused),
+	// promote the entire staking-competition group to ValActive to preserve len(ValActive)>0.
+	// The group is guaranteed non-empty because intra-epoch checks ensure len(ValActive)>=1 at epoch-1.
+	hasActive := slices.ContainsFunc(activeValCompetitors, func(sv sortableValidator) bool {
+		// Optimization: check `activeValCompetitors` instead of `newValidators` — after the loop above,
+		// any ValActive in `newValidators` must have come through `activeValCompetitors`.
+		return sv.State == valset.ValActive
+	})
+	if !hasActive {
+		logger.Warn("All top competitors are ValPaused; force-promoting to ValActive", "count", min(maxValidatorCount, len(activeValCompetitors)))
+		for idx, sv := range activeValCompetitors {
+			if idx >= maxValidatorCount {
+				break
+			}
+			sv.State = valset.ValActive
+			sv.IdleTimeout = time.Time{}
+			sv.PausedTimeout = time.Time{}
+		}
+	}
 	return newValidators
 }
 

--- a/kaiax/valset/impl/state_transition_getter.go
+++ b/kaiax/valset/impl/state_transition_getter.go
@@ -97,23 +97,35 @@ func (v *ValsetModule) getEpochTransition(
 }
 
 // getFallbackTransition is the last-resort committee fallback when getEpochTransition produces no ValActive.
-// It promotes epoch-1's staking competition group members (CandTesting/ValReady/ValActive/ValPaused)
+// It promotes the top maxValidatorCount epoch-1 competition group members (sorted by stake desc, address asc)
 // to ValActive regardless of stake. CandTesting validators are still subject to the vrank test.
-func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, num, cfsThreshold, slotFactor uint64) valset.NodeStateMap {
+func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, num, cfsThreshold, slotFactor uint64, maxValidatorCount int) valset.NodeStateMap {
 	newValidators := validators.Copy()
+
+	var potentialActiveVal []sortableValidator
 	for addr, val := range newValidators {
 		switch val.State {
 		case valset.CandTesting:
 			if v.isPassVrankTest(addr, num, cfsThreshold, slotFactor) {
-				val.State = valset.ValActive
-				val.IdleTimeout = time.Time{}
-				val.PausedTimeout = time.Time{}
+				potentialActiveVal = append(potentialActiveVal, sortableValidator{addr, val})
 			}
 		case valset.ValReady, valset.ValActive, valset.ValPaused:
-			val.State = valset.ValActive
-			val.IdleTimeout = time.Time{}
-			val.PausedTimeout = time.Time{}
+			potentialActiveVal = append(potentialActiveVal, sortableValidator{addr, val})
 		}
+	}
+	slices.SortFunc(potentialActiveVal, func(a, b sortableValidator) int {
+		return cmp.Or(
+			cmp.Compare(b.StakingAmount, a.StakingAmount),
+			bytes.Compare(a.addr[:], b.addr[:]),
+		)
+	})
+	for i, sv := range potentialActiveVal {
+		if i >= maxValidatorCount {
+			break
+		}
+		sv.State = valset.ValActive
+		sv.IdleTimeout = time.Time{}
+		sv.PausedTimeout = time.Time{}
 	}
 	return newValidators
 }

--- a/kaiax/valset/impl/state_transition_getter.go
+++ b/kaiax/valset/impl/state_transition_getter.go
@@ -31,6 +31,20 @@ type sortableValidator struct {
 	*valset.ValidatorState
 }
 
+// compareValidatorRank defines the canonical staking competition order:
+// higher stake first; equal stake breaks ties by address ascending.
+func compareValidatorRank(a, b sortableValidator) int {
+	return cmp.Or(
+		cmp.Compare(b.StakingAmount, a.StakingAmount),
+		bytes.Compare(a.addr[:], b.addr[:]),
+	)
+}
+
+// sortValidatorsByRank sorts activeValCompetitors in place by staking competition order.
+func sortValidatorsByRank(activeValCompetitors []sortableValidator) {
+	slices.SortFunc(activeValCompetitors, compareValidatorRank)
+}
+
 // getEpochTransition returns new validators after applying epoch transition
 func (v *ValsetModule) getEpochTransition(
 	minStake uint64,
@@ -75,12 +89,7 @@ func (v *ValsetModule) getEpochTransition(
 			}
 		}
 	}
-	slices.SortFunc(activeValCompetitors, func(a, b sortableValidator) int {
-		return cmp.Or(
-			cmp.Compare(b.StakingAmount, a.StakingAmount),
-			bytes.Compare(a.addr[:], b.addr[:]), // tie-breaking: address order
-		)
-	})
+	sortValidatorsByRank(activeValCompetitors)
 	for idx, potentialActiveVal := range activeValCompetitors {
 		if idx < maxValidatorCount {
 			if potentialActiveVal.State != valset.ValPaused {
@@ -99,7 +108,7 @@ func (v *ValsetModule) getEpochTransition(
 // getFallbackTransition is the last-resort committee fallback when getEpochTransition produces no ValActive.
 // It promotes the top maxValidatorCount epoch-1 competition group members (sorted by stake desc, address asc)
 // to ValActive regardless of stake. CandTesting validators are still subject to the vrank test.
-func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, num, cfsThreshold, slotFactor uint64, maxValidatorCount int) valset.NodeStateMap {
+func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, now time.Time, idleTimeout time.Duration, num, cfsThreshold, slotFactor uint64, maxValidatorCount int) valset.NodeStateMap {
 	newValidators := validators.Copy()
 
 	var activeValCompetitors []sortableValidator
@@ -113,19 +122,16 @@ func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, num
 			activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val})
 		}
 	}
-	slices.SortFunc(activeValCompetitors, func(a, b sortableValidator) int {
-		return cmp.Or(
-			cmp.Compare(b.StakingAmount, a.StakingAmount),
-			bytes.Compare(a.addr[:], b.addr[:]), // tie-breaking: address order
-		)
-	})
+	sortValidatorsByRank(activeValCompetitors)
 	for idx, potentialActiveVal := range activeValCompetitors {
-		if idx >= maxValidatorCount {
-			break
+		if idx < maxValidatorCount {
+			potentialActiveVal.State = valset.ValActive
+			potentialActiveVal.IdleTimeout = time.Time{}
+			potentialActiveVal.PausedTimeout = time.Time{}
+		} else {
+			potentialActiveVal.State = valset.ValInactive
+			potentialActiveVal.IdleTimeout = now.Add(idleTimeout)
 		}
-		potentialActiveVal.State = valset.ValActive
-		potentialActiveVal.IdleTimeout = time.Time{}
-		potentialActiveVal.PausedTimeout = time.Time{}
 	}
 	return newValidators
 }

--- a/kaiax/valset/impl/state_transition_getter.go
+++ b/kaiax/valset/impl/state_transition_getter.go
@@ -102,30 +102,30 @@ func (v *ValsetModule) getEpochTransition(
 func (v *ValsetModule) getFallbackTransition(validators valset.NodeStateMap, num, cfsThreshold, slotFactor uint64, maxValidatorCount int) valset.NodeStateMap {
 	newValidators := validators.Copy()
 
-	var potentialActiveVal []sortableValidator
+	var activeValCompetitors []sortableValidator
 	for addr, val := range newValidators {
 		switch val.State {
 		case valset.CandTesting:
 			if v.isPassVrankTest(addr, num, cfsThreshold, slotFactor) {
-				potentialActiveVal = append(potentialActiveVal, sortableValidator{addr, val})
+				activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val})
 			}
 		case valset.ValReady, valset.ValActive, valset.ValPaused:
-			potentialActiveVal = append(potentialActiveVal, sortableValidator{addr, val})
+			activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val})
 		}
 	}
-	slices.SortFunc(potentialActiveVal, func(a, b sortableValidator) int {
+	slices.SortFunc(activeValCompetitors, func(a, b sortableValidator) int {
 		return cmp.Or(
 			cmp.Compare(b.StakingAmount, a.StakingAmount),
-			bytes.Compare(a.addr[:], b.addr[:]),
+			bytes.Compare(a.addr[:], b.addr[:]), // tie-breaking: address order
 		)
 	})
-	for i, sv := range potentialActiveVal {
-		if i >= maxValidatorCount {
+	for idx, potentialActiveVal := range activeValCompetitors {
+		if idx >= maxValidatorCount {
 			break
 		}
-		sv.State = valset.ValActive
-		sv.IdleTimeout = time.Time{}
-		sv.PausedTimeout = time.Time{}
+		potentialActiveVal.State = valset.ValActive
+		potentialActiveVal.IdleTimeout = time.Time{}
+		potentialActiveVal.PausedTimeout = time.Time{}
 	}
 	return newValidators
 }

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -203,11 +203,11 @@ func TestGetFallbackTransition(t *testing.T) {
 	// maxValidatorCount=3: top 3 are addr3, addr2, addr1 → ValActive; addr4 stays ValPaused.
 	result := v.getFallbackTransition(validators, 0, 0, 0, 3)
 
-	assert.Equal(t, valset.ValActive, result[addr3].State)
-	assert.Equal(t, valset.ValActive, result[addr2].State)
 	assert.Equal(t, valset.ValActive, result[addr1].State) // CandTesting passes vrank (nil scores)
-	assert.Equal(t, valset.ValPaused, result[addr4].State) // outside cap, unchanged
-	assert.Equal(t, valset.Registered, result[addr5].State) // non-competition, unchanged
+	assert.Equal(t, valset.ValActive, result[addr2].State)
+	assert.Equal(t, valset.ValActive, result[addr3].State)
+	assert.Equal(t, valset.ValPaused, result[addr4].State)           // outside cap, unchanged
+	assert.Equal(t, valset.Registered, result[addr5].State)          // non-competition, unchanged
 	assert.True(t, result[addr4].PausedTimeout.Equal(pausedTimeout)) // timeout preserved
 	// Input not mutated.
 	assert.Equal(t, valset.ValPaused, validators[addr4].State)

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -63,7 +63,7 @@ const (
 
 	// noSlotLimit disables slot checks in tests that don't test slot math.
 	noSlotLimit = uint64(100)
-	noMinActive = uint64(0)
+	noMinActive = uint64(1)
 )
 
 var (
@@ -98,7 +98,7 @@ func newTestValsetModule(ctrl *gomock.Controller) *ValsetModule {
 // TestGetEpochTransition
 // ============================================================
 
-func TestGetEpochTransition_StateTransitions(t *testing.T) {
+func TestDoEpochTransition_StateTransitions(t *testing.T) {
 	testcases := []struct {
 		name          string
 		inputState    valset.State
@@ -126,7 +126,7 @@ func TestGetEpochTransition_StateTransitions(t *testing.T) {
 			validators := valset.NodeStateMap{
 				addr1: {State: tc.inputState, StakingAmount: tc.stakingAmount},
 			}
-			result := v.getEpochTransition(testMinStake, validators, testIdleTimeout, testMaxValCount, testBlockTime, 0, 0, 0)
+			result := v.doEpochTransition(validators, testMinStake, testIdleTimeout, testMaxValCount, testBlockTime, 0, 0, 0, false)
 			assert.Equal(t, tc.expectedState, result[addr1].State)
 			if tc.expectTimeout {
 				assert.False(t, result[addr1].IdleTimeout.IsZero())
@@ -182,33 +182,32 @@ func TestGetEpochTransition_DoesNotMutateInput(t *testing.T) {
 }
 
 // ============================================================
-// TestGetFallbackTransition
+// TestGetEpochTransition_Fallback
 // ============================================================
 
-func TestGetFallbackTransition(t *testing.T) {
+func TestGetEpochTransition_Fallback(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	v := newTestValsetModule(ctrl) // mockVRank returns nil scores → isPassVrankTest passes
 
-	pausedTimeout := testBlockTime.Add(8 * time.Hour)
-	// Staking amounts differ so the cap selects by stake rank.
-	// Rank: addr3(highStake) > addr2(midStake) > addr1,addr4(lowStake, addr1<addr4 by address)
+	// All competition members are below minStake → normal path yields 0 ValActive → fallback triggers.
+	// Stakes differ to give a clear rank: addr3 > addr2 > addr1 = addr4 (addr1 < addr4 by address).
 	validators := valset.NodeStateMap{
-		addr1: {State: valset.CandTesting, StakingAmount: lowStake},
-		addr2: {State: valset.ValReady, StakingAmount: midStake},
-		addr3: {State: valset.ValActive, StakingAmount: highStake},
-		addr4: {State: valset.ValPaused, StakingAmount: lowStake, PausedTimeout: pausedTimeout},
+		addr1: {State: valset.CandTesting, StakingAmount: belowMinStake},
+		addr2: {State: valset.ValReady, StakingAmount: belowMinStake - 1000},
+		addr3: {State: valset.ValActive, StakingAmount: belowMinStake - 500},
+		addr4: {State: valset.ValPaused, StakingAmount: belowMinStake},
 		addr5: {State: valset.Registered, StakingAmount: highStake},
 	}
 
-	// maxValidatorCount=3: top 3 are addr3, addr2, addr1 → ValActive; addr4 → ValInactive.
-	result := v.getFallbackTransition(validators, testBlockTime, testIdleTimeout, 0, 0, 0, 3)
+	// Fallback rank (stake desc, addr asc): addr1=addr4(belowMin) > addr3(belowMin-500) > addr2(belowMin-1000)
+	// With cap=3: addr1, addr4, addr3 within cap; addr2 → ValInactive.
+	result := v.getEpochTransition(testMinStake, validators, testIdleTimeout, 3, testBlockTime, 0, 0, 0)
 
-	assert.Equal(t, valset.ValActive, result[addr1].State) // CandTesting passes vrank (nil scores)
-	assert.Equal(t, valset.ValActive, result[addr2].State)
+	assert.Equal(t, valset.ValActive, result[addr1].State)   // CandTesting passes vrank, promoted despite low stake
+	assert.Equal(t, valset.ValInactive, result[addr2].State) // outside cap
 	assert.Equal(t, valset.ValActive, result[addr3].State)
-	assert.Equal(t, valset.ValInactive, result[addr4].State)                            // outside cap → ValInactive
-	assert.True(t, result[addr4].IdleTimeout.Equal(testBlockTime.Add(testIdleTimeout))) // idleTimeout set
-	assert.Equal(t, valset.Registered, result[addr5].State)                             // non-competition, unchanged
+	assert.Equal(t, valset.ValPaused, result[addr4].State)  // ValPaused preserved within cap
+	assert.Equal(t, valset.Registered, result[addr5].State) // non-competition, unchanged
 	// Input not mutated.
 	assert.Equal(t, valset.ValPaused, validators[addr4].State)
 }
@@ -308,7 +307,7 @@ func TestGetEpochTransition_CandTestingCFS(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			v := newTestValsetModule(ctrl)
 			mockVRank := vrank_mock.NewMockVRankModule(ctrl)
-			mockVRank.EXPECT().GetCFSWithSlotFactor(testCFSBlockNum, uint64(0)).Return(map[common.Address]uint64{addr1: tc.cfs}, nil)
+			mockVRank.EXPECT().GetCFSWithSlotFactor(testCFSBlockNum, uint64(0)).Return(map[common.Address]uint64{addr1: tc.cfs}, nil).AnyTimes()
 			v.VRankModule = mockVRank
 
 			validators := valset.NodeStateMap{
@@ -654,19 +653,18 @@ func TestApplyAllTransitions(t *testing.T) {
 			testNonEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.ValActive, StakingAmount: belowMinStake},
+				addr2: {State: valset.ValActive, StakingAmount: aboveMinStake}, // prevents fallback
 			},
-			map[common.Address]valset.State{addr1: valset.ValExiting},
+			map[common.Address]valset.State{addr1: valset.ValExiting, addr2: valset.ValActive},
 		},
 		{
 			// addr1: CandReady+aboveMin → violation(noop) → timeout(noop) → epoch(CandTesting)
-			// addr2: ValActive+aboveMin → epoch(ValActive) — prevents fallback from firing
 			"candidate promotion at epoch",
 			testEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.CandReady, StakingAmount: aboveMinStake},
-				addr2: {State: valset.ValActive, StakingAmount: aboveMinStake},
 			},
-			map[common.Address]valset.State{addr1: valset.CandTesting, addr2: valset.ValActive},
+			map[common.Address]valset.State{addr1: valset.CandTesting},
 		},
 		{
 			// addr1: ValActive+belowMin  → violation(ValExiting) → timeout(noop) → epoch(ValInactive)
@@ -693,14 +691,12 @@ func TestApplyAllTransitions(t *testing.T) {
 		},
 		{
 			// addr1: ValInactive+expiredIdle → violation(noop) → timeout(Registered) → epoch(noop)
-			// addr2: ValActive+aboveMin → epoch(ValActive) — prevents fallback from firing
 			"timeout fires: expired idle → Registered",
 			testEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.ValInactive, StakingAmount: aboveMinStake, IdleTimeout: testBlockTime.Add(-1 * time.Hour)},
-				addr2: {State: valset.ValActive, StakingAmount: aboveMinStake},
 			},
-			map[common.Address]valset.State{addr1: valset.Registered, addr2: valset.ValActive},
+			map[common.Address]valset.State{addr1: valset.Registered},
 		},
 		{
 			// addr1: ValPaused+expiredPause → violation(noop) → timeout(ValInactive+IdleTimeout set) → epoch(noop, non-epoch)
@@ -713,23 +709,20 @@ func TestApplyAllTransitions(t *testing.T) {
 		},
 		{
 			// addr1: ValPaused+expiredPause → violation(noop) → timeout(ValInactive) → epoch(ValInactive not in competition → stays)
-			// addr2: ValActive+aboveMin → epoch(ValActive) — prevents fallback from firing
 			"timeout→epoch chain (epoch): expired pause → ValInactive",
 			testEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.ValPaused, StakingAmount: aboveMinStake, PausedTimeout: testBlockTime.Add(-1 * time.Hour)},
-				addr2: {State: valset.ValActive, StakingAmount: aboveMinStake},
 			},
-			map[common.Address]valset.State{addr1: valset.ValInactive, addr2: valset.ValActive},
+			map[common.Address]valset.State{addr1: valset.ValInactive},
 		},
 		{
-			// All validators below minStake → epoch transition produces no ValActive → fallback fires.
-			// getFallbackTransition(original) promotes epoch-1 competition group to ValActive.
-			// addr1: ValActive+below   → violation(ValExiting) → epoch(ValInactive) → fallback(ValActive)
-			// addr2: ValReady+below    → epoch(T3b → ValInactive)                   → fallback(ValActive)
-			// addr3: ValPaused+below   → epoch(T3b → ValInactive)                   → fallback(ValActive)
-			// addr4: CandTesting+below → epoch(pass vrank, T3b → ValInactive)       → fallback(pass vrank → ValActive)
-			"fallback: all below minStake → epoch-1 committee restored",
+			// Only addr1 is ValActive; minActive guard (countActive=1, not > minActive=1) blocks violation.
+			// addr1: ValActive+below   → violation(skipped: minActive guard) → fallback(enters competition → ValActive)
+			// addr2: ValReady+below    → fallback(enters competition → ValActive)
+			// addr3: ValPaused+below   → fallback(enters competition → ValPaused preserved)
+			// addr4: CandTesting+below → fallback(passes vrank, enters competition → ValActive)
+			"fallback: 1 ValActive below minStake, minActive blocks violation → fallback promotes all",
 			testEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.ValActive, StakingAmount: belowMinStake},
@@ -740,8 +733,29 @@ func TestApplyAllTransitions(t *testing.T) {
 			map[common.Address]valset.State{
 				addr1: valset.ValActive,
 				addr2: valset.ValActive,
-				addr3: valset.ValActive,
+				addr3: valset.ValPaused,
 				addr4: valset.ValActive,
+			},
+		},
+		{
+			// Two ValActive below minStake → violation fires on one (countActive=2 > minActive=1 allows it).
+			// addr1: ValActive+below   → violation(ValExiting) → fallback(T1 → ValInactive, not in competition)
+			// addr2: ValActive+below   → violation(skipped: minActive guard after addr1 kicked) → fallback(enters competition → ValActive)
+			// addr3: ValPaused+below   → fallback(enters competition → ValPaused preserved)
+			// addr4: ValInactive+below → not in competition group (no state change)
+			"fallback: 2 ValActive below minStake, violation kicks one → other promoted in fallback",
+			testEpochNum,
+			valset.NodeStateMap{
+				addr1: {State: valset.ValActive, StakingAmount: belowMinStake},
+				addr2: {State: valset.ValActive, StakingAmount: belowMinStake},
+				addr3: {State: valset.ValPaused, StakingAmount: belowMinStake},
+				addr4: {State: valset.ValInactive, StakingAmount: belowMinStake},
+			},
+			map[common.Address]valset.State{
+				addr1: valset.ValInactive, // filtered by violation
+				addr2: valset.ValActive,
+				addr3: valset.ValPaused,
+				addr4: valset.ValInactive,
 			},
 		},
 	}

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -190,23 +190,25 @@ func TestGetFallbackTransition(t *testing.T) {
 	v := newTestValsetModule(ctrl) // mockVRank returns nil scores → isPassVrankTest passes
 
 	pausedTimeout := testBlockTime.Add(8 * time.Hour)
+	// Staking amounts differ so the cap selects by stake rank.
+	// Rank: addr3(highStake) > addr2(midStake) > addr1,addr4(lowStake, addr1<addr4 by address)
 	validators := valset.NodeStateMap{
-		addr1: {State: valset.CandTesting, StakingAmount: belowMinStake},
-		addr2: {State: valset.ValReady, StakingAmount: belowMinStake},
-		addr3: {State: valset.ValActive, StakingAmount: belowMinStake},
-		addr4: {State: valset.ValPaused, StakingAmount: belowMinStake, PausedTimeout: pausedTimeout},
-		addr5: {State: valset.Registered, StakingAmount: belowMinStake},
+		addr1: {State: valset.CandTesting, StakingAmount: lowStake},
+		addr2: {State: valset.ValReady, StakingAmount: midStake},
+		addr3: {State: valset.ValActive, StakingAmount: highStake},
+		addr4: {State: valset.ValPaused, StakingAmount: lowStake, PausedTimeout: pausedTimeout},
+		addr5: {State: valset.Registered, StakingAmount: highStake},
 	}
-	result := v.getFallbackTransition(validators, 0, 0, 0)
 
-	// Competition group promoted to ValActive with timeouts cleared.
-	assert.Equal(t, valset.ValActive, result[addr1].State) // CandTesting passes vrank (nil scores)
-	assert.Equal(t, valset.ValActive, result[addr2].State)
+	// maxValidatorCount=3: top 3 are addr3, addr2, addr1 → ValActive; addr4 stays ValPaused.
+	result := v.getFallbackTransition(validators, 0, 0, 0, 3)
+
 	assert.Equal(t, valset.ValActive, result[addr3].State)
-	assert.Equal(t, valset.ValActive, result[addr4].State)
-	assert.True(t, result[addr4].PausedTimeout.IsZero())
-	// Non-competition state unchanged.
-	assert.Equal(t, valset.Registered, result[addr5].State)
+	assert.Equal(t, valset.ValActive, result[addr2].State)
+	assert.Equal(t, valset.ValActive, result[addr1].State) // CandTesting passes vrank (nil scores)
+	assert.Equal(t, valset.ValPaused, result[addr4].State) // outside cap, unchanged
+	assert.Equal(t, valset.Registered, result[addr5].State) // non-competition, unchanged
+	assert.True(t, result[addr4].PausedTimeout.Equal(pausedTimeout)) // timeout preserved
 	// Input not mutated.
 	assert.Equal(t, valset.ValPaused, validators[addr4].State)
 }

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -466,10 +466,12 @@ func TestGetViolationTransition_PFSAboveThreshold(t *testing.T) {
 	validators := valset.NodeStateMap{
 		addr1: {State: valset.ValActive, StakingAmount: aboveMinStake},
 		addr2: {State: valset.ValActive, StakingAmount: aboveMinStake},
+		addr3: {State: valset.ValActive, StakingAmount: aboveMinStake}, // because minActive=1
 	}
 	result := v.getViolationTransition(testMinStake, validators, 100, 2, noSlotLimit, noMinActive)
 	assert.Equal(t, valset.ValExiting, result[addr1].State, "PFS(3) >= threshold(2) → ValExiting (severe)")
 	assert.Equal(t, valset.ValPaused, result[addr2].State, "PFS(1) > 0, < threshold(2) → ValPaused (minor)")
+	assert.Equal(t, valset.ValActive, result[addr3].State)
 }
 
 func TestGetViolationTransition_PFSNonActiveNotAffected(t *testing.T) {

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -200,17 +200,38 @@ func TestGetFallbackTransition(t *testing.T) {
 		addr5: {State: valset.Registered, StakingAmount: highStake},
 	}
 
-	// maxValidatorCount=3: top 3 are addr3, addr2, addr1 → ValActive; addr4 stays ValPaused.
-	result := v.getFallbackTransition(validators, 0, 0, 0, 3)
+	// maxValidatorCount=3: top 3 are addr3, addr2, addr1 → ValActive; addr4 → ValInactive.
+	result := v.getFallbackTransition(validators, testBlockTime, testIdleTimeout, 0, 0, 0, 3)
 
 	assert.Equal(t, valset.ValActive, result[addr1].State) // CandTesting passes vrank (nil scores)
 	assert.Equal(t, valset.ValActive, result[addr2].State)
 	assert.Equal(t, valset.ValActive, result[addr3].State)
-	assert.Equal(t, valset.ValPaused, result[addr4].State)           // outside cap, unchanged
-	assert.Equal(t, valset.Registered, result[addr5].State)          // non-competition, unchanged
-	assert.True(t, result[addr4].PausedTimeout.Equal(pausedTimeout)) // timeout preserved
+	assert.Equal(t, valset.ValInactive, result[addr4].State)                              // outside cap → ValInactive
+	assert.True(t, result[addr4].IdleTimeout.Equal(testBlockTime.Add(testIdleTimeout)))  // idleTimeout set
+	assert.Equal(t, valset.Registered, result[addr5].State)                              // non-competition, unchanged
 	// Input not mutated.
 	assert.Equal(t, valset.ValPaused, validators[addr4].State)
+}
+
+// ============================================================
+// TestCompareValidatorRank
+// ============================================================
+
+func TestCompareValidatorRank(t *testing.T) {
+	sv := func(addr common.Address, stake uint64) sortableValidator {
+		return sortableValidator{addr, &valset.ValidatorState{StakingAmount: stake}}
+	}
+
+	// Higher stake ranks first (negative result means a < b in sort order).
+	assert.Negative(t, compareValidatorRank(sv(addr1, highStake), sv(addr2, lowStake)))
+	assert.Positive(t, compareValidatorRank(sv(addr1, lowStake), sv(addr2, highStake)))
+
+	// Equal stake: lower address ranks first.
+	assert.Negative(t, compareValidatorRank(sv(addr1, highStake), sv(addr2, highStake)))
+	assert.Positive(t, compareValidatorRank(sv(addr2, highStake), sv(addr1, highStake)))
+
+	// Equal stake and address: tie.
+	assert.Zero(t, compareValidatorRank(sv(addr1, highStake), sv(addr1, highStake)))
 }
 
 // ============================================================

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -113,7 +113,7 @@ func TestGetEpochTransition_StateTransitions(t *testing.T) {
 		{"T3b: CandTesting + stake<min → ValInactive", valset.CandTesting, belowMinStake, valset.ValInactive, true},
 		{"ValReady + stake>=min → ValActive", valset.ValReady, aboveMinStake, valset.ValActive, false},
 		{"ValActive + stake>=min → ValActive", valset.ValActive, aboveMinStake, valset.ValActive, false},
-		{"ValPaused + stake>=min → ValPaused (preserved)", valset.ValPaused, aboveMinStake, valset.ValPaused, false},
+		{"ValPaused + stake>=min → ValActive (fallback)", valset.ValPaused, aboveMinStake, valset.ValActive, false},
 		{"T3b: ValActive + stake<min → ValInactive", valset.ValActive, belowMinStake, valset.ValInactive, true},
 		{"T3b: ValReady + stake<min → ValInactive", valset.ValReady, belowMinStake, valset.ValInactive, true},
 		{"T3b: ValPaused + stake<min → ValInactive", valset.ValPaused, belowMinStake, valset.ValInactive, true},

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -206,9 +206,9 @@ func TestGetFallbackTransition(t *testing.T) {
 	assert.Equal(t, valset.ValActive, result[addr1].State) // CandTesting passes vrank (nil scores)
 	assert.Equal(t, valset.ValActive, result[addr2].State)
 	assert.Equal(t, valset.ValActive, result[addr3].State)
-	assert.Equal(t, valset.ValInactive, result[addr4].State)                              // outside cap → ValInactive
-	assert.True(t, result[addr4].IdleTimeout.Equal(testBlockTime.Add(testIdleTimeout)))  // idleTimeout set
-	assert.Equal(t, valset.Registered, result[addr5].State)                              // non-competition, unchanged
+	assert.Equal(t, valset.ValInactive, result[addr4].State)                            // outside cap → ValInactive
+	assert.True(t, result[addr4].IdleTimeout.Equal(testBlockTime.Add(testIdleTimeout))) // idleTimeout set
+	assert.Equal(t, valset.Registered, result[addr5].State)                             // non-competition, unchanged
 	// Input not mutated.
 	assert.Equal(t, valset.ValPaused, validators[addr4].State)
 }

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -113,7 +113,7 @@ func TestGetEpochTransition_StateTransitions(t *testing.T) {
 		{"T3b: CandTesting + stake<min → ValInactive", valset.CandTesting, belowMinStake, valset.ValInactive, true},
 		{"ValReady + stake>=min → ValActive", valset.ValReady, aboveMinStake, valset.ValActive, false},
 		{"ValActive + stake>=min → ValActive", valset.ValActive, aboveMinStake, valset.ValActive, false},
-		{"ValPaused + stake>=min → ValActive (fallback)", valset.ValPaused, aboveMinStake, valset.ValActive, false},
+		{"ValPaused + stake>=min → ValPaused (preserved)", valset.ValPaused, aboveMinStake, valset.ValPaused, false},
 		{"T3b: ValActive + stake<min → ValInactive", valset.ValActive, belowMinStake, valset.ValInactive, true},
 		{"T3b: ValReady + stake<min → ValInactive", valset.ValReady, belowMinStake, valset.ValInactive, true},
 		{"T3b: ValPaused + stake<min → ValInactive", valset.ValPaused, belowMinStake, valset.ValInactive, true},
@@ -151,31 +151,6 @@ func TestGetEpochTransition_MaxValidatorCount(t *testing.T) {
 	assert.False(t, result[addr3].IdleTimeout.IsZero())
 }
 
-// TestGetEpochTransition_NoValActiveFallback tests the edge case where the sole ValActive node
-// lost its stake (T3b → ValInactive), leaving only ValPaused nodes in the competition.
-// The fallback must force-promote ValPaused nodes to preserve len(ValActive)>0.
-func TestGetEpochTransition_NoValActiveFallback(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	v := newTestValsetModule(ctrl)
-
-	// addr1 was the only ValActive node but lost its stake below minStake → T3b (ValInactive, exits competition).
-	// addr2 and addr3 are ValPaused with sufficient stake → enter competition but stay paused in the normal path.
-	validators := valset.NodeStateMap{
-		addr1: {State: valset.ValActive, StakingAmount: belowMinStake},
-		addr2: {State: valset.ValPaused, StakingAmount: highStake},
-		addr3: {State: valset.ValPaused, StakingAmount: aboveMinStake},
-	}
-	result := v.getEpochTransition(testMinStake, validators, testIdleTimeout, testMaxValCount, testBlockTime, 0, 0, 0)
-
-	// addr1 dropped below minStake → ValInactive, not in competition.
-	assert.Equal(t, valset.ValInactive, result[addr1].State)
-	// Fallback: addr2 and addr3 are force-promoted to ValActive with PausedTimeout cleared.
-	assert.Equal(t, valset.ValActive, result[addr2].State)
-	assert.Equal(t, valset.ValActive, result[addr3].State)
-	assert.True(t, result[addr2].PausedTimeout.IsZero())
-	assert.True(t, result[addr3].PausedTimeout.IsZero())
-}
-
 func TestGetEpochTransition_TieBreakingByAddress(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	v := newTestValsetModule(ctrl)
@@ -204,6 +179,36 @@ func TestGetEpochTransition_DoesNotMutateInput(t *testing.T) {
 	result := v.getEpochTransition(testMinStake, validators, testIdleTimeout, testMaxValCount, testBlockTime, 0, 0, 0)
 	assert.Equal(t, valset.ValInactive, result[addr1].State)    // result is transitioned
 	assert.Equal(t, valset.ValExiting, validators[addr1].State) // original is unchanged
+}
+
+// ============================================================
+// TestGetFallbackTransition
+// ============================================================
+
+func TestGetFallbackTransition(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	v := newTestValsetModule(ctrl) // mockVRank returns nil scores → isPassVrankTest passes
+
+	pausedTimeout := testBlockTime.Add(8 * time.Hour)
+	validators := valset.NodeStateMap{
+		addr1: {State: valset.CandTesting, StakingAmount: belowMinStake},
+		addr2: {State: valset.ValReady, StakingAmount: belowMinStake},
+		addr3: {State: valset.ValActive, StakingAmount: belowMinStake},
+		addr4: {State: valset.ValPaused, StakingAmount: belowMinStake, PausedTimeout: pausedTimeout},
+		addr5: {State: valset.Registered, StakingAmount: belowMinStake},
+	}
+	result := v.getFallbackTransition(validators, 0, 0, 0)
+
+	// Competition group promoted to ValActive with timeouts cleared.
+	assert.Equal(t, valset.ValActive, result[addr1].State) // CandTesting passes vrank (nil scores)
+	assert.Equal(t, valset.ValActive, result[addr2].State)
+	assert.Equal(t, valset.ValActive, result[addr3].State)
+	assert.Equal(t, valset.ValActive, result[addr4].State)
+	assert.True(t, result[addr4].PausedTimeout.IsZero())
+	// Non-competition state unchanged.
+	assert.Equal(t, valset.Registered, result[addr5].State)
+	// Input not mutated.
+	assert.Equal(t, valset.ValPaused, validators[addr4].State)
 }
 
 // ============================================================
@@ -631,12 +636,14 @@ func TestApplyAllTransitions(t *testing.T) {
 		},
 		{
 			// addr1: CandReady+aboveMin → violation(noop) → timeout(noop) → epoch(CandTesting)
+			// addr2: ValActive+aboveMin → epoch(ValActive) — prevents fallback from firing
 			"candidate promotion at epoch",
 			testEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.CandReady, StakingAmount: aboveMinStake},
+				addr2: {State: valset.ValActive, StakingAmount: aboveMinStake},
 			},
-			map[common.Address]valset.State{addr1: valset.CandTesting},
+			map[common.Address]valset.State{addr1: valset.CandTesting, addr2: valset.ValActive},
 		},
 		{
 			// addr1: ValActive+belowMin  → violation(ValExiting) → timeout(noop) → epoch(ValInactive)
@@ -663,12 +670,14 @@ func TestApplyAllTransitions(t *testing.T) {
 		},
 		{
 			// addr1: ValInactive+expiredIdle → violation(noop) → timeout(Registered) → epoch(noop)
+			// addr2: ValActive+aboveMin → epoch(ValActive) — prevents fallback from firing
 			"timeout fires: expired idle → Registered",
 			testEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.ValInactive, StakingAmount: aboveMinStake, IdleTimeout: testBlockTime.Add(-1 * time.Hour)},
+				addr2: {State: valset.ValActive, StakingAmount: aboveMinStake},
 			},
-			map[common.Address]valset.State{addr1: valset.Registered},
+			map[common.Address]valset.State{addr1: valset.Registered, addr2: valset.ValActive},
 		},
 		{
 			// addr1: ValPaused+expiredPause → violation(noop) → timeout(ValInactive+IdleTimeout set) → epoch(noop, non-epoch)
@@ -681,12 +690,36 @@ func TestApplyAllTransitions(t *testing.T) {
 		},
 		{
 			// addr1: ValPaused+expiredPause → violation(noop) → timeout(ValInactive) → epoch(ValInactive not in competition → stays)
+			// addr2: ValActive+aboveMin → epoch(ValActive) — prevents fallback from firing
 			"timeout→epoch chain (epoch): expired pause → ValInactive",
 			testEpochNum,
 			valset.NodeStateMap{
 				addr1: {State: valset.ValPaused, StakingAmount: aboveMinStake, PausedTimeout: testBlockTime.Add(-1 * time.Hour)},
+				addr2: {State: valset.ValActive, StakingAmount: aboveMinStake},
 			},
-			map[common.Address]valset.State{addr1: valset.ValInactive},
+			map[common.Address]valset.State{addr1: valset.ValInactive, addr2: valset.ValActive},
+		},
+		{
+			// All validators below minStake → epoch transition produces no ValActive → fallback fires.
+			// getFallbackTransition(original) promotes epoch-1 competition group to ValActive.
+			// addr1: ValActive+below   → violation(ValExiting) → epoch(ValInactive) → fallback(ValActive)
+			// addr2: ValReady+below    → epoch(T3b → ValInactive)                   → fallback(ValActive)
+			// addr3: ValPaused+below   → epoch(T3b → ValInactive)                   → fallback(ValActive)
+			// addr4: CandTesting+below → epoch(pass vrank, T3b → ValInactive)       → fallback(pass vrank → ValActive)
+			"fallback: all below minStake → epoch-1 committee restored",
+			testEpochNum,
+			valset.NodeStateMap{
+				addr1: {State: valset.ValActive, StakingAmount: belowMinStake},
+				addr2: {State: valset.ValReady, StakingAmount: belowMinStake},
+				addr3: {State: valset.ValPaused, StakingAmount: belowMinStake},
+				addr4: {State: valset.CandTesting, StakingAmount: belowMinStake},
+			},
+			map[common.Address]valset.State{
+				addr1: valset.ValActive,
+				addr2: valset.ValActive,
+				addr3: valset.ValActive,
+				addr4: valset.ValActive,
+			},
 		},
 	}
 	for _, tc := range testcases {

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -151,6 +151,31 @@ func TestGetEpochTransition_MaxValidatorCount(t *testing.T) {
 	assert.False(t, result[addr3].IdleTimeout.IsZero())
 }
 
+// TestGetEpochTransition_NoValActiveFallback tests the edge case where the sole ValActive node
+// lost its stake (T3b → ValInactive), leaving only ValPaused nodes in the competition.
+// The fallback must force-promote ValPaused nodes to preserve len(ValActive)>0.
+func TestGetEpochTransition_NoValActiveFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	v := newTestValsetModule(ctrl)
+
+	// addr1 was the only ValActive node but lost its stake below minStake → T3b (ValInactive, exits competition).
+	// addr2 and addr3 are ValPaused with sufficient stake → enter competition but stay paused in the normal path.
+	validators := valset.NodeStateMap{
+		addr1: {State: valset.ValActive, StakingAmount: belowMinStake},
+		addr2: {State: valset.ValPaused, StakingAmount: highStake},
+		addr3: {State: valset.ValPaused, StakingAmount: aboveMinStake},
+	}
+	result := v.getEpochTransition(testMinStake, validators, testIdleTimeout, testMaxValCount, testBlockTime, 0, 0, 0)
+
+	// addr1 dropped below minStake → ValInactive, not in competition.
+	assert.Equal(t, valset.ValInactive, result[addr1].State)
+	// Fallback: addr2 and addr3 are force-promoted to ValActive with PausedTimeout cleared.
+	assert.Equal(t, valset.ValActive, result[addr2].State)
+	assert.Equal(t, valset.ValActive, result[addr3].State)
+	assert.True(t, result[addr2].PausedTimeout.IsZero())
+	assert.True(t, result[addr3].PausedTimeout.IsZero())
+}
+
 func TestGetEpochTransition_TieBreakingByAddress(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	v := newTestValsetModule(ctrl)


### PR DESCRIPTION
## Proposed changes

If all ValActive are below stake, `len(ValActive) = 0`. In this case, remove stake filter (minStake check) for collecting `activeValCompetitors`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
