### PR TITLE
node/cn: cap DB lookups in P2P request handlers

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -938,17 +938,20 @@ func handleBlockBodiesRequest(pm *ProtocolManager, p Peer, msg p2p.Msg) ([]rlp.R
 	}
 	// Gather blocks until the fetch or network limits is reached
 	var (
-		hash   common.Hash
-		bytes  int
-		bodies []rlp.RawValue
+		hash    common.Hash
+		bytes   int
+		bodies  []rlp.RawValue
+		lookups int
 	)
-	for bytes < softResponseLimit && len(bodies) < downloader.MaxBlockFetch {
+	for bytes < softResponseLimit && len(bodies) < downloader.MaxBlockFetch &&
+		lookups < 2*downloader.MaxBlockFetch {
 		// Retrieve the hash of the next block
 		if err := msgStream.Decode(&hash); err == rlp.EOL {
 			break
 		} else if err != nil {
 			return nil, errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+		lookups++
 		// Retrieve the requested block body, stopping if enough was found
 		if data := pm.blockchain.GetBodyRLP(hash); len(data) != 0 {
 			bodies = append(bodies, data)
@@ -999,17 +1002,20 @@ func handleNodeDataRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	}
 	// Gather state data until the fetch or network limits is reached
 	var (
-		hash  common.Hash
-		bytes int
-		data  [][]byte
+		hash    common.Hash
+		bytes   int
+		data    [][]byte
+		lookups int
 	)
-	for bytes < softResponseLimit && len(data) < downloader.MaxStateFetch {
+	for bytes < softResponseLimit && len(data) < downloader.MaxStateFetch &&
+		lookups < 2*downloader.MaxStateFetch {
 		// Retrieve the hash of the next state entry
 		if err := msgStream.Decode(&hash); err == rlp.EOL {
 			break
 		} else if err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+		lookups++
 		// Retrieve the requested state entry, stopping if enough was found
 		// TODO-Kaia-Snapsync now the code and trienode is mixed in the protocol level, separate these two types.
 		entry, err := pm.blockchain.TrieNode(hash)
@@ -1051,14 +1057,17 @@ func handleReceiptsRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		hash     common.Hash
 		bytes    int
 		receipts []rlp.RawValue
+		lookups  int
 	)
-	for bytes < softResponseLimit && len(receipts) < downloader.MaxReceiptFetch {
+	for bytes < softResponseLimit && len(receipts) < downloader.MaxReceiptFetch &&
+		lookups < 2*downloader.MaxReceiptFetch {
 		// Retrieve the hash of the next block
 		if err := msgStream.Decode(&hash); err == rlp.EOL {
 			break
 		} else if err != nil {
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
+		lookups++
 		// Retrieve the requested block's receipts, skipping if unknown to us
 		results := pm.blockchain.GetReceiptsByBlockHash(hash)
 		if results == nil {
@@ -1107,8 +1116,10 @@ func handleStakingInfoRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 		hash         common.Hash
 		bytes        int
 		stakingInfos []rlp.RawValue
+		lookups      int
 	)
-	for bytes < softResponseLimit && len(stakingInfos) < downloader.MaxStakingInfoFetch {
+	for bytes < softResponseLimit && len(stakingInfos) < downloader.MaxStakingInfoFetch &&
+		lookups < 2*downloader.MaxStakingInfoFetch {
 		// Retrieve the hash of the next block
 		if err := msgStream.Decode(&hash); err == rlp.EOL {
 			break
@@ -1116,6 +1127,7 @@ func handleStakingInfoRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
+		lookups++
 		// Retrieve the requested block's staking information, skipping if unknown to us
 		header := pm.blockchain.GetHeaderByHash(hash)
 		if header == nil {
@@ -1141,7 +1153,6 @@ func handleStakingInfoRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 		if encoded, err := rlp.EncodeToBytes(result); err != nil {
 			logger.Error("Failed to encode staking info", "err", err)
 		} else {
-			fmt.Println("encoding", result, "len", len(encoded))
 			stakingInfos = append(stakingInfos, encoded)
 			bytes += len(encoded)
 		}
@@ -1194,8 +1205,10 @@ func handleBlobSidecarsRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 		data     blobSidecarsRequestData
 		bytes    int
 		sidecars []rlp.RawValue
+		lookups  int
 	)
-	for bytes < softResponseLimit && len(sidecars) < downloader.MaxBlobSidecarsFetch {
+	for bytes < softResponseLimit && len(sidecars) < downloader.MaxBlobSidecarsFetch &&
+		lookups < 2*downloader.MaxBlobSidecarsFetch {
 		// Retrieve data
 		if err := msgStream.Decode(&data); err == rlp.EOL {
 			break
@@ -1203,6 +1216,7 @@ func handleBlobSidecarsRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 			return errResp(ErrDecode, "msg %v: %v", msg, err)
 		}
 
+		lookups++
 		// Retrieve a requested tx's blob sidecar, skipping if unknown to us
 		result, err := pm.txpool.GetBlobSidecarFromStorage(big.NewInt(int64(data.BlockNum)), int(data.TxIndex))
 		if result == nil {

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -29,9 +29,11 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/kzg4844"
+	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/kaiax/auction"
 	auction_mock "github.com/kaiachain/kaia/kaiax/auction/mock"
 	"github.com/kaiachain/kaia/kaiax/staking"
@@ -1029,6 +1031,128 @@ func TestHandleBlobSidecarsMsg(t *testing.T) {
 		assert.NotNil(t, req, "should not be deleted from blobSidecarReqManager even on error")
 		mockCtrl.Finish()
 	}
+}
+
+// makePhantomHashes returns n distinct hashes whose i-th byte is i+1, suitable
+// for phantom-flood tests where every lookup is expected to miss.
+func makePhantomHashes(n int) []common.Hash {
+	out := make([]common.Hash, n)
+	for i := range out {
+		out[i][0] = byte(i & 0xff)
+		out[i][1] = byte((i >> 8) & 0xff)
+		out[i][2] = byte((i >> 16) & 0xff)
+	}
+	return out
+}
+
+// The next set of tests verifies the per-iteration lookup counter that bounds
+// DB work when a peer floods the handler with hashes that all miss on disk.
+// Each test sends 4*cap phantom hashes and asserts the handler runs at most
+// 2*cap iterations before returning, matching the pattern geth adopted in
+// eth/66.
+
+func TestHandleBlockBodiesRequestMsg_PhantomFlood(t *testing.T) {
+	cap := downloader.MaxBlockFetch
+	hashes := makePhantomHashes(4 * cap)
+
+	mockCtrl, mockBlockChain, mockPeer, pm := prepareBlockChain(t)
+	defer mockCtrl.Finish()
+
+	msg := generateMsg(t, BlockBodiesRequestMsg, hashes)
+
+	// With the fix, lookups (incremented once per iteration) stops at 2*cap,
+	// so GetBodyRLP is invoked exactly 2*cap times for all-miss input.
+	mockBlockChain.EXPECT().GetBodyRLP(gomock.Any()).Return(nil).Times(2 * cap)
+
+	bodies, err := handleBlockBodiesRequest(pm, mockPeer, msg)
+	assert.NoError(t, err)
+	assert.Empty(t, bodies)
+}
+
+func TestHandleNodeDataRequestMsg_PhantomFlood(t *testing.T) {
+	cap := downloader.MaxStateFetch
+	hashes := makePhantomHashes(4 * cap)
+
+	mockCtrl, mockBlockChain, mockPeer, pm := prepareBlockChain(t)
+	defer mockCtrl.Finish()
+
+	msg := generateMsg(t, NodeDataRequestMsg, hashes)
+
+	// lookups increments once per iteration, capped at 2*cap. Every miss falls
+	// through TrieNode to ContractCodeWithPrefix, so both fire 2*cap times.
+	mockBlockChain.EXPECT().TrieNode(gomock.Any()).Return(nil, nil).Times(2 * cap)
+	mockBlockChain.EXPECT().ContractCodeWithPrefix(gomock.Any()).Return(nil, nil).Times(2 * cap)
+	mockPeer.EXPECT().SendNodeData([][]byte(nil)).Return(nil).Times(1)
+
+	assert.NoError(t, handleNodeDataRequestMsg(pm, mockPeer, msg))
+}
+
+func TestHandleReceiptsRequestMsg_PhantomFlood(t *testing.T) {
+	cap := downloader.MaxReceiptFetch
+	hashes := makePhantomHashes(4 * cap)
+
+	mockCtrl, mockBlockChain, mockPeer, pm := prepareBlockChain(t)
+	defer mockCtrl.Finish()
+
+	msg := generateMsg(t, ReceiptsRequestMsg, hashes)
+
+	// lookups increments once per iteration, capped at 2*cap. Every miss falls
+	// through GetReceiptsByBlockHash to GetHeaderByHash, so both fire 2*cap times.
+	mockBlockChain.EXPECT().GetReceiptsByBlockHash(gomock.Any()).Return(nil).Times(2 * cap)
+	mockBlockChain.EXPECT().GetHeaderByHash(gomock.Any()).Return(nil).Times(2 * cap)
+	mockPeer.EXPECT().SendReceiptsRLP(gomock.Any()).Return(nil).Times(1)
+
+	assert.NoError(t, handleReceiptsRequestMsg(pm, mockPeer, msg))
+}
+
+func TestHandleStakingInfoRequestMsg_PhantomFlood(t *testing.T) {
+	cap := downloader.MaxStakingInfoFetch
+	hashes := makePhantomHashes(4 * cap)
+
+	mockCtrl, mockBlockChain, mockPeer, pm := prepareBlockChain(t)
+	defer mockCtrl.Finish()
+
+	cfg := params.TestChainConfig.Copy()
+	cfg.Istanbul = &params.IstanbulConfig{ProposerPolicy: uint64(istanbul.WeightedRandom)}
+	cfg.Governance = params.GetDefaultGovernanceConfig()
+	pm.chainconfig = cfg
+
+	msg := generateMsg(t, StakingInfoRequestMsg, hashes)
+
+	// lookups increments once per iteration, capped at 2*cap. Phantom header
+	// triggers `continue`, so only GetHeaderByHash fires (2*cap times).
+	mockBlockChain.EXPECT().GetHeaderByHash(gomock.Any()).Return(nil).Times(2 * cap)
+	mockPeer.EXPECT().SendStakingInfoRLP(gomock.Any()).Return(nil).Times(1)
+
+	assert.NoError(t, handleStakingInfoRequestMsg(pm, mockPeer, msg))
+}
+
+func TestHandleBlobSidecarsRequestMsg_PhantomFlood(t *testing.T) {
+	cap := downloader.MaxBlobSidecarsFetch
+	hashes := makePhantomHashes(4 * cap)
+	requestData := make([]blobSidecarsRequestData, 4*cap)
+	for i := range requestData {
+		requestData[i] = blobSidecarsRequestData{
+			BlockNum: hexutil.Uint64(i + 1),
+			TxIndex:  hexutil.Uint(i),
+			Hash:     hashes[i],
+		}
+	}
+
+	mockCtrl, _, mockPeer, pm := prepareBlockChain(t)
+	defer mockCtrl.Finish()
+
+	msg := generateMsg(t, BlobSidecarsRequestMsg, requestData)
+
+	mockTxPool := mocks.NewMockTxPool(mockCtrl)
+	// lookups increments once per iteration, capped at 2*cap. Every miss falls
+	// through storage to pool, so both fire 2*cap times.
+	mockTxPool.EXPECT().GetBlobSidecarFromStorage(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2 * cap)
+	mockTxPool.EXPECT().GetBlobSidecarFromPool(gomock.Any()).Return(nil, nil).Times(2 * cap)
+	pm.txpool = mockTxPool
+	mockPeer.EXPECT().SendBlobSidecarsRLP(gomock.Any()).Return(nil).Times(1)
+
+	assert.NoError(t, handleBlobSidecarsRequestMsg(pm, mockPeer, msg))
 }
 
 // generateTestSidecar generates a test BlobTxSidecar for a given transaction hash.


### PR DESCRIPTION
## Proposed changes

- Limits the number of p2p queries (i.e. wanted hashes) even when the requested information are missing.
- Previously, `MaxAbcFetch` only capped the successful result. Now, `2*MaxAbcFetch` caps all queries in a request.

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
