### PR TITLE
refactor: remove redundant variable declarations in for loops

### DIFF
--- a/cmd/utils/nodecmd/defaultcmd_test.go
+++ b/cmd/utils/nodecmd/defaultcmd_test.go
@@ -1062,7 +1062,6 @@ func parseExpectationFromLegacyResult(resultCode int) (strict bool, wantErr bool
 func TestDefaultCmd_ParseOnlyAllFlagCases(t *testing.T) {
 	runner := newParseOnlyRunner(t)
 	for _, fwv := range flagsWithValues {
-		fwv := fwv
 		switch fwv.flagType {
 		case FlagTypeBoolean:
 			t.Run("parseonly"+sanitizeTestName(fwv.flag), func(t *testing.T) {
@@ -1072,7 +1071,6 @@ func TestDefaultCmd_ParseOnlyAllFlagCases(t *testing.T) {
 			})
 		case FlagTypeArgument:
 			for _, item := range fwv.values {
-				item := item
 				t.Run("parseonly"+sanitizeTestName(fwv.flag)+"-"+sanitizeTestName(item), func(t *testing.T) {
 					if err := runner.parse(fwv.flag, item); err != nil {
 						t.Fatalf("expected parse success for %s %q, got error: %v", fwv.flag, item, err)
@@ -1080,8 +1078,6 @@ func TestDefaultCmd_ParseOnlyAllFlagCases(t *testing.T) {
 				})
 			}
 			for idx2, wrongItem := range fwv.wrongValues {
-				idx2 := idx2
-				wrongItem := wrongItem
 				t.Run("parseonly"+sanitizeTestName(fwv.flag)+"-"+sanitizeTestName(wrongItem), func(t *testing.T) {
 					strict, wantErr := parseExpectationFromLegacyResult(fwv.errors[idx2])
 					err := runner.parse(fwv.flag, wrongItem)

--- a/node/sc/vt_recovery_test.go
+++ b/node/sc/vt_recovery_test.go
@@ -298,7 +298,6 @@ func TestRecoveryScenarios(t *testing.T) {
 	}
 
 	for idx, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%02d_%s", idx, tc.name), func(t *testing.T) {
 			requestBridge := tc.requestBridge(info)
 			for i := 0; i < testTxCount; i++ {


### PR DESCRIPTION
## Proposed changes



The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore




## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
