### PR TITLE
blockchain/types: reject zero threshold in WeightedMultiSig account key

### DIFF
--- a/blockchain/types/accountkey/account_key_test.go
+++ b/blockchain/types/accountkey/account_key_test.go
@@ -261,6 +261,23 @@ func TestAccountKeyWeightedMultiSig_Validate(t *testing.T) {
 	}
 }
 
+func TestAccountKeyWeightedMultiSig_CheckInstallable_ZeroThreshold(t *testing.T) {
+	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)})
+
+	k, _ := crypto.GenerateKey()
+	keys := WeightedPublicKeys{
+		NewWeightedPublicKey(1, (*PublicKeySerializable)(&k.PublicKey)),
+	}
+	m := NewAccountKeyWeightedMultiSigWithValues(0, keys)
+
+	// CheckInstallable must reject threshold=0 to prevent signature bypass via Validate().
+	assert.EqualError(t, m.CheckInstallable(0), "threshold is zero")
+
+	// Validate() also rejects threshold=0 directly, covering any pre-existing accounts
+	// that may have been installed before CheckInstallable began enforcing this.
+	assert.False(t, m.Validate(0, RoleTransaction, []*ecdsa.PublicKey{}, common.Address{}))
+}
+
 func TestAccountKeyWeightedMultiSig_SigValidationGas(t *testing.T) {
 	// declare special block numbers and set hardForkBlockNumberConfig
 	var (

--- a/blockchain/types/accountkey/account_key_weighted_multi_sig.go
+++ b/blockchain/types/accountkey/account_key_weighted_multi_sig.go
@@ -84,6 +84,9 @@ func (a *AccountKeyWeightedMultiSig) Equal(b AccountKey) bool {
 }
 
 func (a *AccountKeyWeightedMultiSig) Validate(currentBlockNumber uint64, r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
+	if a.Threshold == 0 {
+		return false
+	}
 	isIstanbul := fork.Rules(new(big.Int).SetUint64(currentBlockNumber)).IsIstanbul
 
 	// Validation 1. if isIstanbul is true, check whether the signature number exceeds key number
@@ -179,6 +182,9 @@ func (a *AccountKeyWeightedMultiSig) CheckInstallable(currentBlockNumber uint64)
 	prevSum := uint(0)
 	if len(a.Keys) == 0 {
 		return kerrors.ErrZeroLength
+	}
+	if a.Threshold == 0 {
+		return kerrors.ErrZeroThreshold
 	}
 	if uint64(len(a.Keys)) > MaxNumKeysForMultiSig {
 		return kerrors.ErrMaxKeysExceed

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -61,6 +61,7 @@ var logger = log.NewModuleLogger(log.VM)
 var (
 	errInputTooShort        = errors.New("input length is too short")
 	errWrongSignatureLength = errors.New("wrong signature length")
+	errNoSignatures         = errors.New("no signatures provided")
 )
 
 // PrecompiledContract is the basic interface for native Go contracts. The implementation
@@ -898,6 +899,9 @@ func (c *validateSender) validateSender(input []byte, picker types.AccountKeyPic
 	}
 
 	numSigs := len(ptr) / common.SignatureLength
+	if numSigs == 0 {
+		return errNoSignatures
+	}
 	pubs := make([]*ecdsa.PublicKey, numSigs)
 	for i := range numSigs {
 		p, err := crypto.Ecrecover(msg, ptr[0:common.SignatureLength])

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -626,3 +626,37 @@ func TestConsoleLog(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateSenderPrecompile_ZeroSignatures verifies that the validateSender precompile
+// (0x400) rejects inputs that carry no signatures.
+func TestValidateSenderPrecompile_ZeroSignatures(t *testing.T) {
+	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+
+	k, err := crypto.HexToECDSA("98275a145bc1726eb0445433088f5f882f8a4a9499135239cfb4040e78991dab")
+	require.NoError(t, err)
+	addr := crypto.PubkeyToAddress(k.PublicKey)
+	stateDb.CreateEOA(addr, false, accountkey.NewAccountKeyPublicWithValue(&k.PublicKey))
+
+	// Build input: [20-byte address][32-byte hash] with no trailing signature bytes.
+	input := make([]byte, common.AddressLength+common.HashLength)
+	copy(input[:common.AddressLength], addr.Bytes())
+
+	c := &validateSender{}
+	assert.ErrorIs(t, c.validateSender(input, stateDb, 0), errNoSignatures)
+
+	// Run() swallows the error and returns 0x00 (failure indicator).
+	contract := NewContract(
+		types.NewAccountRefWithFeePayer(addr, addr),
+		nil, new(big.Int), 1e6, nil,
+	)
+	evm := NewEVM(
+		BlockContext{BlockNumber: big.NewInt(0)},
+		TxContext{},
+		stateDb,
+		&params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)},
+		&Config{},
+	)
+	out, _, runErr := RunPrecompiledContract(c, input, contract, evm)
+	assert.NoError(t, runErr)
+	assert.Equal(t, []byte{0}, out)
+}

--- a/kerrors/kerrors.go
+++ b/kerrors/kerrors.go
@@ -47,6 +47,7 @@ var (
 	ErrAccountKeyNilUninitializable         = errors.New("AccountKeyNil cannot be initialized to an account")
 	ErrNotOnCurve                           = errors.New("public key is not on curve")
 	ErrZeroKeyWeight                        = errors.New("key weight is zero")
+	ErrZeroThreshold                        = errors.New("threshold is zero")
 	ErrUnserializableKey                    = errors.New("key is not serializable")
 	ErrDuplicatedKey                        = errors.New("duplicated key")
 	ErrWeightedSumOverflow                  = errors.New("weighted sum overflow")


### PR DESCRIPTION
## Proposed changes

Add missing validation for zero threshold in AccountKeyWeightedMultiSig:

- `CheckInstallable()`: reject Threshold=0 with `ErrZeroThreshold`, consistent with the existing check that rejects zero key weight
- `Validate()`: return false early when Threshold=0 as an additional guard
- validateSender precompile (`0x3ff`): reject inputs with zero signatures, consistent with the existing check that rejects malformed signature length

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
