### PR TITLE
api: fix `eth_feeHistory` response format

### DIFF
--- a/api/api_eth_test.go
+++ b/api/api_eth_test.go
@@ -3732,12 +3732,13 @@ func TestEthAPI_FeeHistory(t *testing.T) {
 					big.NewInt(30000000000),
 				}
 				gasUsedRatio := []float64{0.5, 0.6}
+				blobGasUsedRatio := []float64{0.25, 0.5}
 				mockBackend.EXPECT().FeeHistory(
 					gomock.Any(),
 					uint64(2),
 					rpc.LatestBlockNumber,
 					[]float64{50.0, 90.0},
-				).Return(oldestBlock, reward, baseFee, gasUsedRatio, nil)
+				).Return(oldestBlock, reward, baseFee, gasUsedRatio, blobGasUsedRatio, nil)
 			},
 			expected: &FeeHistoryResult{
 				OldestBlock: (*hexutil.Big)(big.NewInt(100)),
@@ -3753,7 +3754,8 @@ func TestEthAPI_FeeHistory(t *testing.T) {
 					(*hexutil.Big)(params.CalcBlobFee(big.NewInt(25000000000))),
 					(*hexutil.Big)(params.CalcBlobFee(big.NewInt(30000000000))),
 				},
-				GasUsedRatio: []float64{0.5, 0.6},
+				GasUsedRatio:     []float64{0.5, 0.6},
+				BlobGasUsedRatio: []float64{0.25, 0.5},
 			},
 		},
 		{
@@ -3766,19 +3768,21 @@ func TestEthAPI_FeeHistory(t *testing.T) {
 				var reward [][]*big.Int
 				var baseFee []*big.Int
 				gasUsedRatio := []float64{0.5}
+				blobGasUsedRatio := []float64{0}
 				mockBackend.EXPECT().FeeHistory(
 					gomock.Any(),
 					uint64(1),
 					rpc.BlockNumber(100),
 					[]float64(nil),
-				).Return(oldestBlock, reward, baseFee, gasUsedRatio, nil)
+				).Return(oldestBlock, reward, baseFee, gasUsedRatio, blobGasUsedRatio, nil)
 			},
 			expected: &FeeHistoryResult{
-				OldestBlock:  (*hexutil.Big)(big.NewInt(100)),
-				Reward:       nil,
-				BaseFee:      nil,
-				BlobBaseFee:  nil,
-				GasUsedRatio: []float64{0.5},
+				OldestBlock:      (*hexutil.Big)(big.NewInt(100)),
+				Reward:           nil,
+				BaseFee:          nil,
+				BlobBaseFee:      nil,
+				GasUsedRatio:     []float64{0.5},
+				BlobGasUsedRatio: []float64{0},
 			},
 		},
 		{
@@ -3792,7 +3796,7 @@ func TestEthAPI_FeeHistory(t *testing.T) {
 					uint64(1),
 					rpc.LatestBlockNumber,
 					[]float64{50.0},
-				).Return(nil, nil, nil, nil, errors.New("fee history error"))
+				).Return(nil, nil, nil, nil, nil, errors.New("fee history error"))
 			},
 			expectedErr: "fee history error",
 		},
@@ -3818,6 +3822,7 @@ func TestEthAPI_FeeHistory(t *testing.T) {
 
 				assert.Equal(t, tc.expected.OldestBlock, result.OldestBlock)
 				assert.Equal(t, tc.expected.GasUsedRatio, result.GasUsedRatio)
+				assert.Equal(t, tc.expected.BlobGasUsedRatio, result.BlobGasUsedRatio)
 
 				if tc.expected.Reward != nil {
 					require.NotNil(t, result.Reward)

--- a/api/api_kaia.go
+++ b/api/api_kaia.go
@@ -71,22 +71,24 @@ func (s *KaiaAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error
 }
 
 type FeeHistoryResult struct {
-	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
-	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
-	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
-	BlobBaseFee  []*hexutil.Big   `json:"blobBaseFeePerGas,omitempty"`
-	GasUsedRatio []float64        `json:"gasUsedRatio"`
+	OldestBlock      *hexutil.Big     `json:"oldestBlock"`
+	Reward           [][]*hexutil.Big `json:"reward,omitempty"`
+	BaseFee          []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
+	BlobBaseFee      []*hexutil.Big   `json:"baseFeePerBlobGas,omitempty"`
+	GasUsedRatio     []float64        `json:"gasUsedRatio"`
+	BlobGasUsedRatio []float64        `json:"blobGasUsedRatio"`
 }
 
 // FeeHistory returns data relevant for fee estimation based on the specified range of blocks.
 func (s *KaiaAPI) FeeHistory(ctx context.Context, blockCount DecimalOrHex, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*FeeHistoryResult, error) {
-	oldest, reward, baseFee, gasUsed, err := s.b.FeeHistory(ctx, uint64(blockCount), lastBlock, rewardPercentiles)
+	oldest, reward, baseFee, gasUsed, blobGasUsed, err := s.b.FeeHistory(ctx, uint64(blockCount), lastBlock, rewardPercentiles)
 	if err != nil {
 		return nil, err
 	}
 	results := &FeeHistoryResult{
-		OldestBlock:  (*hexutil.Big)(oldest),
-		GasUsedRatio: gasUsed,
+		OldestBlock:      (*hexutil.Big)(oldest),
+		GasUsedRatio:     gasUsed,
+		BlobGasUsedRatio: blobGasUsed,
 	}
 	if reward != nil {
 		results.Reward = make([][]*hexutil.Big, len(reward))

--- a/api/backend.go
+++ b/api/backend.go
@@ -62,7 +62,7 @@ type Backend interface {
 	RPCTxFeeCap() float64         // global tx fee cap in eth_signTransaction
 	Sealer() consensus.Sealer
 	ValsetModule() valset.ValsetModule
-	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error)
+	FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []float64, error)
 
 	// BlockChain API
 	SetHead(number uint64) error

--- a/api/mocks/backend_mock.go
+++ b/api/mocks/backend_mock.go
@@ -165,15 +165,16 @@ func (mr *MockBackendMockRecorder) EventMux() *gomock.Call {
 }
 
 // FeeHistory mocks base method.
-func (m *MockBackend) FeeHistory(arg0 context.Context, arg1 uint64, arg2 rpc.BlockNumber, arg3 []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
+func (m *MockBackend) FeeHistory(arg0 context.Context, arg1 uint64, arg2 rpc.BlockNumber, arg3 []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FeeHistory", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].([][]*big.Int)
 	ret2, _ := ret[2].([]*big.Int)
 	ret3, _ := ret[3].([]float64)
-	ret4, _ := ret[4].(error)
-	return ret0, ret1, ret2, ret3, ret4
+	ret4, _ := ret[4].([]float64)
+	ret5, _ := ret[5].(error)
+	return ret0, ret1, ret2, ret3, ret4, ret5
 }
 
 // FeeHistory indicates an expected call of FeeHistory.

--- a/node/cn/api_backend.go
+++ b/node/cn/api_backend.go
@@ -417,7 +417,7 @@ func (b *CNAPIBackend) StateAtTransaction(ctx context.Context, block *types.Bloc
 	return b.cn.stateAtTransaction(block, txIndex, reexec, base, readOnly, preferDisk)
 }
 
-func (b *CNAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
+func (b *CNAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, []float64, error) {
 	return b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 }
 

--- a/node/cn/gasprice/feehistory.go
+++ b/node/cn/gasprice/feehistory.go
@@ -72,6 +72,7 @@ type processedFees struct {
 	reward               []*big.Int
 	baseFee, nextBaseFee *big.Int
 	gasUsedRatio         float64
+	blobGasUsedRatio     float64
 }
 
 // txGasAndReward is sorted in ascending order based on reward
@@ -124,6 +125,14 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	}
 	if bf.results.gasUsedRatio > 1 {
 		bf.results.gasUsedRatio = 1
+	}
+
+	if bf.header.BlobGasUsed != nil {
+		if bcfg := chainconfig.BlobConfig(bf.header.Number); bcfg != nil {
+			if maxBlobGas := bcfg.MaxBlobGas(); maxBlobGas > 0 {
+				bf.results.blobGasUsedRatio = float64(*bf.header.BlobGasUsed) / float64(maxBlobGas)
+			}
+		}
 	}
 
 	if len(percentiles) == 0 {
@@ -247,16 +256,16 @@ func (oracle *Oracle) FeeHistory(
 	ctx context.Context, blocks uint64,
 	unresolvedLastBlock rpc.BlockNumber,
 	rewardPercentiles []float64,
-) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
+) (*big.Int, [][]*big.Int, []*big.Int, []float64, []float64, error) {
 	if blocks < 1 {
-		return common.Big0, nil, nil, nil, nil // returning with no data and no error means there are no retrievable blocks
+		return common.Big0, nil, nil, nil, nil, nil // returning with no data and no error means there are no retrievable blocks
 	}
 	maxFeeHistory := oracle.maxHeaderHistory
 	if len(rewardPercentiles) != 0 {
 		maxFeeHistory = oracle.maxBlockHistory
 	}
 	if len(rewardPercentiles) > maxQueryLimit {
-		return common.Big0, nil, nil, nil, fmt.Errorf("%w: over the query limit %d", errInvalidPercentile, maxQueryLimit)
+		return common.Big0, nil, nil, nil, nil, fmt.Errorf("%w: over the query limit %d", errInvalidPercentile, maxQueryLimit)
 	}
 	if blocks > maxFeeHistory {
 		logger.Warn("Sanitizing fee history length", "requested", blocks, "truncated", maxFeeHistory)
@@ -264,16 +273,16 @@ func (oracle *Oracle) FeeHistory(
 	}
 	for i, p := range rewardPercentiles {
 		if p < 0 || p > 100 {
-			return common.Big0, nil, nil, nil, fmt.Errorf("%w: %f", errInvalidPercentile, p)
+			return common.Big0, nil, nil, nil, nil, fmt.Errorf("%w: %f", errInvalidPercentile, p)
 		}
 		if i > 0 && p < rewardPercentiles[i-1] {
-			return common.Big0, nil, nil, nil, fmt.Errorf("%w: #%d:%f > #%d:%f", errInvalidPercentile, i-1, rewardPercentiles[i-1], i, p)
+			return common.Big0, nil, nil, nil, nil, fmt.Errorf("%w: #%d:%f > #%d:%f", errInvalidPercentile, i-1, rewardPercentiles[i-1], i, p)
 		}
 	}
 	var err error
 	pendingBlock, pendingReceipts, lastBlock, blocks, err := oracle.resolveBlockRange(ctx, unresolvedLastBlock, blocks)
 	if err != nil || blocks == 0 {
-		return common.Big0, nil, nil, nil, err
+		return common.Big0, nil, nil, nil, nil, err
 	}
 	oldestBlock := lastBlock + 1 - uint64(blocks)
 
@@ -329,19 +338,20 @@ func (oracle *Oracle) FeeHistory(
 		}()
 	}
 	var (
-		reward       = make([][]*big.Int, blocks)
-		baseFee      = make([]*big.Int, blocks+1)
-		gasUsedRatio = make([]float64, blocks)
-		firstMissing = blocks
+		reward           = make([][]*big.Int, blocks)
+		baseFee          = make([]*big.Int, blocks+1)
+		gasUsedRatio     = make([]float64, blocks)
+		blobGasUsedRatio = make([]float64, blocks)
+		firstMissing     = blocks
 	)
 	for ; blocks > 0; blocks-- {
 		fees := <-results
 		if fees.err != nil {
-			return common.Big0, nil, nil, nil, fees.err
+			return common.Big0, nil, nil, nil, nil, fees.err
 		}
 		i := fees.blockNumber - oldestBlock
 		if fees.results.baseFee != nil {
-			reward[i], baseFee[i], baseFee[i+1], gasUsedRatio[i] = fees.results.reward, fees.results.baseFee, fees.results.nextBaseFee, fees.results.gasUsedRatio
+			reward[i], baseFee[i], baseFee[i+1], gasUsedRatio[i], blobGasUsedRatio[i] = fees.results.reward, fees.results.baseFee, fees.results.nextBaseFee, fees.results.gasUsedRatio, fees.results.blobGasUsedRatio
 		} else {
 			// getting no block and no error means we are requesting into the future (might happen because of a reorg)
 			if i < firstMissing {
@@ -350,13 +360,13 @@ func (oracle *Oracle) FeeHistory(
 		}
 	}
 	if firstMissing == 0 {
-		return common.Big0, nil, nil, nil, nil
+		return common.Big0, nil, nil, nil, nil, nil
 	}
 	if len(rewardPercentiles) != 0 {
 		reward = reward[:firstMissing]
 	} else {
 		reward = nil
 	}
-	baseFee, gasUsedRatio = baseFee[:firstMissing+1], gasUsedRatio[:firstMissing]
-	return new(big.Int).SetUint64(oldestBlock), reward, baseFee, gasUsedRatio, nil
+	baseFee, gasUsedRatio, blobGasUsedRatio = baseFee[:firstMissing+1], gasUsedRatio[:firstMissing], blobGasUsedRatio[:firstMissing]
+	return new(big.Int).SetUint64(oldestBlock), reward, baseFee, gasUsedRatio, blobGasUsedRatio, nil
 }

--- a/node/cn/gasprice/feehistory_test.go
+++ b/node/cn/gasprice/feehistory_test.go
@@ -26,6 +26,11 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	mock_api "github.com/kaiachain/kaia/api/mocks"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/kaiax/gov"
+	mock_gov "github.com/kaiachain/kaia/kaiax/gov/mock"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
@@ -59,17 +64,17 @@ func TestFeeHistory(t *testing.T) {
 		{true, 1000, 1000, 2, rpc.PendingBlockNumber, nil, 32, 2, nil},
 		{true, 1000, 1000, 2, rpc.PendingBlockNumber, []float64{0, 10}, 32, 2, nil},
 	}
-	magmaBlock, kaiaBlock := int64(16), int64(20)
+	magmaBlock, kaiaBlock, osakaBlock := int64(16), int64(20), int64(28)
 	for i, c := range cases {
 		config := Config{
 			MaxHeaderHistory: c.maxHeader,
 			MaxBlockHistory:  c.maxBlock,
 			MaxPrice:         big.NewInt(500000000000),
 		}
-		backend, govModule := newTestBackend(t, big.NewInt(magmaBlock), big.NewInt(kaiaBlock), c.pending)
+		backend, govModule := newTestBackend(t, big.NewInt(magmaBlock), big.NewInt(kaiaBlock), nil, c.pending)
 		oracle := NewOracle(backend, config, nil, govModule)
 
-		first, reward, baseFee, ratio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
+		first, reward, baseFee, ratio, blobRatio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
 
 		expReward := c.expCount
 		if len(c.percent) == 0 {
@@ -84,6 +89,10 @@ func TestFeeHistory(t *testing.T) {
 		assert.Equal(t, expReward, len(reward), "Test case %d: reward array length mismatch, want %d, got %d", i, expReward, len(reward))
 		assert.Equal(t, expBaseFee, len(baseFee), "Test case %d: baseFee array length mismatch, want %d, got %d", i, expBaseFee, len(baseFee))
 		assert.Equal(t, c.expCount, len(ratio), "Test case %d: baseFee array length mismatch, want %d, got %d", i, c.expCount, len(ratio))
+		assert.Equal(t, c.expCount, len(blobRatio), "Test case %d: blobGasUsedRatio array length mismatch, want %d, got %d", i, c.expCount, len(blobRatio))
+		for j, v := range blobRatio {
+			assert.Equal(t, 0.0, v, "Test case %d: blobGasUsedRatio[%d] should be zero when blob fork is inactive, got %v", i, j, v)
+		}
 		assert.Equal(t, c.expErr, err, "Test case %d: error mismatch, want %v, got %v", i, c.expErr, err)
 	}
 
@@ -94,7 +103,7 @@ func TestFeeHistory(t *testing.T) {
 			MaxBlockHistory:  1000,
 			MaxPrice:         big.NewInt(500000000000),
 		}
-		backend, govModule = newTestBackend(t, big.NewInt(magmaBlock), big.NewInt(kaiaBlock), false)
+		backend, govModule = newTestBackend(t, big.NewInt(magmaBlock), big.NewInt(kaiaBlock), big.NewInt(osakaBlock), false)
 		oracle             = NewOracle(backend, config, nil, govModule)
 
 		atMagmaPset    = oracle.govModule.GetParamSet(uint64(magmaBlock))
@@ -109,7 +118,7 @@ func TestFeeHistory(t *testing.T) {
 		afterMagmaExpectedGasUsedRatio  = float64(21000) / float64(afterMagmaPset.MaxBlockGasUsedForBaseFee)
 	)
 
-	first, _, baseFee, ratio, err := oracle.FeeHistory(context.Background(), 32, rpc.LatestBlockNumber, nil)
+	first, _, baseFee, ratio, blobRatio, err := oracle.FeeHistory(context.Background(), 32, rpc.LatestBlockNumber, nil)
 	assert.Equal(t, first, big.NewInt(1))
 	assert.Nil(t, err)
 
@@ -117,7 +126,78 @@ func TestFeeHistory(t *testing.T) {
 	assert.Equal(t, []*big.Int{beforeMagmaExpectedBaseFee, atMagmaExpectedBaseFee, afterMagmaExpectedBaseFee}, baseFee[14:17])
 	assert.Equal(t, []float64{beforeMagmaExpectedGasUsedRatio, atMagmaExpectedGasUsedRatio, afterMagmaExpectedGasUsedRatio}, ratio[14:17])
 
+	// osaka hardfork
+	atOsakaExpectedBlobRatio := 1.0 / float64(params.DefaultOsakaBlobConfig.Max)
+	assert.Equal(t, []float64{0.0, atOsakaExpectedBlobRatio, atOsakaExpectedBlobRatio}, blobRatio[26:29])
+
 	// kaia hardfork
 	// check the value of reward
 	// assert.Equal(t, <impl>, gasTip[18:21])
 }
+
+// TestProcessBlock_BlobGasUsedRatio verifies processBlock computes
+// blobGasUsedRatio = BlobGasUsed / MaxBlobGasPerBlock when the Osaka
+// blob schedule is active (zero with no blobs, partial with one blob,
+// 1.0 at maximum), and stays zero for blocks before the Osaka fork.
+func TestProcessBlock_BlobGasUsedRatio(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	const osakaBlock = 5
+
+	config := params.TestChainConfig.Copy()
+	config.MagmaCompatibleBlock = big.NewInt(0)
+	config.KaiaCompatibleBlock = big.NewInt(0)
+	config.OsakaCompatibleBlock = big.NewInt(osakaBlock)
+	config.BlobScheduleConfig = &params.BlobScheduleConfig{Osaka: params.DefaultOsakaBlobConfig}
+	config.Governance = params.GetDefaultGovernanceConfig()
+	config.Istanbul = params.GetDefaultIstanbulConfig()
+
+	mockBackend := mock_api.NewMockBackend(mockCtrl)
+	mockBackend.EXPECT().ChainConfig().Return(config).AnyTimes()
+
+	mockGov := mock_gov.NewMockGovModule(mockCtrl)
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		LowerBoundBaseFee:         uint64(config.Governance.KIP71.LowerBoundBaseFee),
+		UpperBoundBaseFee:         uint64(config.Governance.KIP71.UpperBoundBaseFee),
+		GasTarget:                 uint64(config.Governance.KIP71.GasTarget),
+		MaxBlockGasUsedForBaseFee: uint64(config.Governance.KIP71.MaxBlockGasUsedForBaseFee),
+		BaseFeeDenominator:        uint64(config.Governance.KIP71.BaseFeeDenominator),
+	}).AnyTimes()
+
+	oracle := NewOracle(mockBackend, Config{MaxHeaderHistory: 1, MaxBlockHistory: 1, MaxPrice: big.NewInt(500000000000)}, nil, mockGov)
+
+	maxBlobGas := uint64(params.DefaultOsakaBlobConfig.Max) * params.BlobTxBlobGasPerBlob
+
+	cases := []struct {
+		name        string
+		blockNum    int64
+		blobGasUsed *uint64
+		expected    float64
+	}{
+		{"pre-osaka", osakaBlock - 1, uint64Ptr(params.BlobTxBlobGasPerBlob), 0},
+		{"no-blob", osakaBlock, nil, 0},
+		{"one-blob", osakaBlock, uint64Ptr(params.BlobTxBlobGasPerBlob), float64(params.BlobTxBlobGasPerBlob) / float64(maxBlobGas)},
+		{"max-blob", osakaBlock, uint64Ptr(maxBlobGas), 1.0}, // in case the max blob count increases
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bf := &blockFees{
+				blockNumber: uint64(tc.blockNum),
+				header: &types.Header{
+					Number:      big.NewInt(tc.blockNum),
+					BaseFee:     big.NewInt(25 * params.Gkei),
+					GasUsed:     21000,
+					BlobGasUsed: tc.blobGasUsed,
+				},
+			}
+			oracle.processBlock(bf, nil)
+			assert.Equal(t, tc.expected, bf.results.blobGasUsedRatio)
+		})
+	}
+}
+
+func uint64Ptr(v uint64) *uint64 { return &v }

--- a/node/cn/gasprice/gasprice_test.go
+++ b/node/cn/gasprice/gasprice_test.go
@@ -20,6 +20,9 @@ package gasprice
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -33,6 +36,7 @@ import (
 	"github.com/kaiachain/kaia/common/math"
 	"github.com/kaiachain/kaia/consensus/faker"
 	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/kzg4844"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	gov_impl "github.com/kaiachain/kaia/kaiax/gov/impl"
 	mock_gov "github.com/kaiachain/kaia/kaiax/gov/mock"
@@ -109,9 +113,54 @@ func (b *testBackend) teardown() {
 	b.chain.Stop()
 }
 
+// makeBlobTx creates a signed single-blob transaction for use in tests.
+func makeBlobTx(nonce uint64, key *ecdsa.PrivateKey, chainID *big.Int) *types.Transaction {
+	blob := kzg4844.Blob{}
+	commitment, err := kzg4844.BlobToCommitment(&blob)
+	if err != nil {
+		panic(fmt.Sprintf("blob commitment: %v", err))
+	}
+	cellProofs, err := kzg4844.ComputeCellProofs(&blob)
+	if err != nil {
+		panic(fmt.Sprintf("cell proofs: %v", err))
+	}
+	hasher := sha256.New()
+	blobHash := kzg4844.CalcBlobHashV1(hasher, &commitment)
+
+	sidecar := &types.BlobTxSidecar{
+		Version:     types.BlobSidecarVersion1,
+		Blobs:       []kzg4844.Blob{blob},
+		Commitments: []kzg4844.Commitment{commitment},
+		Proofs:      cellProofs,
+	}
+	values := map[types.TxValueKeyType]interface{}{
+		types.TxValueKeyNonce:      nonce,
+		types.TxValueKeyTo:         common.HexToAddress("0xAAAA"),
+		types.TxValueKeyAmount:     big.NewInt(0),
+		types.TxValueKeyData:       []byte{},
+		types.TxValueKeyGasLimit:   uint64(100000),
+		types.TxValueKeyGasFeeCap:  big.NewInt(100 * params.Gkei),
+		types.TxValueKeyGasTipCap:  big.NewInt(params.Gkei),
+		types.TxValueKeyBlobFeeCap: big.NewInt(1000 * params.Gkei),
+		types.TxValueKeyBlobHashes: []common.Hash{blobHash},
+		types.TxValueKeySidecar:    sidecar,
+		types.TxValueKeyAccessList: types.AccessList{},
+		types.TxValueKeyChainID:    chainID,
+	}
+	tx, err := types.NewTransactionWithMap(types.TxTypeEthereumBlob, values)
+	if err != nil {
+		panic(fmt.Sprintf("new blob tx: %v", err))
+	}
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+	if err != nil {
+		panic(fmt.Sprintf("sign blob tx: %v", err))
+	}
+	return signedTx
+}
+
 // newTestBackend creates a test backend. OBS: don't forget to invoke tearDown
 // after use, otherwise the blockchain instance will mem-leak via goroutines.
-func newTestBackend(t *testing.T, magmaBlock, kaiaBlock *big.Int, pending bool) (*testBackend, gov.GovModule) {
+func newTestBackend(t *testing.T, magmaBlock, kaiaBlock, osakaBlock *big.Int, pending bool) (*testBackend, gov.GovModule) {
 	var (
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr   = crypto.PubkeyToAddress(key.PublicKey)
@@ -133,8 +182,26 @@ func newTestBackend(t *testing.T, magmaBlock, kaiaBlock *big.Int, pending bool) 
 	config.ShanghaiCompatibleBlock = kaiaBlock
 	config.CancunCompatibleBlock = kaiaBlock
 	config.KaiaCompatibleBlock = kaiaBlock
+	config.OsakaCompatibleBlock = osakaBlock
+	config.BlobScheduleConfig = nil
+	if osakaBlock != nil {
+		config.BlobScheduleConfig = &params.BlobScheduleConfig{Osaka: params.DefaultOsakaBlobConfig}
+	}
 	config.Governance = params.GetDefaultGovernanceConfig()
 	config.Istanbul = params.GetDefaultIstanbulConfig()
+	// Construct testing chain before GenerateChain so AddTxWithChain can be used for blob txs.
+	chain, err := blockchain.NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to create local chain, %v", err)
+	}
+	govModule := gov_impl.NewGovModule()
+	govModule.Init(&gov_impl.InitOpts{
+		ChainKv:     db.GetMiscDB(),
+		ChainConfig: gspec.Config,
+		Chain:       chain,
+		NodeAddress: addr,
+	})
+
 	blocks, _ := blockchain.GenerateChain(gspec.Config, genesis, faker.NewFaker(), db, testHead+1, func(i int, b *blockchain.BlockGen) {
 		toaddr := common.Address{}
 		// To test fee history, rewardbase should be different from the sender address
@@ -163,23 +230,13 @@ func newTestBackend(t *testing.T, magmaBlock, kaiaBlock *big.Int, pending bool) 
 			}
 		}
 		tx, _ := types.SignTx(types.NewTx(txdata), signer, key)
-
 		b.AddTx(tx)
+		if config.IsOsakaForkEnabled(b.Number()) {
+			b.SetBlobGasUsed(params.BlobTxBlobGasPerBlob)
+			b.SetExcessBlobGas(0)
+			b.AddTxWithChain(chain, makeBlobTx(b.TxNonce(addr), key, gspec.Config.ChainID))
+		}
 	})
-	// Construct testing chain
-	chain, err := blockchain.NewBlockChain(db, nil, gspec.Config, faker.NewFaker(), vm.Config{})
-	if err != nil {
-		t.Fatalf("Failed to create local chain, %v", err)
-	}
-	// govModule := mock_gov.NewMockGovModule(gomock.NewController(t))
-	govModule := gov_impl.NewGovModule()
-	govModule.Init(&gov_impl.InitOpts{
-		ChainKv:     db.GetMiscDB(),
-		ChainConfig: gspec.Config,
-		Chain:       chain,
-		NodeAddress: addr,
-	})
-
 	chain.InsertChain(blocks)
 
 	return &testBackend{chain: chain, pending: pending}, govModule
@@ -242,7 +299,7 @@ func TestGasPrice_SuggestPrice(t *testing.T) {
 	defer mockCtrl.Finish()
 	mockBackend := mock_api.NewMockBackend(mockCtrl)
 	params := Config{}
-	testBackend, _ := newTestBackend(t, nil, nil, false)
+	testBackend, _ := newTestBackend(t, nil, nil, nil, false)
 	defer testBackend.teardown()
 	chainConfig := testBackend.ChainConfig()
 	mockGov := mock_gov.NewMockGovModule(gomock.NewController(t))
@@ -309,7 +366,7 @@ func TestSuggestTipCap(t *testing.T) {
 		{big.NewInt(33), big.NewInt(33), big.NewInt(params.Gkei * int64(30)), true}, // Fork point in the future
 	}
 	for _, c := range cases {
-		testBackend, testGov := newTestBackend(t, c.magmaBlock, c.kaiaBlock, false)
+		testBackend, testGov := newTestBackend(t, c.magmaBlock, c.kaiaBlock, nil, false)
 		chainConfig := testBackend.ChainConfig()
 		if c.isBusy {
 			mockGov := mock_gov.NewMockGovModule(gomock.NewController(t))


### PR DESCRIPTION
## Proposed changes

In `eth_feeHistory` response,
- Rename `blobBaseFeePerGas` to `baseFeePerBlobGas`
- Add missing `blobGasUsedRatio` field

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

CI (RPC test) is failing due to updated response format. We should merge kaiachain/kaia-rpc-tester#27 first.
