### PR TITLE
node/sc: clarify misleading comments in SubBridgeHandler

### DIFF
--- a/node/sc/sub_bridge_handler.go
+++ b/node/sc/sub_bridge_handler.go
@@ -316,7 +316,6 @@ func (sbh *SubBridgeHandler) handleParentChainReceiptResponseMsg(p BridgePeer, m
 	if err := msg.Decode(&receipts); err != nil && err != rlp.EOL {
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
-	// Stores receipt and remove tx from sentServiceChainTxs only if the tx is successfully executed.
 	sbh.writeServiceChainTxReceipts(sbh.subbridge.blockchain, receipts)
 	return nil
 }
@@ -396,7 +395,8 @@ func (sbh *SubBridgeHandler) handleParentChainInvalidTxResponseMsg(msg p2p.Msg) 
 				sbh.SyncNonceAndGasPrice()
 
 				logger.Error("Bridge tx is removed which has lower gasPrice than UpperBoundBaseFee")
-				// Remove the tx and delegate re-execution of the tx by Value Transfer Recovery feature
+				// Remove the tx from the pool. For value transfer txs, Value Transfer Recovery
+				// will retry if enabled. For anchoring txs, there is no automatic retry mechanism;
 				if err := sbh.subbridge.GetBridgeTxPool().RemoveTx(tx); err != nil {
 					logger.Error("Failed to remove bridge tx",
 						"txType", tx.Type(), "txNonce", tx.Nonce(), "txHash", tx.Hash().String())


### PR DESCRIPTION
## Proposed changes

Fix two inaccurate comments in `node/sc/sub_bridge_handler.go`. No behavior change.

1. `handleParentChainReceiptResponseMsg`: removed incorrect claim that txs are removed only on successful execution.
2. `handleParentChainInvalidTxResponseMsg`: VT Recovery only covers value transfer txs, not anchoring txs.

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments