### PR TITLE
params: Declare Permissionless hardfork configuration

### DIFF
--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -159,7 +159,8 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideOsaka *big.Int
+	OverrideOsaka          *big.Int
+	OverridePermissionless *big.Int
 }
 
 // apply applies the chain overrides on the supplied chain config.
@@ -169,6 +170,9 @@ func (o *ChainOverrides) apply(cfg *params.ChainConfig) error {
 	}
 	if o.OverrideOsaka != nil {
 		cfg.OsakaCompatibleBlock = new(big.Int).Set(o.OverrideOsaka)
+	}
+	if o.OverridePermissionless != nil {
+		cfg.PermissionlessCompatibleBlock = new(big.Int).Set(o.OverridePermissionless)
 	}
 	return cfg.CheckConfigForkOrder()
 }

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -137,6 +137,8 @@ var HomiFlags = []cli.Flag{
 	altsrc.NewInt64Flag(randaoCompatibleBlockNumberFlag),
 	altsrc.NewInt64Flag(pragueCompatibleBlockNumberFlag),
 	altsrc.NewInt64Flag(osakaCompatibleBlockNumberFlag),
+	altsrc.NewInt64Flag(permissionlessCompatibleBlockNumberFlag),
+	altsrc.NewUint64Flag(vrankEpochFlag),
 	altsrc.NewStringFlag(kip113ProxyAddressFlag),
 	altsrc.NewStringFlag(kip113LogicAddressFlag),
 	altsrc.NewBoolFlag(kip113MockFlag),
@@ -767,6 +769,10 @@ func Gen(ctx *cli.Context) error {
 	genesisJson.Config.RandaoCompatibleBlock = big.NewInt(ctx.Int64(randaoCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.PragueCompatibleBlock = big.NewInt(ctx.Int64(pragueCompatibleBlockNumberFlag.Name))
 	genesisJson.Config.OsakaCompatibleBlock = big.NewInt(ctx.Int64(osakaCompatibleBlockNumberFlag.Name))
+	genesisJson.Config.PermissionlessCompatibleBlock = big.NewInt(ctx.Int64(permissionlessCompatibleBlockNumberFlag.Name))
+	if epoch := ctx.Uint64(vrankEpochFlag.Name); epoch != params.DefaultVRankEpoch {
+		genesisJson.Config.VRankEpoch = epoch
+	}
 	genesisJson.Config.BlobScheduleConfig = params.DefaultBlobSchedule
 
 	// EIP-2935: pre-deploy history storage contract when Prague is active from genesis

--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -549,6 +549,20 @@ var (
 		Aliases: []string{"genesis.hardfork.osaka-compatible-blocknumber"},
 	}
 
+	permissionlessCompatibleBlockNumberFlag = &cli.Int64Flag{
+		Name:    "permissionless-compatible-blocknumber",
+		Usage:   "permissionlessCompatible blockNumber",
+		Value:   0,
+		Aliases: []string{"genesis.hardfork.permissionless-compatible-blocknumber"},
+	}
+
+	vrankEpochFlag = &cli.Uint64Flag{
+		Name:    "vrank-epoch",
+		Usage:   "VRank epoch block interval for permissionless mode (default: 86400)",
+		Value:   params.DefaultVRankEpoch,
+		Aliases: []string{"genesis.vrank-epoch"},
+	}
+
 	kip113ProxyAddressFlag = &cli.StringFlag{
 		Name:    "kip113-proxy-contract-address",
 		Usage:   "kip113 proxy contract address",

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -602,6 +602,10 @@ func (kCfg *KaiaConfig) SetKaiaConfig(ctx *cli.Context, stack *node.Node) {
 		v := ctx.Uint64(OverrideOsaka.Name)
 		overrides.OverrideOsaka = new(big.Int).SetUint64(v)
 	}
+	if ctx.IsSet(OverridePermissionless.Name) {
+		v := ctx.Uint64(OverridePermissionless.Name)
+		overrides.OverridePermissionless = new(big.Int).SetUint64(v)
+	}
 	cfg.Overrides = &overrides
 	cfg.StartBlockNumber = ctx.Uint64(StartBlockNumberFlag.Name)
 

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -51,6 +51,7 @@ var FlagGroups = []FlagGroup{
 			ExtraDataFlag,
 			ConfigFileFlag,
 			OverrideOsaka,
+			OverridePermissionless,
 			StartBlockNumberFlag,
 			BlockGenerationIntervalFlag,
 			BlockGenerationTimeLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -194,6 +194,11 @@ var (
 		Usage:    "Manually specify the Osaka fork block, overriding the bundled setting",
 		Category: "KAIA",
 	}
+	OverridePermissionless = &cli.Uint64Flag{
+		Name:     "override.permissionless",
+		Usage:    "Manually specify the permissionless hardfork block, overriding the bundled setting",
+		Category: "KAIA",
+	}
 	StartBlockNumberFlag = &cli.Uint64Flag{
 		Name:     "start-block-num",
 		Usage:    "Starts the node from the given block number. Starting from 0 is not supported.",

--- a/cmd/utils/nodecmd/chaincmd.go
+++ b/cmd/utils/nodecmd/chaincmd.go
@@ -71,6 +71,7 @@ var (
 			utils.RocksDBMaxOpenFilesFlag,
 			utils.RocksDBCacheIndexAndFilterFlag,
 			utils.OverrideOsaka,
+			utils.OverridePermissionless,
 			utils.LivePruningFlag,
 			utils.FlatTrieFlag,
 		},
@@ -125,6 +126,10 @@ func initGenesis(ctx *cli.Context) error {
 	if ctx.IsSet(utils.OverrideOsaka.Name) {
 		v := ctx.Uint64(utils.OverrideOsaka.Name)
 		overrides.OverrideOsaka = new(big.Int).SetUint64(v)
+	}
+	if ctx.IsSet(utils.OverridePermissionless.Name) {
+		v := ctx.Uint64(utils.OverridePermissionless.Name)
+		overrides.OverridePermissionless = new(big.Int).SetUint64(v)
 	}
 
 	// Update undefined config with default values

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -177,6 +177,7 @@ var CommonNodeFlags = []cli.Flag{
 	altsrc.NewPathFlag(DataDirFlag),
 	altsrc.NewPathFlag(ChainDataDirFlag),
 	altsrc.NewUint64Flag(OverrideOsaka),
+	altsrc.NewUint64Flag(OverridePermissionless),
 	altsrc.NewUint64Flag(StartBlockNumberFlag),
 	altsrc.NewPathFlag(KeyStoreDirFlag),
 	altsrc.NewBoolFlag(TxPoolNoLocalsFlag),

--- a/params/config.go
+++ b/params/config.go
@@ -59,9 +59,10 @@ var (
 			},
 			Owner: common.HexToAddress("0x04992a2B7E7CE809d409adE32185D49A96AAa32d"),
 		},
-		KaiaCompatibleBlock:   big.NewInt(162900480),
-		PragueCompatibleBlock: big.NewInt(190670000),
-		OsakaCompatibleBlock:  big.NewInt(213333000),
+		KaiaCompatibleBlock:           big.NewInt(162900480),
+		PragueCompatibleBlock:         big.NewInt(190670000),
+		OsakaCompatibleBlock:          big.NewInt(213333000),
+		PermissionlessCompatibleBlock: nil, // TODO-kaia-permissionless: set Mainnet's PermissionlessCompatibleBlock
 		// Optional forks
 		Kip103CompatibleBlock: big.NewInt(119750400),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),
@@ -110,9 +111,10 @@ var (
 			},
 			Owner: common.HexToAddress("0x04992a2B7E7CE809d409adE32185D49A96AAa32d"),
 		},
-		KaiaCompatibleBlock:   big.NewInt(156660000),
-		PragueCompatibleBlock: big.NewInt(187930000),
-		OsakaCompatibleBlock:  big.NewInt(209134000),
+		KaiaCompatibleBlock:           big.NewInt(156660000),
+		PragueCompatibleBlock:         big.NewInt(187930000),
+		OsakaCompatibleBlock:          big.NewInt(209134000),
+		PermissionlessCompatibleBlock: nil, // TODO-kaia-permissionless: set Kairos's PermissionlessCompatibleBlock
 		// Optional forks
 		Kip103CompatibleBlock: big.NewInt(119145600),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),
@@ -164,6 +166,7 @@ func TestKaiaConfig(maxHardfork string) *ChainConfig {
 		UnitPrice:     1, // NOTE-Kaia Use 1 for testing
 		DeriveShaImpl: 0,
 		Governance:    testGovConfig,
+		VRankEpoch:    DefaultVRankEpoch,
 	}
 	if maxHardfork == "istanbul" {
 		return chainConfig
@@ -213,6 +216,11 @@ func TestKaiaConfig(maxHardfork string) *ChainConfig {
 		return chainConfig
 	}
 
+	chainConfig.PermissionlessCompatibleBlock = big.NewInt(0)
+	if maxHardfork == "permissionless" {
+		return chainConfig
+	}
+
 	return chainConfig
 }
 
@@ -236,6 +244,9 @@ const (
 
 const (
 	PasswordLength = 16
+
+	// DefaultVRankEpoch is the default number of blocks per VRank epoch.
+	DefaultVRankEpoch = uint64(86400)
 )
 
 var (
@@ -258,16 +269,17 @@ type ChainConfig struct {
 
 	// "Compatible" means that it is EVM compatible(the opcode and precompiled contracts are the same as Ethereum EVM).
 	// In other words, not all the hard fork items are included.
-	IstanbulCompatibleBlock  *big.Int `json:"istanbulCompatibleBlock,omitempty"`  // IstanbulCompatibleBlock switch block (nil = no fork, 0 = already on istanbul)
-	LondonCompatibleBlock    *big.Int `json:"londonCompatibleBlock,omitempty"`    // LondonCompatibleBlock switch block (nil = no fork, 0 = already on london)
-	EthTxTypeCompatibleBlock *big.Int `json:"ethTxTypeCompatibleBlock,omitempty"` // EthTxTypeCompatibleBlock switch block (nil = no fork, 0 = already on ethTxType)
-	MagmaCompatibleBlock     *big.Int `json:"magmaCompatibleBlock,omitempty"`     // MagmaCompatible switch block (nil = no fork, 0 already on Magma)
-	KoreCompatibleBlock      *big.Int `json:"koreCompatibleBlock,omitempty"`      // KoreCompatible switch block (nil = no fork, 0 already on Kore)
-	ShanghaiCompatibleBlock  *big.Int `json:"shanghaiCompatibleBlock,omitempty"`  // ShanghaiCompatible switch block (nil = no fork, 0 already on shanghai)
-	CancunCompatibleBlock    *big.Int `json:"cancunCompatibleBlock,omitempty"`    // CancunCompatible switch block (nil = no fork, 0 already on Cancun)
-	KaiaCompatibleBlock      *big.Int `json:"kaiaCompatibleBlock,omitempty"`      // KaiaCompatible switch block (nil = no fork, 0 already on Kaia)
-	PragueCompatibleBlock    *big.Int `json:"pragueCompatibleBlock,omitempty"`    // PragueCompatible switch block (nil = no fork)
-	OsakaCompatibleBlock     *big.Int `json:"osakaCompatibleBlock,omitempty"`     // OsakaCompatible switch block (nil = no fork)
+	IstanbulCompatibleBlock       *big.Int `json:"istanbulCompatibleBlock,omitempty"`       // IstanbulCompatibleBlock switch block (nil = no fork, 0 = already on istanbul)
+	LondonCompatibleBlock         *big.Int `json:"londonCompatibleBlock,omitempty"`         // LondonCompatibleBlock switch block (nil = no fork, 0 = already on london)
+	EthTxTypeCompatibleBlock      *big.Int `json:"ethTxTypeCompatibleBlock,omitempty"`      // EthTxTypeCompatibleBlock switch block (nil = no fork, 0 = already on ethTxType)
+	MagmaCompatibleBlock          *big.Int `json:"magmaCompatibleBlock,omitempty"`          // MagmaCompatible switch block (nil = no fork, 0 already on Magma)
+	KoreCompatibleBlock           *big.Int `json:"koreCompatibleBlock,omitempty"`           // KoreCompatible switch block (nil = no fork, 0 already on Kore)
+	ShanghaiCompatibleBlock       *big.Int `json:"shanghaiCompatibleBlock,omitempty"`       // ShanghaiCompatible switch block (nil = no fork, 0 already on shanghai)
+	CancunCompatibleBlock         *big.Int `json:"cancunCompatibleBlock,omitempty"`         // CancunCompatible switch block (nil = no fork, 0 already on Cancun)
+	KaiaCompatibleBlock           *big.Int `json:"kaiaCompatibleBlock,omitempty"`           // KaiaCompatible switch block (nil = no fork, 0 already on Kaia)
+	PragueCompatibleBlock         *big.Int `json:"pragueCompatibleBlock,omitempty"`         // PragueCompatible switch block (nil = no fork)
+	OsakaCompatibleBlock          *big.Int `json:"osakaCompatibleBlock,omitempty"`          // OsakaCompatible switch block (nil = no fork)
+	PermissionlessCompatibleBlock *big.Int `json:"permissionlessCompatibleBlock,omitempty"` // PermissionlessCompatible switch block (nil = no fork)
 
 	// Kip103 is a special purpose hardfork feature that can be executed only once
 	// Both Kip103CompatibleBlock and Kip103ContractAddress should be specified to enable KIP103
@@ -290,6 +302,8 @@ type ChainConfig struct {
 	UnitPrice     uint64            `json:"unitPrice"`
 	DeriveShaImpl int               `json:"deriveShaImpl"`
 	Governance    *GovernanceConfig `json:"governance"`
+
+	VRankEpoch uint64 `json:"vrankEpoch,omitempty"` // Blocks per VRank epoch (permissionless); defaults to DefaultVRankEpoch (86400)
 }
 
 // UnmarshalJSON implements json.Unmarshaler to detect deprecated consensus engine configurations
@@ -400,6 +414,7 @@ func (c *ChainConfig) String() string {
 		" RandaoCompatibleBlock: %v"+
 		" PragueCompatibleBlock: %v"+
 		" OsakaCompatibleBlock: %v"+
+		" PermissionlessCompatibleBlock: %v"+
 		"%s%s%s"+
 		" UnitPrice: %d"+
 		" DeriveShaImpl: %d"+
@@ -416,6 +431,7 @@ func (c *ChainConfig) String() string {
 		c.RandaoCompatibleBlock,
 		c.PragueCompatibleBlock,
 		c.OsakaCompatibleBlock,
+		c.PermissionlessCompatibleBlock,
 		kip103, kip160, subGroupSize,
 		c.UnitPrice,
 		c.DeriveShaImpl,
@@ -533,6 +549,11 @@ func (c *ChainConfig) IsOsakaForkEnabled(num *big.Int) bool {
 	return isForked(c.OsakaCompatibleBlock, num)
 }
 
+// IsPermissionlessForkEnabled returns whether num is either equal to the permissionless block or greater.
+func (c *ChainConfig) IsPermissionlessForkEnabled(num *big.Int) bool {
+	return isForked(c.PermissionlessCompatibleBlock, num)
+}
+
 // IsKIP103ForkBlock returns whether num is equal to the kip103 block.
 func (c *ChainConfig) IsKIP103ForkBlock(num *big.Int) bool {
 	return isForkBlock(c.Kip103CompatibleBlock, num)
@@ -561,6 +582,11 @@ func (c *ChainConfig) IsKaiaForkBlockParent(num *big.Int) bool {
 // IsOsakaForkBlockParent returns whether num is one block before the osaka block.
 func (c *ChainConfig) IsOsakaForkBlockParent(num *big.Int) bool {
 	return isForkBlockParent(c.OsakaCompatibleBlock, num)
+}
+
+// IsPermissionlessForkBlockParent returns whether num is equal to the permissionless block.
+func (c *ChainConfig) IsPermissionlessForkBlockParent(num *big.Int) bool {
+	return isForkBlockParent(c.PermissionlessCompatibleBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -602,6 +628,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "kaiaBlock", block: c.KaiaCompatibleBlock},
 		{name: "pragueBlock", block: c.PragueCompatibleBlock},
 		{name: "osakaBlock", block: c.OsakaCompatibleBlock},
+		{name: "permissionlessBlock", block: c.PermissionlessCompatibleBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -660,6 +687,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.OsakaCompatibleBlock, newcfg.OsakaCompatibleBlock, head) {
 		return newCompatError("Osaka Block", c.OsakaCompatibleBlock, newcfg.OsakaCompatibleBlock)
 	}
+	if isForkIncompatible(c.PermissionlessCompatibleBlock, newcfg.PermissionlessCompatibleBlock, head) {
+		return newCompatError("Permissionless Block", c.PermissionlessCompatibleBlock, newcfg.PermissionlessCompatibleBlock)
+	}
 	return nil
 }
 
@@ -711,6 +741,9 @@ func (c *ChainConfig) SetDefaults() {
 	}
 	if c.Governance.Reward.StakingRewardThreshold == nil {
 		c.Governance.Reward.StakingRewardThreshold = DefaultStakingRewardThreshold
+	}
+	if c.VRankEpoch == 0 {
+		c.VRankEpoch = DefaultVRankEpoch
 	}
 }
 
@@ -791,18 +824,19 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID     *big.Int
-	IsIstanbul  bool
-	IsLondon    bool
-	IsEthTxType bool
-	IsMagma     bool
-	IsKore      bool
-	IsShanghai  bool
-	IsCancun    bool
-	IsKaia      bool
-	IsRandao    bool
-	IsPrague    bool
-	IsOsaka     bool
+	ChainID          *big.Int
+	IsIstanbul       bool
+	IsLondon         bool
+	IsEthTxType      bool
+	IsMagma          bool
+	IsKore           bool
+	IsShanghai       bool
+	IsCancun         bool
+	IsKaia           bool
+	IsRandao         bool
+	IsPrague         bool
+	IsOsaka          bool
+	IsPermissionless bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -812,18 +846,19 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		chainID = new(big.Int)
 	}
 	return Rules{
-		ChainID:     new(big.Int).Set(chainID),
-		IsIstanbul:  c.IsIstanbulForkEnabled(num),
-		IsLondon:    c.IsLondonForkEnabled(num),
-		IsEthTxType: c.IsEthTxTypeForkEnabled(num),
-		IsMagma:     c.IsMagmaForkEnabled(num),
-		IsKore:      c.IsKoreForkEnabled(num),
-		IsShanghai:  c.IsShanghaiForkEnabled(num),
-		IsCancun:    c.IsCancunForkEnabled(num),
-		IsKaia:      c.IsKaiaForkEnabled(num),
-		IsRandao:    c.IsRandaoForkEnabled(num),
-		IsPrague:    c.IsPragueForkEnabled(num),
-		IsOsaka:     c.IsOsakaForkEnabled(num),
+		ChainID:          new(big.Int).Set(chainID),
+		IsIstanbul:       c.IsIstanbulForkEnabled(num),
+		IsLondon:         c.IsLondonForkEnabled(num),
+		IsEthTxType:      c.IsEthTxTypeForkEnabled(num),
+		IsMagma:          c.IsMagmaForkEnabled(num),
+		IsKore:           c.IsKoreForkEnabled(num),
+		IsShanghai:       c.IsShanghaiForkEnabled(num),
+		IsCancun:         c.IsCancunForkEnabled(num),
+		IsKaia:           c.IsKaiaForkEnabled(num),
+		IsRandao:         c.IsRandaoForkEnabled(num),
+		IsPrague:         c.IsPragueForkEnabled(num),
+		IsOsaka:          c.IsOsakaForkEnabled(num),
+		IsPermissionless: c.IsPermissionlessForkEnabled(num),
 	}
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -62,7 +62,7 @@ var (
 		KaiaCompatibleBlock:           big.NewInt(162900480),
 		PragueCompatibleBlock:         big.NewInt(190670000),
 		OsakaCompatibleBlock:          big.NewInt(213333000),
-		PermissionlessCompatibleBlock: nil, // TODO-kaia-permissionless: set Mainnet's PermissionlessCompatibleBlock
+		PermissionlessCompatibleBlock: nil, // TODO-permissionless: set Mainnet's PermissionlessCompatibleBlock
 		// Optional forks
 		Kip103CompatibleBlock: big.NewInt(119750400),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),
@@ -114,7 +114,7 @@ var (
 		KaiaCompatibleBlock:           big.NewInt(156660000),
 		PragueCompatibleBlock:         big.NewInt(187930000),
 		OsakaCompatibleBlock:          big.NewInt(209134000),
-		PermissionlessCompatibleBlock: nil, // TODO-kaia-permissionless: set Kairos's PermissionlessCompatibleBlock
+		PermissionlessCompatibleBlock: nil, // TODO-permissionless: set Kairos's PermissionlessCompatibleBlock
 		// Optional forks
 		Kip103CompatibleBlock: big.NewInt(119145600),
 		Kip103ContractAddress: common.HexToAddress("0xD5ad6D61Dd87EdabE2332607C328f5cc96aeCB95"),


### PR DESCRIPTION
## Proposed changes

- Add PermissionlessCompatibleBlock field to ChainConfig
- Add VRankEpoch field + DefaultVRankEpoch = 86400 constant
- Add --override.permissionless CLI flag
- Register in FlagGroups, CommonNodeFlags, initGenesis
- Add homi flags `--permissionless-compatible-blocknumber`, `--vrank-epoch` flag

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

#735, #818, #827, #832

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
