### PR TITLE
fix(crypto): add canonical-v check for signature

### DIFF
--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -124,6 +124,33 @@ func TestSign(t *testing.T) {
 	}
 }
 
+// TestNonCanonicalRecoveryID ensures Ecrecover rejects v >= 2. The underlying
+// libsecp256k1 / decred secp256k1 accept v ∈ {0..3}, which would let a single
+// (r, s, hash) recover multiple distinct pubkeys (signature malleability).
+// Ethereum convention requires v ∈ {0, 1}.
+func TestNonCanonicalRecoveryID(t *testing.T) {
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := Keccak256([]byte("hello"))
+	sig, err := Sign(msg, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, badV := range []byte{2, 3, 4, 27, 28, 255} {
+		tampered := make([]byte, len(sig))
+		copy(tampered, sig)
+		tampered[RecoveryIDOffset] = badV
+		if _, err := Ecrecover(msg, tampered); err == nil {
+			t.Errorf("Ecrecover: v=%d must be rejected", badV)
+		}
+		if _, err := SigToPub(msg, tampered); err == nil {
+			t.Errorf("SigToPub: v=%d must be rejected", badV)
+		}
+	}
+}
+
 func TestInvalidSign(t *testing.T) {
 	if _, err := Sign(make([]byte, 1), nil); err == nil {
 		t.Errorf("expected sign with hash 1 byte to error")

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -26,6 +26,7 @@ package crypto
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 
 	"github.com/erigontech/secp256k1" // To avoid CGO duplicate symbol error.
@@ -36,7 +37,7 @@ import (
 func Ecrecover(hash, sig []byte) ([]byte, error) {
 	// Enforce canonical Ethereum recovery id v ∈ {0, 1}.
 	if sig[RecoveryIDOffset] >= 2 {
-		return nil, fmt.Errorf("invalid signature recovery id")
+		return nil, errors.New("invalid signature recovery id")
 	}
 	return secp256k1.RecoverPubkey(hash, sig)
 }

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -35,6 +35,12 @@ import (
 
 // Ecrecover returns the uncompressed public key that created the given signature.
 func Ecrecover(hash, sig []byte) ([]byte, error) {
+	if len(sig) != SignatureLength {
+		return nil, errors.New("invalid signature")
+	}
+	if len(hash) != DigestLength {
+		return nil, fmt.Errorf("hash is required to be exactly %d bytes (%d)", DigestLength, len(hash))
+	}
 	// Enforce canonical Ethereum recovery id v ∈ {0, 1}.
 	if sig[RecoveryIDOffset] >= 2 {
 		return nil, errors.New("invalid signature recovery id")

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -34,6 +34,10 @@ import (
 
 // Ecrecover returns the uncompressed public key that created the given signature.
 func Ecrecover(hash, sig []byte) ([]byte, error) {
+	// Enforce canonical Ethereum recovery id v ∈ {0, 1}.
+	if sig[RecoveryIDOffset] >= 2 {
+		return nil, fmt.Errorf("invalid signature recovery id")
+	}
 	return secp256k1.RecoverPubkey(hash, sig)
 }
 

--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -30,9 +30,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcec/v2"
-	btc_ecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	decred_ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 )
 
 // Ecrecover returns the uncompressed public key that created the given signature.
@@ -45,19 +44,23 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 	return bytes, err
 }
 
-func sigToPub(hash, sig []byte) (*btcec.PublicKey, error) {
+func sigToPub(hash, sig []byte) (*secp256k1.PublicKey, error) {
 	if len(sig) != SignatureLength {
 		return nil, errors.New("invalid signature")
 	}
 	if len(hash) != DigestLength {
 		return nil, fmt.Errorf("hash is required to be exactly %d bytes (%d)", DigestLength, len(hash))
 	}
-	// Convert to btcec input format with 'recovery id' v at the beginning.
+	// Enforce canonical Ethereum recovery id v ∈ {0, 1}.
+	if sig[RecoveryIDOffset] >= 2 {
+		return nil, errors.New("invalid signature recovery id")
+	}
+	// Convert to secp256k1 input format with 'recovery id' v at the beginning.
 	btcsig := make([]byte, SignatureLength)
 	btcsig[0] = sig[RecoveryIDOffset] + 27
 	copy(btcsig[1:], sig)
 
-	pub, _, err := btc_ecdsa.RecoverCompact(btcsig, hash)
+	pub, _, err := decred_ecdsa.RecoverCompact(btcsig, hash)
 	return pub, err
 }
 
@@ -88,19 +91,16 @@ func Sign(hash []byte, prv *ecdsa.PrivateKey) ([]byte, error) {
 	if len(hash) != DigestLength {
 		return nil, fmt.Errorf("hash is required to be exactly %d bytes (%d)", DigestLength, len(hash))
 	}
-	if prv.Curve != btcec.S256() {
+	if prv.Curve != S256() {
 		return nil, errors.New("private key curve is not secp256k1")
 	}
-	// ecdsa.PrivateKey -> btcec.PrivateKey
-	var priv btcec.PrivateKey
+	// ecdsa.PrivateKey -> secp256k1.PrivateKey
+	var priv secp256k1.PrivateKey
 	if overflow := priv.Key.SetByteSlice(prv.D.Bytes()); overflow || priv.Key.IsZero() {
 		return nil, errors.New("invalid private key")
 	}
 	defer priv.Zero()
-	sig, err := btc_ecdsa.SignCompact(&priv, hash, false) // ref uncompressed pubkey
-	if err != nil {
-		return nil, err
-	}
+	sig := decred_ecdsa.SignCompact(&priv, hash, false) // ref uncompressed pubkey
 	// Convert to Ethereum signature format with 'recovery id' v at the end.
 	v := sig[0] - 27
 	copy(sig, sig[1:])
@@ -112,22 +112,22 @@ func Sign(hash []byte, prv *ecdsa.PrivateKey) ([]byte, error) {
 // The public key should be in compressed (33 bytes) or uncompressed (65 bytes) format.
 // The signature should have the 64 byte [R || S] format.
 func VerifySignature(pubkey, hash, signature []byte) bool {
-	if len(signature) != 64 {
+	if len(signature) != 64 || len(hash) != DigestLength {
 		return false
 	}
-	var r, s btcec.ModNScalar
+	var r, s secp256k1.ModNScalar
 	if r.SetByteSlice(signature[:32]) {
 		return false // overflow
 	}
 	if s.SetByteSlice(signature[32:]) {
 		return false
 	}
-	sig := btc_ecdsa.NewSignature(&r, &s)
-	key, err := btcec.ParsePubKey(pubkey)
+	sig := decred_ecdsa.NewSignature(&r, &s)
+	key, err := secp256k1.ParsePubKey(pubkey)
 	if err != nil {
 		return false
 	}
-	// Reject malleable signatures. libsecp256k1 does this check but btcec doesn't.
+	// Reject malleable signatures. libsecp256k1 does this check but decred doesn't.
 	if s.IsOverHalfOrder() {
 		return false
 	}
@@ -139,7 +139,7 @@ func DecompressPubkey(pubkey []byte) (*ecdsa.PublicKey, error) {
 	if len(pubkey) != 33 {
 		return nil, errors.New("invalid compressed public key length")
 	}
-	key, err := btcec.ParsePubKey(pubkey)
+	key, err := secp256k1.ParsePubKey(pubkey)
 	if err != nil {
 		return nil, err
 	}
@@ -160,20 +160,20 @@ func DecompressPubkey(pubkey []byte) (*ecdsa.PublicKey, error) {
 // when constructing a PrivateKey.
 func CompressPubkey(pubkey *ecdsa.PublicKey) []byte {
 	// NOTE: the coordinates may be validated with
-	// btcec.ParsePubKey(FromECDSAPub(pubkey))
-	var x, y btcec.FieldVal
+	// secp256k1.ParsePubKey(FromECDSAPub(pubkey))
+	var x, y secp256k1.FieldVal
 	x.SetByteSlice(pubkey.X.Bytes())
 	y.SetByteSlice(pubkey.Y.Bytes())
-	return btcec.NewPublicKey(&x, &y).SerializeCompressed()
+	return secp256k1.NewPublicKey(&x, &y).SerializeCompressed()
 }
 
 // S256 returns an instance of the secp256k1 curve.
 func S256() EllipticCurve {
-	return btCurve{btcec.S256()}
+	return btCurve{secp256k1.S256()}
 }
 
 type btCurve struct {
-	*btcec.KoblitzCurve
+	*secp256k1.KoblitzCurve
 }
 
 func (curve btCurve) IsOnCurve(x, y *big.Int) bool {

--- a/go.mod
+++ b/go.mod
@@ -76,8 +76,9 @@ require (
 )
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.5
+	github.com/alicebob/miniredis/v2 v2.34.0
 	github.com/cockroachdb/pebble v1.1.5
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/dop251/goja v0.0.0-20231014103939-873a1496dc8e
 	github.com/erigontech/erigon-lib v0.0.0-00010101000000-000000000000
 	github.com/erigontech/secp256k1 v1.2.1-0.20260221042510-ac99ccb83278
@@ -87,7 +88,6 @@ require (
 	github.com/tyler-smith/go-bip32 v1.0.0
 	github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1
 	go.uber.org/mock v0.5.0
-	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
 	golang.org/x/sync v0.12.0
 	golang.org/x/time v0.9.0
 )
@@ -105,7 +105,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/RoaringBitmap/roaring/v2 v2.4.3 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
-	github.com/alicebob/miniredis/v2 v2.34.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
@@ -120,7 +119,6 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
 	github.com/dlclark/regexp2 v1.7.0 // indirect
@@ -191,6 +189,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
+	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,10 +95,6 @@ github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+Wji
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bt51/ntpclient v0.0.0-20140310165113-3045f71e2530 h1:2W1J2qL8feh1Av0KJq5cbBACg+lx6DfIm18vt45P+DA=
 github.com/bt51/ntpclient v0.0.0-20140310165113-3045f71e2530/go.mod h1:OahuhAz81f/KxpjyyO0H3rTNypHk3qd9s8BWriP7DAI=
-github.com/btcsuite/btcd/btcec/v2 v2.3.5 h1:dpAlnAwmT1yIBm3exhT1/8iUSD98RDJM5vqJVQDQLiU=
-github.com/btcsuite/btcd/btcec/v2 v2.3.5/go.mod h1:m22FrOAiuxl/tht9wIqAoGHcbnCCaPWyauO8y2LGGtQ=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 h1:6lhrsTEnloDPXyeZBvSYvQf8u86jbKehZPVDDlkgDl4=
 github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=


### PR DESCRIPTION
## Proposed changes

This PR adds a strict `high-v` check for signature consistency. It also brings refactoring PR from [geth](https://github.com/ethereum/go-ethereum/pull/30595).

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
