### PR TITLE
node/cn: fix nil deref race in sidecarReqManager.update

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1905,6 +1905,9 @@ func (m *sidecarReqManager) get(txHash common.Hash) *sidecarReq {
 func (m *sidecarReqManager) update(txHash common.Hash, peer string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.list[txHash] == nil {
+		return // already deleted by a concurrent response
+	}
 	// no longer keep the request if the try count is too high
 	if m.list[txHash].try+1 >= m.maxTry {
 		delete(m.list, txHash)

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -1574,6 +1574,28 @@ func TestSidecarReqManager_Update(t *testing.T) {
 	assert.Nil(t, req, "Request should be deleted when try >= maxTry")
 }
 
+// TestSidecarReqManager_UpdateNilEntry tests that update does not panic when the entry
+// has been concurrently deleted before update() acquires the lock.
+func TestSidecarReqManager_UpdateNilEntry(t *testing.T) {
+	m := newTestSidecarReqManager(10*time.Second, 5)
+	txHash := tx1.Hash()
+
+	// update on a never-added (nil) entry must not panic
+	assert.NotPanics(t, func() {
+		m.update(txHash, "peer-1")
+	}, "update on missing entry should be a no-op, not a panic")
+
+	// add, delete, then update — simulates the race: response arrives before update()
+	m.add(txHash, newTestBlobSidecarsRequestData(txHash, 100, 0))
+	m.delete(txHash)
+	assert.NotPanics(t, func() {
+		m.update(txHash, "peer-1")
+	}, "update after concurrent delete should be a no-op, not a panic")
+
+	// entry must remain absent
+	assert.Nil(t, m.get(txHash), "entry should remain deleted after no-op update")
+}
+
 // TestSidecarReqManager_Delete tests the delete method
 func TestSidecarReqManager_Delete(t *testing.T) {
 	cooldown := 10 * time.Second


### PR DESCRIPTION
## Proposed changes

Fix a nil pointer dereference race condition in `sidecarReqManager.update()` in `node/cn/handler.go`.

A concurrent delete (e.g. `handleBlobSidecarsMsg` removing the map entry just before `blobSidecarSyncLoop` calls `update()`) could cause a panic when `update()` dereferences `m.list[txHash]` without checking for nil. Since `update()` already holds the write lock, adding a nil guard at the top is a safe and sufficient fix.

Also adds `TestSidecarReqManager_UpdateNilEntry` as a regression test covering this path.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

N/A

## Further comments

The race window is narrow and requires a responsive peer, so this is classified as low severity. The fix is a one-line nil guard with no behavioral change under normal operation.