### PR TITLE
blockchain/types: enforce fee ratio range on the consensus path

### DIFF
--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -546,6 +546,10 @@ func (tx *Transaction) Validate(db StateDB, signer Signer, currentBlockNumber ui
 			}
 		}
 	}
+	// Range-check the fee ratio on the consensus path.
+	if feeRatio, isRatioTx := tx.FeeRatio(); isRatioTx && !feeRatio.IsValid() {
+		return kerrors.ErrFeeRatioOutOfRange
+	}
 	return tx.data.Validate(db, currentBlockNumber, checkMutableValue)
 }
 

--- a/tests/tx_fee_ratio_range_test.go
+++ b/tests/tx_fee_ratio_range_test.go
@@ -311,3 +311,78 @@ func testTxFeeRatioRange(t *testing.T, feeRatio types.FeeRatio, expected error) 
 		reservoir.Nonce += 1
 	}
 }
+
+// TestTxFeeRatioBlockExecutionRejectsOutOfRange exercises the consensus-side
+// check in Transaction.Validate (invoked from BlockChain.ApplyTransaction).
+func TestTxFeeRatioBlockExecutionRejectsOutOfRange(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
+
+	bcdata, err := NewBCData(6, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bcdata.Shutdown()
+
+	sender := &TestAccountType{
+		Addr:  *bcdata.addrs[1],
+		Keys:  []*ecdsa.PrivateKey{bcdata.privKeys[1]},
+		Nonce: 0,
+	}
+	feePayer := &TestAccountType{
+		Addr:  *bcdata.addrs[2],
+		Keys:  []*ecdsa.PrivateKey{bcdata.privKeys[2]},
+		Nonce: 0,
+	}
+	recipient := &TestAccountType{
+		Addr:  *bcdata.addrs[3],
+		Keys:  []*ecdsa.PrivateKey{bcdata.privKeys[3]},
+		Nonce: 0,
+	}
+
+	signer := types.MakeSigner(bcdata.bc.Config(), bcdata.bc.CurrentHeader().Number)
+	gasPrice := new(big.Int).SetUint64(bcdata.bc.Config().UnitPrice)
+
+	build := func(ratio types.FeeRatio) *types.Transaction {
+		values := map[types.TxValueKeyType]interface{}{
+			types.TxValueKeyNonce:              sender.Nonce,
+			types.TxValueKeyFrom:               sender.Addr,
+			types.TxValueKeyTo:                 recipient.Addr,
+			types.TxValueKeyAmount:             new(big.Int),
+			types.TxValueKeyGasLimit:           gasLimit,
+			types.TxValueKeyGasPrice:           gasPrice,
+			types.TxValueKeyFeePayer:           feePayer.Addr,
+			types.TxValueKeyFeeRatioOfFeePayer: ratio,
+		}
+		tx, err := types.NewTransactionWithMap(types.TxTypeFeeDelegatedValueTransferWithRatio, values)
+		assert.NoError(t, err)
+		assert.NoError(t, tx.SignWithKeys(signer, sender.Keys))
+		assert.NoError(t, tx.SignFeePayerWithKeys(signer, feePayer.Keys))
+		return tx
+	}
+
+	statedb, err := bcdata.bc.State()
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockNumber := bcdata.bc.CurrentHeader().Number.Uint64()
+
+	cases := []struct {
+		ratio   types.FeeRatio
+		wantErr error
+	}{
+		{0, kerrors.ErrFeeRatioOutOfRange},
+		{1, nil},
+		{50, nil},
+		{99, nil},
+		{100, kerrors.ErrFeeRatioOutOfRange},
+		{200, kerrors.ErrFeeRatioOutOfRange},
+		{255, kerrors.ErrFeeRatioOutOfRange},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("ratio_%d", tc.ratio), func(t *testing.T) {
+			tx := build(tc.ratio)
+			assert.Equal(t, tc.wantErr, tx.Validate(statedb, signer, blockNumber, false))
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

- The tx pool already range-checks the fee ratio for fee-delegated-with-ratio transactions on admission.
- This PR adds the same check to `Transaction.Validate` so the block-application path enforces it independently.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
