### PR TITLE
api: drop web3 namespace

### DIFF
--- a/cmd/utils/nodecmd/consolecmd_test.go
+++ b/cmd/utils/nodecmd/consolecmd_test.go
@@ -37,8 +37,8 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 governance:1.0 istanbul:1.0 kaia:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0"
-	httpAPIs = "eth:1.0 kaia:1.0 net:1.0 rpc:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 governance:1.0 istanbul:1.0 kaia:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0"
+	httpAPIs = "eth:1.0 kaia:1.0 net:1.0 rpc:1.0"
 )
 
 // Tests that a node embedded within a console can be started up properly and

--- a/node/api_kaia.go
+++ b/node/api_kaia.go
@@ -32,7 +32,7 @@ type KaiaNodeAPI struct {
 	stack *Node
 }
 
-// NewKaiaNodeAPI creates a new Web3Service instance
+// NewKaiaNodeAPI creates a new KaiaNodeAPI instance
 func NewKaiaNodeAPI(stack *Node) *KaiaNodeAPI {
 	return &KaiaNodeAPI{stack}
 }

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -53,11 +53,11 @@ var DefaultConfig = Config{
 	DBType:           DefaultDBType(),
 	DataDir:          DefaultDataDir(),
 	HTTPPort:         DefaultHTTPPort,
-	HTTPModules:      []string{"net", "web3"},
+	HTTPModules:      []string{"net"},
 	HTTPVirtualHosts: []string{"localhost"},
 	HTTPTimeouts:     rpc.DefaultHTTPTimeouts,
 	WSPort:           DefaultWSPort,
-	WSModules:        []string{"net", "web3"},
+	WSModules:        []string{"net"},
 	GRPCPort:         DefaultGRPCPort,
 	P2P: p2p.Config{
 		ListenAddr:             fmt.Sprintf(":%d", DefaultP2PPort),

--- a/node/doc.go
+++ b/node/doc.go
@@ -39,8 +39,7 @@ about other hosts is persisted.
 
 JSON-RPC servers which run HTTP, WebSocket or IPC can be started on a Node. RPC modules
 offered by registered services will be offered on those endpoints. Users can restrict any
-endpoint to a subset of RPC modules. Node itself offers the "debug", "admin" and "web3"
-modules.
+endpoint to a subset of RPC modules. Node itself offers the "debug" and "admin" modules.
 
 Service implementations can open LevelDB databases through the service context. Package
 node chooses the file system location of each database. If the node is configured to run

--- a/node/node.go
+++ b/node/node.go
@@ -742,12 +742,6 @@ func (n *Node) apis() []rpc.API {
 			Version:   "1.0",
 			Service:   NewDebugNodeAPI(n),
 		}, {
-			// "web3" namespace will be deprecated soon. The same APIs in "web3" are available in "kaia" namespace.
-			Namespace: "web3",
-			Version:   "1.0",
-			Service:   NewKaiaNodeAPI(n),
-			Public:    true,
-		}, {
 			Namespace: "kaia",
 			Version:   "1.0",
 			Service:   NewKaiaNodeAPI(n),


### PR DESCRIPTION
## Proposed changes

- The `web3` namespace APIs (`web3_clientVersion`, `web3_sha3`) have been removed as the same APIs are available under the kaia namespace.
- Also removed web3 from the default HTTP/WS exposed modules list
- Updated tests and docs.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
