### PR TITLE
storage/database: surface errors from offline DB migration

### DIFF
--- a/storage/database/db_migration.go
+++ b/storage/database/db_migration.go
@@ -19,13 +19,13 @@
 package database
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"path"
 	"syscall"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -62,7 +62,7 @@ func copyDB(name string, srcDB, dstDB Database, quit chan struct{}) error {
 		// write fetched keys and values to DB
 		// If dstDB is dynamoDB, Put will Write when the number items reach dynamoBatchSize.
 		if err := dstBatch.Put(key, val); err != nil {
-			return errors.WithMessage(err, "failed to put batch")
+			return fmt.Errorf("failed to put batch: %w", err)
 		}
 
 		if dstBatch.ValueSize() > IdealBatchSize {
@@ -88,7 +88,7 @@ func copyDB(name string, srcDB, dstDB Database, quit chan struct{}) error {
 	}
 
 	if err := dstBatch.Write(); err != nil {
-		return errors.WithMessage(err, "failed to write items")
+		return fmt.Errorf("failed to write items: %w", err)
 	}
 	dstBatch.Reset()
 
@@ -96,7 +96,7 @@ func copyDB(name string, srcDB, dstDB Database, quit chan struct{}) error {
 
 	srcIter.Release()
 	if err := srcIter.Error(); err != nil { // any accumulated error from iterator
-		return errors.WithMessage(err, "failed to iterate")
+		return fmt.Errorf("failed to iterate: %w", err)
 	}
 
 	return nil
@@ -152,20 +152,18 @@ func (dbm *databaseManager) StartDBMigration(dstdbm DBManager) error {
 			}()
 		}
 
-		var firstErr error
+		var errs []error
 		for range databaseEntryTypeSize {
 			if err := <-errChan; err != nil {
 				logger.Error("copyDB got an error", "err", err)
-				if firstErr == nil {
-					firstErr = err
-				}
+				errs = append(errs, err)
 			}
 		}
 
 		// Reset state trie DB path if migrated state trie path ("statetrie_migrated_XXXXXX") is set
 		dstdbm.setDBDir(DBEntryType(StateTrieDB), "")
 
-		return firstErr
+		return errors.Join(errs...)
 	}
 
 	// single DB -> single DB

--- a/storage/database/db_migration.go
+++ b/storage/database/db_migration.go
@@ -32,6 +32,12 @@ const (
 	reportCycle = IdealBatchSize * 20
 )
 
+// ErrDBMigrationInterrupted is returned by copyDB when migration is aborted
+// because the quit channel was closed (e.g. by SIGINT or SIGTERM).
+// Callers can use errors.Is to distinguish an interrupted migration from a
+// successful completion.
+var ErrDBMigrationInterrupted = errors.New("db migration interrupted")
+
 // copyDB migrates a DB to another DB.
 // This feature uses Iterator. A src DB should have implementation of Iteratee to use this function.
 func copyDB(name string, srcDB, dstDB Database, quit chan struct{}) error {
@@ -76,7 +82,7 @@ func copyDB(name string, srcDB, dstDB Database, quit chan struct{}) error {
 		select {
 		case <-quit:
 			logger.Warn("exit called", "db", name, "fetchedTotal", fetched, "elapsedTotal", time.Since(start))
-			return nil
+			return ErrDBMigrationInterrupted
 		default:
 		}
 	}
@@ -146,17 +152,20 @@ func (dbm *databaseManager) StartDBMigration(dstdbm DBManager) error {
 			}()
 		}
 
+		var firstErr error
 		for range databaseEntryTypeSize {
-			err := <-errChan
-			if err != nil {
+			if err := <-errChan; err != nil {
 				logger.Error("copyDB got an error", "err", err)
+				if firstErr == nil {
+					firstErr = err
+				}
 			}
 		}
 
 		// Reset state trie DB path if migrated state trie path ("statetrie_migrated_XXXXXX") is set
 		dstdbm.setDBDir(DBEntryType(StateTrieDB), "")
 
-		return nil
+		return firstErr
 	}
 
 	// single DB -> single DB

--- a/storage/database/db_migration_test.go
+++ b/storage/database/db_migration_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func filledMemDB(entries int, valueSize int) *MemDB {
+	db := NewMemDB()
+	val := bytes.Repeat([]byte("v"), valueSize)
+	for i := 0; i < entries; i++ {
+		_ = db.Put([]byte(fmt.Sprintf("k%06d", i)), val)
+	}
+	return db
+}
+
+// TestCopyDB_InterruptedReturnsSentinel verifies that copyDB returns
+// ErrDBMigrationInterrupted when the quit channel is closed mid-copy,
+// instead of nil. Without this, callers cannot distinguish an interrupted
+// migration from a successful one.
+func TestCopyDB_InterruptedReturnsSentinel(t *testing.T) {
+	src := filledMemDB(64, 32)
+	dst := NewMemDB()
+
+	quit := make(chan struct{})
+	close(quit)
+
+	err := copyDB("single", src, dst, quit)
+	require.Error(t, err, "copyDB must return an error when migration is interrupted")
+	assert.True(t, errors.Is(err, ErrDBMigrationInterrupted),
+		"copyDB must return ErrDBMigrationInterrupted, got: %v", err)
+}
+
+// TestCopyDB_CompletesReturnsNil is a positive control: a non-interrupted
+// run must still return nil.
+func TestCopyDB_CompletesReturnsNil(t *testing.T) {
+	src := filledMemDB(8, 16)
+	dst := NewMemDB()
+
+	err := copyDB("single", src, dst, make(chan struct{}))
+	require.NoError(t, err)
+}
+
+// failingBatch is a Batch whose Put always returns an error.
+// Used to force copyDB into the error path without depending on a real backend.
+type failingBatch struct{ err error }
+
+func (b *failingBatch) Put(_, _ []byte) error       { return b.err }
+func (b *failingBatch) Delete(_ []byte) error       { return nil }
+func (b *failingBatch) ValueSize() int              { return 0 }
+func (b *failingBatch) Write() error                { return nil }
+func (b *failingBatch) Reset()                      {}
+func (b *failingBatch) Release()                    {}
+func (b *failingBatch) Replay(KeyValueWriter) error { return nil }
+
+// failingBatchDB wraps a Database but returns a failingBatch from NewBatch.
+type failingBatchDB struct {
+	Database
+	err error
+}
+
+func (db *failingBatchDB) NewBatch() Batch { return &failingBatch{err: db.err} }
+
+// TestStartDBMigration_NonSingleSurfacesCopyError verifies that StartDBMigration
+// returns a non-nil error when a per-DB copy fails in the non-single source
+// path, instead of swallowing the error and reporting success.
+func TestStartDBMigration_NonSingleSurfacesCopyError(t *testing.T) {
+	newMgr := func() *databaseManager {
+		return &databaseManager{
+			config: &DBConfig{DBType: MemoryDB, SingleDB: false},
+			dbs:    make([]Database, databaseEntryTypeSize),
+			cm:     newCacheManager(),
+		}
+	}
+
+	src := newMgr()
+	dst := newMgr()
+
+	// Populate one src slot with data; the matching dst slot returns batches
+	// whose Put fails. All other slots remain nil and are skipped.
+	srcSlot := NewMemDB()
+	require.NoError(t, srcSlot.Put([]byte("k"), []byte("v")))
+	src.dbs[MiscDB] = srcSlot
+	dst.dbs[MiscDB] = &failingBatchDB{Database: NewMemDB(), err: errors.New("forced put failure")}
+
+	err := src.StartDBMigration(dst)
+	require.Error(t, err, "StartDBMigration must surface per-DB copy errors in the non-single path")
+}


### PR DESCRIPTION
## Proposed changes

DB migration does not correctly return errors:
- `copyDB` returned `nil` error when the quit channel was closed by SIGINT/SIGTERM, so an interrupted migration was indistinguishable from a completed one.
  - Introduce `ErrDBMigrationInterrupted` and return it from copyDB on interruption
- `StartDBMigration`'s non-single source path collected per-DB copy errors into a channel but always returned `nil` after logging them.
  - Propagate the first error so the CLI exits non-zero when any per-DB copy fails (including interruption)
- Add regression tests covering interrupt-on-copy, the successful path, and non-single error propagation via a failing-batch stub.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
