### PR TITLE
Permissionless: rename kcn abv2 command to valops

### DIFF
--- a/cmd/kcn/README.md
+++ b/cmd/kcn/README.md
@@ -1,11 +1,11 @@
-# kcn abv2 — AddressBookV2 CLI
+# kcn valops — Validator Operations CLI
 
 Command-line interface for interacting with the AddressBookV2 contract (`0x400`) on-chain.
 
 ## Usage
 
 ```
-kcn abv2 <command> [flags] [args]
+kcn valops <command> [flags] [args]
 ```
 
 ## Flags (all commands)
@@ -26,8 +26,8 @@ Chain ID is fetched automatically from the endpoint.
 These commands require the caller to hold the suspender role in AddressBookV2.
 
 ```
-kcn abv2 suspend-validator --node-id <address>
-kcn abv2 unsuspend-validator --node-id <address>
+kcn valops suspend-validator --node-id <address>
+kcn valops unsuspend-validator --node-id <address>
 ```
 
 | Flag | Description |
@@ -39,14 +39,14 @@ kcn abv2 unsuspend-validator --node-id <address>
 These commands require `msg.sender == node-id` (the private key **is** the node key).
 
 ```
-kcn abv2 ready-candidate
-kcn abv2 unready-candidate
-kcn abv2 ready-validator
-kcn abv2 unready-validator
-kcn abv2 pause
-kcn abv2 resume
-kcn abv2 exit
-kcn abv2 offboard
+kcn valops ready-candidate
+kcn valops unready-candidate
+kcn valops ready-validator
+kcn valops unready-validator
+kcn valops pause
+kcn valops resume
+kcn valops exit
+kcn valops offboard
 ```
 
 No extra arguments. The node-id is derived from the private key.
@@ -55,16 +55,16 @@ No extra arguments. The node-id is derived from the private key.
 
 ```sh
 # Suspend a validator (as suspender)
-kcn abv2 suspend-validator --node-id 0xABCD... --private-key 0x1234...
+kcn valops suspend-validator --node-id 0xABCD... --private-key 0x1234...
 
 # Use default IPC endpoint and nodekey file
-kcn abv2 ready-candidate
+kcn valops ready-candidate
 
 # Specify a custom endpoint
-kcn abv2 pause --endpoint http://localhost:8551
+kcn valops pause --endpoint http://localhost:8551
 
 # Use a custom private key and endpoint
-kcn abv2 ready-validator --private-key 0x1234... --endpoint /tmp/klay.ipc
+kcn valops ready-validator --private-key 0x1234... --endpoint /tmp/klay.ipc
 ```
 
 ## Output

--- a/cmd/kcn/abv2.go
+++ b/cmd/kcn/abv2.go
@@ -66,9 +66,9 @@ var (
 	}
 )
 
-var ABv2Command = &cli.Command{
-	Name:     "abv2",
-	Usage:    "AddressBookV2 contract commands",
+var ValOpsCommand = &cli.Command{
+	Name:     "valops",
+	Usage:    "Validator state transition and suspension commands",
 	Category: "PERMISSIONLESS COMMANDS",
 	Subcommands: []*cli.Command{
 		{

--- a/cmd/kcn/main.go
+++ b/cmd/kcn/main.go
@@ -75,7 +75,7 @@ func init() {
 		nodecmd.SnapshotCommand,
 
 		// See cmd/kcn/abv2.go:
-		ABv2Command,
+		ValOpsCommand,
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
 


### PR DESCRIPTION
## Proposed changes

- **Rename CLI command**: `kcn abv2` → `kcn valops`

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
