### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -76,10 +76,7 @@ func getRoundCommitteeState(c *core, seq, r uint64) (qualified *valset.AddressSe
 // For less than 4 validators, quorum size equals the effective size;
 // otherwise it is ceil(2 * min(qualifiedLen, committeeSize) / 3).
 func calcQuorumSize(qualifiedLen int, committeeSize uint64) int {
-	size := qualifiedLen
-	if size > int(committeeSize) {
-		size = int(committeeSize)
-	}
+	size := min(qualifiedLen, int(committeeSize))
 	if size < 4 {
 		return size
 	}

--- a/datasync/fetcher/fetcher_test.go
+++ b/datasync/fetcher/fetcher_test.go
@@ -364,10 +364,7 @@ func testOverlappingAnnouncements(t *testing.T, protocol int) {
 	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
 
 	// Iteratively announce blocks, but overlap them continuously
-	overlap := 16
-	if overlap > targetBlocks {
-		overlap = targetBlocks
-	}
+	overlap := min(16, targetBlocks)
 	imported := make(chan *types.Block, len(hashes)-1)
 	for range overlap {
 		imported <- nil


### PR DESCRIPTION
## Proposed changes

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.



## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
