### PR TITLE
Permissionless: refactor entity group methods

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -24,7 +24,6 @@ package backend
 
 import (
 	"crypto/ecdsa"
-	"errors"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -448,18 +447,6 @@ func (sb *backend) GetValidatorSet(num uint64) (*istanbul.BlockValSet, error) {
 	}
 
 	return istanbul.NewBlockValSet(council, demoted), nil
-}
-
-// GetCandidates returns the candidate (CandTesting) addresses at block num.
-func (sb *backend) GetCandidates(num uint64) ([]common.Address, error) {
-	if sb.valsetModule == nil {
-		return nil, errors.New("valsetModule is nil")
-	}
-	candidates, err := sb.valsetModule.GetCandidates(num)
-	if err != nil {
-		return nil, err
-	}
-	return candidates, nil
 }
 
 func (sb *backend) GetCommitteeState(num uint64) (*istanbul.RoundCommitteeState, error) {

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/networks/p2p"
 )
 
@@ -124,13 +125,22 @@ func (sb *backend) ValidatePeerType(addr common.Address) error {
 	}
 	num := sb.chain.CurrentHeader().Number.Uint64() + 1
 
-	// Permissionless: use CNPeers (VA+VR+VP+CR+CT) for P2P connection validation
+	// Permissionless: CNPeers (VA+VR+VP+CR+CT) for active participants,
+	// plus VI/VE for block sync until CN-EN connectivity is available.
+	// TODO: Remove VI/VE exception after CN-EN connectivity PR lands.
 	if sb.chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
 		cnPeers, err := sb.valsetModule.GetCNPeers(num)
 		if err != nil {
 			return err
 		}
 		if slices.Contains(cnPeers, addr) {
+			return nil
+		}
+		viVe, err := sb.valsetModule.GetNodeByState(num, []valset.State{valset.ValInactive, valset.ValExiting})
+		if err != nil {
+			return err
+		}
+		if slices.Contains(viVe.Addresses(), addr) {
 			return nil
 		}
 		return errInvalidPeerAddress
@@ -169,8 +179,8 @@ func (sb *backend) NewChainHead() error {
 	}
 
 	go sb.istanbulEventMux.Post(istanbul.FinalCommittedEvent{})
-	// TODO: Discuss in team whether to enable active CN peer disconnect.
-	// Concern: VI/VE nodes lose block sync since CN discovery doesn't cover EN/PN.
+	// TODO: Enable after CN-EN connectivity PR lands; VI/VE block sync is handled
+	// by ValidatePeerType allowing VI/VE until then.
 	// sb.disconnectNonCNPeers()
 	return nil
 }

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -24,6 +24,7 @@ package backend
 
 import (
 	"errors"
+	"math/big"
 	"slices"
 	"time"
 
@@ -122,19 +123,24 @@ func (sb *backend) ValidatePeerType(addr common.Address) error {
 		return errNoChainReader
 	}
 	num := sb.chain.CurrentHeader().Number.Uint64() + 1
+
+	// Permissionless: use CNPeers (VA+VR+VP+CR+CT) for P2P connection validation
+	if sb.chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		cnPeers, err := sb.valsetModule.GetCNPeers(num)
+		if err != nil {
+			return err
+		}
+		if slices.Contains(cnPeers, addr) {
+			return nil
+		}
+		return errInvalidPeerAddress
+	}
+
 	valSet, err := sb.GetValidatorSet(num)
 	if err != nil {
 		return errInvalidPeerAddress
 	}
 	if valSet.Council().Contains(addr) {
-		return nil
-	}
-
-	candidates, err := sb.GetCandidates(num)
-	if err != nil {
-		return errInvalidPeerAddress
-	}
-	if slices.Contains(candidates, addr) {
 		return nil
 	}
 	return errInvalidPeerAddress
@@ -163,5 +169,40 @@ func (sb *backend) NewChainHead() error {
 	}
 
 	go sb.istanbulEventMux.Post(istanbul.FinalCommittedEvent{})
+	// TODO: Discuss in team whether to enable active CN peer disconnect.
+	// Concern: VI/VE nodes lose block sync since CN discovery doesn't cover EN/PN.
+	// sb.disconnectNonCNPeers()
 	return nil
+}
+
+// disconnectNonCNPeers disconnects CN peers that are no longer in the CNPeers set.
+func (sb *backend) disconnectNonCNPeers() {
+	if sb.broadcaster == nil || sb.valsetModule == nil || sb.chain == nil {
+		return
+	}
+	header := sb.chain.CurrentHeader()
+	if header == nil {
+		return
+	}
+	num := header.Number.Uint64()
+	if !sb.chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return
+	}
+	cnPeers, err := sb.valsetModule.GetCNPeers(num)
+	if err != nil {
+		return
+	}
+	cnPeerSet := make(map[common.Address]bool, len(cnPeers))
+	for _, addr := range cnPeers {
+		cnPeerSet[addr] = true
+	}
+	var toDisconnect []common.Address
+	for addr := range sb.broadcaster.GetCNPeers() {
+		if !cnPeerSet[addr] {
+			toDisconnect = append(toDisconnect, addr)
+		}
+	}
+	if len(toDisconnect) > 0 {
+		sb.broadcaster.DisconnectCNPeers(toDisconnect)
+	}
 }

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -19,15 +19,20 @@
 package backend
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/istanbul"
+	vrank_mock "github.com/kaiachain/kaia/kaiax/vrank/mock"
 	"github.com/kaiachain/kaia/networks/p2p"
+	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackend_HandleMsg(t *testing.T) {
@@ -136,20 +141,24 @@ func TestBackend_Protocol(t *testing.T) {
 }
 
 func TestBackend_ValidatePeerType(t *testing.T) {
-	_, backend := newBlockChain(1)
-	defer backend.Stop()
+	t.Run("permissioned", func(t *testing.T) {
+		_, b := newBlockChain(1)
+		defer b.Stop()
 
-	// Return nil if the input address is a validator
-	{
-		err := backend.ValidatePeerType(backend.address)
-		assert.Nil(t, err)
-	}
+		assert.NoError(t, b.ValidatePeerType(b.address))
+		assert.Equal(t, errInvalidPeerAddress, b.ValidatePeerType(common.HexToAddress("0xdead")))
+	})
 
-	// Return an error if the input address is invalid
-	{
-		err := backend.ValidatePeerType(common.Address{})
-		assert.Equal(t, errInvalidPeerAddress, err)
-	}
+	t.Run("permissionless", func(t *testing.T) {
+		b, cleanup := newPermissionlessBlockChain(t, 1)
+		defer cleanup()
+
+		cnPeers, err := b.valsetModule.GetCNPeers(1)
+		require.NoError(t, err)
+		require.NotEmpty(t, cnPeers)
+		assert.NoError(t, b.ValidatePeerType(cnPeers[0]))
+		assert.Equal(t, errInvalidPeerAddress, b.ValidatePeerType(common.HexToAddress("0xdead")))
+	})
 }
 
 // startBlockedValidatePeer creates a test backend and starts a goroutine that
@@ -196,5 +205,42 @@ func TestValidatePeerType_UnblocksOnStop(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("ValidatePeerType should unblock after Stop")
+	}
+}
+
+func TestGetHeaderGovVoters(t *testing.T) {
+	t.Run("permissioned", func(t *testing.T) {
+		_, b := newBlockChain(1)
+		defer b.Stop()
+
+		voters, err := b.valsetModule.GetHeaderGovVoters(1)
+		require.NoError(t, err)
+		assert.Contains(t, voters, b.address)
+	})
+
+	t.Run("permissionless", func(t *testing.T) {
+		b, cleanup := newPermissionlessBlockChain(t, 1)
+		defer cleanup()
+
+		voters, err := b.valsetModule.GetHeaderGovVoters(1)
+		require.NoError(t, err)
+		// MakeTestPermissionlessConfig(1) registers 1 ValActive node → 1 gov voter
+		assert.Len(t, voters, 1)
+	})
+}
+
+func newPermissionlessBlockChain(t *testing.T, n int) (*backend, func()) {
+	t.Helper()
+	config := params.TestChainConfig.Copy()
+	config.PermissionlessCompatibleBlock = big.NewInt(0)
+
+	ctrl := gomock.NewController(t)
+	mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+	mockVRank.EXPECT().GetPfReport(gomock.Any()).Return(nil, nil).AnyTimes()
+
+	_, b := newBlockChain(n, config, mockVRank)
+	return b, func() {
+		b.Stop()
+		ctrl.Finish()
 	}
 }

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -70,6 +70,9 @@ type Broadcaster interface {
 	GetENPeers() map[common.Address]Peer
 
 	RegisterValidator(conType common.ConnType, validator p2p.PeerTypeValidator)
+
+	// DisconnectCNPeers disconnects the CN peers with the given addresses.
+	DisconnectCNPeers(addrs []common.Address)
 }
 
 // Peer defines the interface to communicate with peer

--- a/kaiax/gov/headergov/impl/api.go
+++ b/kaiax/gov/headergov/impl/api.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"maps"
+	"slices"
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
@@ -58,6 +59,19 @@ func (api *headerGovAPI) Vote(name string, value any) (string, error) {
 
 	if gMode == "single" && voter != gp.GoverningNode {
 		return "", ErrVotePermissionDenied
+	}
+
+	// Fail-fast check at queue time: block voting if not currently eligible.
+	// The canonical enforcement is at VerifyVote (proposal time), but blocking
+	// here gives immediate feedback and avoids queuing votes that will never apply.
+	if api.h.ValSet != nil {
+		voters, err := api.h.ValSet.GetHeaderGovVoters(blockNumber)
+		if err != nil {
+			return "", err
+		}
+		if !slices.Contains(voters, voter) {
+			return "", ErrVotePermissionDenied
+		}
 	}
 
 	vote := headergov.NewVoteData(voter, name, value)

--- a/kaiax/gov/headergov/impl/api_test.go
+++ b/kaiax/gov/headergov/impl/api_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kaiachain/kaia/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,6 +26,23 @@ func TestVoteLowerBoundBaseFee(t *testing.T) {
 	s, err := api.Vote("kip71.lowerboundbasefee", uint64(1e18))
 	assert.Equal(t, ErrLowerBoundBaseFee, err)
 	assert.Equal(t, "", s)
+}
+
+func TestVoteEligibility(t *testing.T) {
+	t.Run("eligible voter succeeds", func(t *testing.T) {
+		api := newHeaderGovAPI(t)
+		// nodeAddress is GoverningNode which is in HeaderGovVoters mock
+		_, err := api.Vote("governance.unitprice", uint64(25000000000))
+		assert.NoError(t, err)
+	})
+
+	t.Run("ineligible voter denied", func(t *testing.T) {
+		api := newHeaderGovAPI(t)
+		// Simulate voter not in HeaderGovVoters (e.g. suspended VA or ValPaused)
+		api.h.nodeAddress = common.Address{99}
+		_, err := api.Vote("governance.unitprice", uint64(25000000000))
+		assert.Equal(t, ErrVotePermissionDenied, err)
+	})
 }
 
 func TestValidatorVotes(t *testing.T) {

--- a/kaiax/gov/headergov/impl/consensus.go
+++ b/kaiax/gov/headergov/impl/consensus.go
@@ -29,9 +29,16 @@ func (h *headerGovModule) VerifyHeader(header *types.Header) error {
 
 func (h *headerGovModule) PrepareHeader(header *types.Header) error {
 	// if this node has a vote waiting to be casted, put Vote field.
+	// Skip if not in HeaderGovVoters to avoid VerifyVote failure and RC.
+	// A queued vote can exist despite Vote() blocking: node voted while unsuspended,
+	// then got suspended before proposing.
 	if vote, ok := h.peekMyVote(); ok {
-		header.Vote, _ = vote.ToVoteBytes()
-		logger.Debug("Prepare header with vote", "num", header.Number.Uint64(), "vote", hexutil.Encode(header.Vote))
+		blockNum := header.Number.Uint64()
+		voters, err := h.ValSet.GetHeaderGovVoters(blockNum)
+		if err == nil && slices.Contains(voters, h.nodeAddress) {
+			header.Vote, _ = vote.ToVoteBytes()
+			logger.Debug("Prepare header with vote", "num", blockNum, "vote", hexutil.Encode(header.Vote))
+		}
 	}
 
 	// if epoch block & vote exists in the last epoch, put Governance field.
@@ -50,8 +57,9 @@ func (h *headerGovModule) FinalizeHeader(header *types.Header, state *state.Stat
 	return nil
 }
 
-// VerifyVote checks the following:
-// (1) voter must be in valset,
+// VerifyVote is the canonical enforcement point for vote eligibility at proposal time.
+// It checks the following:
+// (1) voter must be in HeaderGovVoters at this block (suspended VA excluded),
 // (2) integrity of the voter (the voter must be the block proposer),
 // (3) the vote value must be consistent compared to the latest ParamSet.
 func (h *headerGovModule) VerifyVote(header *types.Header) error {
@@ -73,14 +81,14 @@ func (h *headerGovModule) VerifyVote(header *types.Header) error {
 		return err
 	}
 
-	council, err := h.ValSet.GetCouncil(blockNum)
+	voters, err := h.ValSet.GetHeaderGovVoters(blockNum)
 	if err != nil {
 		return err
 	}
 
-	// check if the voter is in council
-	if !slices.Contains(council, vote.Voter()) {
-		return ErrInvalidKeyValue
+	// check if the voter is a governance-eligible validator
+	if !slices.Contains(voters, vote.Voter()) {
+		return ErrVotePermissionDenied
 	}
 
 	// check if Voter is the block proposer.
@@ -149,15 +157,15 @@ func (h *headerGovModule) checkConsistency(blockNum uint64, vote headergov.VoteD
 			return nil
 		}
 
-		// we'll use blockNum-1 for the blocknumber of GetCouncil since blockNum cannot be available(eg. vote)
+		// we'll use blockNum-1 since blockNum cannot be available(eg. vote)
 		// it's definite that the valSet vote is not included in this block
-		// so the council(blockNum - 1) and council(blockNum) should be same
-		council, err := h.ValSet.GetCouncil(blockNum - 1)
+		// so the voters(blockNum - 1) and voters(blockNum) should be same
+		voters, err := h.ValSet.GetHeaderGovVoters(blockNum - 1)
 		if err != nil {
 			return err
 		}
 
-		if slices.Contains(council, params.GoverningNode) {
+		if slices.Contains(voters, params.GoverningNode) {
 			return nil
 		}
 		return ErrGovNodeNotInValSetList

--- a/kaiax/gov/headergov/impl/consensus_test.go
+++ b/kaiax/gov/headergov/impl/consensus_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	"github.com/kaiachain/kaia/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyHeader(t *testing.T) {
@@ -105,6 +106,10 @@ func TestVerifyVote(t *testing.T) {
 		// RewardUseGiniCoeff vote is forbidden
 		{desc: "valid addvalidator", vote: headergov.NewVoteData(validVoter, string(gov.AddValidator), eoa), expectedError: nil},
 		{desc: "valid removevalidator", vote: headergov.NewVoteData(validVoter, string(gov.RemoveValidator), eoa), expectedError: nil},
+
+		// HeaderGovVoters enforcement: VP and suspended VA are not eligible
+		{desc: "ValPaused voter not eligible", vote: headergov.NewVoteData(common.Address{99}, string(gov.GovernanceUnitPrice), uint64(25000000000)), expectedError: ErrVotePermissionDenied},
+		{desc: "suspended VA not eligible", vote: headergov.NewVoteData(common.Address{98}, string(gov.GovernanceUnitPrice), uint64(25000000000)), expectedError: ErrVotePermissionDenied},
 	}
 
 	for _, tc := range tcs {
@@ -113,6 +118,38 @@ func TestVerifyVote(t *testing.T) {
 			assert.NoError(t, err)
 			err = h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra})
 			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}
+
+func TestPrepareHeader_VoteEligibility(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlCrit)
+
+	tcs := []struct {
+		desc         string
+		overrideAddr *common.Address // nil = keep eligible nodeAddress
+		wantVote     bool
+	}{
+		{"eligible voter includes vote in header", nil, true},
+		{"ineligible voter skips vote in header", &common.Address{99}, false},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			h := newHeaderGovModule(t, getTestChainConfig())
+			h.PushMyVotes(headergov.NewVoteData(h.nodeAddress, string(gov.GovernanceUnitPrice), uint64(100)))
+
+			if tc.overrideAddr != nil {
+				h.nodeAddress = *tc.overrideAddr
+			}
+
+			header := &types.Header{Number: big.NewInt(1)}
+			require.NoError(t, h.PrepareHeader(header))
+			if tc.wantVote {
+				assert.NotNil(t, header.Vote)
+			} else {
+				assert.Nil(t, header.Vote)
+			}
 		})
 	}
 }

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -37,7 +37,7 @@ type chain interface {
 }
 
 type ValsetModule interface {
-	GetCouncil(num uint64) ([]common.Address, error)
+	GetHeaderGovVoters(num uint64) ([]common.Address, error)
 	GetProposer(num uint64, round uint64) (common.Address, error)
 }
 

--- a/kaiax/gov/headergov/impl/init_test.go
+++ b/kaiax/gov/headergov/impl/init_test.go
@@ -75,8 +75,7 @@ func newHeaderGovModule(t *testing.T, config *params.ChainConfig) *headerGovModu
 	chain.EXPECT().Engine().Return(engine).AnyTimes()
 	engine.EXPECT().Author(gomock.Any()).Return(validVoter, nil).AnyTimes()
 
-	valSet.EXPECT().GetCouncil(uint64(0)).Return([]common.Address{validVoter}, nil).AnyTimes()
-	valSet.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{validVoter}, nil).AnyTimes()
+	valSet.EXPECT().GetHeaderGovVoters(gomock.Any()).Return([]common.Address{validVoter, config.Governance.GoverningNode}, nil).AnyTimes()
 	valSet.EXPECT().GetProposer(uint64(1), uint64(0)).Return(validVoter, nil).AnyTimes()
 
 	h := NewHeaderGovModule()

--- a/kaiax/gov/headergov/impl/rewind.go
+++ b/kaiax/gov/headergov/impl/rewind.go
@@ -39,7 +39,6 @@ func (h *headerGovModule) RemoveVotesAfter(blockNum uint64) {
 }
 
 func (h *headerGovModule) RemoveGovAfter(blockNum uint64) {
-
 	dirty := false
 	for blockNumIter := range h.governances {
 		if blockNumIter > blockNum {

--- a/kaiax/staking/impl/getter.go
+++ b/kaiax/staking/impl/getter.go
@@ -199,7 +199,7 @@ func parsePermissionlessCallResult(num uint64, profiles []multicall.Profile, amo
 		stakingAmounts   []uint64
 	)
 	for i, p := range profiles {
-		if p.State != uint8(valset.ValActive) {
+		if !valset.State(p.State).IsRewardEligible() {
 			continue
 		}
 		nodeIds = append(nodeIds, p.NodeId)

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -26,13 +26,14 @@ import (
 )
 
 // GetCouncil returns the whole validator list for validating the block `num`.
+// In permissionless: Council = {ValActive, ValPaused}. VR excluded (voluntary standby).
 func (v *ValsetModule) GetCouncil(num uint64) ([]common.Address, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		nodes, err := v.GetNodeByState(num, valset.CouncilStates)
+		nodes, err := v.getNodeStates(num)
 		if err != nil {
 			return nil, err
 		}
-		return nodes.Addresses(), nil
+		return nodes.Council().Addresses(), nil
 	}
 	council, err := v.getCouncil(num)
 	if err != nil {
@@ -42,14 +43,15 @@ func (v *ValsetModule) GetCouncil(num uint64) ([]common.Address, error) {
 }
 
 // GetDemotedValidators returns the demoted validators at block `num`.
-// In permissionless: demoted = council - qualified = ValReady + ValPaused + suspended ValActive
+// In permissionless: demoted = council - committee = {ValPaused, suspended ValActive}
 // In permissioned: demoted = council members with staking < minimum
 func (v *ValsetModule) GetDemotedValidators(num uint64) ([]common.Address, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		council, err := v.GetNodeByState(num, valset.CouncilStates)
+		nodes, err := v.getNodeStates(num)
 		if err != nil {
 			return nil, err
 		}
+		council := nodes.Council()
 		qualified, err := v.getQualifiedValidators(num)
 		if err != nil {
 			return nil, err
@@ -65,22 +67,22 @@ func (v *ValsetModule) GetDemotedValidators(num uint64) ([]common.Address, error
 
 func (v *ValsetModule) getQualifiedValidators(num uint64) (*valset.AddressSet, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		// qualified = ValActive excluding suspended
-		m, err := v.GetNodeByState(num, valset.CommitteeStates)
+		nodes, err := v.getNodeStates(num)
 		if err != nil {
 			return nil, err
 		}
-		qualified := m.ExcludeSuspended()
+		committee := nodes.Committee()
 		// Safety fallback: if all ValActive are suspended, ignore the suspended set
 		// to prevent consensus halt.
-		if len(qualified) == 0 && len(m) > 0 {
+		allActive := nodes.FilterByState(valset.ValActive)
+		if len(committee) == 0 && len(allActive) > 0 {
 			if v.lastSuspendFallbackLog != num {
 				logger.Warn("all ValActive are suspended, ignoring suspended set for committee", "num", num)
 				v.lastSuspendFallbackLog = num
 			}
-			return valset.NewAddressSet(m.Addresses()), nil
+			return valset.NewAddressSet(allActive.Addresses()), nil
 		}
-		return valset.NewAddressSet(qualified.Addresses()), nil
+		return valset.NewAddressSet(committee.Addresses()), nil
 	}
 	council, demoted, err := v.getCouncilAndDemoted(num)
 	if err != nil {
@@ -132,9 +134,8 @@ func (v *ValsetModule) GetProposer(num, round uint64) (common.Address, error) {
 	return v.getProposer(c, round)
 }
 
-// GetNodeByState returns validators filtered by the given states at block num.
-// If no states are provided, returns all nodes.
-func (v *ValsetModule) GetNodeByState(num uint64, states []valset.State) (valset.NodeStateMap, error) {
+// getNodeStates returns all node states at block num. Internal use only — no Copy.
+func (v *ValsetModule) getNodeStates(num uint64) (valset.NodeStateMap, error) {
 	if !v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
 		return nil, errors.New("permissionless fork is not enabled")
 	}
@@ -170,29 +171,54 @@ func (v *ValsetModule) GetNodeByState(num uint64, states []valset.State) (valset
 			return nil, err
 		}
 	}
-
-	// empty states means return all
-	if len(states) == 0 {
-		return nodes.Copy(), nil
-	}
-
-	desiredStates := make(map[valset.State]struct{}, len(states))
-	for _, s := range states {
-		desiredStates[s] = struct{}{}
-	}
-	filtered := make(valset.NodeStateMap)
-	for addr, val := range nodes {
-		if _, ok := desiredStates[val.State]; ok {
-			filtered[addr] = val
-		}
-	}
-	return filtered.Copy(), nil
+	return nodes, nil
 }
 
-func (v *ValsetModule) GetCandidates(num uint64) ([]common.Address, error) {
-	candTestings, err := v.GetNodeByState(num, valset.CandidateStates)
+// GetNodeByState returns validators filtered by the given states at block num.
+// If no states are provided, returns all nodes. Used by RPC API.
+func (v *ValsetModule) GetNodeByState(num uint64, states []valset.State) (valset.NodeStateMap, error) {
+	nodes, err := v.getNodeStates(num)
 	if err != nil {
 		return nil, err
 	}
-	return candTestings.Addresses(), nil
+	if len(states) == 0 {
+		return nodes.Copy(), nil
+	}
+	return nodes.FilterByState(states...).Copy(), nil
+}
+
+func (v *ValsetModule) GetCandTesting(num uint64) ([]common.Address, error) {
+	nodes, err := v.getNodeStates(num)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.FilterByState(valset.CandTesting).Addresses(), nil
+}
+
+// GetCNPeers returns addresses of nodes that should maintain CN-CN P2P connections.
+// In permissionless: CNPeers = {VA, VR, VP, CR, CT}
+// In permissioned: equivalent to council (all council members are CN peers)
+func (v *ValsetModule) GetCNPeers(num uint64) ([]common.Address, error) {
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		nodes, err := v.getNodeStates(num)
+		if err != nil {
+			return nil, err
+		}
+		return nodes.CNPeers().Addresses(), nil
+	}
+	return v.GetCouncil(num)
+}
+
+// GetHeaderGovVoters returns addresses of validators eligible for governance header votes.
+// In permissionless: HeaderGovVoters = {VA} excluding suspended
+// In permissioned: equivalent to council
+func (v *ValsetModule) GetHeaderGovVoters(num uint64) ([]common.Address, error) {
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		nodes, err := v.getNodeStates(num)
+		if err != nil {
+			return nil, err
+		}
+		return nodes.HeaderGovVoters().Addresses(), nil
+	}
+	return v.GetCouncil(num)
 }

--- a/kaiax/valset/impl/state_transition_getter.go
+++ b/kaiax/valset/impl/state_transition_getter.go
@@ -44,6 +44,16 @@ func (v *ValsetModule) getEpochTransition(
 		newValidators        = validators.Copy()
 		activeValCompetitors []sortableValidator
 	)
+	// T3a/T3b: compete for top-N or demote to ValInactive.
+	// Shared by EpochCompetitors = {VA, VR, VP, CT}.
+	competeOrDemote := func(addr common.Address, val *valset.ValidatorState) {
+		if val.StakingAmount >= minStake {
+			activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val}) // T3a
+		} else {
+			val.State = valset.ValInactive // T3b
+			val.IdleTimeout = now.Add(idleTimeout)
+		}
+	}
 	for addr, val := range newValidators {
 		switch val.State {
 		case valset.ValExiting:
@@ -57,22 +67,12 @@ func (v *ValsetModule) getEpochTransition(
 			}
 		case valset.CandTesting:
 			if v.isPassVrankTest(addr, num, cfsThreshold, slotFactor) {
-				if val.StakingAmount >= minStake {
-					activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val}) // T3a
-				} else {
-					val.State = valset.ValInactive // T3b
-					val.IdleTimeout = now.Add(idleTimeout)
-				}
+				competeOrDemote(addr, val)
 			} else {
 				val.State = valset.Registered // T2
 			}
 		case valset.ValReady, valset.ValActive, valset.ValPaused:
-			if val.StakingAmount >= minStake {
-				activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val}) // T3a
-			} else {
-				val.State = valset.ValInactive // T3b
-				val.IdleTimeout = now.Add(idleTimeout)
-			}
+			competeOrDemote(addr, val)
 		}
 	}
 	slices.SortFunc(activeValCompetitors, func(a, b sortableValidator) int {

--- a/kaiax/valset/impl/state_transition_getter_test.go
+++ b/kaiax/valset/impl/state_transition_getter_test.go
@@ -902,47 +902,157 @@ func TestApplyAllTransitions(t *testing.T) {
 	}
 }
 
-// TestGetCouncilPermissionless tests GetCouncil filters by council states via GetNodeByState.
-func TestGetCouncilPermissionless(t *testing.T) {
-	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
-	config, _ := system.MakeTestPermissionlessConfig(7)
+// newPermlessValsetModule creates a ValsetModule backed by a simulated permissionless chain with n nodes.
+func newPermlessValsetModule(t *testing.T, n int) (*system.AllocPermissionlessConfig, *ValsetModule) {
+	t.Helper()
+	config, _ := system.MakeTestPermissionlessConfig(n)
 
 	alloc, err := system.AllocPermissionless(config)
 	require.NoError(t, err)
 
-	simBackend := backends.NewSimulatedBackend(blockchain.GenesisAlloc(alloc))
-	defer simBackend.Close()
-	chain := simBackend.BlockChain()
-	chain.Config().PermissionlessCompatibleBlock = big.NewInt(0)
+	chainConfig := params.TestChainConfig.Copy()
+	chainConfig.PermissionlessCompatibleBlock = big.NewInt(0)
+
+	simBackend := backends.NewSimulatedBackendWithChainConfig(blockchain.GenesisAlloc(alloc), chainConfig)
+	t.Cleanup(func() { simBackend.Close() })
 
 	v := NewValsetModule()
-	v.Chain = chain
+	v.Chain = simBackend.BlockChain()
+	return config, v
+}
+
+// TestGetCouncilPermissionless tests GetCouncil filters by council states via GetNodeByState.
+func TestGetCouncilPermissionless(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config, v := newPermlessValsetModule(t, 7)
 
 	// Seed cache: 7 validators covering all states
 	nodes := valset.NodeStateMap{
-		config.NodeIds[0]: {State: valset.ValActive},   // included
-		config.NodeIds[1]: {State: valset.ValPaused},   // included
-		config.NodeIds[2]: {State: valset.ValReady},    // included
-		config.NodeIds[3]: {State: valset.ValInactive}, // excluded
-		config.NodeIds[4]: {State: valset.ValExiting},  // excluded
-		config.NodeIds[5]: {State: valset.CandReady},   // excluded
-		config.NodeIds[6]: {State: valset.Registered},  // excluded
+		config.NodeIds[0]: {State: valset.ValActive},
+		config.NodeIds[1]: {State: valset.ValPaused},
+		config.NodeIds[2]: {State: valset.ValReady},
+		config.NodeIds[3]: {State: valset.ValInactive},
+		config.NodeIds[4]: {State: valset.ValExiting},
+		config.NodeIds[5]: {State: valset.CandReady},
+		config.NodeIds[6]: {State: valset.Registered},
 	}
 	v.nodeStatesCache.Add(uint64(1), nodeStatesCacheEntry{validators: nodes})
 
 	council, err := v.GetCouncil(1)
 	require.NoError(t, err)
 
-	// Only ValActive, ValPaused, ValReady should be in council (3 of 7)
-	councilAddrs := council
-	assert.Len(t, councilAddrs, 3)
-	assert.Contains(t, councilAddrs, config.NodeIds[0])
-	assert.Contains(t, councilAddrs, config.NodeIds[1])
-	assert.Contains(t, councilAddrs, config.NodeIds[2])
-	assert.NotContains(t, councilAddrs, config.NodeIds[3])
-	assert.NotContains(t, councilAddrs, config.NodeIds[4])
-	assert.NotContains(t, councilAddrs, config.NodeIds[5])
-	assert.NotContains(t, councilAddrs, config.NodeIds[6])
+	// Council = {ValActive, ValPaused} (2 of 7)
+	assert.Len(t, council, 2)
+	assert.Contains(t, council, config.NodeIds[0])
+	assert.Contains(t, council, config.NodeIds[1])
+	assert.NotContains(t, council, config.NodeIds[2], "ValReady is not in council")
+	assert.NotContains(t, council, config.NodeIds[3])
+	assert.NotContains(t, council, config.NodeIds[4])
+	assert.NotContains(t, council, config.NodeIds[5])
+	assert.NotContains(t, council, config.NodeIds[6])
+}
+
+func TestGetCNPeers(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config, v := newPermlessValsetModule(t, 7)
+
+	nodes := valset.NodeStateMap{
+		config.NodeIds[0]: {State: valset.ValActive},
+		config.NodeIds[1]: {State: valset.ValReady},
+		config.NodeIds[2]: {State: valset.ValPaused},
+		config.NodeIds[3]: {State: valset.CandReady},
+		config.NodeIds[4]: {State: valset.CandTesting},
+		config.NodeIds[5]: {State: valset.ValInactive},
+		config.NodeIds[6]: {State: valset.Registered},
+	}
+	v.nodeStatesCache.Add(uint64(1), nodeStatesCacheEntry{validators: nodes})
+
+	peers, err := v.GetCNPeers(1)
+	require.NoError(t, err)
+
+	// CNPeers = {VA, VR, VP, CR, CT} (5 of 7)
+	assert.Len(t, peers, 5)
+	assert.Contains(t, peers, config.NodeIds[0], "ValActive in CNPeers")
+	assert.Contains(t, peers, config.NodeIds[1], "ValReady in CNPeers")
+	assert.Contains(t, peers, config.NodeIds[2], "ValPaused in CNPeers")
+	assert.Contains(t, peers, config.NodeIds[3], "CandReady in CNPeers")
+	assert.Contains(t, peers, config.NodeIds[4], "CandTesting in CNPeers")
+	assert.NotContains(t, peers, config.NodeIds[5], "ValInactive not in CNPeers")
+	assert.NotContains(t, peers, config.NodeIds[6], "Registered not in CNPeers")
+}
+
+func TestGetHeaderGovVoters(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config, v := newPermlessValsetModule(t, 4)
+
+	nodes := valset.NodeStateMap{
+		config.NodeIds[0]: {State: valset.ValActive},
+		config.NodeIds[1]: {State: valset.ValActive, Suspended: true},
+		config.NodeIds[2]: {State: valset.ValPaused},
+		config.NodeIds[3]: {State: valset.ValReady},
+	}
+	v.nodeStatesCache.Add(uint64(1), nodeStatesCacheEntry{validators: nodes})
+
+	voters, err := v.GetHeaderGovVoters(1)
+	require.NoError(t, err)
+
+	// HeaderGovVoters = {VA} excl. suspended (1 of 4)
+	assert.Len(t, voters, 1)
+	assert.Contains(t, voters, config.NodeIds[0], "unsuspended ValActive in HeaderGovVoters")
+	assert.NotContains(t, voters, config.NodeIds[1], "suspended ValActive not in HeaderGovVoters")
+	assert.NotContains(t, voters, config.NodeIds[2], "ValPaused not in HeaderGovVoters")
+	assert.NotContains(t, voters, config.NodeIds[3], "ValReady not in HeaderGovVoters")
+}
+
+func TestGetDemotedValidatorsPermissionless(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config, v := newPermlessValsetModule(t, 4)
+
+	nodes := valset.NodeStateMap{
+		config.NodeIds[0]: {State: valset.ValActive},
+		config.NodeIds[1]: {State: valset.ValActive, Suspended: true},
+		config.NodeIds[2]: {State: valset.ValPaused},
+		config.NodeIds[3]: {State: valset.ValReady},
+	}
+	v.nodeStatesCache.Add(uint64(1), nodeStatesCacheEntry{validators: nodes})
+
+	demoted, err := v.GetDemotedValidators(1)
+	require.NoError(t, err)
+
+	// Council = {VA, VP} = {0,1,2}. Qualified = {0} (non-suspended VA). Demoted = {1,2}.
+	assert.Len(t, demoted, 2)
+	assert.Contains(t, demoted, config.NodeIds[1], "suspended ValActive is demoted")
+	assert.Contains(t, demoted, config.NodeIds[2], "ValPaused is demoted")
+	assert.NotContains(t, demoted, config.NodeIds[0], "unsuspended ValActive not demoted")
+	assert.NotContains(t, demoted, config.NodeIds[3], "ValReady not in council, not demoted")
+}
+
+func TestGetCommitteePermissionless(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config, v := newPermlessValsetModule(t, 4)
+
+	ctrl := gomock.NewController(t)
+	mockGov := gov_mock.NewMockGovModule(ctrl)
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{CommitteeSize: 100}).AnyTimes()
+	v.GovModule = mockGov
+
+	nodes := valset.NodeStateMap{
+		config.NodeIds[0]: {State: valset.ValActive},
+		config.NodeIds[1]: {State: valset.ValActive, Suspended: true},
+		config.NodeIds[2]: {State: valset.ValPaused},
+		config.NodeIds[3]: {State: valset.ValReady},
+	}
+	v.nodeStatesCache.Add(uint64(1), nodeStatesCacheEntry{validators: nodes})
+
+	committee, err := v.GetCommittee(1, 0)
+	require.NoError(t, err)
+
+	// Committee = {VA} excl. suspended (1 of 4)
+	assert.Len(t, committee, 1)
+	assert.Contains(t, committee, config.NodeIds[0], "unsuspended ValActive in committee")
+	assert.NotContains(t, committee, config.NodeIds[1], "suspended ValActive not in committee")
+	assert.NotContains(t, committee, config.NodeIds[2], "ValPaused not in committee")
+	assert.NotContains(t, committee, config.NodeIds[3], "ValReady not in committee")
 }
 
 // TestGetNodeByState tests GetNodeByState filtering by state.
@@ -1079,11 +1189,11 @@ func TestSuspendedFallback(t *testing.T) {
 
 		demoted, err := v.GetDemotedValidators(1)
 		require.NoError(t, err)
-		// demoted = council(4) - qualified(1 non-suspended ValActive) = 3
-		assert.Len(t, demoted, 3)
+		// Council = {VA, VP}. demoted = council(3) - qualified(1 non-suspended VA) = 2
+		assert.Len(t, demoted, 2)
 		assert.Contains(t, demoted, config.NodeIds[0], "suspended ValActive is demoted")
-		assert.Contains(t, demoted, config.NodeIds[2], "ValReady is demoted")
 		assert.Contains(t, demoted, config.NodeIds[3], "ValPaused is demoted")
 		assert.NotContains(t, demoted, config.NodeIds[1], "non-suspended ValActive is not demoted")
+		assert.NotContains(t, demoted, config.NodeIds[2], "ValReady is not in council, not demoted")
 	})
 }

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -51,6 +51,7 @@ type ValsetModule interface {
 	GetCandTesting(num uint64) ([]common.Address, error)
 	GetCNPeers(num uint64) ([]common.Address, error)
 	GetHeaderGovVoters(num uint64) ([]common.Address, error)
+	GetNodeByState(num uint64, states []State) (NodeStateMap, error)
 	WriteStatesToContract(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 	InstallABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 }

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -35,11 +35,12 @@ type ValsetModule interface {
 	// Council = {Demoted Validators} ∪ {Validators with Staking >= 5M}
 	// Committee = Council - {Demoted Validators}
 
-	// NOTE: In permissionless, the entities are defined as below
-	// Validator = ValActive + ValReady + ValPaused + ValExiting + ValInactive
-	// Council = ValActive + ValReady + ValPaused
-	// Committee = ValActive
-	// Candidate = CandTesting
+	// NOTE: In permissionless, the entities are defined as NodeStateMap methods:
+	// Council()          = {ValActive, ValPaused}
+	// Committee()        = {ValActive} excluding suspended
+	// HeaderGovVoters() = {ValActive} excluding suspended
+	// CNPeers()          = {ValActive, ValReady, ValPaused, CandReady, CandTesting}
+	// RewardEligible()   = {ValActive}
 
 	GetCouncil(num uint64) ([]common.Address, error)
 	GetCommittee(num uint64, round uint64) ([]common.Address, error)
@@ -47,7 +48,9 @@ type ValsetModule interface {
 	GetProposer(num uint64, round uint64) (common.Address, error)
 
 	// Permissionless
-	GetCandidates(num uint64) ([]common.Address, error)
+	GetCandTesting(num uint64) ([]common.Address, error)
+	GetCNPeers(num uint64) ([]common.Address, error)
+	GetHeaderGovVoters(num uint64) ([]common.Address, error)
 	WriteStatesToContract(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 	InstallABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 }

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -12,6 +12,7 @@ import (
 	types "github.com/kaiachain/kaia/blockchain/types"
 	vm "github.com/kaiachain/kaia/blockchain/vm"
 	common "github.com/kaiachain/kaia/common"
+	valset "github.com/kaiachain/kaia/kaiax/valset"
 	rpc "github.com/kaiachain/kaia/networks/rpc"
 )
 
@@ -140,6 +141,21 @@ func (m *MockValsetModule) GetHeaderGovVoters(arg0 uint64) ([]common.Address, er
 func (mr *MockValsetModuleMockRecorder) GetHeaderGovVoters(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderGovVoters", reflect.TypeOf((*MockValsetModule)(nil).GetHeaderGovVoters), arg0)
+}
+
+// GetNodeByState mocks base method.
+func (m *MockValsetModule) GetNodeByState(arg0 uint64, arg1 []valset.State) (valset.NodeStateMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeByState", arg0, arg1)
+	ret0, _ := ret[0].(valset.NodeStateMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeByState indicates an expected call of GetNodeByState.
+func (mr *MockValsetModuleMockRecorder) GetNodeByState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeByState", reflect.TypeOf((*MockValsetModule)(nil).GetNodeByState), arg0, arg1)
 }
 
 // GetProposer mocks base method.

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -52,19 +52,34 @@ func (mr *MockValsetModuleMockRecorder) APIs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockValsetModule)(nil).APIs))
 }
 
-// GetCandidates mocks base method.
-func (m *MockValsetModule) GetCandidates(arg0 uint64) ([]common.Address, error) {
+// GetCNPeers mocks base method.
+func (m *MockValsetModule) GetCNPeers(arg0 uint64) ([]common.Address, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCandidates", arg0)
+	ret := m.ctrl.Call(m, "GetCNPeers", arg0)
 	ret0, _ := ret[0].([]common.Address)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetCandidates indicates an expected call of GetCandidates.
-func (mr *MockValsetModuleMockRecorder) GetCandidates(arg0 interface{}) *gomock.Call {
+// GetCNPeers indicates an expected call of GetCNPeers.
+func (mr *MockValsetModuleMockRecorder) GetCNPeers(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCandidates", reflect.TypeOf((*MockValsetModule)(nil).GetCandidates), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCNPeers", reflect.TypeOf((*MockValsetModule)(nil).GetCNPeers), arg0)
+}
+
+// GetCandTesting mocks base method.
+func (m *MockValsetModule) GetCandTesting(arg0 uint64) ([]common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCandTesting", arg0)
+	ret0, _ := ret[0].([]common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCandTesting indicates an expected call of GetCandTesting.
+func (mr *MockValsetModuleMockRecorder) GetCandTesting(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCandTesting", reflect.TypeOf((*MockValsetModule)(nil).GetCandTesting), arg0)
 }
 
 // GetCommittee mocks base method.
@@ -110,6 +125,21 @@ func (m *MockValsetModule) GetDemotedValidators(arg0 uint64) ([]common.Address, 
 func (mr *MockValsetModuleMockRecorder) GetDemotedValidators(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDemotedValidators", reflect.TypeOf((*MockValsetModule)(nil).GetDemotedValidators), arg0)
+}
+
+// GetHeaderGovVoters mocks base method.
+func (m *MockValsetModule) GetHeaderGovVoters(arg0 uint64) ([]common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeaderGovVoters", arg0)
+	ret0, _ := ret[0].([]common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHeaderGovVoters indicates an expected call of GetHeaderGovVoters.
+func (mr *MockValsetModuleMockRecorder) GetHeaderGovVoters(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderGovVoters", reflect.TypeOf((*MockValsetModule)(nil).GetHeaderGovVoters), arg0)
 }
 
 // GetProposer mocks base method.

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -25,18 +25,6 @@ const (
 	ValExiting               // 8
 )
 
-// State groups for permissionless consensus.
-// Validator = ValActive + ValReady + ValPaused + ValExiting + ValInactive
-// Council = ValActive + ValReady + ValPaused
-// Committee = ValActive
-// Candidate = CandTesting
-var (
-	ValidatorStates = []State{ValActive, ValReady, ValPaused, ValExiting, ValInactive}
-	CouncilStates   = []State{ValActive, ValReady, ValPaused}
-	CommitteeStates = []State{ValActive}
-	CandidateStates = []State{CandTesting}
-)
-
 const (
 	RegisteredStr  = "Registered"
 	CandReadyStr   = "CandReady"
@@ -51,6 +39,11 @@ const (
 // ToUint8 converts the State to its uint8 representation for ABI encoding.
 func (s State) ToUint8() uint8 {
 	return uint8(s)
+}
+
+// IsRewardEligible returns true if the state is eligible for block rewards.
+func (s State) IsRewardEligible() bool {
+	return s == ValActive
 }
 
 // String returns the human-readable name of the state.
@@ -223,4 +216,42 @@ func (v NodeStateMap) ExcludeSuspended() NodeStateMap {
 		}
 	}
 	return filtered
+}
+
+// FilterByState returns a new NodeStateMap containing only validators in one of the given states.
+func (v NodeStateMap) FilterByState(states ...State) NodeStateMap {
+	filtered := make(NodeStateMap)
+	for addr, val := range v {
+		for _, s := range states {
+			if val.State == s {
+				filtered[addr] = val
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// Council returns validators committed to the Istanbul consensus cycle.
+// {ValActive, ValPaused}. ValReady excluded — voluntary standby, not consensus commitment.
+func (v NodeStateMap) Council() NodeStateMap {
+	return v.FilterByState(ValActive, ValPaused)
+}
+
+// Committee returns validators eligible for consensus signing and proposing.
+// {ValActive} excluding suspended validators.
+func (v NodeStateMap) Committee() NodeStateMap {
+	return v.FilterByState(ValActive).ExcludeSuspended()
+}
+
+// HeaderGovVoters returns validators eligible for governance header votes.
+// {ValActive} excluding suspended validators.
+func (v NodeStateMap) HeaderGovVoters() NodeStateMap {
+	return v.FilterByState(ValActive).ExcludeSuspended()
+}
+
+// CNPeers returns nodes that should maintain CN-CN P2P connections.
+// Includes CandReady — P2P must be established before CandTesting promotion.
+func (v NodeStateMap) CNPeers() NodeStateMap {
+	return v.FilterByState(ValActive, ValReady, ValPaused, CandReady, CandTesting)
 }

--- a/kaiax/valset/types_test.go
+++ b/kaiax/valset/types_test.go
@@ -75,3 +75,74 @@ func TestCountByState(t *testing.T) {
 	assert.Equal(t, uint64(1), m.CountByState(ValPaused))
 	assert.Equal(t, uint64(0), m.CountByState(ValExiting))
 }
+
+func TestCouncil(t *testing.T) {
+	addr4 := common.HexToAddress("0x0004")
+	addr5 := common.HexToAddress("0x0005")
+	m := NodeStateMap{
+		addr1: {State: ValActive},
+		addr2: {State: ValPaused},
+		addr3: {State: ValReady},
+		addr4: {State: ValInactive},
+		addr5: {State: CandTesting},
+	}
+	council := m.Council()
+	assert.Len(t, council, 2)
+	assert.NotNil(t, council[addr1], "ValActive in council")
+	assert.NotNil(t, council[addr2], "ValPaused in council")
+	assert.Nil(t, council[addr3], "ValReady not in council")
+	assert.Nil(t, council[addr4], "ValInactive not in council")
+	assert.Nil(t, council[addr5], "CandTesting not in council")
+}
+
+func TestCommittee(t *testing.T) {
+	addr4 := common.HexToAddress("0x0004")
+	m := NodeStateMap{
+		addr1: {State: ValActive},
+		addr2: {State: ValActive, Suspended: true},
+		addr3: {State: ValPaused},
+		addr4: {State: ValReady},
+	}
+	committee := m.Committee()
+	assert.Len(t, committee, 1)
+	assert.NotNil(t, committee[addr1], "unsuspended ValActive in committee")
+	assert.Nil(t, committee[addr2], "suspended ValActive not in committee")
+	assert.Nil(t, committee[addr3], "ValPaused not in committee")
+	assert.Nil(t, committee[addr4], "ValReady not in committee")
+}
+
+func TestCNPeers(t *testing.T) {
+	addr4 := common.HexToAddress("0x0004")
+	addr5 := common.HexToAddress("0x0005")
+	addr6 := common.HexToAddress("0x0006")
+	addr7 := common.HexToAddress("0x0007")
+	m := NodeStateMap{
+		addr1: {State: ValActive},
+		addr2: {State: ValReady},
+		addr3: {State: ValPaused},
+		addr4: {State: CandReady},
+		addr5: {State: CandTesting},
+		addr6: {State: ValInactive},
+		addr7: {State: Registered},
+	}
+	peers := m.CNPeers()
+	assert.Len(t, peers, 5)
+	assert.NotNil(t, peers[addr1], "ValActive in CNPeers")
+	assert.NotNil(t, peers[addr2], "ValReady in CNPeers")
+	assert.NotNil(t, peers[addr3], "ValPaused in CNPeers")
+	assert.NotNil(t, peers[addr4], "CandReady in CNPeers")
+	assert.NotNil(t, peers[addr5], "CandTesting in CNPeers")
+	assert.Nil(t, peers[addr6], "ValInactive not in CNPeers")
+	assert.Nil(t, peers[addr7], "Registered not in CNPeers")
+}
+
+func TestIsRewardEligible(t *testing.T) {
+	assert.True(t, ValActive.IsRewardEligible())
+	assert.False(t, ValPaused.IsRewardEligible())
+	assert.False(t, ValReady.IsRewardEligible())
+	assert.False(t, ValInactive.IsRewardEligible())
+	assert.False(t, ValExiting.IsRewardEligible())
+	assert.False(t, CandReady.IsRewardEligible())
+	assert.False(t, CandTesting.IsRewardEligible())
+	assert.False(t, Registered.IsRewardEligible())
+}

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -22,7 +22,7 @@ var (
 	ErrInitUnexpectedNil      = errors.New("unexpected nil during module init")
 	ErrVRankPreprepareNil     = errors.New("VRankPreprepare is nil")
 	ErrVRankCandidateNil      = errors.New("VRankCandidate is nil")
-	ErrGetCandidateFailed     = errors.New("valset.GetCandidates failed")
+	ErrGetCandidateFailed     = errors.New("valset.GetCandTesting failed")
 	ErrPrepreparedViewNotSet  = errors.New("preprepared view is not set")
 	ErrViewMismatch           = errors.New("view mismatch")
 	ErrBlockHashMismatch      = errors.New("block hash mismatch")

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -30,7 +30,7 @@ import (
 //   - Before the permissionless fork: VRank must be empty.
 //   - At epoch-start blocks: VRank must be empty.
 //   - Otherwise: VRank must be a valid encoded report whose addresses are sorted,
-//     deduplicated, and all present in GetCandidates(calcEpochStart(N)).
+//     deduplicated, and all present in GetCandTesting(calcEpochStart(N)).
 func (v *VRankModule) VerifyHeader(header *types.Header) error {
 	number := header.Number.Uint64()
 	permissionless := v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(number))
@@ -57,10 +57,10 @@ func (v *VRankModule) VerifyHeader(header *types.Header) error {
 
 	// Validate every address in the cfReport is an actual candidate.
 	// header(N).VRank is produced by TallyCfReport(N-1, ...) which uses
-	// GetCandidates(N), so mirror that here.
+	// GetCandTesting(N), so mirror that here.
 	// This prevents a malicious proposer from injecting arbitrary addresses (e.g. validator
 	// addresses) into header.VRank to manipulate CFS scores.
-	candidates, err := v.Valset.GetCandidates(number)
+	candidates, err := v.Valset.GetCandTesting(number)
 	if err != nil {
 		return err
 	}

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -55,11 +55,11 @@ func TestVerifyHeader(t *testing.T) {
 		return mock_valset.NewMockValsetModule(gomock.NewController(t))
 	}
 
-	// withCandidates returns a mock that returns `candidates` for GetCandidates(number).
+	// withCandidates returns a mock that returns `candidates` for GetCandTesting(number).
 	withCandidates := func(t *testing.T, number uint64) *mock_valset.MockValsetModule {
 		t.Helper()
 		vs := mock_valset.NewMockValsetModule(gomock.NewController(t))
-		vs.EXPECT().GetCandidates(number).Return(candidates, nil).Times(1)
+		vs.EXPECT().GetCandTesting(number).Return(candidates, nil).Times(1)
 		return vs
 	}
 

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -106,9 +106,9 @@ func (v *VRankModule) TallyCfReport(blockNum, round uint64) ([]common.Address, e
 		// or it missed the PREPREPARE message. Either way, nothing to report.
 		return []common.Address{}, nil
 	}
-	candidates, err := v.Valset.GetCandidates(blockNum)
+	candidates, err := v.Valset.GetCandTesting(blockNum)
 	if err != nil {
-		logger.Error("GetCandidates failed", "blockNum", blockNum, "err", err)
+		logger.Error("GetCandTesting failed", "blockNum", blockNum, "err", err)
 		return nil, vrank.ErrGetCandidateFailed
 	}
 	if len(candidates) == 0 {

--- a/kaiax/vrank/impl/getter_test.go
+++ b/kaiax/vrank/impl/getter_test.go
@@ -302,7 +302,7 @@ func TestTallyCfReport(t *testing.T) {
 	}
 
 	valset.EXPECT().GetCommittee(gomock.Any(), gomock.Any()).Return(valAddrs, nil).AnyTimes()
-	valset.EXPECT().GetCandidates(gomock.Any()).Return(candAddrs, nil).AnyTimes()
+	valset.EXPECT().GetCandTesting(gomock.Any()).Return(candAddrs, nil).AnyTimes()
 	valset.EXPECT().GetProposer(gomock.Any(), gomock.Any()).Return(validators[0].Addr, nil).AnyTimes()
 
 	for i := 0; i < 8; i++ {
@@ -399,7 +399,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		randao := mock_randao.NewMockRandaoModule(ctrl)
 		val := createCN(t, valset, randao)
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
@@ -414,7 +414,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		randao := mock_randao.NewMockRandaoModule(ctrl)
 		val := createCN(t, valset, randao)
 		valset.EXPECT().GetCommittee(uint64(params.DefaultVRankEpoch-1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(params.DefaultVRankEpoch-1)).Return([]common.Address{candAddr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(params.DefaultVRankEpoch-1)).Return([]common.Address{candAddr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(params.DefaultVRankEpoch-1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 		block := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(params.DefaultVRankEpoch - 1)})
 		view := &istanbul.View{Sequence: new(big.Int).SetUint64(params.DefaultVRankEpoch - 1), Round: common.Big0}
@@ -431,7 +431,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		randao := mock_randao.NewMockRandaoModule(ctrl)
 		val := createCN(t, valset, randao)
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
@@ -450,7 +450,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		val, otherVal := createCN(t, valset, randao), createCN(t, valset, randao)
 		// This node is not in the council for block 1.
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{otherVal.Addr}, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
@@ -473,13 +473,13 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		assert.Empty(t, report)
 	})
 
-	t.Run("GetCandidates failed returns error", func(t *testing.T) {
+	t.Run("GetCandTesting failed returns error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		valset := mock_valset.NewMockValsetModule(ctrl)
 		randao := mock_randao.NewMockRandaoModule(ctrl)
 		val := createCN(t, valset, randao)
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(1)).Return(nil, assert.AnError).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return(nil, assert.AnError).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -227,9 +227,9 @@ func (v *VRankModule) vrankCandidateSigHash(blockNum uint64, round uint8, blockH
 // BroadcastVRankPreprepare is called by the proposer. It signs the message before broadcasting.
 func (v *VRankModule) BroadcastVRankPreprepare(vrankPreprepare *vrank.VRankPreprepare) {
 	block := vrankPreprepare.Block
-	candidates, err := v.Valset.GetCandidates(block.NumberU64())
+	candidates, err := v.Valset.GetCandTesting(block.NumberU64())
 	if err != nil {
-		logger.Error("GetCandidates failed", "blockNum", block.NumberU64(), "err", err)
+		logger.Error("GetCandTesting failed", "blockNum", block.NumberU64(), "err", err)
 		return
 	}
 	if len(candidates) == 0 {
@@ -277,9 +277,9 @@ func (v *VRankModule) isProposer(blockNum, round uint64) bool {
 }
 
 func (v *VRankModule) isCandidate(blockNum uint64) bool {
-	candidates, err := v.Valset.GetCandidates(blockNum)
+	candidates, err := v.Valset.GetCandTesting(blockNum)
 	if err != nil {
-		logger.Error("GetCandidates failed", "blockNum", blockNum, "err", err)
+		logger.Error("GetCandTesting failed", "blockNum", blockNum, "err", err)
 		return false
 	}
 

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -188,7 +188,7 @@ func runVRankScenario(t *testing.T, s VRankScenario) {
 	}
 	proposerAddr := nameToCN[s.Proposer].Addr
 	valset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(councilAddrs, nil).AnyTimes()
-	valset.EXPECT().GetCandidates(blockNum).Return(candAddrs, nil).AnyTimes()
+	valset.EXPECT().GetCandTesting(blockNum).Return(candAddrs, nil).AnyTimes()
 	valset.EXPECT().GetProposer(blockNum, uint64(0)).Return(proposerAddr, nil).AnyTimes()
 
 	block1 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
@@ -339,7 +339,7 @@ func TestHandleIstanbulPreprepare(t *testing.T) {
 		// proposer is not in the next council, so it should only broadcast and does not start collection.
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{validator.Addr}, nil).Times(2)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(2)
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(2)
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(2)
 
 		proposer.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 		prepreparedTime, _, _ := proposer.VRankModule.collector.GetViewData(vrank.ViewKey{N: 1, R: 0})
@@ -360,7 +360,7 @@ func TestHandleIstanbulPreprepare(t *testing.T) {
 
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(3)
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(3)
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(3)
 
 		proposer.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 		nonProposer.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
@@ -403,7 +403,7 @@ func TestHandleVRankPreprepare(t *testing.T) {
 		randao := mock_randao.NewMockRandaoModule(ctrl)
 		proposer, nonProposer, candidate := createCN(t, valset, randao), createCN(t, valset, randao), createCN(t, valset, randao)
 
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).AnyTimes()
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).AnyTimes()
 
@@ -432,7 +432,7 @@ func TestHandleVRankPreprepare(t *testing.T) {
 		pppSig := signVRankPreprepare(t, proposer.VRankModule, proposer.Key, block1.NumberU64(), 1, block1.Hash())
 		pppMsg := &vrank.VRankPreprepare{Block: block1, View: view1_1, Sig: pppSig}
 
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(1)).Return(proposer.Addr, nil).AnyTimes()
 		valset.EXPECT().GetCommittee(uint64(1), uint64(1)).Return([]common.Address{round1Val1.Addr, round1Val2.Addr}, nil).Times(1)
 
@@ -451,7 +451,7 @@ func TestHandleVRankPreprepare(t *testing.T) {
 		randao := mock_randao.NewMockRandaoModule(ctrl)
 		proposer, nonProposer, candidate := createCN(t, valset, randao), createCN(t, valset, randao), createCN(t, valset, randao)
 
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).AnyTimes()
 
 		// signed by nonProposer instead of proposer
@@ -489,7 +489,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(3)
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(3)
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(3)
 
 		proposer.VRankModule.HandleVRankCandidate(&msg)
 		nonProposer.VRankModule.HandleVRankCandidate(&msg)
@@ -511,7 +511,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		// proposer is not in the next council, so it should only broadcast and does not start collection.
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{validator.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(2)
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(1)
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).Times(1)
 
 		proposer.VRankModule.HandleIstanbulPreprepare(block1, view1_0) // this won't happen in production
 		err := proposer.VRankModule.HandleVRankCandidate(&msg)
@@ -540,7 +540,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{cand.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{cand.Addr}, nil).AnyTimes()
 
 		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
@@ -577,7 +577,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: sig, BlsSig: blsSig}
 
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
-		valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{cand.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{cand.Addr}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
 
 		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
@@ -654,7 +654,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		v, c := createCN(t, vs, rd), createCN(t, vs, rd)
 		vs.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{v.Addr}, nil).AnyTimes()
 		vs.EXPECT().GetProposer(uint64(1), uint64(0)).Return(v.Addr, nil).AnyTimes()
-		vs.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{c.Addr}, nil).AnyTimes()
+		vs.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{c.Addr}, nil).AnyTimes()
 		v.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 		return v, c
 	}
@@ -687,7 +687,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		rd.EXPECT().GetBlsPubkey(candAddr, gomock.Any()).Return(nil, assert.AnError).AnyTimes()
 		vs.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{val.Addr}, nil).AnyTimes()
 		vs.EXPECT().GetProposer(uint64(1), uint64(0)).Return(val.Addr, nil).AnyTimes()
-		vs.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
+		vs.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candAddr}, nil).AnyTimes()
 		val.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 		var (
 			ecdsaSig, blsSig = signVRankCandidate(t, val.VRankModule, candKey, candBlsKey, block1.NumberU64(), 0, block1.Hash())

--- a/kaiax/vrank/impl/rewind_test.go
+++ b/kaiax/vrank/impl/rewind_test.go
@@ -38,7 +38,7 @@ func TestRewindTo_PurgesCache(t *testing.T) {
 	db := database.NewMemDB()
 
 	headers := map[uint64]*types.Header{
-		0:                           makeHeaderWithRound(0, 0),
+		0:                          makeHeaderWithRound(0, 0),
 		testCheckpointInterval:     makeHeaderWithRound(testCheckpointInterval, 0),
 		testCheckpointInterval + 1: makeHeaderWithRound(testCheckpointInterval+1, 0),
 	}

--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -155,7 +155,7 @@ func (v *VRankModule) lookupCFSSeed(blockNum uint64) (start uint64, seed vrank.C
 }
 
 func (v *VRankModule) newCPMatrix(blockNum uint64) (vrank.CPMatrix, error) {
-	candidates, err := v.Valset.GetCandidates(blockNum)
+	candidates, err := v.Valset.GetCandTesting(blockNum)
 	if err != nil {
 		return nil, err
 	}

--- a/kaiax/vrank/impl/scoring_test.go
+++ b/kaiax/vrank/impl/scoring_test.go
@@ -489,7 +489,7 @@ func TestGetCFS(t *testing.T) {
 		headers[epochStart+1] = makeHeaderWithVRank(epochStart+1, 0, []common.Address{C1})
 		v.Chain = &testChain{headers: headers}
 
-		valset.EXPECT().GetCandidates(gomock.Any()).Return([]common.Address{C1}, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(gomock.Any()).Return([]common.Address{C1}, nil).AnyTimes()
 		valset.EXPECT().GetProposer(gomock.Any(), uint64(0)).Return(P1, nil).AnyTimes()
 
 		cfs, err := v.GetCFSWithSlotFactor(epochStart, 1)
@@ -522,7 +522,7 @@ func TestGetCFS(t *testing.T) {
 			},
 		}
 
-		valset.EXPECT().GetCandidates(gomock.Any()).Return(candidates, nil).AnyTimes()
+		valset.EXPECT().GetCandTesting(gomock.Any()).Return(candidates, nil).AnyTimes()
 		valset.EXPECT().GetProposer(epochStart, uint64(0)).Return(P1, nil)
 		valset.EXPECT().GetProposer(epochStart+1, uint64(0)).Return(P1, nil)
 		valset.EXPECT().GetProposer(epochStart+2, uint64(1)).Return(P2, nil)
@@ -570,7 +570,7 @@ func TestGetCFS_ErrFutureBlock(t *testing.T) {
 	}
 	v := newTestModuleWithHeaders(t, valset, db, headers)
 
-	valset.EXPECT().GetCandidates(gomock.Any()).Return(nil, nil).AnyTimes()
+	valset.EXPECT().GetCandTesting(gomock.Any()).Return(nil, nil).AnyTimes()
 	valset.EXPECT().GetProposer(gomock.Any(), uint64(0)).Return(addrN(0), nil).AnyTimes()
 
 	_, err := v.GetCFSWithSlotFactor(5, 1)
@@ -596,7 +596,7 @@ func TestGetCFS_CacheHit(t *testing.T) {
 
 	v := newTestModuleWithHeaders(t, valset, db, headers)
 	// GetProposer is only called for blocks with non-empty cfReports (block 5 has VRank=[C1]).
-	valset.EXPECT().GetCandidates(uint64(5)).Return([]common.Address{C1}, nil).Times(1)
+	valset.EXPECT().GetCandTesting(uint64(5)).Return([]common.Address{C1}, nil).Times(1)
 	valset.EXPECT().GetProposer(uint64(5), uint64(0)).Return(P1, nil).Times(1)
 
 	cfs1, err := v.GetCFSWithSlotFactor(5, 1)
@@ -626,7 +626,7 @@ func TestGetCFS_NearbyCacheHit(t *testing.T) {
 	headers[6] = makeHeaderWithVRank(6, 0, []common.Address{C1})
 
 	v := newTestModuleWithHeaders(t, valset, db, headers)
-	valset.EXPECT().GetCandidates(gomock.Any()).Return([]common.Address{C1}, nil).AnyTimes()
+	valset.EXPECT().GetCandTesting(gomock.Any()).Return([]common.Address{C1}, nil).AnyTimes()
 	// GetProposer only called for blocks with non-empty cfReports (blocks 5 and 6).
 	valset.EXPECT().GetProposer(uint64(5), uint64(0)).Return(P1, nil).Times(1)
 	valset.EXPECT().GetProposer(uint64(6), uint64(0)).Return(P2, nil).Times(1)
@@ -720,7 +720,7 @@ func TestGetCFS_EpochScan(t *testing.T) {
 	require.False(t, inCache, "cache must be cold before first call")
 
 	// GetProposer only called for blocks with non-empty cfReports (blocks 1 and 2).
-	valset.EXPECT().GetCandidates(uint64(2)).Return([]common.Address{C1}, nil).Times(1)
+	valset.EXPECT().GetCandTesting(uint64(2)).Return([]common.Address{C1}, nil).Times(1)
 	valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(P1, nil).Times(1)
 	valset.EXPECT().GetProposer(uint64(2), uint64(0)).Return(P1, nil).Times(1)
 
@@ -730,7 +730,7 @@ func TestGetCFS_EpochScan(t *testing.T) {
 }
 
 // TestGetCFS_EpochStart verifies that GetCFS at the first block of an epoch returns a zero score
-// for every candidate (pre-seeded from GetCandidates) and does NOT carry over state from the
+// for every candidate (pre-seeded from GetCandTesting) and does NOT carry over state from the
 // previous epoch.
 func TestGetCFS_EpochStart(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -750,7 +750,7 @@ func TestGetCFS_EpochStart(t *testing.T) {
 	})
 
 	// GetProposer is NOT called: the epoch-start block has a nil/empty cfReport (VRank=nil encoded).
-	valset.EXPECT().GetCandidates(epochStart).Return([]common.Address{C1, C2}, nil).Times(1)
+	valset.EXPECT().GetCandTesting(epochStart).Return([]common.Address{C1, C2}, nil).Times(1)
 
 	cfs, err := v.GetCFSWithSlotFactor(epochStart, 1)
 	require.NoError(t, err)
@@ -781,8 +781,8 @@ func TestGetCFS_EpochBoundaryClamp(t *testing.T) {
 	})
 
 	// Probe limit = min(64, blockNum-epochStart)=3; epochStart-1 is at distance 4, not reached.
-	// Must call GetCandidates to start a fresh epoch (Times(1)).
-	valset.EXPECT().GetCandidates(blockNum).Return([]common.Address{C1}, nil).Times(1)
+	// Must call GetCandTesting to start a fresh epoch (Times(1)).
+	valset.EXPECT().GetCandTesting(blockNum).Return([]common.Address{C1}, nil).Times(1)
 	valset.EXPECT().GetProposer(gomock.Any(), uint64(0)).Return(P1, nil).AnyTimes()
 
 	cfs, err := v.GetCFSWithSlotFactor(blockNum, 1)
@@ -816,7 +816,7 @@ func TestGetCFS_NearbyProbe_SameEpoch(t *testing.T) {
 		C1: {P1: 99},
 	})
 
-	// Nearby hit at epochStart+1 (distance=1). GetCandidates must NOT be called.
+	// Nearby hit at epochStart+1 (distance=1). GetCandTesting must NOT be called.
 	// epochStart+2 has no cfReport, so GetProposer is NOT called (cfReport checked first).
 	cfs, err := v.GetCFSWithSlotFactor(epochStart+2, 1)
 	require.NoError(t, err)
@@ -837,7 +837,7 @@ func TestGetCFS_GetProposerError(t *testing.T) {
 	}
 	v := newTestModuleWithHeaders(t, valset, db, headers)
 
-	valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{C1}, nil).Times(1)
+	valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{C1}, nil).Times(1)
 	// GetProposer is NOT called for block 0 (empty cfReport); only for block 1.
 	valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(common.Address{}, assert.AnError).Times(1)
 
@@ -859,7 +859,7 @@ func TestGetCFS_MissingHeader(t *testing.T) {
 	}
 	v := newTestModuleWithHeaders(t, valset, db, headers)
 
-	valset.EXPECT().GetCandidates(uint64(1)).Return([]common.Address{C1}, nil).Times(1)
+	valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{C1}, nil).Times(1)
 
 	_, err := v.GetCFSWithSlotFactor(1, 0)
 	assert.ErrorIs(t, err, vrank.ErrHeaderNotFound)
@@ -934,7 +934,7 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		}
 		// GetProposer only called for blocks with non-empty cfReports (blocks 7–9).
 		// Blocks 5 and 6 have nil cfReports so GetProposer is skipped for them.
-		valset.EXPECT().GetCandidates(uint64(5)).Return(candidates, nil)
+		valset.EXPECT().GetCandTesting(uint64(5)).Return(candidates, nil)
 		valset.EXPECT().GetProposer(uint64(7), uint64(0)).Return(P3, nil)
 		valset.EXPECT().GetProposer(uint64(8), uint64(0)).Return(P4, nil)
 		valset.EXPECT().GetProposer(uint64(9), uint64(0)).Return(P4, nil)
@@ -981,7 +981,7 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		v := createCN(t, valset, randao).VRankModule
 		v.Chain = &testChain{headers: headers}
 
-		valset.EXPECT().GetCandidates(start).Return(candidates, nil).Times(1)
+		valset.EXPECT().GetCandTesting(start).Return(candidates, nil).Times(1)
 		valset.EXPECT().GetProposer(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(blockNum, round uint64) (common.Address, error) {
 				if round != 0 {
@@ -1023,11 +1023,11 @@ func TestApplyBlocksForCFS(t *testing.T) {
 			},
 		}
 		// GetProposer is NOT called: block 0 has no VRank set (nil → empty cfReport).
-		valset.EXPECT().GetCandidates(uint64(0)).Return(candidates, nil)
+		valset.EXPECT().GetCandTesting(uint64(0)).Return(candidates, nil)
 
 		cfs, err := computeCFS(v, 0, 0, 1)
 		require.NoError(t, err)
-		// C1 is pre-seeded from GetCandidates but no block reported any failure, so CFS=0.
+		// C1 is pre-seeded from GetCandTesting but no block reported any failure, so CFS=0.
 		score, hasC1 := cfs[C1]
 		assert.True(t, hasC1, "C1 should appear in CFS map (pre-seeded from candidates)")
 		assert.Equal(t, uint64(0), score, "C1 CFS should be 0 (no failures reported)")

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1958,6 +1958,18 @@ func (pm *ProtocolManager) FindCNPeers(targets map[common.Address]bool) map[comm
 	return m
 }
 
+func (pm *ProtocolManager) DisconnectCNPeers(addrs []common.Address) {
+	addrSet := make(map[common.Address]bool, len(addrs))
+	for _, addr := range addrs {
+		addrSet[addr] = true
+	}
+	for addr, p := range pm.peers.CNPeers() {
+		if addrSet[addr] {
+			p.DisconnectP2PPeer(p2p.DiscUselessPeer)
+		}
+	}
+}
+
 func (pm *ProtocolManager) GetENPeers() map[common.Address]consensus.Peer {
 	m := make(map[common.Address]consensus.Peer)
 	for addr, p := range pm.peers.ENPeers() {


### PR DESCRIPTION
## Proposed changes

- **`refactor(valset)`: introduce NodeStateMap entity group methods**
  - Replace global `[]State` vars (`CouncilStates`, `CommitteeStates`, etc.) with `NodeStateMap` methods that encapsulate suspended-flag filtering at the group definition level, simplifying all callsites
  - New methods: `Council()` = {VA, VP}, `Committee()` = {VA} excl. suspended, `HeaderGovVoters()` = {VA} excl. suspended, `CNPeers()` = {VA, VR, VP, CR, CT}, `State.IsRewardEligible()`
  - Add `GetCNPeers` / `GetHeaderGovVoters` / `GetCandTesting` to `ValsetModule` interface
  - Consolidate duplicated T3a/T3b logic via `competeOrDemote` closure

- **`refactor(vrank,headergov,staking)`: update callsites to entity group methods**
  - vrank: `GetCandidates` → `GetCandTesting`
  - headergov: `GetCouncil` → `GetHeaderGovVoters` in `VerifyVote` (VP and suspended VA are not eligible to cast governance votes)
  - staking: `p.State != ValActive` → `State.IsRewardEligible()`

- **`feat(backend,p2p)`: add permissionless CN peer gating**
  - `ValidatePeerType` validates P2P connections against `GetCNPeers()` (VA+VR+VP+CR+CT) when permissionless fork is enabled
  - VI/VE (ValInactive/ValExiting) nodes are additionally allowed for block sync until CN-EN connectivity is available
  - Add `GetNodeByState` to `ValsetModule` interface to support filtering by arbitrary state set
  - Add `DisconnectCNPeers` to `consensus.Broadcaster` interface and `ProtocolManager` (infrastructure only; call is disabled pending CN-EN connectivity PR)

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

### CN peer gating design note

`ValidatePeerType` additionally accepts **VI/VE** (ValInactive/ValExiting) nodes as a temporary measure for block sync.
VI/VE nodes are no longer active validators but still need to receive blocks since CN discovery does not cover EN/PN connectivity.
Once the CN-EN connectivity PR lands, this exception can be removed and `disconnectNonCNPeers()` can be enabled.