### PR TITLE
Fix/valset missing parent state

### DIFF
--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -139,10 +139,10 @@ func (v *ValsetModule) getNodeStates(num uint64) (valset.NodeStateMap, error) {
 	if !v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
 		return nil, errors.New("permissionless fork is not enabled")
 	}
-	var nodes valset.NodeStateMap
 	if cached, ok := v.nodeStatesCache.Get(num); ok {
-		nodes = cached.(nodeStatesCacheEntry).validators
-	} else if num == 0 {
+		return cached.(nodeStatesCacheEntry).validators, nil
+	}
+	if num == 0 {
 		// Block 0 has no parent; read ABv2 directly from genesis state.
 		genesisHeader := v.Chain.GetHeaderByNumber(0)
 		if genesisHeader == nil {
@@ -156,20 +156,34 @@ func (v *ValsetModule) getNodeStates(num uint64) (valset.NodeStateMap, error) {
 		if err != nil {
 			return nil, err
 		}
-		nodes = res.Validators
-	} else {
-		parentHeader := v.Chain.GetHeaderByNumber(num - 1)
-		if parentHeader == nil {
-			return nil, errParentHeaderNotFound(num)
+		return res.Validators, nil
+	}
+	// Shortcut: if block num is already committed, read NodeStates(num) from S(num) directly.
+	// Initialize(num) writes NodeStates(num) to ABv2 via system tx, so ABv2(num) == NodeStates(num)
+	// after commit — no applyTr needed.
+	// Without this shortcut, getNodeStates(K) reads S(K-1); callers like TallyCfReport(N-1)
+	// invoke getNodeStates(N-1), which would read S(N-2) — absent on a non-archive node
+	// after graceful shutdown/restart (only head state is preserved on Stop).
+	if header := v.Chain.GetHeaderByNumber(num); header != nil {
+		if statedb, err := v.Chain.StateAt(header.Root); err == nil {
+			if res, err := system.ReadNodeStates(statedb, v.Chain, header); err == nil {
+				res.Validators.MarkSuspended(res.SuspendedValidators)
+				v.nodeStatesCache.Add(num, nodeStatesCacheEntry{validators: res.Validators})
+				return res.Validators, nil
+			}
 		}
-		parentStatedb, err := v.Chain.StateAt(parentHeader.Root)
-		if err != nil {
-			return nil, err
-		}
-		nodes, _, err = v.getOrComputeNodeStates(num, parentStatedb)
-		if err != nil {
-			return nil, err
-		}
+	}
+	parentHeader := v.Chain.GetHeaderByNumber(num - 1)
+	if parentHeader == nil {
+		return nil, errParentHeaderNotFound(num)
+	}
+	parentStatedb, err := v.Chain.StateAt(parentHeader.Root)
+	if err != nil {
+		return nil, err
+	}
+	nodes, _, err := v.getOrComputeNodeStates(num, parentStatedb)
+	if err != nil {
+		return nil, err
 	}
 	return nodes, nil
 }

--- a/kaiax/valset/impl/getter_regen_test.go
+++ b/kaiax/valset/impl/getter_regen_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+
+package impl
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/system"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	consensus_mock "github.com/kaiachain/kaia/consensus/mocks"
+	"github.com/kaiachain/kaia/kaiax/gov"
+	gov_mock "github.com/kaiachain/kaia/kaiax/gov/mock"
+	vrank_mock "github.com/kaiachain/kaia/kaiax/vrank/mock"
+	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/kaiachain/kaia/storage/statedb"
+	chain_mock "github.com/kaiachain/kaia/work/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetNodeStates_MissingParentState verifies that getNodeStates(K) succeeds
+// when S(K-1) is unavailable (non-archive node after graceful shutdown + restart preserves
+// only the head state). getNodeStates(K) must read NodeStates(K) directly from S(K),
+// not depend on S(K-1).
+//
+// Setup: head=4, S(4) available (real ABv2 state), S(3) returns MissingNodeError.
+func TestGetNodeStates_MissingParentState(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
+
+	// Build a real statedb that contains an initialized ABv2.
+	config, _ := system.MakeTestPermissionlessConfig(4)
+	alloc, err := system.AllocPermissionless(config)
+	require.NoError(t, err)
+
+	chainConfig := params.TestChainConfig.Copy()
+	chainConfig.PermissionlessCompatibleBlock = big.NewInt(0)
+	chainConfig.VRankEpoch = 5
+
+	db := database.NewMemoryDBManager()
+	genesisBlock := (&blockchain.Genesis{Config: chainConfig, Alloc: blockchain.GenesisAlloc(alloc)}).MustCommit(db)
+
+	// Fake headers: pretend block 4 (head) has the genesis state root.
+	// Block 3 has a different (fake) root that we will deliberately fail.
+	headHeader := &types.Header{Number: big.NewInt(4), Root: genesisBlock.Root(), Time: big.NewInt(0), BlockScore: big.NewInt(0)}
+	parentHeader := &types.Header{Number: big.NewInt(3), Root: common.HexToHash("0xdeadbeef"), Time: big.NewInt(0), BlockScore: big.NewInt(0)}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(chainConfig).AnyTimes()
+	mockChain.EXPECT().GetHeaderByNumber(uint64(4)).Return(headHeader).AnyTimes()
+	mockChain.EXPECT().GetHeaderByNumber(uint64(3)).Return(parentHeader).AnyTimes()
+	// Return real statedb for head (S(4)), MissingNodeError for parent (S(3)).
+	stateCache := state.NewDatabaseWithNewCache(db, statedb.GetEmptyTrieNodeCacheConfig())
+	headState, err := state.New(genesisBlock.Root(), stateCache, nil, nil)
+	require.NoError(t, err)
+	mockChain.EXPECT().StateAt(genesisBlock.Root()).Return(headState, nil).AnyTimes()
+	mockChain.EXPECT().StateAt(parentHeader.Root).Return(nil, &statedb.MissingNodeError{}).AnyTimes()
+	// MultiCall path needs CurrentBlock for EVM context.
+	mockChain.EXPECT().CurrentBlock().Return(types.NewBlockWithHeader(headHeader)).AnyTimes()
+	// EVM block context resolves Coinbase via chain.Engine().Author(header).
+	mockEngine := consensus_mock.NewMockEngine(ctrl)
+	mockEngine.EXPECT().Author(gomock.Any()).Return(common.Address{}, nil).AnyTimes()
+	mockChain.EXPECT().Engine().Return(mockEngine).AnyTimes()
+
+	mockGov := gov_mock.NewMockGovModule(ctrl)
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		MinimumStake: new(big.Int).SetUint64(5_000_000),
+	}).AnyTimes()
+	mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+	mockVRank.EXPECT().GetPfReport(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockVRank.EXPECT().GetPFS(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockVRank.EXPECT().GetCFSWithEpochVACount(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+	v.GovModule = mockGov
+	v.VRankModule = mockVRank
+
+	// Without shortcut: getNodeStates(4) reads S(3) → ErrPrunedAncestor.
+	// With shortcut: reads S(4) directly → success.
+	nodes, err := v.getNodeStates(4)
+	require.NoError(t, err, "getNodeStates(4) should succeed: ABv2 lives in S(4) (head); S(3) missing must NOT block this")
+	require.Len(t, nodes, len(config.NodeIds))
+	for _, id := range config.NodeIds {
+		_, ok := nodes[id]
+		require.True(t, ok, "nodeId %s should be in NodeStates(4)", id.Hex())
+	}
+}

--- a/kaiax/valset/impl/state_transition.go
+++ b/kaiax/valset/impl/state_transition.go
@@ -99,8 +99,8 @@ func (v *ValsetModule) applyAllTransitions(
 	slotLimitsFn func(n uint64) (uint64, uint64, error),
 ) (valset.NodeStateMap, uint64, error) {
 	var (
-		num       = header.Number.Uint64() + 1
-		pset      = v.GovModule.GetParamSet(num)
+		nextNum   = header.Number.Uint64() + 1
+		pset      = v.GovModule.GetParamSet(nextNum)
 		minStake  = pset.MinimumStake.Uint64()
 		blockTime = time.Unix(header.Time.Int64(), 0)
 
@@ -110,7 +110,7 @@ func (v *ValsetModule) applyAllTransitions(
 	)
 
 	newValidators := res.Validators
-	if v.isVrankEpoch(num) {
+	if v.isVrankEpoch(nextNum) {
 		newValidators = v.getEpochTransition(minStake, newValidators, res.IdleTimeout, int(res.MaxValActivePausedCount), blockTime, header.Number.Uint64(), res.CfsThreshold, res.EpochVACount)
 		// Recompute slot limits from new epochVACount(VA count after epoch, before violation).
 		// This epochVACountdefines the epoch's canonical slot budget and is stored in the contract.


### PR DESCRIPTION
## Proposed changes

- **Bug fix**: `getNodeStates(K)` previously read State(K-1) via the parent path. Callers like `TallyCfReport(N-1)` invoke `getNodeStates(N-1)`, which reads State(N-2). On a non-archive node after graceful shutdown/restart, only the head state is preserved on `Stop()`, so State(N-2) may be absent — causing `MissingNodeError`.
- **Shortcut path**: When block K is already committed, read `NodeStates(K)` directly from State(K). `Initialize(K)` writes `NodeStates(K)` to ABv2 via system tx, so `ABv2(K) == NodeStates(K)` holds after commit — no applyTr recomputation needed. Falls back to the original parent path for in-flight blocks (header(K) not yet in chain).
- **Refactor**: Rename `num` → `nextNum` in `applyAllTransitions` to clarify it represents the next block number (`header.Number + 1`).

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

`TestGetNodeStates_MissingParentState`: mocks head=4 with real ABv2 state at State(4), State(3) returning `statedb.MissingNodeError`. Verifies `getNodeStates(4)` succeeds by reading State(4) directly via the shortcut path.