### PR TITLE
p2p: fix findNodesOnce and DialMulti

### DIFF
--- a/networks/p2p/discover/table_lookup.go
+++ b/networks/p2p/discover/table_lookup.go
@@ -17,6 +17,7 @@
 package discover
 
 import (
+	"errors"
 	"time"
 
 	"github.com/kaiachain/kaia/crypto"
@@ -164,9 +165,14 @@ func (tab *Table2) findNodes(seeds []*Node, targetID NodeID, targetType NodeType
 
 func (tab *Table2) findNodesOnce(seed *Node, targetID NodeID, targetType NodeType, max int) []*Node {
 	r, err := tab.udp.findnode(seed.ID, seed.addr(), targetID, targetType, max)
-	if err != nil {
+	// A timeout with no NEIGHBORS at all means the seed is unresponsive
+	if errors.Is(err, errTimeout) && len(r) == 0 {
 		tab.recordFindFailure(seed)
 		return nil
+	}
+	// Drop bootnodes from the response unless the caller is explicitly looking for them
+	if targetType != NodeTypeBN {
+		r = removeBn(r)
 	}
 	// Out of the find results, return only reachable (bonded) nodes.
 	return tab.bondall(r)

--- a/networks/p2p/discover/table_lookup_test.go
+++ b/networks/p2p/discover/table_lookup_test.go
@@ -106,7 +106,7 @@ func Test_Table_findNodesOnce_error(t *testing.T) {
 	tab.db.updateNode(seed)
 
 	result := tab.findNodesOnce(seed, NodeID{}, NodeTypeEN, 10)
-	assert.Nil(t, result)
+	assert.Empty(t, result)
 	assert.Equal(t, 1, tab.db.findFails(seed.ID), "failure should be recorded in DB")
 }
 
@@ -123,6 +123,27 @@ func Test_Table_findNodesOnce_success(t *testing.T) {
 	// Peer is bonded (ping returns nil by default) so it appears in results.
 	require.Len(t, result, 1)
 	assert.Equal(t, peer.ID, result[0].ID)
+}
+
+func Test_Table_findNodesOnce_timeout_noFailure(t *testing.T) {
+	// When the responder has fewer nodes than requested, findnode sends a
+	// short NEIGHBORS packet and the matcher times out waiting for more.
+	// findNodesOnce must keep the peer result instead of discarding it,
+	// and must not bump the seed's failure counter.
+	peer := newTestNode(t, NodeTypeCN)
+	udp := newMockTransport()
+	udp.findnodeFn = func(NodeID, *net.UDPAddr, NodeID, NodeType, int) ([]*Node, error) {
+		return []*Node{peer}, errTimeout
+	}
+	tab := newTestTable2(t, udp)
+	seed := newTestNode(t, NodeTypeEN)
+	tab.addNode(seed)
+	tab.db.updateNode(seed)
+
+	result := tab.findNodesOnce(seed, NodeID{}, NodeTypeCN, 100)
+	require.Len(t, result, 1)
+	assert.Equal(t, peer.ID, result[0].ID)
+	assert.Equal(t, 0, tab.db.findFails(seed.ID), "timeout with response must not record a find failure")
 }
 
 func Test_Table_lookup_emptyTable(t *testing.T) {

--- a/networks/p2p/discover/udp_test.go
+++ b/networks/p2p/discover/udp_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/rlp"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -249,7 +250,7 @@ func TestUDP_findnodeTimeout(t *testing.T) {
 	}
 }
 
-func TestUDP_findnode(t *testing.T) {
+func TestUDP_findnode_EN(t *testing.T) {
 	test := newUDPTest(t)
 	defer test.table.Close()
 
@@ -289,6 +290,68 @@ func TestUDP_findnode(t *testing.T) {
 	}
 	waitNeighbors(expected.entries[:maxNeighbors])
 	waitNeighbors(expected.entries[maxNeighbors:])
+}
+
+func TestUDP_findnode_CN_overfill(t *testing.T) {
+	test := newUDPTest(t)
+	defer test.table.Close()
+
+	// Fill the CN storage with more nodes than the per-request retrieve cap.
+	const filled = 200
+	retrieve := findnodeRetrieveSize(NodeTypeCN)
+	assert.Greater(t, filled, retrieve)
+	selfSha := crypto.Keccak256Hash(test.table.selfID[:])
+	s := test.table.storages[NodeTypeCN]
+	addedIDs := make(map[NodeID]struct{}, filled)
+	for i := range filled {
+		n := nodeAtDistance(selfSha, i+2, NodeTypeCN)
+		n.IP = net.IPv4(1, byte((i>>8)&0xff), byte(i&0xff), 1)
+		s.add(n)
+		addedIDs[n.ID] = struct{}{}
+	}
+
+	// ensure there's a bond with the test node,
+	// findnode won't be accepted otherwise.
+	test.table.db.updateBondTime(PubkeyID(&test.remotekey.PublicKey), time.Now())
+
+	// Trigger the findnode. retrieveSize for NodeTypeCN is 100.
+	test.packetIn(nil, findnodePacket, &findnode{Target: testTarget, TargetType: NodeTypeCN, Expiration: futureExp})
+
+	// Collect all NEIGHBORS packets. The handler sends ceil(retrieve/maxNeighbors)
+	// packets, with the last one possibly short.
+	numPackets := (retrieve + maxNeighbors - 1) / maxNeighbors
+	t.Logf("expecting %d NEIGHBORS packets (retrieve=%d, maxNeighbors=%d)",
+		numPackets, retrieve, maxNeighbors)
+
+	seen := make(map[NodeID]struct{}, retrieve)
+	totalReceived := 0
+	for p := range numPackets {
+		test.waitPacketOut(func(pkt *neighbors) {
+			// Intermediate packets must be full; the last packet carries the remainder.
+			isLast := p == numPackets-1
+			if !isLast && len(pkt.Nodes) != maxNeighbors {
+				t.Errorf("packet %d: got %d nodes, want %d (maxNeighbors)",
+					p, len(pkt.Nodes), maxNeighbors)
+			} else if isLast && len(pkt.Nodes) != retrieve-(numPackets-1)*maxNeighbors {
+				t.Errorf("packet %d: got %d nodes, want %d (last packet)",
+					p, len(pkt.Nodes), retrieve-(numPackets-1)*maxNeighbors)
+			}
+			for _, rn := range pkt.Nodes {
+				if _, ok := addedIDs[rn.ID]; !ok {
+					t.Errorf("packet %d: unexpected NodeID %x returned", p, rn.ID[:8])
+				}
+				if _, dup := seen[rn.ID]; dup {
+					t.Errorf("packet %d: duplicate NodeID %x", p, rn.ID[:8])
+				}
+				seen[rn.ID] = struct{}{}
+				totalReceived++
+			}
+		})
+	}
+
+	if totalReceived != retrieve {
+		t.Errorf("total returned nodes = %d, want %d", totalReceived, retrieve)
+	}
 }
 
 func TestUDP_findnodeMultiReply(t *testing.T) {

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -148,17 +148,22 @@ func (t TCPDialer) Dial(dest *discover.Node) (net.Conn, error) {
 
 // DialMulti creates TCP connections to the node.
 func (t TCPDialer) DialMulti(dest *discover.Node) ([]net.Conn, error) {
-	var conns []net.Conn
-	if dest.TCPs != nil || len(dest.TCPs) != 0 {
-		conns = make([]net.Conn, 0, len(dest.TCPs))
-		for _, tcp := range dest.TCPs {
-			addr := &net.TCPAddr{IP: dest.IP, Port: int(tcp)}
-			conn, err := t.Dialer.Dial("tcp", addr.String())
-			conns = append(conns, conn)
-			if err != nil {
-				return nil, err
+	if len(dest.TCPs) == 0 {
+		return nil, nil
+	}
+	conns := make([]net.Conn, 0, len(dest.TCPs))
+	for _, tcp := range dest.TCPs {
+		addr := &net.TCPAddr{IP: dest.IP, Port: int(tcp)}
+		conn, err := t.Dialer.Dial("tcp", addr.String())
+		if err != nil {
+			// Close any connections opened so far to avoid leaking sockets
+			// when only some of the ports could be reached.
+			for _, c := range conns {
+				c.Close()
 			}
+			return nil, err
 		}
+		conns = append(conns, conn)
 	}
 	return conns, nil
 }


### PR DESCRIPTION
## Proposed changes

- Fix `findNodeOnce` logic to match the [pre-refactor](https://github.com/kaiachain/kaia/blob/ac7c81f3a9759704b5ce77b42ae91851ce45a9c3/networks/p2p/discover/table.go#L303-L306)
  - Even if NEIGHBORS response contains less than requested, bond with the nodes in the response
- Call `recordFindFailure` only when the counterparty is unresponsive
  - It is not an error that NEIGHBORS response contains less than requested
- Fix `DialMulti`
  - It now closes successful dials upon error

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
