### PR TITLE
feat(valset,gov): ignore committeeSize and block validator votes 

### DIFF
--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"maps"
+	"math/big"
 	"reflect"
 	"slices"
 
@@ -140,6 +141,15 @@ func (h *headerGovModule) VerifyGov(header *types.Header) error {
 
 // checkConsistency checks if vote values are consistent with chain states such as other parameters and validator set.
 func (h *headerGovModule) checkConsistency(blockNum uint64, vote headergov.VoteData) error {
+	// In permissionless mode, validator/committee governance votes are forbidden.
+	// Validators are managed by ABv2 contract, and committee = all qualified validators.
+	if h.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) {
+		switch vote.Name() {
+		case gov.AddValidator, gov.RemoveValidator, gov.IstanbulCommitteeSize:
+			return ErrVoteForbiddenPermless
+		}
+	}
+
 	switch vote.Name() {
 	case gov.GovernanceGoverningNode:
 		params := h.GetParamSet(blockNum)

--- a/kaiax/gov/headergov/impl/consensus_test.go
+++ b/kaiax/gov/headergov/impl/consensus_test.go
@@ -117,6 +117,29 @@ func TestVerifyVote(t *testing.T) {
 	}
 }
 
+func TestVerifyVote_PermissionlessForbidden(t *testing.T) {
+	config := getTestChainConfig()
+	config.PermissionlessCompatibleBlock = common.Big0
+	h := newHeaderGovModule(t, config)
+
+	tcs := []struct {
+		desc string
+		vote headergov.VoteData
+	}{
+		{"addvalidator forbidden", headergov.NewVoteData(validVoter, string(gov.AddValidator), common.HexToAddress("0x1234"))},
+		{"removevalidator forbidden", headergov.NewVoteData(validVoter, string(gov.RemoveValidator), common.HexToAddress("0x1234"))},
+		{"committeesize forbidden", headergov.NewVoteData(validVoter, string(gov.IstanbulCommitteeSize), uint64(7))},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			vb, err := tc.vote.ToVoteBytes()
+			assert.NoError(t, err)
+			err = h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra})
+			assert.Equal(t, ErrVoteForbiddenPermless, err)
+		})
+	}
+}
+
 func TestGetVotesInEpoch(t *testing.T) {
 	h := newHeaderGovModule(t, getTestChainConfig())
 

--- a/kaiax/gov/headergov/impl/error.go
+++ b/kaiax/gov/headergov/impl/error.go
@@ -23,6 +23,7 @@ var (
 	ErrGovNodeInValSetVoteValue = errors.New("gov node is found in the valset vote value")
 	ErrGovNodeNotInValSetList   = errors.New("gov node is not found in the valset list")
 	ErrInvalidVoter             = errors.New("invalid voter")
+	ErrVoteForbiddenPermless    = errors.New("vote is forbidden in permissionless mode")
 )
 
 func errInitNil(msg string) error {

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -95,6 +95,11 @@ func (v *ValsetModule) getCommittee(c *blockContext, round uint64) ([]common.Add
 	if c.num == 0 {
 		return c.qualified.List(), nil
 	}
+	// In permissionless mode, all qualified validators form the committee.
+	// CommitteeSize is not used; subset selection is disabled.
+	if c.rules.IsPermissionless {
+		return c.qualified.List(), nil
+	}
 	if c.qualified.Len() <= int(c.pset.CommitteeSize) {
 		return c.qualified.List(), nil
 	}
@@ -200,7 +205,12 @@ func (v *ValsetModule) getProposer(c *blockContext, round uint64) (common.Addres
 		return selectStickyProposer(c.qualified, c.prevProposer, round), nil
 	case istanbul.WeightedRandom:
 		if c.rules.IsRandao {
-			committee := selectRandaoCommittee(c.qualified, c.pset.CommitteeSize, c.prevHeader.MixHash)
+			var committee []common.Address
+			if c.rules.IsPermissionless {
+				committee = c.qualified.List()
+			} else {
+				committee = selectRandaoCommittee(c.qualified, c.pset.CommitteeSize, c.prevHeader.MixHash)
+			}
 			return selectRandaoProposer(committee, round), nil
 		} else {
 			list, sourceNum, err := v.getProposerList(c)

--- a/kaiax/valset/impl/getter_context_test.go
+++ b/kaiax/valset/impl/getter_context_test.go
@@ -71,18 +71,21 @@ func TestGetCommittee(t *testing.T) {
 	)
 
 	testcases := []struct {
-		desc     string
-		isKore   bool
-		isRandao bool
-		policy   istanbul.ProposerPolicy
-		expected []common.Address
+		desc             string
+		isKore           bool
+		isRandao         bool
+		isPermissionless bool
+		policy           istanbul.ProposerPolicy
+		expected         []common.Address
 	}{
 		// Refer to other Test*Proposer tests for the expected results.
-		{"RoundRobin", false, false, istanbul.RoundRobin, numsToAddrs(2, 3, 4, 1, 7, 5)},                      // prev=1, curr=2, next=3
-		{"Sticky", false, false, istanbul.Sticky, numsToAddrs(1, 2, 4, 3, 7, 5)},                              // prev=1, curr=1, next=2
-		{"WeightedRandom, before Kore", false, false, istanbul.WeightedRandom, numsToAddrs(4, 6, 2, 1, 7, 3)}, // curr=4, next=6, list=[4,6,1,7,...]
-		{"WeightedRandom, after Kore", true, false, istanbul.WeightedRandom, numsToAddrs(7, 1, 3, 2, 6, 4)},   // curr=7, next=1, list=[7,1,0,4,...]
-		{"WeightedRandom, after Randao", true, true, istanbul.WeightedRandom, numsToAddrs(8, 3, 5, 1, 0, 9)},  // committee=[8,3,5,1,0,9]
+		{"RoundRobin", false, false, false, istanbul.RoundRobin, numsToAddrs(2, 3, 4, 1, 7, 5)},                      // prev=1, curr=2, next=3
+		{"Sticky", false, false, false, istanbul.Sticky, numsToAddrs(1, 2, 4, 3, 7, 5)},                              // prev=1, curr=1, next=2
+		{"WeightedRandom, before Kore", false, false, false, istanbul.WeightedRandom, numsToAddrs(4, 6, 2, 1, 7, 3)}, // curr=4, next=6, list=[4,6,1,7,...]
+		{"WeightedRandom, after Kore", true, false, false, istanbul.WeightedRandom, numsToAddrs(7, 1, 3, 2, 6, 4)},   // curr=7, next=1, list=[7,1,0,4,...]
+		{"WeightedRandom, after Randao", true, true, false, istanbul.WeightedRandom, numsToAddrs(8, 3, 5, 1, 0, 9)},  // committee=[8,3,5,1,0,9]
+		// Permissionless: all qualified validators form the committee regardless of committeeSize
+		{"Permissionless, all qualified", true, true, true, istanbul.WeightedRandom, qualified},
 	}
 
 	var (
@@ -113,6 +116,7 @@ func TestGetCommittee(t *testing.T) {
 		c.rules.IsShanghai = tc.isRandao
 		c.rules.IsCancun = tc.isRandao
 		c.rules.IsRandao = tc.isRandao
+		c.rules.IsPermissionless = tc.isPermissionless
 
 		v.proposerListCache.Purge()
 		v.removeVotesCache.Purge()


### PR DESCRIPTION
> **Note**: This is a proposal for discussion. The committee policy change (all qualified = committee) and governance vote blocking have not been finalized yet.

## Proposed changes

- **Committee = all qualified**: In permissionless mode, all qualified validators form the committee. `istanbul.committeesize` is ignored — subset selection is disabled.
- **Proposer fix**: Randao proposer selection uses full qualified set instead of `selectRandaoCommittee(committeeSize)`, preventing committeeSize from silently affecting proposer selection.
- **Block governance votes**: Reject `governance.addvalidator`, `governance.removevalidator`, `istanbul.committeesize` votes in permissionless mode. Validators are managed by ABv2 contract, not header votes.

Both layers are needed (dual defense):
- **Vote blocking** (`checkConsistency`): prevents meaningless votes from accumulating in block headers.
- **Ignoring** (`getCommittee`/`getProposer`/`PostInsertBlock`): ensures pre-existing values have no effect — `committeeSize` is bypassed in committee/proposer selection, and `addValidator`/`removeValidator` votes are skipped in `PostInsertBlock`.

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

After this PR is merged, KIP-286 needs to be updated to reflect the committee change (all qualified = committee, no subset selection).