### PR TITLE
reward: Verify header.Rewardbase against StakingInfo

### DIFF
--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -330,6 +330,7 @@ func newBlockChain(t *testing.T, n int, items ...interface{}) (*blockchain.Block
 			GovModule:     mGov,
 			StakingModule: mStaking, // Irrelevant in ProposerPolicy=0. Won't inject mock.
 			ValsetModule:  mValset,
+			NodeAddress:   b.address,
 		}),
 		mValset.Init(&valset_impl.InitOpts{
 			Chain:         bc,

--- a/kaiax/reward/errors.go
+++ b/kaiax/reward/errors.go
@@ -28,6 +28,7 @@ var (
 	ErrNoReceipts            = errors.New("receipts not found")
 	ErrInvalidBlockRange     = errors.New("invalid block number range")
 	ErrBlockRangeLimit       = errors.New("exceeds block number range limit")
+	ErrInvalidRewardbase     = errors.New("rewardbase mismatches with expected address")
 )
 
 func errMalformedRewardRatio(ratio string) error {

--- a/kaiax/reward/impl/header.go
+++ b/kaiax/reward/impl/header.go
@@ -16,9 +16,36 @@
 
 package impl
 
-import "github.com/kaiachain/kaia/blockchain/types"
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/kaiax/reward"
+)
 
-func (r *RewardModule) VerifyHeader(_ *types.Header, _ *types.Header) error {
+func (r *RewardModule) VerifyHeader(header *types.Header, _ *types.Header) error {
+	if header.Number.Sign() == 0 {
+		return nil
+	}
+	// Only WeightedRandom has a staking-registered reward address. Under RoundRobin
+	// the proposer's Rewardbase is unconstrained, matching FinalizeState's behavior.
+	if r.GovModule.GetParamSet(header.Number.Uint64()).ProposerPolicy != uint64(istanbul.WeightedRandom) {
+		return nil
+	}
+	proposer, err := r.Chain.Sealer().Author(header)
+	if err != nil {
+		return err
+	}
+	expected := r.GetRewardAddress(header.Number.Uint64(), proposer)
+	// No staking entry for this proposer: nothing to check against. FinalizeState
+	// falls back to the node's own configured Rewardbase in this case, so do not
+	// reject the header here.
+	if expected == (common.Address{}) {
+		return nil
+	}
+	if header.Rewardbase != expected {
+		return reward.ErrInvalidRewardbase
+	}
 	return nil
 }
 

--- a/kaiax/reward/impl/header_test.go
+++ b/kaiax/reward/impl/header_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/reward"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyHeader(t *testing.T) {
+	var (
+		node1   = common.HexToAddress("0xa01") // matches stakingInfo.NodeIds[0]
+		reward1 = common.HexToAddress("0xc01") // matches stakingInfo.RewardAddrs[0]
+		unknown = common.HexToAddress("0xdead")
+		evil    = common.HexToAddress("0xbeef")
+	)
+
+	t.Run("genesis is always accepted", func(t *testing.T) {
+		r := makeTestRewardModuleWithConfig(t, rewardModuleTestConfig{Proposer: node1})
+		header := &types.Header{Number: big.NewInt(0), Rewardbase: evil}
+		assert.NoError(t, r.VerifyHeader(header, nil))
+	})
+
+	t.Run("matching rewardbase passes", func(t *testing.T) {
+		r := makeTestRewardModuleWithConfig(t, rewardModuleTestConfig{Proposer: node1})
+		header := &types.Header{Number: big.NewInt(100), Rewardbase: reward1}
+		assert.NoError(t, r.VerifyHeader(header, nil))
+	})
+
+	t.Run("mismatched rewardbase is rejected", func(t *testing.T) {
+		r := makeTestRewardModuleWithConfig(t, rewardModuleTestConfig{Proposer: node1})
+		header := &types.Header{Number: big.NewInt(100), Rewardbase: evil}
+		assert.ErrorIs(t, r.VerifyHeader(header, nil), reward.ErrInvalidRewardbase)
+	})
+
+	t.Run("RoundRobin policy skips verification", func(t *testing.T) {
+		r := makeTestRewardModuleWithConfig(t, rewardModuleTestConfig{Simple: true, Proposer: node1})
+		header := &types.Header{Number: big.NewInt(100), Rewardbase: evil}
+		assert.NoError(t, r.VerifyHeader(header, nil))
+	})
+
+	t.Run("proposer not in staking info passes", func(t *testing.T) {
+		// Mirrors FinalizeState's "else" branch where the node falls back to its
+		// configured Rewardbase. We can't verify against staking, so accept the header.
+		r := makeTestRewardModuleWithConfig(t, rewardModuleTestConfig{Proposer: unknown})
+		header := &types.Header{Number: big.NewInt(100), Rewardbase: evil}
+		assert.NoError(t, r.VerifyHeader(header, nil))
+	})
+}

--- a/kaiax/reward/impl/init_test.go
+++ b/kaiax/reward/impl/init_test.go
@@ -40,18 +40,51 @@ func init() {
 	blockchain.InitDeriveSha(&params.ChainConfig{DeriveShaImpl: 0}) // DeriveSha is irrelevant for this test. Set any value.
 }
 
+// rewardModuleTestConfig configures makeTestRewardModuleWithConfig. Zero values are sensible defaults.
+type rewardModuleTestConfig struct {
+	Simple   bool // false => WeightedRandom, true => RoundRobin
+	Deferred bool
+	IsPrague bool
+
+	// Proposer address returned by Chain.Sealer().Author(header).
+	// Zero value falls back to params.AuthorAddressForTesting.
+	Proposer common.Address
+
+	// Block fixture. When Header is nil, block- and number-keyed mocks are
+	// replaced with gomock.Any() so the helper can be used by tests that
+	// don't fix a block (e.g. VerifyHeader).
+	Header   *types.Header
+	Txs      []*types.Transaction
+	Receipts []*types.Receipt
+}
+
 // Make a RewardModule that works with the given block.
 func makeTestRewardModule(t *testing.T,
 	simple, deferred, isPrague bool,
 	header *types.Header, txs []*types.Transaction, receipts []*types.Receipt,
 ) *RewardModule {
+	return makeTestRewardModuleWithConfig(t, rewardModuleTestConfig{
+		Simple:   simple,
+		Deferred: deferred,
+		IsPrague: isPrague,
+		Header:   header,
+		Txs:      txs,
+		Receipts: receipts,
+	})
+}
+
+func makeTestRewardModuleWithConfig(t *testing.T, cfg rewardModuleTestConfig) *RewardModule {
 	proposerPolicy := uint64(istanbul.WeightedRandom)
 	var pragueForkBlock *big.Int
-	if simple {
+	if cfg.Simple {
 		proposerPolicy = uint64(istanbul.RoundRobin)
 	}
-	if isPrague {
+	if cfg.IsPrague {
 		pragueForkBlock = big.NewInt(60)
+	}
+	proposer := cfg.Proposer
+	if proposer == (common.Address{}) {
+		proposer = params.AuthorAddressForTesting
 	}
 
 	var (
@@ -79,16 +112,14 @@ func makeTestRewardModule(t *testing.T,
 			UnitPrice:              25e9,
 			MintingAmount:          big.NewInt(6.4e18),
 			MinimumStake:           big.NewInt(5_000_000),
-			DeferredTxFee:          deferred,
+			DeferredTxFee:          cfg.Deferred,
 			Ratio:                  "50/20/30",
 			Kip82Ratio:             "20/80",
 			StakingRewardThreshold: big.NewInt(5_000_000),
 			UseFlexReward:          false,
 		}
 
-		stakingInfo = makeTestStakingInfo([]uint64{5_000_001, 5_000_002, 5_000_003, 5_000_000}, isPrague)
-
-		block = types.NewBlock(header, txs, receipts)
+		stakingInfo = makeTestStakingInfo([]uint64{5_000_001, 5_000_002, 5_000_003, 5_000_000}, cfg.IsPrague)
 	)
 
 	r := NewRewardModule()
@@ -100,11 +131,17 @@ func makeTestRewardModule(t *testing.T,
 		ValsetModule:  mValset,
 	})
 
-	chain.EXPECT().GetBlockByNumber(header.Number.Uint64()).Return(block).AnyTimes()
-	chain.EXPECT().GetReceiptsByBlockHash(block.Hash()).Return(receipts).AnyTimes()
-	chain.EXPECT().Sealer().Return(faker.NewFaker()).AnyTimes() // Author is different from Rewardbase
-	mGov.EXPECT().GetParamSet(header.Number.Uint64()).Return(paramset).AnyTimes()
+	chain.EXPECT().Sealer().Return(faker.NewFakerWithFixedSealer(proposer)).AnyTimes()
 	mStaking.EXPECT().GetStakingInfo(gomock.Any()).Return(stakingInfo, nil).AnyTimes()
+
+	if cfg.Header != nil {
+		block := types.NewBlock(cfg.Header, cfg.Txs, cfg.Receipts)
+		chain.EXPECT().GetBlockByNumber(cfg.Header.Number.Uint64()).Return(block).AnyTimes()
+		chain.EXPECT().GetReceiptsByBlockHash(block.Hash()).Return(cfg.Receipts).AnyTimes()
+		mGov.EXPECT().GetParamSet(cfg.Header.Number.Uint64()).Return(paramset).AnyTimes()
+	} else {
+		mGov.EXPECT().GetParamSet(gomock.Any()).Return(paramset).AnyTimes()
+	}
 
 	return r
 }


### PR DESCRIPTION
## Proposed changes

- Add a sanity check to `VerifyHeader` (specifically in RewardModule) for the `header.Rewardbase` field.
- Under WeightedRandom proposer policy (the Mainnet policy), `Rewardbase` must match the address declared in the `StakingInfo`.
- RoundRobin and Sticky policies remain unchecked, matching `FinalizeState()`'s existing behavior of trusting the proposer's Rewardbase input.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
