### PR TITLE
kaiabft: slim consensus interface

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -62,6 +62,9 @@ type ChainReader interface {
 	// GetBlock retrieves a block from the database by hash and number.
 	GetBlock(hash common.Hash, number uint64) *types.Block
 
+	// HasBadBlock reports whether the given hash is on the bad-block blacklist.
+	HasBadBlock(hash common.Hash) bool
+
 	// State retrieves statedb
 	State() (*state.StateDB, error)
 
@@ -120,7 +123,7 @@ type Engine interface {
 
 	// Start starts any consensus-specific background lifecycle.
 	// Engines without a background runtime should implement this as a no-op.
-	Start(chain ChainReader, currentBlock func() *types.Block, hasBadBlock func(hash common.Hash) bool, executor Executor) error
+	Start(chain ChainReader, executor Executor) error
 
 	// Stop stops any consensus-specific background lifecycle.
 	// Engines without a background runtime should implement this as a no-op.
@@ -142,11 +145,8 @@ type Engine interface {
 	SubscribeNewSequence() *event.TypeMuxSubscription
 }
 
-// Handler should be implemented is the consensus needs to handle and send peer's message
+// Handler should be implemented if the consensus needs to handle peer messages.
 type Handler interface {
-	// Protocol returns the protocol metadata for this consensus handler.
-	Protocol() Protocol
-
 	// NewChainHead handles a new head block comes
 	NewChainHead() error
 
@@ -154,8 +154,5 @@ type Handler interface {
 	HandleMsg(address common.Address, data p2p.Msg) (bool, error)
 
 	// SetBroadcaster sets the broadcaster to send message to peers
-	SetBroadcaster(Broadcaster, common.ConnType)
-
-	// RegisterConsensusMsgCode registers the channel of consensus msg.
-	RegisterConsensusMsgCode(Peer)
+	SetBroadcaster(Broadcaster)
 }

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -63,6 +63,18 @@ type Executor interface {
 	// mux is used to post PendingLogsEvent and PendingStateEvent for APIs.
 	Execute(txs *types.TransactionsByPriceAndNonce, mux *event.TypeMux) (*ExecutionResult, error)
 
+	// ExecuteTransactions executes the given transaction list in the provided
+	// order without re-sorting. This is the path validators use during
+	// speculative execution of a received pre-prepare: they must replay the
+	// exact order encoded in the proposer's block body.
+	ExecuteTransactions(txs []*types.Transaction) (*ExecutionResult, error)
+
 	// FinalizeState runs post-transaction state modifications and assembles final block.
 	FinalizeState(result *ExecutionResult) (*types.Block, error)
+
+	// Clone returns a fresh Executor that shares immutable configuration
+	// (chain, config, signer, node address) but carries its own mutable
+	// execution state. The clone starts uninitialized — the caller must
+	// invoke ResetWithState before Execute/ExecuteTransactions.
+	Clone() Executor
 }

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -115,7 +115,7 @@ func (f *Faker) WriteRound(header *types.Header, round int64) {
 }
 
 // Start is a no-op for faker.
-func (f *Faker) Start(chain consensus.ChainReader, currentBlock func() *types.Block, hasBadBlock func(hash common.Hash) bool, executor consensus.Executor) error {
+func (f *Faker) Start(chain consensus.ChainReader, executor consensus.Executor) error {
 	return nil
 }
 
@@ -212,10 +212,7 @@ func (f *Faker) HandleMsg(_ common.Address, _ p2p.Msg) (bool, error) {
 }
 
 // SetBroadcaster is a no-op for faker.
-func (f *Faker) SetBroadcaster(consensus.Broadcaster, common.ConnType) {}
-
-// RegisterConsensusMsgCode is a no-op for faker.
-func (f *Faker) RegisterConsensusMsgCode(consensus.Peer) {}
+func (f *Faker) SetBroadcaster(consensus.Broadcaster) {}
 
 // Prepare prepares the header for mining.
 func (f *Faker) Prepare(chain consensus.ChainReader, header *types.Header) error {
@@ -265,11 +262,6 @@ func (f *Faker) Seal(chain consensus.ChainReader, block *types.Block) (*types.Bl
 // APIs returns RPC APIs (none for faker).
 func (f *Faker) APIs(chain consensus.ChainReader) []rpc.API {
 	return nil
-}
-
-// Protocol returns the consensus protocol.
-func (f *Faker) Protocol() consensus.Protocol {
-	return consensus.KaiaProtocol
 }
 
 // PurgeCache is a no-op for faker.

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -91,8 +91,6 @@ type backend struct {
 	core             istanbulCore.Engine
 	logger           log.Logger
 	chain            consensus.ChainReader
-	currentBlock     func() *types.Block
-	hasBadBlock      func(hash common.Hash) bool
 
 	// the channels for istanbul engine notifications
 	commitCh          chan *types.Result
@@ -214,8 +212,7 @@ func (sb *backend) Gossip(payload []byte) error {
 				Payload:  payload,
 			}
 
-			// go p.Send(IstanbulMsg, payload)
-			go p.Send(IstanbulMsg, cmsg)
+			go p.Send(consensus.ConsensusMsgCode, cmsg)
 		}
 	}
 	return nil
@@ -288,7 +285,7 @@ func (sb *backend) GossipSubPeer(prevHash common.Hash, payload []byte) {
 				Payload:  payload,
 			}
 
-			go p.Send(IstanbulMsg, cmsg)
+			go p.Send(consensus.ConsensusMsgCode, cmsg)
 		}
 	}
 	return
@@ -407,7 +404,7 @@ func (sb *backend) HasPropsal(hash common.Hash, number *big.Int) bool {
 }
 
 func (sb *backend) LastProposal() (bft.Proposal, common.Address) {
-	block := sb.currentBlock()
+	block := sb.chain.CurrentBlock()
 
 	var proposer common.Address
 	if block.Number().Cmp(common.Big0) > 0 {
@@ -424,10 +421,10 @@ func (sb *backend) LastProposal() (bft.Proposal, common.Address) {
 }
 
 func (sb *backend) HasBadProposal(hash common.Hash) bool {
-	if sb.hasBadBlock == nil {
+	if sb.chain == nil {
 		return false
 	}
-	return sb.hasBadBlock(hash)
+	return sb.chain.HasBadBlock(hash)
 }
 
 // SubmitTransactions executes transactions and returns the execution result.
@@ -500,7 +497,7 @@ func (sb *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, st
 		}
 		if sealedBlock == nil {
 			// Not the proposer - this is expected, block will be received via ChainHeadEvent
-			logger.Info("Seal skipped. Not the proposer for block", "number", block.Number(), "sealTime", result.SealTime)
+			logger.Debug("Seal skipped. Not the proposer for block", "number", block.Number(), "sealTime", result.SealTime)
 			resultCh <- nil
 			return
 		}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -174,7 +174,7 @@ func (sb *backend) RegisterKaiaxModules(mGov gov.GovModule, mValset valset.Valse
 }
 
 // Start starts the Istanbul backend core.
-func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types.Block, hasBadBlock func(hash common.Hash) bool, executor consensus.Executor) error {
+func (sb *backend) Start(chain consensus.ChainReader, executor consensus.Executor) error {
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
 	if sb.coreStarted {
@@ -198,8 +198,6 @@ func (sb *backend) Start(chain consensus.ChainReader, currentBlock func() *types
 	defer sb.SignalPeerRegistrable()
 
 	sb.SetChain(chain)
-	sb.currentBlock = currentBlock
-	sb.hasBadBlock = hasBadBlock
 	sb.executor = executor
 
 	if err := sb.core.Start(); err != nil {

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -382,7 +382,7 @@ func newBlockChain(t *testing.T, n int, items ...interface{}) (*blockchain.Block
 	)
 	b.RegisterKaiaxModules(mGov, mValset)
 
-	if b.Start(bc, bc.CurrentBlock, bc.HasBadBlock, nil) != nil {
+	if b.Start(bc, nil) != nil {
 		panic(err)
 	}
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -36,8 +36,6 @@ import (
 )
 
 const (
-	IstanbulMsg = 0x11
-
 	// chainInitTimeout is the maximum time ValidatePeerType waits for the
 	// consensus engine to be ready before rejecting the peer connection.
 	chainInitTimeout = 30 * time.Second
@@ -48,26 +46,14 @@ var (
 	errDecodeFailed       = errors.New("fail to decode istanbul message")
 	errNoChainReader      = errors.New("sb.chain is nil! --mine option might be missing")
 	errInvalidPeerAddress = errors.New("invalid address")
-
-	// TODO-Kaia-Istanbul: define Versions and Lengths with correct values.
-	IstanbulProtocol = consensus.Protocol{
-		Name:     "istanbul",
-		Versions: []uint{67, 66, 65, 64},
-		Lengths:  []uint64{26, 24, 23, 21},
-	}
 )
-
-// Protocol implements consensus.Engine.Protocol
-func (sb *backend) Protocol() consensus.Protocol {
-	return IstanbulProtocol
-}
 
 // HandleMsg implements consensus.Handler.HandleMsg
 func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
 
-	if msg.Code == IstanbulMsg {
+	if msg.Code == consensus.ConsensusMsgCode {
 		if !sb.coreStarted {
 			return true, istanbul.ErrStoppedEngine
 		}
@@ -136,17 +122,10 @@ func (sb *backend) ValidatePeerType(addr common.Address) error {
 }
 
 // SetBroadcaster implements consensus.Handler.SetBroadcaster
-func (sb *backend) SetBroadcaster(broadcaster consensus.Broadcaster, nodetype common.ConnType) {
+func (sb *backend) SetBroadcaster(broadcaster consensus.Broadcaster) {
 	sb.broadcaster = broadcaster
-	if nodetype == common.CONSENSUSNODE {
+	if sb.nodetype == common.CONSENSUSNODE {
 		sb.broadcaster.RegisterValidator(common.CONSENSUSNODE, sb)
-	}
-}
-
-// RegisterConsensusMsgCode registers the channel of consensus msg.
-func (sb *backend) RegisterConsensusMsgCode(peer consensus.Peer) {
-	if err := peer.RegisterConsensusMsgCode(IstanbulMsg); err != nil {
-		logger.Error("RegisterConsensusMsgCode failed", "err", err)
 	}
 }
 

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -24,6 +24,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/bft"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/networks/p2p"
@@ -47,7 +48,7 @@ func TestBackend_HandleMsg(t *testing.T) {
 	// Success case
 	{
 		msg := p2p.Msg{
-			Code:    IstanbulMsg,
+			Code:    consensus.ConsensusMsgCode,
 			Size:    uint32(size),
 			Payload: payload,
 		}
@@ -106,7 +107,7 @@ func TestBackend_HandleMsg(t *testing.T) {
 	{
 		size, payload, _ := rlp.EncodeToReader([]byte{0x1, 0x2})
 		msg := p2p.Msg{
-			Code:    IstanbulMsg,
+			Code:    consensus.ConsensusMsgCode,
 			Size:    uint32(size),
 			Payload: payload,
 		}
@@ -118,7 +119,7 @@ func TestBackend_HandleMsg(t *testing.T) {
 	// Failure case - stopped istanbul engine
 	{
 		msg := p2p.Msg{
-			Code:    IstanbulMsg,
+			Code:    consensus.ConsensusMsgCode,
 			Size:    uint32(size),
 			Payload: payload,
 		}
@@ -127,13 +128,6 @@ func TestBackend_HandleMsg(t *testing.T) {
 		assert.Equal(t, istanbul.ErrStoppedEngine, err)
 		assert.True(t, isHandled)
 	}
-}
-
-func TestBackend_Protocol(t *testing.T) {
-	backend := newTestBackend()
-	defer backend.Stop()
-
-	assert.Equal(t, IstanbulProtocol, backend.Protocol())
 }
 
 func TestBackend_ValidatePeerType(t *testing.T) {

--- a/consensus/istanbul/backend/testutil_test.go
+++ b/consensus/istanbul/backend/testutil_test.go
@@ -245,7 +245,7 @@ func newTestContext(numNodes int, config *params.ChainConfig, overrides *testOve
 		[]kaiax.BlockStateModule{mSystem},
 	)
 	// Start the engine
-	if err = engine.Start(chain, chain.CurrentBlock, chain.HasBadBlock, nil); err != nil {
+	if err = engine.Start(chain, nil); err != nil {
 		panic(err)
 	}
 

--- a/consensus/istanbul/mocks/backend_mock.go
+++ b/consensus/istanbul/mocks/backend_mock.go
@@ -11,7 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/bft"
+	bft "github.com/kaiachain/kaia/consensus/bft"
 	istanbul "github.com/kaiachain/kaia/consensus/istanbul"
 	event "github.com/kaiachain/kaia/event"
 )
@@ -51,20 +51,6 @@ func (m *MockBackend) Address() common.Address {
 func (mr *MockBackendMockRecorder) Address() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockBackend)(nil).Address))
-}
-
-// Sealer mocks base method.
-func (m *MockBackend) Sealer() *istanbul.IstanbulSealer {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Sealer")
-	ret0, _ := ret[0].(*istanbul.IstanbulSealer)
-	return ret0
-}
-
-// Sealer indicates an expected call of Sealer.
-func (mr *MockBackendMockRecorder) Sealer() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sealer", reflect.TypeOf((*MockBackend)(nil).Sealer))
 }
 
 // Broadcast mocks base method.
@@ -190,6 +176,20 @@ func (m *MockBackend) NodeType() common.ConnType {
 func (mr *MockBackendMockRecorder) NodeType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeType", reflect.TypeOf((*MockBackend)(nil).NodeType))
+}
+
+// Sealer mocks base method.
+func (m *MockBackend) Sealer() *istanbul.IstanbulSealer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sealer")
+	ret0, _ := ret[0].(*istanbul.IstanbulSealer)
+	return ret0
+}
+
+// Sealer indicates an expected call of Sealer.
+func (mr *MockBackendMockRecorder) Sealer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sealer", reflect.TypeOf((*MockBackend)(nil).Sealer))
 }
 
 // SetCurrentView mocks base method.

--- a/consensus/mocks/engine_mock.go
+++ b/consensus/mocks/engine_mock.go
@@ -10,7 +10,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
-	common "github.com/kaiachain/kaia/common"
 	consensus "github.com/kaiachain/kaia/consensus"
 	event "github.com/kaiachain/kaia/event"
 	gov "github.com/kaiachain/kaia/kaiax/gov"
@@ -80,17 +79,17 @@ func (mr *MockEngineMockRecorder) RegisterKaiaxModules(arg0, arg1 interface{}) *
 }
 
 // Start mocks base method.
-func (m *MockEngine) Start(arg0 consensus.ChainReader, arg1 func() *types.Block, arg2 func(common.Hash) bool, arg3 consensus.Executor) error {
+func (m *MockEngine) Start(arg0 consensus.ChainReader, arg1 consensus.Executor) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Start", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockEngineMockRecorder) Start(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) Start(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockEngine)(nil).Start), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockEngine)(nil).Start), arg0, arg1)
 }
 
 // Stop mocks base method.

--- a/consensus/mocks/executor_mock.go
+++ b/consensus/mocks/executor_mock.go
@@ -14,30 +14,44 @@ import (
 	event "github.com/kaiachain/kaia/event"
 )
 
-// MockExecutor is a mock of Executor interface
+// MockExecutor is a mock of Executor interface.
 type MockExecutor struct {
 	ctrl     *gomock.Controller
 	recorder *MockExecutorMockRecorder
 }
 
-// MockExecutorMockRecorder is the mock recorder for MockExecutor
+// MockExecutorMockRecorder is the mock recorder for MockExecutor.
 type MockExecutorMockRecorder struct {
 	mock *MockExecutor
 }
 
-// NewMockExecutor creates a new mock instance
+// NewMockExecutor creates a new mock instance.
 func NewMockExecutor(ctrl *gomock.Controller) *MockExecutor {
 	mock := &MockExecutor{ctrl: ctrl}
 	mock.recorder = &MockExecutorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExecutor) EXPECT() *MockExecutorMockRecorder {
 	return m.recorder
 }
 
-// Execute mocks base method
+// Clone mocks base method.
+func (m *MockExecutor) Clone() consensus.Executor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone")
+	ret0, _ := ret[0].(consensus.Executor)
+	return ret0
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockExecutorMockRecorder) Clone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockExecutor)(nil).Clone))
+}
+
+// Execute mocks base method.
 func (m *MockExecutor) Execute(arg0 *types.TransactionsByPriceAndNonce, arg1 *event.TypeMux) (*consensus.ExecutionResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
@@ -46,13 +60,28 @@ func (m *MockExecutor) Execute(arg0 *types.TransactionsByPriceAndNonce, arg1 *ev
 	return ret0, ret1
 }
 
-// Execute indicates an expected call of Execute
+// Execute indicates an expected call of Execute.
 func (mr *MockExecutorMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockExecutor)(nil).Execute), arg0, arg1)
 }
 
-// FinalizeState mocks base method
+// ExecuteTransactions mocks base method.
+func (m *MockExecutor) ExecuteTransactions(arg0 []*types.Transaction) (*consensus.ExecutionResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteTransactions", arg0)
+	ret0, _ := ret[0].(*consensus.ExecutionResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecuteTransactions indicates an expected call of ExecuteTransactions.
+func (mr *MockExecutorMockRecorder) ExecuteTransactions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteTransactions", reflect.TypeOf((*MockExecutor)(nil).ExecuteTransactions), arg0)
+}
+
+// FinalizeState mocks base method.
 func (m *MockExecutor) FinalizeState(arg0 *consensus.ExecutionResult) (*types.Block, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FinalizeState", arg0)
@@ -61,13 +90,13 @@ func (m *MockExecutor) FinalizeState(arg0 *consensus.ExecutionResult) (*types.Bl
 	return ret0, ret1
 }
 
-// FinalizeState indicates an expected call of FinalizeState
+// FinalizeState indicates an expected call of FinalizeState.
 func (mr *MockExecutorMockRecorder) FinalizeState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeState", reflect.TypeOf((*MockExecutor)(nil).FinalizeState), arg0)
 }
 
-// ResetWithState mocks base method
+// ResetWithState mocks base method.
 func (m *MockExecutor) ResetWithState(arg0 *state.StateDB, arg1 *types.Header) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetWithState", arg0, arg1)
@@ -75,7 +104,7 @@ func (m *MockExecutor) ResetWithState(arg0 *state.StateDB, arg1 *types.Header) e
 	return ret0
 }
 
-// ResetWithState indicates an expected call of ResetWithState
+// ResetWithState indicates an expected call of ResetWithState.
 func (mr *MockExecutorMockRecorder) ResetWithState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetWithState", reflect.TypeOf((*MockExecutor)(nil).ResetWithState), arg0, arg1)

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -44,6 +44,16 @@ var KaiaProtocol = Protocol{
 	Lengths:  []uint64{24, 22, 21, 19, 17, 8},
 }
 
+// IstanbulProtocol is the p2p protocol used by Istanbul BFT consensus nodes.
+var IstanbulProtocol = Protocol{
+	Name:     "istanbul",
+	Versions: []uint{Kaia67, Kaia66, Kaia65, Kaia64},
+	Lengths:  []uint64{26, 24, 23, 21},
+}
+
+// ConsensusMsgCode is the p2p message code for BFT consensus messages.
+const ConsensusMsgCode = 0x11
+
 // Protocol defines the protocol of the consensus
 type Protocol struct {
 	// Official short name of the protocol used during capability negotiation.

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -28,43 +28,9 @@ import (
 	"github.com/kaiachain/kaia/networks/p2p"
 )
 
-// Constants to match up protocol versions and messages
-const (
-	Kaia62 = 62
-	Kaia63 = 63
-	Kaia64 = 64
-	Kaia65 = 65
-	Kaia66 = 66
-	Kaia67 = 67
-)
-
-var KaiaProtocol = Protocol{
-	Name:     "kaia",
-	Versions: []uint{Kaia67, Kaia66, Kaia65, Kaia64, Kaia63, Kaia62},
-	Lengths:  []uint64{24, 22, 21, 19, 17, 8},
-}
-
-// IstanbulProtocol is the p2p protocol used by Istanbul BFT consensus nodes.
-var IstanbulProtocol = Protocol{
-	Name:     "istanbul",
-	Versions: []uint{Kaia67, Kaia66, Kaia65, Kaia64},
-	Lengths:  []uint64{26, 24, 23, 21},
-}
-
 // ConsensusMsgCode is the p2p message code for BFT consensus messages.
 const ConsensusMsgCode = 0x11
 
-// Protocol defines the protocol of the consensus
-type Protocol struct {
-	// Official short name of the protocol used during capability negotiation.
-	Name string
-	// Supported versions of the Kaia protocol (first is primary).
-	Versions []uint
-	// Number of implemented message corresponding to different protocol versions.
-	Lengths []uint64
-}
-
-// istanbul BFT
 // Broadcaster defines the interface to enqueue blocks to fetcher and find peer
 type Broadcaster interface {
 	// Enqueue add a block into fetcher queue

--- a/kaiax/gov/impl/mock/blockchain_mock.go
+++ b/kaiax/gov/impl/mock/blockchain_mock.go
@@ -80,6 +80,20 @@ func (mr *MockBlockChainMockRecorder) CurrentHeader() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentHeader", reflect.TypeOf((*MockBlockChain)(nil).CurrentHeader))
 }
 
+// HasBadBlock mocks base method.
+func (m *MockBlockChain) HasBadBlock(arg0 common.Hash) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasBadBlock", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasBadBlock indicates an expected call of HasBadBlock.
+func (mr *MockBlockChainMockRecorder) HasBadBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBadBlock", reflect.TypeOf((*MockBlockChain)(nil).HasBadBlock), arg0)
+}
+
 // GetBlock mocks base method.
 func (m *MockBlockChain) GetBlock(arg0 common.Hash, arg1 uint64) *types.Block {
 	m.ctrl.T.Helper()

--- a/node/cn/channel_manager_test.go
+++ b/node/cn/channel_manager_test.go
@@ -21,7 +21,7 @@ package cn
 import (
 	"testing"
 
-	"github.com/kaiachain/kaia/consensus/istanbul/backend"
+	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/stretchr/testify/assert"
 )
@@ -48,7 +48,7 @@ func TestChannelManager_ChannelSize_5(t *testing.T) {
 // message channels with the given channel size.
 func testChannelManager(t *testing.T, chSize int) {
 	cm := NewChannelManager(chSize)
-	cm.RegisterMsgCode(ConsensusChannel, backend.IstanbulMsg)
+	cm.RegisterMsgCode(ConsensusChannel, consensus.ConsensusMsgCode)
 
 	channel := make(chan p2p.Msg, channelSizePerPeer)
 	consensusChannel := make(chan p2p.Msg, channelSizePerPeer)
@@ -65,7 +65,7 @@ func testChannelManager(t *testing.T, chSize int) {
 			assert.Nil(t, ch)
 			assert.NoError(t, err)
 		}
-		ch, err := cm.GetChannelWithMsgCode(chIdx, backend.IstanbulMsg)
+		ch, err := cm.GetChannelWithMsgCode(chIdx, consensus.ConsensusMsgCode)
 		assert.Nil(t, ch)
 		assert.NoError(t, err)
 
@@ -96,7 +96,7 @@ func testChannelManager(t *testing.T, chSize int) {
 			assert.Equal(t, channel, ch)
 			assert.NoError(t, err)
 		}
-		ch, err := cm.GetChannelWithMsgCode(chIdx, backend.IstanbulMsg)
+		ch, err := cm.GetChannelWithMsgCode(chIdx, consensus.ConsensusMsgCode)
 		assert.Equal(t, consensusChannel, ch)
 		assert.NoError(t, err)
 

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -181,7 +181,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		},
 	}
 
-	handler.SetBroadcaster(manager, manager.nodetype)
+	handler.SetBroadcaster(manager)
 
 	// Figure out whether to allow fast sync or not
 	if (mode == downloader.FastSync || mode == downloader.SnapSync) && blockchain.CurrentBlock().NumberU64() > 0 {
@@ -196,7 +196,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		manager.fastSync = uint32(0)
 		manager.snapSync = uint32(1)
 	}
-	protocol := handler.Protocol()
+	protocol := consensus.IstanbulProtocol
 	logger.Info("Initialising Klaytn protocol", "versions", protocol.Versions, "network", networkId)
 	// Initiate a sub-protocol for every implemented version we can handle
 	manager.SubProtocols = make([]p2p.Protocol, 0, len(protocol.Versions))

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -196,8 +196,8 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		manager.fastSync = uint32(0)
 		manager.snapSync = uint32(1)
 	}
-	protocol := consensus.IstanbulProtocol
-	logger.Info("Initialising Klaytn protocol", "versions", protocol.Versions, "network", networkId)
+	protocol := ConsensusProtocol
+	logger.Info("Initialising Kaia protocol", "versions", protocol.Versions, "network", networkId)
 	// Initiate a sub-protocol for every implemented version we can handle
 	manager.SubProtocols = make([]p2p.Protocol, 0, len(protocol.Versions))
 	for i, version := range protocol.Versions {
@@ -694,9 +694,11 @@ func (pm *ProtocolManager) handleMsg(p Peer, addr common.Address, msg p2p.Msg) e
 	//	return err
 	//}
 	//addr := crypto.PubkeyToAddress(*pubKey)
-	if pm.handler != nil {
+	if msg.Code == consensus.ConsensusMsgCode {
+		if pm.handler == nil {
+			return nil
+		}
 		handled, err := pm.handler.HandleMsg(addr, msg)
-		// if msg is a consensus msg, handled is true and err is nil if handle msg is successful.
 		if handled {
 			return err
 		}

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -137,20 +137,18 @@ func newReceipt(gasUsed int) *types.Receipt {
 	return rct
 }
 
-type testConsensusHandler struct {
-	protocol consensus.Protocol
-}
+type testConsensusHandler struct{}
 
-func (h *testConsensusHandler) Protocol() consensus.Protocol { return h.protocol }
-func (h *testConsensusHandler) NewChainHead() error          { return nil }
+func (h *testConsensusHandler) NewChainHead() error { return nil }
 func (h *testConsensusHandler) HandleMsg(common.Address, p2p.Msg) (bool, error) {
 	return false, nil
 }
-func (h *testConsensusHandler) SetBroadcaster(consensus.Broadcaster, common.ConnType) {}
-func (h *testConsensusHandler) RegisterConsensusMsgCode(consensus.Peer)               {}
+func (h *testConsensusHandler) SetBroadcaster(consensus.Broadcaster) {}
 
 func TestNewProtocolManager(t *testing.T) {
-	// 1. NewProtocolManager can be initialized with faker as consensus handler.
+	// NewProtocolManager uses consensus.IstanbulProtocol directly (not handler-provided).
+	// Verifies successful initialization with all Istanbul versions passing the
+	// FastSync version filter (>= kaia63).
 	{
 		mockCtrl, mockBlockChain, mockTxPool := newMocks(t)
 		defer mockCtrl.Finish()
@@ -159,10 +157,11 @@ func TestNewProtocolManager(t *testing.T) {
 		mockBlockChain.EXPECT().CurrentBlock().Return(block).Times(1)
 
 		pm, err := NewProtocolManager(params.TestChainConfig, downloader.FastSync, 0, nil, mockTxPool,
-			&testConsensusHandler{protocol: consensus.Protocol{}}, mockBlockChain, nil, 1, common.ConnTypeUndefined, &Config{})
+			&testConsensusHandler{}, mockBlockChain, nil, 1, common.CONSENSUSNODE,
+			&Config{DownloaderDisable: true, FetcherDisable: true})
 
-		assert.Nil(t, pm)
-		assert.Equal(t, errIncompatibleConfig, err)
+		assert.NotNil(t, pm)
+		assert.NoError(t, err)
 	}
 }
 

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -146,7 +146,7 @@ func (h *testConsensusHandler) HandleMsg(common.Address, p2p.Msg) (bool, error) 
 func (h *testConsensusHandler) SetBroadcaster(consensus.Broadcaster) {}
 
 func TestNewProtocolManager(t *testing.T) {
-	// NewProtocolManager uses consensus.IstanbulProtocol directly (not handler-provided).
+	// NewProtocolManager uses ConsensusProtocol directly (not handler-provided).
 	// Verifies successful initialization with all Istanbul versions passing the
 	// FastSync version filter (>= kaia63).
 	{

--- a/node/cn/metrics.go
+++ b/node/cn/metrics.go
@@ -23,7 +23,7 @@
 package cn
 
 import (
-	"github.com/kaiachain/kaia/consensus/istanbul/backend"
+	"github.com/kaiachain/kaia/consensus"
 	metricutils "github.com/kaiachain/kaia/metrics/utils"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/rcrowley/go-metrics"
@@ -123,7 +123,7 @@ func (rw *meteredMsgReadWriter) ReadMsg() (p2p.Msg, error) {
 		packets, traffic = propBlockInPacketsMeter, propBlockInTrafficMeter
 	case msg.Code == TxMsg:
 		packets, traffic = propTxnInPacketsMeter, propTxnInTrafficMeter
-	case msg.Code == backend.IstanbulMsg:
+	case msg.Code == consensus.ConsensusMsgCode:
 		packets, traffic = propConsensusIstanbulInPacketsMeter, propConsensusIstanbulInTrafficMeter
 	}
 	packets.Mark(1)
@@ -152,7 +152,7 @@ func (rw *meteredMsgReadWriter) WriteMsg(msg p2p.Msg) error {
 		packets, traffic = propBlockOutPacketsMeter, propBlockOutTrafficMeter
 	case msg.Code == TxMsg:
 		packets, traffic = propTxnOutPacketsMeter, propTxnOutTrafficMeter
-	case msg.Code == backend.IstanbulMsg:
+	case msg.Code == consensus.ConsensusMsgCode:
 		packets, traffic = propConsensusIstanbulOutPacketsMeter, propConsensusIstanbulOutTrafficMeter
 	}
 	packets.Mark(1)

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/kaiax/auction"
@@ -1274,7 +1275,9 @@ func (p *multiChannelPeer) Handle(pm *ProtocolManager) error {
 	if pm.handler != nil && pm.nodetype == common.CONSENSUSNODE {
 		consensusChannel = make(chan p2p.Msg, channelSizePerPeer)
 		defer close(consensusChannel)
-		pm.handler.RegisterConsensusMsgCode(p)
+		if err := p.RegisterConsensusMsgCode(consensus.ConsensusMsgCode); err != nil {
+			logger.Error("RegisterConsensusMsgCode failed", "err", err)
+		}
 		isCN = true
 	}
 

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus/istanbul/backend"
+	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/node/cn/snap"
 )
@@ -588,7 +588,7 @@ func (peers *peerSet) UpdateTypePeersWithoutTxs(tx *types.Transaction, nodeType 
 func (peers *peerSet) RegisterSnapExtension(peer *snap.Peer) error {
 	// Reject the peer if it advertises `snap` without `klay` as `snap` is only a
 	// satellite protocol meaningful with the chain selection of `klay`
-	if !peer.RunningCap(backend.IstanbulProtocol.Name, backend.IstanbulProtocol.Versions) {
+	if !peer.RunningCap(consensus.IstanbulProtocol.Name, consensus.IstanbulProtocol.Versions) {
 		return errSnapWithoutIstanbul
 	}
 	// Ensure nobody can double connect

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
-	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/node/cn/snap"
 )
@@ -588,7 +587,7 @@ func (peers *peerSet) UpdateTypePeersWithoutTxs(tx *types.Transaction, nodeType 
 func (peers *peerSet) RegisterSnapExtension(peer *snap.Peer) error {
 	// Reject the peer if it advertises `snap` without `klay` as `snap` is only a
 	// satellite protocol meaningful with the chain selection of `klay`
-	if !peer.RunningCap(consensus.IstanbulProtocol.Name, consensus.IstanbulProtocol.Versions) {
+	if !peer.RunningCap(ConsensusProtocol.Name, ConsensusProtocol.Versions) {
 		return errSnapWithoutIstanbul
 	}
 	// Ensure nobody can double connect

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -39,14 +39,30 @@ import (
 	"github.com/kaiachain/kaia/rlp"
 )
 
-// `kaia` is the default fallback protocol for all consensus engine types.
-// The name, versions, and lengths are defined in consensus/protocol.go.
 const (
 	kaia63 = 63
+	kaia64 = 64
 	kaia65 = 65
 	kaia66 = 66
 	kaia67 = 67
 )
+
+// Protocol defines the P2P protocol metadata used during capability negotiation.
+type Protocol struct {
+	// Official short name of the protocol used during capability negotiation.
+	Name string
+	// Supported versions of the Kaia protocol (first is primary).
+	Versions []uint
+	// Number of implemented message corresponding to different protocol versions.
+	Lengths []uint64
+}
+
+// ConsensusProtocol is the P2P protocol used by BFT consensus nodes.
+var ConsensusProtocol = Protocol{
+	Name:     "istanbul",
+	Versions: []uint{kaia67, kaia66, kaia65, kaia64},
+	Lengths:  []uint64{26, 24, 23, 21},
+}
 
 const ProtocolMaxMsgSize = 12 * 1024 * 1024 // Maximum cap on the size of a protocol message
 

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -75,7 +75,7 @@ const (
 
 	// Protocol messages belonging to kaia/64
 	Unused10 = 0x10 // Skipped a number because 0x11 is already taken
-	Unused11 = 0x11 // Already used by consensus (IstanbulMsg)
+	Unused11 = 0x11 // Already used by consensus (consensus.ConsensusMsgCode)
 
 	// Protocol messages belonging to kaia/65
 	StakingInfoRequestMsg = 0x12

--- a/tests/executor_test.go
+++ b/tests/executor_test.go
@@ -1,4 +1,4 @@
-// Modifications Copyright 2024 The Kaia Authors
+// Modifications Copyright 2026 The Kaia Authors
 // This file is part of the Kaia library.
 //
 // The Kaia library is free software: you can redistribute it and/or modify

--- a/tests/executor_test.go
+++ b/tests/executor_test.go
@@ -1,0 +1,166 @@
+// Modifications Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/profile"
+	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/work"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultExecutor_Clone verifies that Clone returns a fresh executor that
+// shares immutable config but has independent mutable state.
+func TestDefaultExecutor_Clone(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
+
+	bcdata, err := NewBCDataWithConfigs(6, 4, Forks["Magma"], nil)
+	require.NoError(t, err)
+	defer bcdata.Shutdown()
+
+	executor := work.NewDefaultExecutor(bcdata.bc.Config(), bcdata.bc, nodeAddr)
+
+	// Clone before initialization — clone should also be uninitialized.
+	clone := executor.Clone()
+	require.NotNil(t, clone)
+
+	// Initialize original — clone must remain uninitialized.
+	parent := bcdata.bc.CurrentBlock()
+	parentState, err := bcdata.bc.PrunableStateAt(parent.Root(), parent.NumberU64())
+	require.NoError(t, err)
+
+	header := &types.Header{
+		ParentHash: parent.Hash(),
+		Number:     new(big.Int).Add(parent.Number(), common.Big1),
+		Time:       new(big.Int).Add(parent.Time(), common.Big1),
+	}
+	require.NoError(t, executor.ResetWithState(parentState, header))
+
+	// Clone should fail ExecuteTransactions because it was never initialized.
+	_, err = clone.ExecuteTransactions(nil)
+	assert.ErrorIs(t, err, work.ErrExecutorNotInitialized)
+
+	// Initialize clone separately — should succeed independently.
+	cloneState, err := bcdata.bc.PrunableStateAt(parent.Root(), parent.NumberU64())
+	require.NoError(t, err)
+	require.NoError(t, clone.ResetWithState(cloneState, header))
+
+	result, err := clone.ExecuteTransactions(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), result.UsedGas)
+}
+
+// TestExecuteTransactions_MatchesInsertChain is the single canonical test for
+// speculative execution correctness. It asserts that the speculative pipeline
+// (ExecuteTransactions + FinalizeState) produces identical state root, receipt
+// root, bloom, and gas-used as the proposer's MineABlock AND that InsertChain
+// accepts the same block (confirming StateProcessor.Process also agrees).
+func TestExecuteTransactions_MatchesInsertChain(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
+
+	bcdata, err := NewBCDataWithConfigs(6, 4, Forks["Magma"], nil)
+	require.NoError(t, err)
+	defer bcdata.Shutdown()
+
+	// --- 1. Create value-transfer transactions ---
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
+	gasPrice := new(big.Int).Add(bcdata.bc.CurrentBlock().Header().BaseFee, big.NewInt(1))
+
+	var txs types.Transactions
+	sender := bcdata.privKeys[0]
+	senderAddr := *bcdata.addrs[0]
+
+	stateDb, err := bcdata.bc.State()
+	require.NoError(t, err)
+	nonce := stateDb.GetNonce(senderAddr)
+	for i := range 5 {
+		recipient := *bcdata.addrs[1+i%4]
+		tx := types.NewTransaction(
+			nonce,
+			recipient,
+			new(big.Int).SetUint64(1000),
+			params.TxGas,
+			gasPrice,
+			nil,
+		)
+		signedTx, err := types.SignTx(tx, signer, sender)
+		require.NoError(t, err)
+		txs = append(txs, signedTx)
+		nonce++
+	}
+
+	// --- 2. Mine a block (proposer path) ---
+	prof := profile.NewProfiler()
+	_, block, _, err := bcdata.MineABlock(txs, signer, prof, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(txs), len(block.Transactions()), "all txs should be included")
+
+	// --- 3. Speculative execution (validator path) ---
+	parent := bcdata.bc.CurrentBlock()
+	parentState, err := bcdata.bc.PrunableStateAt(parent.Root(), parent.NumberU64())
+	require.NoError(t, err)
+
+	executor := work.NewDefaultExecutor(bcdata.bc.Config(), bcdata.bc, common.Address{})
+	require.NoError(t, executor.ResetWithState(parentState, block.Header()))
+
+	specResult, err := executor.ExecuteTransactions(block.Transactions())
+	require.NoError(t, err)
+
+	specBlock, err := executor.FinalizeState(specResult)
+	require.NoError(t, err)
+
+	// --- 4. Compare speculative results with block header ---
+	// State root: the most critical invariant.
+	assert.Equal(t, block.Root(), specBlock.Root(),
+		"state root mismatch between proposer and speculative execution")
+
+	// Receipt root.
+	specReceiptRoot := types.DeriveReceiptsRoot(specResult.Receipts, block.Number())
+	assert.Equal(t, block.ReceiptHash(), specReceiptRoot,
+		"receipt root mismatch between proposer and speculative execution")
+
+	// Bloom filter.
+	specBloom := types.CreateBloom(specResult.Receipts)
+	assert.Equal(t, block.Bloom(), specBloom,
+		"bloom mismatch between proposer and speculative execution")
+
+	// Gas used.
+	assert.Equal(t, block.GasUsed(), specResult.UsedGas,
+		"gas used mismatch between proposer and speculative execution")
+
+	// Receipt count.
+	assert.Equal(t, len(block.Transactions()), len(specResult.Receipts),
+		"receipt count mismatch")
+
+	// All receipts successful.
+	for i, receipt := range specResult.Receipts {
+		assert.Equal(t, uint(1), receipt.Status,
+			"receipt %d should succeed", i)
+	}
+
+	// --- 5. InsertChain: confirms Process path also matches ---
+	n, err := bcdata.bc.InsertChain(types.Blocks{block})
+	assert.NoError(t, err, "InsertChain should accept the block")
+	assert.Equal(t, 0, n, "InsertChain should process the block at index 0")
+}

--- a/work/execution.go
+++ b/work/execution.go
@@ -18,10 +18,12 @@ package work
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/event"
@@ -72,6 +74,20 @@ func NewDefaultExecutor(config *params.ChainConfig, chain BlockChain, nodeAddr c
 	}
 }
 
+// Clone returns a fresh DefaultExecutor that shares immutable configuration
+// with e but carries its own mutable execution state.
+func (e *DefaultExecutor) Clone() consensus.Executor {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return &DefaultExecutor{
+		config:            e.config,
+		chain:             e.chain,
+		nodeAddr:          e.nodeAddr,
+		signer:            e.signer,
+		txBundlingModules: e.txBundlingModules,
+	}
+}
+
 // SetTxBundlingModules sets the transaction bundling modules for gasless transactions.
 func (e *DefaultExecutor) SetTxBundlingModules(modules []builder.TxBundlingModule) {
 	e.mu.Lock()
@@ -117,6 +133,57 @@ func (e *DefaultExecutor) Execute(txs *types.TransactionsByPriceAndNonce, mux *e
 	e.txs = task.Transactions()
 	e.receipts = task.Receipts()
 	e.usedGas = e.header.GasUsed
+
+	return e.buildResult(), nil
+}
+
+// ExecuteTransactions executes the given transactions in the provided order
+// without re-sorting. This is the validator-path primitive used during
+// speculative execution of a received pre-prepare block.
+//
+// Mirrors the per-transaction loop of StateProcessor.Process (InitializeState +
+// ApplyTransaction per tx), but deliberately excludes FinalizeState — the caller
+// must invoke FinalizeState separately after this returns.
+func (e *DefaultExecutor) ExecuteTransactions(txs []*types.Transaction) (*consensus.ExecutionResult, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !e.initialized {
+		return nil, ErrExecutorNotInitialized
+	}
+
+	// Pre-tx hooks (EIP-2935, kaiax module pre-hooks, etc.)
+	e.chain.Processor().InitializeState(e.header, e.state)
+
+	// Extract the block proposer from the header seal — must match
+	// StateProcessor.Process so COINBASE and reward distribution are identical.
+	// Using e.nodeAddr here would be wrong: the local validator is not
+	// necessarily the proposer of this block.
+	author, _ := e.chain.Sealer().Author(e.header)
+
+	var (
+		receipts types.Receipts
+		allLogs  []*types.Log
+		usedGas  = new(uint64)
+	)
+
+	for i, tx := range txs {
+		e.state.SetTxContext(tx.Hash(), common.Hash{}, i)
+		receipt, _, err := e.chain.ApplyTransaction(
+			e.config, &author, e.state, e.header, tx, usedGas, &vm.Config{},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("tx %d (%s): %w", i, tx.Hash().Hex(), err)
+		}
+		receipts = append(receipts, receipt)
+		allLogs = append(allLogs, receipt.Logs...)
+	}
+
+	e.header.GasUsed = *usedGas
+	e.txs = txs
+	e.receipts = receipts
+	e.logs = allLogs
+	e.usedGas = *usedGas
 
 	return e.buildResult(), nil
 }

--- a/work/worker.go
+++ b/work/worker.go
@@ -249,7 +249,7 @@ func (self *worker) start() {
 
 	executor := NewDefaultExecutor(self.config, self.chain, self.nodeAddr)
 	executor.SetTxBundlingModules(self.txBundlingModules)
-	self.engine.Start(self.chain, self.chain.CurrentBlock, self.chain.HasBadBlock, executor)
+	self.engine.Start(self.chain, executor)
 }
 
 func (self *worker) stop() {


### PR DESCRIPTION
## Proposed changes

Second PR of the kaiabft series.

This PR introduces slim consensus interfaces so the future consensus/kaiabft engine can plug in cleanly. Both engines share the same wire types, protocol constants, and executor surface without touching each other's internals. No runtime behavior changes.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
