### PR TITLE
blockchain/types: add vrank field

### DIFF
--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -270,7 +270,7 @@ func testGetHeader(t *testing.T, testAPIName string, config *params.ChainConfig)
 		"parentHash": "0xc8036293065bacdfce87debec0094a71dbbe40345b078d21dcc47adb4513f348",
 		"receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
 		"sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-		"size": "0x254",
+		"size": "0x26c",
 		"stateRoot": "0xad31c32942fa033166e4ef588ab973dbe26657c594de4ba98192108becf0fec9",
 		"timestamp": "0x61d53854",
 		"transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
@@ -283,7 +283,7 @@ func testGetHeader(t *testing.T, testAPIName string, config *params.ChainConfig)
 		expected["randomReveal"] = "0x94516a8bc695b5bf43aa077cd682d9475a3a6bed39a633395b78ed8f276e7c5bb00bb26a77825013c6718579f1b3ee2275b158801705ea77989e3acc849ee9c524bd1822bde3cba7be2aae04347f0d91508b7b7ce2f11ec36cbf763173421ae7"
 		expected["mixHash"] = "0xdf117d1245dceaae0a47f05371b23cd0d0db963ff9d5c8ba768dc989f4c31883"
 		expected["hash"] = "0x36f1c36d1723049abf1202a1cda828eec6399edd654dae12b72a1642097a29e4"
-		expected["size"] = "0x2d4"
+		expected["size"] = "0x2ec"
 	}
 	assert.Equal(t, stringifyMap(expected), stringifyMap(ethHeader))
 }

--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -763,6 +763,9 @@ func RpcOutputBlock(b *types.Block, inclTx bool, fullTx bool, config *params.Cha
 		fields["excessBlobGas"] = (*hexutil.Big)(new(big.Int).SetUint64(*head.ExcessBlobGas))
 		fields["blobGasUsed"] = hexutil.Uint64(*head.BlobGasUsed)
 	}
+	if rules.IsPermissionless {
+		fields["vrank"] = hexutil.Bytes(head.VRank)
+	}
 
 	return fields, nil
 }
@@ -865,6 +868,9 @@ func RPCMarshalHeader(head *types.Header, rules params.Rules) map[string]interfa
 	if rules.IsOsaka {
 		result["excessBlobGas"] = (*hexutil.Big)(new(big.Int).SetUint64(*head.ExcessBlobGas))
 		result["blobGasUsed"] = hexutil.Uint64(*head.BlobGasUsed)
+	}
+	if rules.IsPermissionless {
+		result["vrank"] = hexutil.Bytes(head.VRank)
 	}
 
 	return result

--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -76,6 +76,9 @@ type Header struct {
 	// ExcessBlobGas was added by EIP-4844 and is ignored in legacy headers.
 	ExcessBlobGas *uint64 `json:"excessBlobGas" rlp:"optional"`
 
+	// VRank was added by KIP-227 and is ignored in legacy headers.
+	VRank []byte `json:"vrank,omitempty" rlp:"optional"`
+
 	// New header fields must be added at tail for backward compatibility.
 }
 
@@ -97,6 +100,7 @@ type headerMarshaling struct {
 	MixHash       hexutil.Bytes
 	BlobGasUsed   *hexutil.Uint64
 	ExcessBlobGas *hexutil.Uint64
+	VRank         hexutil.Bytes
 }
 
 // HeaderHashFn is an optional override for Header.Hash. When set, it replaces
@@ -291,6 +295,10 @@ func CopyHeader(h *Header) *Header {
 	if h.BlobGasUsed != nil {
 		cpy.BlobGasUsed = new(uint64)
 		*cpy.BlobGasUsed = *h.BlobGasUsed
+	}
+	if len(h.VRank) > 0 {
+		cpy.VRank = make([]byte, len(h.VRank))
+		copy(cpy.VRank, h.VRank)
 	}
 	return &cpy
 }

--- a/blockchain/types/block_test.go
+++ b/blockchain/types/block_test.go
@@ -175,8 +175,9 @@ func TestHeaderSizeCalc(t *testing.T) {
 	// + MixHash slice (24)
 	// + ExcessBlobGas pointer (8)
 	// + BlobGasUsed pointer (8)
+	// + VRank slice (24)
 	constantSize := int(reflect.TypeFor[Header]().Size())
-	assert.Equal(t, 520+8+24+24+8+8, constantSize)
+	assert.Equal(t, 520+8+24+24+8+8+24, constantSize)
 
 	// Test header.Size() while adding fields one by one
 	// Start from a header without any variable length fields.

--- a/blockchain/types/gen_header_json.go
+++ b/blockchain/types/gen_header_json.go
@@ -35,6 +35,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		MixHash       hexutil.Bytes   `json:"mixHash,omitempty" rlp:"optional"`
 		BlobGasUsed   *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		VRank         hexutil.Bytes   `json:"vrank,omitempty" rlp:"optional"`
 		Hash          common.Hash     `json:"hash"`
 	}
 	var enc Header
@@ -57,6 +58,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.MixHash = h.MixHash
 	enc.BlobGasUsed = (*hexutil.Uint64)(h.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
+	enc.VRank = h.VRank
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -83,6 +85,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		MixHash       *hexutil.Bytes  `json:"mixHash,omitempty" rlp:"optional"`
 		BlobGasUsed   *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		VRank         *hexutil.Bytes  `json:"vrank,omitempty" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -157,6 +160,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ExcessBlobGas != nil {
 		h.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.VRank != nil {
+		h.VRank = *dec.VRank
 	}
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

Add a new header field `vrank` as per [KIP-227](https://kips.kaia.io/KIPs/kip-227).
`gencodec` is executed to update `blockchain/types/gen_header_json.go`.
It will be wired after introducing relevant modules.

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

Permissionless tasks: #874

This PR is from permissionless branch #737

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
