### PR TITLE
gRPC: reject JSON-RPC notifications and fix handler cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,6 +188,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect

--- a/networks/grpc/gClient.go
+++ b/networks/grpc/gClient.go
@@ -163,11 +163,13 @@ func (gkc *gKaiaClient) handleBiCall(stream KlaytnNode_BiCallClient, request fun
 			if err := stream.RecvMsg(&recv); err != nil {
 				logger.Warn("fail to recv response", "err", err)
 				waitGroup.Done()
+				return
 			}
 
 			if err := handle(&recv); err != nil {
 				logger.Warn("fail to handle response", "err", err)
 				waitGroup.Done()
+				return
 			}
 		}
 	}()

--- a/networks/grpc/gRPC_test.go
+++ b/networks/grpc/gRPC_test.go
@@ -19,13 +19,21 @@
 package grpc
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -39,8 +47,10 @@ func (a APIgRPC) BlockNumber() float64 {
 }
 
 func TestGRPC(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	wg := &sync.WaitGroup{}
-	wg.Add(2)
+	wg.Add(3)
 
 	addr := "127.0.0.1:4000"
 	handler := rpc.NewServer()
@@ -50,11 +60,13 @@ func TestGRPC(t *testing.T) {
 	listener := &Listener{Addr: addr}
 	listener.SetRPCServer(handler)
 	go listener.Start()
+	defer listener.Stop()
 
 	time.Sleep(2 * time.Second)
 
 	go testCall(t, addr, wg)
 	go testBiCall(t, addr, wg)
+	go testSubscribe(t, addr, wg)
 	wg.Wait()
 }
 
@@ -86,27 +98,137 @@ func testBiCall(t *testing.T, addr string, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	kclient, _ := NewgKaiaClient(addr)
-	defer kclient.Close()
 
 	knclient, err := kclient.makeKaiaClient(timeout)
 	assert.NoError(t, err)
 
 	stream, _ := knclient.BiCall(kclient.ctx)
-	go kclient.handleBiCall(stream, func() (request *RPCRequest, e error) {
-		request, err := kclient.makeRPCRequest("kaia", "kaia_blockNumber", nil)
-		if assert.NoError(t, err) {
-			return request, err
-		}
+	done := make(chan struct{})
+	// Close must precede <-done: closing the connection causes handleBiCall's
+	// internal goroutines to unblock from their stream operations, which lets
+	// handleBiCall return and signal done. Reversing the order deadlocks.
+	defer func() {
+		kclient.Close()
+		<-done
+	}()
 
-		return request, nil
-	}, func(response *RPCResponse) error {
+	go func() {
+		kclient.handleBiCall(stream, func() (request *RPCRequest, e error) {
+			request, err := kclient.makeRPCRequest("kaia", "kaia_blockNumber", nil)
+			if assert.NoError(t, err) {
+				return request, err
+			}
+			return request, nil
+		}, func(response *RPCResponse) error {
+			var out jsonSuccessResponse
+			err = json.Unmarshal(response.Payload, &out)
+			assert.NoError(t, err)
+			assert.Equal(t, out.Result, TEST_BLOCK_NUMBER)
+			return nil
+		})
+		close(done)
+	}()
+
+	time.Sleep(3 * time.Second)
+}
+
+func testSubscribe(t *testing.T, addr string, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	kclient, _ := NewgKaiaClient(addr)
+	defer kclient.Close()
+
+	knclient, err := kclient.makeKaiaClient(timeout)
+	assert.NoError(t, err)
+
+	request, err := kclient.makeRPCRequest("kaia", "kaia_blockNumber", nil)
+	assert.NoError(t, err)
+
+	stream, err := knclient.Subscribe(kclient.ctx, request)
+	assert.NoError(t, err)
+
+	kclient.handleSubscribe(stream, func(response *RPCResponse) error {
 		var out jsonSuccessResponse
 		err = json.Unmarshal(response.Payload, &out)
 		assert.NoError(t, err)
 		assert.Equal(t, out.Result, TEST_BLOCK_NUMBER)
-
 		return nil
 	})
+}
 
-	time.Sleep(3 * time.Second)
+// newNotificationTestServer starts an in-process gRPC server and returns a
+// connected client, the underlying API stub, and a cleanup function.
+func newNotificationTestServer(t *testing.T) (KlaytnNodeClient, *notificationAPI, func()) {
+	t.Helper()
+	handler := rpc.NewServer()
+	api := &notificationAPI{}
+	if err := handler.RegisterName("kaia", api); err != nil {
+		t.Fatal(err)
+	}
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := googlegrpc.NewServer()
+	RegisterKlaytnNodeServer(srv, &kaiaServer{handler: handler})
+	go srv.Serve(lis)
+
+	dialCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	conn, err := googlegrpc.DialContext(dialCtx, lis.Addr().String(),
+		googlegrpc.WithTransportCredentials(insecure.NewCredentials()),
+		googlegrpc.WithBlock(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewKlaytnNodeClient(conn), api, func() { conn.Close(); srv.Stop() }
+}
+
+type notificationAPI struct{ calls int32 }
+
+func (a *notificationAPI) BlockNumber() float64 {
+	atomic.AddInt32(&a.calls, 1)
+	return TEST_BLOCK_NUMBER
+}
+
+// TestNotificationRejected verifies that JSON-RPC notifications (no "id" field)
+// sent over gRPC unary Call are rejected with InvalidArgument before dispatch.
+func TestNotificationRejected(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	client, api, cleanup := newNotificationTestServer(t)
+	defer cleanup()
+
+	notification := []byte(`{"jsonrpc":"2.0","method":"kaia_blockNumber","params":[]}`)
+
+	for i := 0; i < 5; i++ {
+		_, err := client.Call(context.Background(), &RPCRequest{Params: notification})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("request %d: expected InvalidArgument, got %v", i, err)
+		}
+	}
+
+	if n := atomic.LoadInt32(&api.calls); n != 0 {
+		t.Errorf("method was executed %d time(s); want 0 (notification must not be dispatched)", n)
+	}
+}
+
+// TestSubscribeNotificationRejected verifies that JSON-RPC notifications sent
+// over gRPC Subscribe are rejected with InvalidArgument before dispatch.
+func TestSubscribeNotificationRejected(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	client, api, cleanup := newNotificationTestServer(t)
+	defer cleanup()
+
+	notification := []byte(`{"jsonrpc":"2.0","method":"kaia_blockNumber","params":[]}`)
+	stream, err := client.Subscribe(context.Background(), &RPCRequest{Params: notification})
+	if err == nil {
+		_, err = stream.Recv()
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+	if n := atomic.LoadInt32(&api.calls); n != 0 {
+		t.Errorf("method was executed %d time(s); want 0 (notification must not be dispatched)", n)
+	}
 }

--- a/networks/grpc/gServer.go
+++ b/networks/grpc/gServer.go
@@ -35,7 +35,9 @@ import (
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 )
 
 var logger = log.NewModuleLogger(log.NetworksGRPC)
@@ -95,6 +97,16 @@ func (gw *bufWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+// isJSONRPCNotification reports whether params is a JSON-RPC notification —
+// a request object with no "id" member. gRPC transports require a response for
+// every call, so notifications cannot be dispatched over them.
+func isJSONRPCNotification(params []byte) bool {
+	var msg struct {
+		ID json.RawMessage `json:"id"`
+	}
+	return json.Unmarshal(params, &msg) == nil && len(msg.ID) == 0
+}
+
 // BiCall handles bidirectional communication between client and server.
 func (kns *kaiaServer) BiCall(stream KlaytnNode_BiCallServer) error {
 	for {
@@ -135,9 +147,19 @@ func (kns *kaiaServer) BiCall(stream KlaytnNode_BiCallServer) error {
 	}
 }
 
-// only server can send message to client repeatedly
+// Subscribe handles gRPC server-streaming calls. Despite the name, this is NOT
+// a JSON-RPC subscription endpoint: ServeSingleRequest sets allowSubscribe=false,
+// so any kaia_subscribe call is rejected with ErrNotificationsUnsupported
+// ("Notifications" = geth's term for subscription push events, distinct from
+// JSON-RPC 2.0 id-less notifications). Only regular one-shot methods are served
+// here; the server sends exactly one response and closes the stream.
 func (kns *kaiaServer) Subscribe(request *RPCRequest, stream KlaytnNode_SubscribeServer) error {
+	if isJSONRPCNotification(request.Params) {
+		return status.Error(codes.InvalidArgument, "JSON-RPC notifications are not supported over gRPC Subscribe")
+	}
+
 	var (
+		writeOk  = make(chan struct{}, 1)
 		writeErr = make(chan error, 1)
 		readErr  = make(chan error, 1)
 	)
@@ -156,6 +178,7 @@ func (kns *kaiaServer) Subscribe(request *RPCRequest, stream KlaytnNode_Subscrib
 			writeErr <- err
 			return err
 		}
+		writeOk <- struct{}{}
 		return err
 	}
 	decoder := func(v interface{}) error {
@@ -177,6 +200,8 @@ func (kns *kaiaServer) Subscribe(request *RPCRequest, stream KlaytnNode_Subscrib
 loop:
 	for {
 		select {
+		case <-writeOk:
+			break loop
 		case err = <-writeErr:
 			logger.Warn("fail to write", "err", err)
 			break loop
@@ -191,6 +216,10 @@ loop:
 
 // general RPC call, such as one-to-one communication
 func (kns *kaiaServer) Call(ctx context.Context, request *RPCRequest) (*RPCResponse, error) {
+	if isJSONRPCNotification(request.Params) {
+		return nil, status.Error(codes.InvalidArgument, "JSON-RPC notifications are not supported over gRPC unary Call")
+	}
+
 	var (
 		err      error
 		writeErr = make(chan error, 1)

--- a/networks/rpc/subscription.go
+++ b/networks/rpc/subscription.go
@@ -33,7 +33,9 @@ import (
 )
 
 var (
-	// ErrNotificationsUnsupported is returned when the connection doesn't support notifications
+	// ErrNotificationsUnsupported is returned when the connection doesn't support notifications.
+	// Note: "notifications" here is geth's term for server-pushed subscription events (sent after
+	// a *_subscribe call), and is distinct from JSON-RPC 2.0 notifications (id-less requests).
 	ErrNotificationsUnsupported = errors.New("notifications not supported")
 	// ErrNotificationNotFound is returned when the notification for the given id is not found
 	ErrSubscriptionNotFound = errors.New("subscription not found")


### PR DESCRIPTION
## Proposed changes

- Reject JSON-RPC notifications (id-less requests) in gRPC `Call` and `Subscribe` with `InvalidArgument` before dispatch
- Fix `Subscribe` handler to exit cleanly after sending a response (missing `writeOk` signal)
- Fix `BiCall` recv goroutine to return on stream error instead of looping indefinitely
- Add `goleak`-backed tests for rejection and normal-path coverage

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
