### PR TITLE
blockchain: fix slice aliasing in spam throttler classifyTxs

### DIFF
--- a/blockchain/spam_throttler.go
+++ b/blockchain/spam_throttler.go
@@ -238,8 +238,9 @@ func (t *throttler) updateThrottlerState(txs types.Transactions, receipts types.
 // classifyTxs classifies given txs into allowTxs and throttleTxs.
 // If to-address of tx is listed in the throttle list, it is classified as throttleTx.
 func (t *throttler) classifyTxs(txs types.Transactions) (types.Transactions, types.Transactions) {
-	allowTxs := txs[:0]
-	throttleTxs := txs[:0]
+	// Use independent backing arrays so appends to one partition cannot overwrite the other.
+	allowTxs := make(types.Transactions, 0, len(txs))
+	throttleTxs := make(types.Transactions, 0, len(txs))
 
 	t.mu.RLock()
 	for _, tx := range txs {

--- a/blockchain/spam_throttler_test.go
+++ b/blockchain/spam_throttler_test.go
@@ -110,3 +110,52 @@ func TestThrottler_updateThrottlerState(t *testing.T) {
 		assert.Equal(t, tc.throttledWeight, th.throttled[toFail])
 	}
 }
+
+func TestThrottler_classifyTxsPartitionIntegrity(t *testing.T) {
+	throttledAddr := common.HexToAddress("0x00000000000000000000000000000000000000AA")
+	allowedAddr := common.HexToAddress("0x00000000000000000000000000000000000000BB")
+
+	mkTx := func(nonce uint64, to common.Address) *types.Transaction {
+		return types.NewTransaction(nonce, to, big.NewInt(1), 21000, big.NewInt(int64(params.Gkei)), nil)
+	}
+
+	testCases := []struct {
+		name string
+		txs  types.Transactions
+	}{
+		{
+			name: "allowed before throttled",
+			txs:  types.Transactions{mkTx(0, allowedAddr), mkTx(1, throttledAddr)},
+		},
+		{
+			name: "throttled before allowed",
+			txs:  types.Transactions{mkTx(0, throttledAddr), mkTx(1, allowedAddr)},
+		},
+		{
+			name: "interleaved",
+			txs: types.Transactions{
+				mkTx(0, allowedAddr), mkTx(1, throttledAddr),
+				mkTx(2, allowedAddr), mkTx(3, throttledAddr),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			th := newTestThrottler(DefaultSpamThrottlerConfig)
+			th.throttled[throttledAddr] = 10
+
+			allow, throttle := th.classifyTxs(tc.txs)
+
+			for _, tx := range allow {
+				assert.NotNil(t, tx.To())
+				assert.Equal(t, allowedAddr, *tx.To(), "allow set must not contain throttled destinations")
+			}
+			for _, tx := range throttle {
+				assert.NotNil(t, tx.To())
+				assert.Equal(t, throttledAddr, *tx.To(), "throttle set must not contain allowed destinations")
+			}
+			assert.Equal(t, len(tc.txs), len(allow)+len(throttle), "partition must cover the full input")
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

In spam throttler `classifyTxs()`:
- Both output slices were initialized as `txs[:0]`, so they shared the same backing array
   - a throttled tx could overwrite an allowed tx in the partition `HandleTxMsg` consumes, letting a throttled destination enter the immediate admission path and displacing an allowed one.
- Allocate independent backing arrays with `make()` so the two partitions cannot interfere
- Add a regression test covering this case

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
