### PR TITLE
kaiax/supply: fix blob fee discrepancy in `AccReward` checkpoints

### DIFF
--- a/kaiax/supply/impl/fixup_test.go
+++ b/kaiax/supply/impl/fixup_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package supply
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/kaiax/supply"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// Helpers
+
+// newFixupModule creates a bare SupplyModule with only the fields needed by
+// applyBlobFeeFixupIfNeeded: ChainKv and ChainConfig.ChainID.
+func newFixupModule(db database.Database, chainID *big.Int) *SupplyModule {
+	s := NewSupplyModule()
+	s.ChainKv = db
+	s.ChainConfig = &params.ChainConfig{ChainID: chainID}
+	return s
+}
+
+// writeCheckpoints writes identical fake AccReward entries at every 128-block
+// boundary from start to end (inclusive) and sets lastAccRewardNumber to end.
+func writeCheckpoints(db database.Database, start, end uint64) {
+	fake := &supply.AccReward{
+		TotalMinted: big.NewInt(1000),
+		BurntFee:    big.NewInt(50), // intentionally low — simulates missing blob fee
+	}
+	for num := start; num <= end; num += checkpointInterval {
+		WriteAccReward(db, num, fake)
+	}
+	WriteLastAccRewardNumber(db, end)
+}
+
+// ----------------------------------------------------------------------------
+// Tests
+
+func TestApplyBlobFeeFixupIfNeeded(t *testing.T) {
+	// Kairos  (chainID=1001): firstBadCheckpoint=209134080, safeReset=209133952
+	// Mainnet (chainID=8217): firstBadCheckpoint=213333120, safeReset=213332992
+
+	t.Run("kairos: fixup runs and resets pointer", func(t *testing.T) {
+		db := database.NewMemDB()
+		// Write a pre-Osaka checkpoint (safe) and two bad ones.
+		writeCheckpoints(db, 209133952, 209134208) // 209133952, 209134080, 209134208
+
+		s := newFixupModule(db, big.NewInt(int64(params.KairosNetworkId)))
+		s.applyBlobFeeFixupIfNeeded()
+
+		assert.Equal(t, uint64(209133952), ReadLastAccRewardNumber(db), "pointer must be reset to safeReset")
+		assert.NotNil(t, ReadAccReward(db, 209133952), "pre-Osaka checkpoint must be preserved")
+		assert.Nil(t, ReadAccReward(db, 209134080), "first bad checkpoint must be deleted")
+		assert.Nil(t, ReadAccReward(db, 209134208), "subsequent bad checkpoint must be deleted")
+		assert.True(t, ReadSupplyBlobFeeFixupDone(db), "done flag must be set")
+	})
+
+	t.Run("mainnet: fixup runs and resets pointer", func(t *testing.T) {
+		db := database.NewMemDB()
+		writeCheckpoints(db, 213332992, 213333248) // 213332992, 213333120, 213333248
+
+		s := newFixupModule(db, big.NewInt(int64(params.MainnetNetworkId)))
+		s.applyBlobFeeFixupIfNeeded()
+
+		assert.Equal(t, uint64(213332992), ReadLastAccRewardNumber(db))
+		assert.NotNil(t, ReadAccReward(db, 213332992))
+		assert.Nil(t, ReadAccReward(db, 213333120))
+		assert.Nil(t, ReadAccReward(db, 213333248))
+		assert.True(t, ReadSupplyBlobFeeFixupDone(db))
+	})
+
+	t.Run("before bad range: no-op, done flag not set", func(t *testing.T) {
+		// Simulates Mainnet before Osaka activation: lastAccNum < firstBadCheckpoint.
+		db := database.NewMemDB()
+		writeCheckpoints(db, 213332992, 213332992) // only one checkpoint, before the bad range
+		require.Equal(t, uint64(213332992), ReadLastAccRewardNumber(db))
+
+		s := newFixupModule(db, big.NewInt(int64(params.MainnetNetworkId)))
+		s.applyBlobFeeFixupIfNeeded()
+
+		// Pointer and checkpoint must be untouched.
+		assert.Equal(t, uint64(213332992), ReadLastAccRewardNumber(db))
+		assert.NotNil(t, ReadAccReward(db, 213332992))
+		// Done flag must NOT be set so the check re-runs after Osaka activates.
+		assert.False(t, ReadSupplyBlobFeeFixupDone(db))
+	})
+
+	t.Run("already done: immediate no-op", func(t *testing.T) {
+		db := database.NewMemDB()
+		writeCheckpoints(db, 209133952, 209134208)
+		WriteSupplyBlobFeeFixupDone(db) // pre-set done flag
+
+		s := newFixupModule(db, big.NewInt(int64(params.KairosNetworkId)))
+		s.applyBlobFeeFixupIfNeeded()
+
+		// Nothing must change — bad checkpoints remain but the pointer is also untouched.
+		assert.Equal(t, uint64(209134208), ReadLastAccRewardNumber(db), "pointer must not be changed")
+		assert.NotNil(t, ReadAccReward(db, 209134080), "bad checkpoint must not be deleted when already done")
+	})
+
+	t.Run("idempotent: second call is a no-op", func(t *testing.T) {
+		db := database.NewMemDB()
+		writeCheckpoints(db, 209133952, 209134208)
+
+		s := newFixupModule(db, big.NewInt(int64(params.KairosNetworkId)))
+		s.applyBlobFeeFixupIfNeeded()
+		// First call: resets to 209133952 and marks done.
+		assert.Equal(t, uint64(209133952), ReadLastAccRewardNumber(db))
+
+		// Write a new correct checkpoint above the old reset point (as catchup would).
+		WriteAccReward(db, 209134080, &supply.AccReward{TotalMinted: big.NewInt(2000), BurntFee: big.NewInt(200)})
+		WriteLastAccRewardNumber(db, 209134080)
+
+		s.applyBlobFeeFixupIfNeeded()
+		// Second call must not delete the newly correct checkpoint.
+		assert.Equal(t, uint64(209134080), ReadLastAccRewardNumber(db))
+		assert.NotNil(t, ReadAccReward(db, 209134080))
+	})
+
+	t.Run("unknown network: marks done immediately, no-op", func(t *testing.T) {
+		db := database.NewMemDB()
+		writeCheckpoints(db, 100, 100)
+
+		s := newFixupModule(db, big.NewInt(99999)) // non-production chain ID
+		s.applyBlobFeeFixupIfNeeded()
+
+		assert.Equal(t, uint64(100), ReadLastAccRewardNumber(db), "pointer must be unchanged")
+		assert.True(t, ReadSupplyBlobFeeFixupDone(db), "done flag must be set to skip future checks")
+	})
+}

--- a/kaiax/supply/impl/init.go
+++ b/kaiax/supply/impl/init.go
@@ -91,6 +91,9 @@ func (s *SupplyModule) Init(opts *InitOpts) error {
 }
 
 func (s *SupplyModule) Start() error {
+	// One-time DB repair: fix BurntFee undercount caused by missing blob fees in Osaka window.
+	s.applyBlobFeeFixupIfNeeded()
+
 	// Reload the last checkpoint from database.
 	if err := s.loadLastAccReward(); err != nil {
 		return err
@@ -146,6 +149,60 @@ func (s *SupplyModule) loadLastAccReward() error {
 	s.lastAccNum = lastAccNum
 	s.lastAccReward = lastAccReward
 	return nil
+}
+
+// applyBlobFeeFixupIfNeeded repairs AccReward supply checkpoints that were written with incorrect
+// BurntFee values during the Osaka hard fork window. Blob fees were burned at the EVM level but
+// were not included in BurntFee until the corresponding bugfix. This fixup is a no-op once the
+// done-flag is set in the database, or if this node has not yet accumulated past the affected range.
+//
+// Hard-coded first-bad-checkpoint values (first 128-aligned block >= Osaka activation):
+//   - Kairos  (chainID=1001): firstBadCheckpoint=209134080
+//   - Mainnet (chainID=8217): firstBadCheckpoint=213333120
+func (s *SupplyModule) applyBlobFeeFixupIfNeeded() {
+	if ReadSupplyBlobFeeFixupDone(s.ChainKv) {
+		return
+	}
+
+	// Resolve the first checkpoint block that may contain incorrect BurntFee for this network.
+	var firstBadCheckpoint uint64
+	if s.ChainConfig.ChainID != nil {
+		switch s.ChainConfig.ChainID.Uint64() {
+		case params.KairosNetworkId: // 1001
+			firstBadCheckpoint = 209134080
+		case params.MainnetNetworkId: // 8217
+			firstBadCheckpoint = 213333120
+		default:
+			// Not a known production network (devnet, private chain, etc.); mark done and skip.
+			WriteSupplyBlobFeeFixupDone(s.ChainKv)
+			return
+		}
+	} else {
+		// No chain ID configured; mark done and skip.
+		WriteSupplyBlobFeeFixupDone(s.ChainKv)
+		return
+	}
+
+	lastAccNum := ReadLastAccRewardNumber(s.ChainKv)
+	if lastAccNum < firstBadCheckpoint {
+		// The node hasn't accumulated past the affected range yet.
+		// Don't mark done: Mainnet Osaka hasn't activated, so we must check again on next startup.
+		return
+	}
+
+	// Reset to the last safe checkpoint (one interval before the first bad one).
+	safeResetNum := firstBadCheckpoint - checkpointInterval
+	for num := firstBadCheckpoint; num <= lastAccNum; num += checkpointInterval {
+		DeleteAccReward(s.ChainKv, num)
+	}
+	WriteLastAccRewardNumber(s.ChainKv, safeResetNum)
+	WriteSupplyBlobFeeFixupDone(s.ChainKv)
+
+	logger.Warn("Applied supply blob fee BurntFee fixup",
+		"firstBadCheckpoint", firstBadCheckpoint,
+		"safeReset", safeResetNum,
+		"deletedThrough", lastAccNum,
+	)
 }
 
 // catchup is a long-running goroutine that accumulates the supply checkpoint until the current head block.

--- a/kaiax/supply/impl/schema.go
+++ b/kaiax/supply/impl/schema.go
@@ -30,6 +30,9 @@ var (
 	// Using "supplyCheckpoint" for backward compatibility
 	lastAccRewardNumberKey = []byte("lastSupplyCheckpointNumber")
 	accRewardPrefix        = []byte("supplyCheckpoint")
+
+	// supplyBlobFeeFixupDoneKey is set after the one-time blob fee BurntFee fixup has been applied.
+	supplyBlobFeeFixupDoneKey = []byte("supplyBlobFeeFixupDone")
 )
 
 // accRewardStorage is the disk format for checkpoints (i.e. periodically committed AccReward).
@@ -89,5 +92,16 @@ func WriteAccReward(db database.Database, num uint64, accReward *supply.AccRewar
 func DeleteAccReward(db database.Database, num uint64) {
 	if err := db.Delete(accRewardKey(num)); err != nil {
 		logger.Crit("Failed to delete acc reward", "err", err)
+	}
+}
+
+func ReadSupplyBlobFeeFixupDone(db database.Database) bool {
+	b, err := db.Get(supplyBlobFeeFixupDoneKey)
+	return err == nil && len(b) > 0
+}
+
+func WriteSupplyBlobFeeFixupDone(db database.Database) {
+	if err := db.Put(supplyBlobFeeFixupDoneKey, []byte{1}); err != nil {
+		logger.Crit("Failed to write supply blob fee fixup done", "err", err)
 	}
 }


### PR DESCRIPTION
## Proposed changes

This is a follow-up PR of #815.
- After Osaka hardfork, `kaiax/supply` module has been accumulated miscalculated `AccReward` (blob fee ignored)
- This PR adds a function to delete all checkpoints after Oaska hardfork and reset `LastAccRewardNumber` to pre-Oaska block for Kairos/Mainnet
- The deleted checkpoints should be automatically caught up by `catchup()`

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
