### PR TITLE
valset: transition orchestration

### DIFF
--- a/accounts/abi/bind/backends/blockchain_state.go
+++ b/accounts/abi/bind/backends/blockchain_state.go
@@ -1,0 +1,140 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Copyright 2023 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+// Modified and improved for the Kaia development.
+
+package backends
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia/accounts/abi/bind"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/math"
+)
+
+// `StateBlockchainContractCaller` implements `ContractCaller` interface
+type StateBlockchainContractCaller struct {
+	bc    BlockChainForCaller
+	state *state.StateDB
+}
+
+var _ bind.ContractCaller = (*StateBlockchainContractCaller)(nil)
+
+// NewStateBlockchainContractBackend creates a ContractCaller that reads from the given statedb directly.
+// Used when Chain.StateAt is unavailable (e.g., cold start or uncommitted state).
+func NewStateBlockchainContractBackend(bc BlockChainForCaller, state *state.StateDB) (*StateBlockchainContractCaller, error) {
+	if state == nil {
+		return nil, errors.New("statedb is nil")
+	}
+	return &StateBlockchainContractCaller{bc, state}, nil
+}
+
+func (b *StateBlockchainContractCaller) getBlock(num *big.Int) (*types.Block, error) {
+	var block *types.Block
+	if num == nil {
+		block = b.bc.CurrentBlock()
+	} else {
+		header := b.bc.GetHeaderByNumber(num.Uint64())
+		if header == nil {
+			return nil, errBlockDoesNotExist
+		}
+		block = b.bc.GetBlock(header.Hash(), header.Number.Uint64())
+	}
+	if block == nil {
+		return nil, errBlockDoesNotExist
+	}
+	return block, nil
+}
+
+// bind.ContractCaller defined methods
+
+func (b *StateBlockchainContractCaller) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+	return b.state.GetCode(account), nil
+}
+
+func (b *StateBlockchainContractCaller) CallContract(ctx context.Context, call kaia.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	block, err := b.getBlock(blockNumber)
+	if err != nil {
+		return nil, err
+	}
+	res, err := b.callContract(call, block, b.state)
+	if err != nil {
+		return nil, err
+	}
+	if len(res.Revert()) > 0 {
+		return nil, blockchain.NewRevertError(res)
+	}
+	return res.Return(), res.Unwrap()
+}
+
+func (b *StateBlockchainContractCaller) callContract(call kaia.CallMsg, block *types.Block, state *state.StateDB) (*blockchain.ExecutionResult, error) {
+	gasPrice := common.Big0
+	if call.GasPrice != nil && (call.GasFeeCap != nil || call.GasTipCap != nil) {
+		return nil, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
+	}
+	if !b.bc.Config().IsKaiaForkEnabled(block.Number()) { // before KIP-162
+		if call.GasPrice != nil {
+			gasPrice = call.GasPrice
+		}
+	} else { // after KIP-162
+		if call.GasPrice != nil {
+			gasPrice = call.GasPrice
+		} else {
+			if call.GasFeeCap == nil {
+				call.GasFeeCap = big.NewInt(0)
+			}
+			if call.GasTipCap == nil {
+				call.GasTipCap = big.NewInt(0)
+			}
+			gasPrice = math.BigMin(new(big.Int).Add(call.GasTipCap, block.Header().BaseFee), call.GasFeeCap)
+		}
+	}
+
+	if call.Gas == 0 {
+		call.Gas = uint64(3e8) // enough gas for ordinary contract calls
+	}
+
+	var accessList types.AccessList
+	if call.AccessList != nil {
+		accessList = *call.AccessList
+	}
+	intrinsicGas, err := types.IntrinsicGas(call.Data, accessList, nil, call.To == nil, b.bc.Config().Rules(block.Number()))
+	if err != nil {
+		return nil, err
+	}
+
+	msg := types.NewMessage(call.From, call.To, 0, call.Value, call.Gas, gasPrice, nil, nil, nil, call.Data,
+		false, intrinsicGas, accessList, nil, nil, nil, nil)
+
+	txContext := blockchain.NewEVMTxContext(msg, block.Header(), b.bc.Config())
+	blockContext := blockchain.NewEVMBlockContext(block.Header(), b.bc, nil)
+
+	// EVM demands the sender to have enough KAIA balance (gasPrice * gasLimit) in buyGas()
+	// After KIP-71, gasPrice is nonzero baseFee, regardless of the msg.gasPrice (usually 0)
+	// But our sender (usually 0x0) won't have enough balance. Instead we override gasPrice = 0 here
+	txContext.GasPrice = big.NewInt(0)
+	evm := vm.NewEVM(blockContext, txContext, state, b.bc.Config(), &vm.Config{})
+
+	return blockchain.ApplyMessage(evm, msg)
+}

--- a/blockchain/state_processor.go
+++ b/blockchain/state_processor.go
@@ -187,3 +187,22 @@ func ProcessParentBlockHash(header *types.Header, vmenv *vm.EVM, statedb vm.Stat
 	statedb.Finalise(true, true)
 	return nil
 }
+
+// SystemTxCall executes a system transaction (e.g., state-transition contract
+// writes) within the EVM. Used by kaiax modules that perform contract writes
+// during block finalization.
+func SystemTxCall(
+	msg *types.Transaction,
+	from common.Address,
+	header *types.Header,
+	vmenv *vm.EVM,
+	statedb vm.StateDB,
+	rules params.Rules,
+) ([]byte, error) {
+	gasLimit := params.UpperGasLimit
+	vmenv.Reset(NewEVMTxContext(msg, header, vmenv.ChainConfig()), statedb)
+	statedb.AddAddressToAccessList(*msg.To())
+	ret, _, err := vmenv.Call(vm.AccountRef(from), *msg.To(), msg.Data(), gasLimit, common.Big0)
+	statedb.Finalise(true, true)
+	return ret, err
+}

--- a/blockchain/state_processor.go
+++ b/blockchain/state_processor.go
@@ -188,9 +188,7 @@ func ProcessParentBlockHash(header *types.Header, vmenv *vm.EVM, statedb vm.Stat
 	return nil
 }
 
-// SystemTxCall executes a system transaction (e.g., state-transition contract
-// writes) within the EVM. Used by kaiax modules that perform contract writes
-// during block finalization.
+// SystemTxCall executes a system transaction (e.g., state transition contract writes) within the EVM.
 func SystemTxCall(
 	msg *types.Transaction,
 	from common.Address,

--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -85,15 +85,15 @@ func EncodeInitializeABv2(rules params.Rules) (common.Address, *types.Transactio
 	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
-// EncodeNodeStateUpdate encodes the processSystemTransition call with the given validator state changes.
+// EncodeNodeStateUpdate encodes the processSystemTransition call with the given node state changes.
 // epochVACount is the VA count after epoch transition (newSF); 0 for non-epoch blocks.
 func EncodeNodeStateUpdate(
 	rules params.Rules,
-	validators valset.NodeMap,
+	nodes valset.NodeMap,
 	epochVACount uint64,
 ) (common.Address, *types.Transaction, error) {
-	nodeIds := make([]common.Address, 0, len(validators))
-	for addr := range validators {
+	nodeIds := make([]common.Address, 0, len(nodes))
+	for addr := range nodes {
 		nodeIds = append(nodeIds, addr)
 	}
 	// Sort for deterministic ABI encoding across all nodes
@@ -106,7 +106,7 @@ func EncodeNodeStateUpdate(
 		timeoutAts = make([]*big.Int, len(nodeIds))
 	)
 	for idx, addr := range nodeIds {
-		vs := validators[addr]
+		vs := nodes[addr]
 		newStates[idx] = vs.State.ToUint8()
 		var timeout time.Time
 		switch vs.State {
@@ -129,9 +129,11 @@ func EncodeNodeStateUpdate(
 	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
-// NodeStatesResult holds the result of ReadNodeStates.
-type NodeStatesResult struct {
-	Validators              valset.NodeMap
+// ABv2StateSnapshot holds the result of ReadNodeStates.
+type ABv2StateSnapshot struct {
+	Nodes valset.NodeMap
+
+	// parameters for transition
 	PauseTimeout            time.Duration
 	IdleTimeout             time.Duration
 	PfsThreshold            uint64
@@ -143,12 +145,12 @@ type NodeStatesResult struct {
 	SuspendedValidators     []common.Address
 }
 
-// ReadNodeStates reads all validator states, timeouts, max counts, and thresholds from ABv2 in a single MultiCall.
+// ReadNodeStates reads all node states, timeouts, max counts, and thresholds from ABv2 in a single MultiCall.
 func ReadNodeStates(
 	statedb *state.StateDB,
 	chain backends.BlockChainForCaller,
 	header *types.Header,
-) (*NodeStatesResult, error) {
+) (*ABv2StateSnapshot, error) {
 	caller, err := NewMultiCallContractCaller(statedb, chain, header)
 	if err != nil {
 		return nil, err
@@ -160,7 +162,7 @@ func ReadNodeStates(
 		return nil, err
 	}
 
-	validators := make(valset.NodeMap)
+	nodes := make(valset.NodeMap)
 	for i, p := range res.Profiles {
 		nodeState := valset.NodeState(p.State)
 		vs := &valset.Node{
@@ -177,11 +179,11 @@ func ReadNodeStates(
 				vs.PausedTimeout = time.Unix(p.TimeoutAt.Int64(), 0)
 			}
 		}
-		validators[p.NodeId] = vs
+		nodes[p.NodeId] = vs
 	}
 
-	return &NodeStatesResult{
-		Validators:              validators,
+	return &ABv2StateSnapshot{
+		Nodes:                   nodes,
 		PauseTimeout:            time.Duration(res.PauseTimeout.Int64()) * time.Second,
 		IdleTimeout:             time.Duration(res.IdleTimeout.Int64()) * time.Second,
 		PfsThreshold:            res.PfsThreshold.Uint64(),

--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -18,6 +18,7 @@ package system
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"sort"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	abv2data "github.com/kaiachain/kaia/contracts/bindings/abv2data"
 	abv2contracts "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
+	"github.com/kaiachain/kaia/contracts/bindings/multicall"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/params"
 )
@@ -85,9 +87,9 @@ func EncodeInitializeABv2(rules params.Rules) (common.Address, *types.Transactio
 	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
-// EncodeNodeStateUpdate encodes the processSystemTransition call with the given node state changes.
+// EncodeProcessSystemTransition encodes the processSystemTransition call with the given node state changes.
 // epochVACount is the VA count after epoch transition (newSF); 0 for non-epoch blocks.
-func EncodeNodeStateUpdate(
+func EncodeProcessSystemTransition(
 	rules params.Rules,
 	nodes valset.NodeMap,
 	epochVACount uint64,
@@ -141,8 +143,8 @@ type ABv2TransitionParam struct {
 	MaxValActivePausedCount uint64
 }
 
-// ABv2StateSnapshot holds the result of ReadNodeStates.
-type ABv2StateSnapshot struct {
+// ABv2Snapshot holds the result of ReadNodeStates.
+type ABv2Snapshot struct {
 	Nodes valset.NodeMap
 	ABv2TransitionParam
 
@@ -151,11 +153,38 @@ type ABv2StateSnapshot struct {
 	SuspendedValidators []common.Address
 }
 
-func (s *ABv2StateSnapshot) TransitionParam() ABv2TransitionParam {
+func (s *ABv2Snapshot) TransitionParam() ABv2TransitionParam {
 	if s == nil {
 		return ABv2TransitionParam{}
 	}
 	return s.ABv2TransitionParam
+}
+
+func NewNodeMapFromABv2(profiles []multicall.Profile, stakingAmounts []*big.Int) (valset.NodeMap, error) {
+	if len(profiles) != len(stakingAmounts) {
+		return nil, fmt.Errorf("profile/staking amount length mismatch: profiles=%d stakingAmounts=%d", len(profiles), len(stakingAmounts))
+	}
+
+	nodes := make(valset.NodeMap)
+	for i, p := range profiles {
+		nodeState := valset.NodeState(p.State)
+		node := &valset.Node{
+			State:         nodeState,
+			StakingAmount: new(big.Int).Div(stakingAmounts[i], big.NewInt(params.KAIA)).Uint64(),
+		}
+		switch nodeState {
+		case valset.ValReady, valset.ValInactive:
+			if p.TimeoutAt.Sign() > 0 {
+				node.IdleTimeout = time.Unix(p.TimeoutAt.Int64(), 0)
+			}
+		case valset.ValPaused:
+			if p.TimeoutAt.Sign() > 0 {
+				node.PausedTimeout = time.Unix(p.TimeoutAt.Int64(), 0)
+			}
+		}
+		nodes[p.NodeId] = node
+	}
+	return nodes, nil
 }
 
 // ReadNodeStates reads all node states, timeouts, max counts, and thresholds from ABv2 in a single MultiCall.
@@ -163,7 +192,7 @@ func ReadNodeStates(
 	statedb *state.StateDB,
 	chain backends.BlockChainForCaller,
 	header *types.Header,
-) (*ABv2StateSnapshot, error) {
+) (*ABv2Snapshot, error) {
 	caller, err := NewMultiCallContractCaller(statedb, chain, header)
 	if err != nil {
 		return nil, err
@@ -175,27 +204,12 @@ func ReadNodeStates(
 		return nil, err
 	}
 
-	nodes := make(valset.NodeMap)
-	for i, p := range res.Profiles {
-		nodeState := valset.NodeState(p.State)
-		vs := &valset.Node{
-			State:         nodeState,
-			StakingAmount: new(big.Int).Div(res.StakingAmounts[i], big.NewInt(params.KAIA)).Uint64(),
-		}
-		switch nodeState {
-		case valset.ValReady, valset.ValInactive:
-			if p.TimeoutAt.Sign() > 0 {
-				vs.IdleTimeout = time.Unix(p.TimeoutAt.Int64(), 0)
-			}
-		case valset.ValPaused:
-			if p.TimeoutAt.Sign() > 0 {
-				vs.PausedTimeout = time.Unix(p.TimeoutAt.Int64(), 0)
-			}
-		}
-		nodes[p.NodeId] = vs
+	nodes, err := NewNodeMapFromABv2(res.Profiles, res.StakingAmounts)
+	if err != nil {
+		return nil, err
 	}
 
-	return &ABv2StateSnapshot{
+	return &ABv2Snapshot{
 		Nodes: nodes,
 		ABv2TransitionParam: ABv2TransitionParam{
 			PauseTimeout:            time.Duration(res.PauseTimeout.Int64()) * time.Second,

--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -129,20 +129,33 @@ func EncodeNodeStateUpdate(
 	return encodeSystemMessage(rules, AddressBookAddr, data)
 }
 
+// ABv2TransitionParam is the subset of ABv2 reads consumed by the transition
+// pipeline. NodeMap is passed separately as the mutable pipeline input.
+type ABv2TransitionParam struct {
+	EpochVACount uint64 // pipeline initial value; carried through on non-epoch blocks
+
+	PfsThreshold            uint64
+	CfsThreshold            uint64
+	IdleTimeout             time.Duration
+	PauseTimeout            time.Duration
+	MaxValActivePausedCount uint64
+}
+
 // ABv2StateSnapshot holds the result of ReadNodeStates.
 type ABv2StateSnapshot struct {
 	Nodes valset.NodeMap
+	ABv2TransitionParam
 
-	// parameters for transition
-	PauseTimeout            time.Duration
-	IdleTimeout             time.Duration
-	PfsThreshold            uint64
-	CfsThreshold            uint64
-	EpochVACount            uint64
-	MaxSlotAvailable        uint64
-	MinActiveCount          uint64
-	MaxValActivePausedCount uint64
-	SuspendedValidators     []common.Address
+	MaxSlotAvailable    uint64
+	MinActiveCount      uint64
+	SuspendedValidators []common.Address
+}
+
+func (s *ABv2StateSnapshot) TransitionParam() ABv2TransitionParam {
+	if s == nil {
+		return ABv2TransitionParam{}
+	}
+	return s.ABv2TransitionParam
 }
 
 // ReadNodeStates reads all node states, timeouts, max counts, and thresholds from ABv2 in a single MultiCall.
@@ -183,16 +196,18 @@ func ReadNodeStates(
 	}
 
 	return &ABv2StateSnapshot{
-		Nodes:                   nodes,
-		PauseTimeout:            time.Duration(res.PauseTimeout.Int64()) * time.Second,
-		IdleTimeout:             time.Duration(res.IdleTimeout.Int64()) * time.Second,
-		PfsThreshold:            res.PfsThreshold.Uint64(),
-		CfsThreshold:            res.CfsThreshold.Uint64(),
-		EpochVACount:            res.EpochVACount.Uint64(),
-		MaxSlotAvailable:        res.MaxSlotAvailable.Uint64(),
-		MinActiveCount:          res.MinActiveCount.Uint64(),
-		MaxValActivePausedCount: res.MaxValActivePausedCount.Uint64(),
-		SuspendedValidators:     res.SuspendedValidators,
+		Nodes: nodes,
+		ABv2TransitionParam: ABv2TransitionParam{
+			PauseTimeout:            time.Duration(res.PauseTimeout.Int64()) * time.Second,
+			IdleTimeout:             time.Duration(res.IdleTimeout.Int64()) * time.Second,
+			PfsThreshold:            res.PfsThreshold.Uint64(),
+			CfsThreshold:            res.CfsThreshold.Uint64(),
+			EpochVACount:            res.EpochVACount.Uint64(),
+			MaxValActivePausedCount: res.MaxValActivePausedCount.Uint64(),
+		},
+		MaxSlotAvailable:    res.MaxSlotAvailable.Uint64(),
+		MinActiveCount:      res.MinActiveCount.Uint64(),
+		SuspendedValidators: res.SuspendedValidators,
 	}, nil
 }
 

--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -143,7 +143,7 @@ type ABv2TransitionParam struct {
 	MaxValActivePausedCount uint64
 }
 
-// ABv2Snapshot holds the result of ReadNodeStates.
+// ABv2Snapshot holds the result of ReadABv2Snapshot.
 type ABv2Snapshot struct {
 	Nodes valset.NodeMap
 	ABv2TransitionParam
@@ -187,8 +187,8 @@ func NewNodeMapFromABv2(profiles []multicall.Profile, stakingAmounts []*big.Int)
 	return nodes, nil
 }
 
-// ReadNodeStates reads all node states, timeouts, max counts, and thresholds from ABv2 in a single MultiCall.
-func ReadNodeStates(
+// ReadABv2Snapshot reads all node states, timeouts, max counts, and thresholds from ABv2 in a single MultiCall.
+func ReadABv2Snapshot(
 	statedb *state.StateDB,
 	chain backends.BlockChainForCaller,
 	header *types.Header,

--- a/blockchain/system/addressbook_v2_test.go
+++ b/blockchain/system/addressbook_v2_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/contracts/bindings/multicall"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/params"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNodeMapFromABv2(t *testing.T) {
+	addr1 := common.HexToAddress("0x0001")
+	addr2 := common.HexToAddress("0x0002")
+	addr3 := common.HexToAddress("0x0003")
+
+	profiles := []multicall.Profile{
+		{NodeId: addr1, State: valset.ValReady.ToUint8(), TimeoutAt: big.NewInt(100)},
+		{NodeId: addr2, State: valset.ValPaused.ToUint8(), TimeoutAt: big.NewInt(200)},
+		{NodeId: addr3, State: valset.ValActive.ToUint8(), TimeoutAt: big.NewInt(300)},
+	}
+	stakingAmounts := []*big.Int{
+		new(big.Int).Mul(big.NewInt(3), big.NewInt(params.KAIA)),
+		new(big.Int).Mul(big.NewInt(4), big.NewInt(params.KAIA)),
+		new(big.Int).Mul(big.NewInt(5), big.NewInt(params.KAIA)),
+	}
+
+	nodes, err := NewNodeMapFromABv2(profiles, stakingAmounts)
+	require.NoError(t, err)
+
+	assert.Equal(t, valset.ValReady, nodes[addr1].State)
+	assert.Equal(t, uint64(3), nodes[addr1].StakingAmount)
+	assert.Equal(t, time.Unix(100, 0), nodes[addr1].IdleTimeout)
+	assert.True(t, nodes[addr1].PausedTimeout.IsZero())
+
+	assert.Equal(t, valset.ValPaused, nodes[addr2].State)
+	assert.Equal(t, uint64(4), nodes[addr2].StakingAmount)
+	assert.Equal(t, time.Unix(200, 0), nodes[addr2].PausedTimeout)
+	assert.True(t, nodes[addr2].IdleTimeout.IsZero())
+
+	assert.Equal(t, valset.ValActive, nodes[addr3].State)
+	assert.Equal(t, uint64(5), nodes[addr3].StakingAmount)
+	assert.True(t, nodes[addr3].IdleTimeout.IsZero())
+	assert.True(t, nodes[addr3].PausedTimeout.IsZero())
+}
+
+func TestNewNodeMapFromABv2LengthMismatch(t *testing.T) {
+	_, err := NewNodeMapFromABv2([]multicall.Profile{{}}, nil)
+	require.ErrorContains(t, err, "profile/staking amount length mismatch")
+}
+
+func TestABv2SnapshotTransitionParam(t *testing.T) {
+	snapshot := &ABv2Snapshot{
+		ABv2TransitionParam: ABv2TransitionParam{
+			EpochVACount:            10,
+			PfsThreshold:            20,
+			CfsThreshold:            30,
+			IdleTimeout:             40 * time.Second,
+			PauseTimeout:            50 * time.Second,
+			MaxValActivePausedCount: 60,
+		},
+	}
+
+	param := snapshot.TransitionParam()
+
+	assert.Equal(t, uint64(10), param.EpochVACount)
+	assert.Equal(t, uint64(20), param.PfsThreshold)
+	assert.Equal(t, uint64(30), param.CfsThreshold)
+	assert.Equal(t, 40*time.Second, param.IdleTimeout)
+	assert.Equal(t, 50*time.Second, param.PauseTimeout)
+	assert.Equal(t, uint64(60), param.MaxValActivePausedCount)
+}

--- a/kaiax/valset/impl/blockstate.go
+++ b/kaiax/valset/impl/blockstate.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
+)
+
+// InitializeState writes the post-fork node-state diff into the
+// AddressBookV2 contract via a system tx. No-op pre-fork. Runs before user
+// transactions while statedb still represents parent state.
+func (v *ValsetModule) InitializeState(header *types.Header, statedb *state.StateDB) {
+	config := v.Chain.Config()
+	if !config.IsPermissionlessForkEnabled(header.Number) {
+		return
+	}
+	context := blockchain.NewEVMBlockContext(header, v.Chain, nil)
+	vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, config, &vm.Config{})
+	if err := v.WriteTransitionToABv2(vmenv, header, statedb); err != nil {
+		logger.Error("Failed to apply node transition to ABv2", "number", header.Number.Uint64(), "err", err)
+	}
+}
+
+// FinalizeState installs and initializes the AddressBookV2 proxy at the HF-1
+// block. Runs after user transactions so the install is the last thing in the
+// block's state root. No-op outside that single block.
+func (v *ValsetModule) FinalizeState(header *types.Header, statedb *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) error {
+	config := v.Chain.Config()
+	if !config.IsPermissionlessForkBlockParent(header.Number) {
+		return nil
+	}
+	context := blockchain.NewEVMBlockContext(header, v.Chain, nil)
+	vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, config, &vm.Config{})
+	return v.InstallABv2(vmenv, header, statedb)
+}

--- a/kaiax/valset/impl/error.go
+++ b/kaiax/valset/impl/error.go
@@ -47,3 +47,7 @@ var (
 func ErrNoIstanbulSnapshot(num uint64) error {
 	return fmt.Errorf("no istanbul snapshot at block %d", num)
 }
+
+func errParentHeaderNotFound(num uint64) error {
+	return fmt.Errorf("parent header not found for block %d", num)
+}

--- a/kaiax/valset/impl/execution.go
+++ b/kaiax/valset/impl/execution.go
@@ -46,6 +46,7 @@ func (v *ValsetModule) PostInsertBlock(block *types.Block) error {
 func (v *ValsetModule) RewindTo(block *types.Block) {
 	trimValidatorVoteBlockNums(v.ChainKv, block.Header().Number.Uint64())
 	v.validatorVoteBlockNumsCache = nil
+	v.transitionResultCache.Purge()
 }
 
 func (v *ValsetModule) RewindDelete(hash common.Hash, num uint64) {

--- a/kaiax/valset/impl/execution.go
+++ b/kaiax/valset/impl/execution.go
@@ -46,7 +46,6 @@ func (v *ValsetModule) PostInsertBlock(block *types.Block) error {
 func (v *ValsetModule) RewindTo(block *types.Block) {
 	trimValidatorVoteBlockNums(v.ChainKv, block.Header().Number.Uint64())
 	v.validatorVoteBlockNumsCache = nil
-	v.transitionResultCache.Purge()
 }
 
 func (v *ValsetModule) RewindDelete(hash common.Hash, num uint64) {

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -134,6 +134,7 @@ func (v *ValsetModule) Start() error {
 	// Reset all caches
 	v.proposerListCache.Purge()
 	v.removeVotesCache.Purge()
+	v.transitionResultCache.Purge()
 
 	// Reset the quit state.
 	v.quit.Store(0)

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -52,7 +52,7 @@ type InitOpts struct {
 	Chain         consensus.ChainReaderWithSealer
 	GovModule     gov.GovModule
 	StakingModule staking.StakingModule
-	VRankModule   vrank.VRankModule // optional, nil before permissionless fork
+	VRankModule   vrank.VRankModule
 }
 
 type ValsetModule struct {

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/staking"
 	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/storage/database"
 )
@@ -51,6 +52,7 @@ type InitOpts struct {
 	Chain         consensus.ChainReaderWithSealer
 	GovModule     gov.GovModule
 	StakingModule staking.StakingModule
+	VRankModule   vrank.VRankModule // optional, nil before permissionless fork
 }
 
 type ValsetModule struct {
@@ -60,9 +62,10 @@ type ValsetModule struct {
 	wg   sync.WaitGroup
 
 	// cache for weightedRandom and uniformRandom proposerLists.
-	proposerListCache *lru.Cache // uint64 -> []common.Address
-	removeVotesCache  *lru.Cache // uint64 -> removeVoteList
-	councilCache      *lru.Cache // uint64 -> *valset.AddressSet
+	proposerListCache     *lru.Cache // uint64 -> []common.Address
+	removeVotesCache      *lru.Cache // uint64 -> removeVoteList
+	councilCache          *lru.Cache // uint64 -> *valset.AddressSet
+	transitionResultCache *lru.Cache // uint64 -> *TransitionResult (permissionless)
 
 	validatorVoteBlockNumsCache []uint64
 	lowestScannedVoteNumCache   *uint64
@@ -72,10 +75,12 @@ func NewValsetModule() *ValsetModule {
 	pListCache, _ := lru.New(128)
 	rVoteCache, _ := lru.New(128)
 	councilCache, _ := lru.New(128)
+	transitionResultCache, _ := lru.New(128)
 	return &ValsetModule{
-		proposerListCache: pListCache,
-		removeVotesCache:  rVoteCache,
-		councilCache:      councilCache,
+		proposerListCache:     pListCache,
+		removeVotesCache:      rVoteCache,
+		councilCache:          councilCache,
+		transitionResultCache: transitionResultCache,
 	}
 }
 

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -65,6 +65,7 @@ func (v *ValsetModule) getTransitionResult(num uint64, parentStatedb *state.Stat
 	if cached, ok := v.transitionResultCache.Get(num); ok {
 		return cached.(*TransitionResult), nil
 	}
+
 	parentHeader := v.Chain.GetHeaderByNumber(num - 1)
 	if parentHeader == nil {
 		return nil, errParentHeaderNotFound(num)
@@ -86,31 +87,31 @@ func (v *ValsetModule) getTransitionResult(num uint64, parentStatedb *state.Stat
 //
 // Caller must ensure statedb == StateAt(header.Root).
 func (v *ValsetModule) applyTransition(header *types.Header, statedb *state.StateDB) (*TransitionResult, error) {
-	headNum := header.Number.Uint64()
-	nextNum := headNum + 1
-
-	// ABv2 read from state `headNum`
+	// ABv2 read from state(header.Root), i.e. ABv2(N).
 	abv2result, err := system.ReadABv2Snapshot(statedb, v.Chain, header)
 	if err != nil {
 		return nil, err
 	}
 	abv2result.Nodes.MarkSuspended(abv2result.SuspendedValidators)
 
-	// Gov read from `nextNum`
-	pset := v.GovModule.GetParamSet(nextNum)
+	ctx := v.newTransitionContext(header, abv2result)
+	return ctx.ApplyAllTransitions(abv2result.Nodes), nil
+}
 
-	// VRank reads `headNum` (fail-open via nil maps on error).
+func (v *ValsetModule) newTransitionContext(header *types.Header, abv2result *system.ABv2Snapshot) *TransitionContext {
+	headNum := header.Number.Uint64()
+	nextNum := headNum + 1
+
+	pset := v.GovModule.GetParamSet(nextNum)
 	cfs, pfs, pfReport := v.fetchVRankCtx(headNum)
 
-	// Build the transition context.
 	ctx := NewTransitionContext()
 	ctx.SetBlockCtx(header, v.isVrankEpoch(nextNum))
 	ctx.SetGovCtx(pset)
 	ctx.SetABv2TransitionParam(abv2result.TransitionParam())
 	ctx.SetSlotsCtx(slotLimitsFor(abv2result.EpochVACount))
 	ctx.SetVRankCtx(cfs, pfs, pfReport)
-
-	return ctx.ApplyAllTransitions(abv2result.Nodes), nil
+	return ctx
 }
 
 // fetchVRankCtx pulls the three vrank scores transitions need at block num.

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -114,8 +114,7 @@ func (v *ValsetModule) applyTransition(header *types.Header, statedb *state.Stat
 }
 
 // fetchVRankCtx pulls the three vrank scores transitions need at block num.
-// Errors are swallowed here so the orchestrator stays robust to transient
-// vrank failures; the resulting nil/empty maps cause transitions to fail open.
+// Errors are swallowed here so the orchestrator stays robust to transient vrank failures.
 func (v *ValsetModule) fetchVRankCtx(num uint64) (cfs, pfs map[common.Address]uint64, pfReport []common.Address) {
 	if v.VRankModule == nil {
 		logger.Error("VRankModule is nil")
@@ -155,8 +154,8 @@ func (v *ValsetModule) isVrankEpoch(num uint64) bool {
 // WriteTransitionToABv2 computes the node-state transition for the current
 // block and writes any diffs to AddressBookV2 via SystemTx (ABv2.processSystemTransition).
 // No-op pre-fork.
-// WriteTransitionToABv2(n) is for generating the next block.
-// WriteTransitionToABv2(n) = Write NodeStates(N) - NodeStates(N-1) at Initialize(N).
+// WriteTransitionToABv2(N) is for generating the next block.
+// WriteTransitionToABv2(N) = Write NodeStates(N) - NodeStates(N-1) at Initialize(N).
 func (v *ValsetModule) WriteTransitionToABv2(
 	vmenv *vm.EVM,
 	header *types.Header,

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -123,21 +123,21 @@ func (v *ValsetModule) fetchVRankCtx(num uint64) (cfs, pfs map[common.Address]ui
 	if nextNum := num + 1; v.isVrankEpoch(nextNum) {
 		c, err := v.VRankModule.GetCFS(num)
 		if err != nil {
-			logger.Warn("fetchVRankCtx: GetCFS failed", "num", num, "err", err)
+			logger.Error("fetchVRankCtx: GetCFS failed", "num", num, "err", err)
 		} else {
 			cfs = c
 		}
 	}
 	r, err := v.VRankModule.GetPfReport(num)
 	if err != nil {
-		logger.Warn("fetchVRankCtx: GetPfReport failed", "num", num, "err", err)
+		logger.Error("fetchVRankCtx: GetPfReport failed", "num", num, "err", err)
 	} else {
 		pfReport = r
 	}
 	if len(pfReport) > 0 {
 		p, err := v.VRankModule.GetPFS(num)
 		if err != nil {
-			logger.Warn("fetchVRankCtx: GetPFS failed", "num", num, "err", err)
+			logger.Error("fetchVRankCtx: GetPFS failed", "num", num, "err", err)
 		} else {
 			pfs = p
 		}

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -46,6 +46,23 @@ func (v *ValsetModule) getNodes(num uint64) (valset.NodeMap, error) {
 	if cached, ok := v.transitionResultCache.Get(num); ok {
 		return cached.(*TransitionResult).Nodes, nil
 	}
+	if num == 0 {
+		// Block 0 has no parent; read ABv2 directly from genesis state.
+		genesisHeader := v.Chain.GetHeaderByNumber(0)
+		if genesisHeader == nil {
+			return nil, errParentHeaderNotFound(num)
+		}
+		statedb, err := v.Chain.StateAt(genesisHeader.Root)
+		if err != nil {
+			return nil, fmt.Errorf("StateAt(%d) failed: %w", num, err)
+		}
+		result, err := system.ReadABv2Snapshot(statedb, v.Chain, genesisHeader)
+		if err != nil {
+			return nil, err
+		}
+		result.Nodes.MarkSuspended(result.SuspendedValidators)
+		return result.Nodes, nil
+	}
 	parentHeader := v.Chain.GetHeaderByNumber(num - 1)
 	if parentHeader == nil {
 		return nil, errParentHeaderNotFound(num)
@@ -62,6 +79,9 @@ func (v *ValsetModule) getNodes(num uint64) (valset.NodeMap, error) {
 }
 
 func (v *ValsetModule) getTransitionResult(num uint64, parentStatedb *state.StateDB) (*TransitionResult, error) {
+	if num == 0 {
+		return nil, errParentHeaderNotFound(num)
+	}
 	if cached, ok := v.transitionResultCache.Get(num); ok {
 		return cached.(*TransitionResult), nil
 	}

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -106,11 +106,11 @@ func (v *ValsetModule) applyTransition(header *types.Header, statedb *state.Stat
 	ctx := NewTransitionContext()
 	ctx.SetBlockCtx(header, v.isVrankEpoch(nextNum))
 	ctx.SetGovCtx(pset)
-	ctx.SetABv2Ctx(abv2result)
+	ctx.SetABv2TransitionParam(abv2result.TransitionParam())
 	ctx.SetSlotsCtx(slotLimitsFor(abv2result.EpochVACount))
 	ctx.SetVRankCtx(cfs, pfs, pfReport)
 
-	return ctx.ApplyAllTransitions(), nil
+	return ctx.ApplyAllTransitions(abv2result.Nodes), nil
 }
 
 // fetchVRankCtx pulls the three vrank scores transitions need at block num.

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -1,0 +1,285 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/system"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/valset"
+)
+
+const (
+	DefaultValPausedTimeout        = time.Hour * 8
+	DefaultValIdleTimeout          = 30 * 24 * time.Hour
+	DefaultMaxNodeCount            = 100
+	DefaultMaxValActivePausedCount = 50
+)
+
+// #region getter
+
+// getNodes returns the transitioned node map for producing block `num`.
+// Resolves parent state from chain (StateAt(parent.Root)). Use this for
+// post-commit reads (RPC, peer set queries).
+func (v *ValsetModule) getNodes(num uint64) (valset.NodeMap, error) {
+	if cached, ok := v.transitionResultCache.Get(num); ok {
+		return cached.(*TransitionResult).Nodes, nil
+	}
+	parentHeader := v.Chain.GetHeaderByNumber(num - 1)
+	if parentHeader == nil {
+		return nil, errParentHeaderNotFound(num)
+	}
+	parentStatedb, err := v.Chain.StateAt(parentHeader.Root)
+	if err != nil {
+		return nil, fmt.Errorf("StateAt(%d) failed: %w", num-1, err)
+	}
+	result, err := v.getTransitionResult(num, parentStatedb)
+	if err != nil {
+		return nil, err
+	}
+	return result.Nodes, nil
+}
+
+func (v *ValsetModule) getTransitionResult(num uint64, parentStatedb *state.StateDB) (*TransitionResult, error) {
+	if cached, ok := v.transitionResultCache.Get(num); ok {
+		return cached.(*TransitionResult), nil
+	}
+	parentHeader := v.Chain.GetHeaderByNumber(num - 1)
+	if parentHeader == nil {
+		return nil, errParentHeaderNotFound(num)
+	}
+	result, err := v.applyTransition(parentHeader, parentStatedb)
+	if err != nil {
+		return nil, err
+	}
+	v.transitionResultCache.Add(num, result)
+	return result, nil
+}
+
+// applyTransition does all chain/contract/gov/vrank reads and invokes applyTr(N).
+// The argument header number `N` is used as an input to generate the next block.
+// That is, it produces NodeStates(N+1).
+// applyTransition(header(N), state(N)) = ABv2(N) + applyTr(N)
+//
+//	= ABv2(N) + Block(N) + Gov(N+1) + isVrankEpoch(N+1) + GetCFS(N) + GetPFS(N) + GetPfReport(N)
+//
+// Caller must ensure statedb == StateAt(header.Root).
+func (v *ValsetModule) applyTransition(header *types.Header, statedb *state.StateDB) (*TransitionResult, error) {
+	headNum := header.Number.Uint64()
+	nextNum := headNum + 1
+
+	// ABv2 read from state `headNum`
+	abv2result, err := system.ReadNodeStates(statedb, v.Chain, header)
+	if err != nil {
+		return nil, err
+	}
+	abv2result.Nodes.MarkSuspended(abv2result.SuspendedValidators)
+
+	// Gov read from `nextNum`
+	pset := v.GovModule.GetParamSet(nextNum)
+
+	// VRank reads `headNum` (fail-open via nil maps on error).
+	cfs, pfs, pfReport := v.fetchVRankCtx(headNum)
+
+	// Build the transition context.
+	ctx := NewTransitionContext()
+	ctx.SetBlockCtx(header, v.isVrankEpoch(nextNum))
+	ctx.SetGovCtx(pset)
+	ctx.SetABv2Ctx(abv2result)
+	ctx.SetSlotsCtx(slotLimitsFor(abv2result.EpochVACount))
+	ctx.SetVRankCtx(cfs, pfs, pfReport)
+
+	return ctx.ApplyAllTransitions(), nil
+}
+
+// fetchVRankCtx pulls the three vrank scores transitions need at block num.
+// Errors are swallowed here so the orchestrator stays robust to transient
+// vrank failures; the resulting nil/empty maps cause transitions to fail open.
+func (v *ValsetModule) fetchVRankCtx(num uint64) (cfs, pfs map[common.Address]uint64, pfReport []common.Address) {
+	if v.VRankModule == nil {
+		logger.Error("VRankModule is nil")
+		return nil, nil, nil
+	}
+	if nextNum := num + 1; v.isVrankEpoch(nextNum) {
+		c, err := v.VRankModule.GetCFS(num)
+		if err != nil {
+			logger.Warn("fetchVRankCtx: GetCFS failed", "num", num, "err", err)
+		} else {
+			cfs = c
+		}
+	}
+	r, err := v.VRankModule.GetPfReport(num)
+	if err != nil {
+		logger.Warn("fetchVRankCtx: GetPfReport failed", "num", num, "err", err)
+	} else {
+		pfReport = r
+	}
+	if len(pfReport) > 0 {
+		p, err := v.VRankModule.GetPFS(num)
+		if err != nil {
+			logger.Warn("fetchVRankCtx: GetPFS failed", "num", num, "err", err)
+		} else {
+			pfs = p
+		}
+	}
+	return cfs, pfs, pfReport
+}
+
+func (v *ValsetModule) isVrankEpoch(num uint64) bool {
+	return num%v.Chain.Config().VRankEpoch == 0
+}
+
+// #region writer
+
+// WriteTransitionToABv2 computes the node-state transition for the current
+// block and writes any diffs to AddressBookV2 via SystemTx (ABv2.processSystemTransition).
+// No-op pre-fork.
+// WriteTransitionToABv2(n) is for generating the next block.
+// WriteTransitionToABv2(n) = Write NodeStates(N) - NodeStates(N-1) at Initialize(N).
+func (v *ValsetModule) WriteTransitionToABv2(
+	vmenv *vm.EVM,
+	header *types.Header,
+	state *state.StateDB,
+) error {
+	config := v.Chain.Config()
+	if !config.IsPermissionlessForkEnabled(header.Number) {
+		return nil
+	}
+	return v.writeTransitionToABv2(vmenv, header, state)
+}
+
+// writeTransitionToABv2 computes the diff between NodeStates(N-1) and NodeStates(N),
+// and writes only the changed nodes to AddressBookV2 via SystemTx (ABv2.processSystemTransition).
+// At epoch blocks, the call is always made (even with empty diff) to update the epochVACount snapshot.
+func (v *ValsetModule) writeTransitionToABv2(
+	vmenv *vm.EVM,
+	header *types.Header,
+	statedb *state.StateDB,
+) error {
+	num := header.Number.Uint64()
+	tr, err := v.getTransitionResult(num, statedb)
+	if err != nil {
+		return err
+	}
+
+	// Compute diff against committed ABv2(N-1) to get only applyTr(N-1) changes.
+	parentHeader := v.Chain.GetHeaderByNumber(num - 1)
+	if parentHeader == nil {
+		return errParentHeaderNotFound(num)
+	}
+	parentRes, err := system.ReadNodeStates(statedb, v.Chain, parentHeader)
+	if err != nil {
+		return fmt.Errorf("failed to read ABv2(N-1): %w", err)
+	}
+	diff := diffNodeStates(parentRes.Nodes, tr.Nodes)
+
+	// Skip the call if no changes and not an epoch block (epoch blocks need
+	// the epochVACount snapshot update regardless)
+	if len(diff) == 0 && !v.isVrankEpoch(num) {
+		return nil
+	}
+
+	config := v.Chain.Config()
+	from, msg, err := system.EncodeNodeStateUpdate(config.Rules(header.Number), diff, tr.epochVACountForWrite)
+	if err != nil {
+		logger.Error("Failed to encode processSystemTransition", "number", header.Number.Uint64(), "err", err.Error(), "nodes", diff.String())
+		return err
+	}
+	if ret, err := blockchain.SystemTxCall(msg, from, header, vmenv, statedb, config.Rules(header.Number)); err != nil {
+		return fmt.Errorf("processSystemTransition failed: %w (ret=%s)", err, common.Bytes2Hex(ret))
+	}
+	return nil
+}
+
+// diffNodeStates returns nodes whose state or timeout changed between parent and current.
+// Other Node fields are intentionally omitted: processSystemTransition writes
+// only lifecycle state and timeoutAt. StakingAmount comes from staking reads,
+// and Suspended is derived from ABv2's suspended validator list.
+func diffNodeStates(parent, current valset.NodeMap) valset.NodeMap {
+	diff := make(valset.NodeMap)
+	for addr, cur := range current {
+		prev, exists := parent[addr]
+		if !exists || prev.State != cur.State || prev.IdleTimeout != cur.IdleTimeout || prev.PausedTimeout != cur.PausedTimeout {
+			copied := *cur
+			diff[addr] = &copied
+		}
+	}
+	return diff
+}
+
+// InstallABv2 installs and initializes the AddressBookV2 proxy at the
+// HF-1 block's Finalize step. No-op outside that single block.
+func (v *ValsetModule) InstallABv2(
+	vmenv *vm.EVM,
+	header *types.Header,
+	statedb *state.StateDB,
+) error {
+	config := v.Chain.Config()
+	if !config.IsPermissionlessForkBlockParent(header.Number) {
+		return nil
+	}
+	return v.installAndInitializeABv2(vmenv, header, statedb)
+}
+
+// installAndInitializeABv2 deploys and initializes ABv2 at the hardfork block.
+func (v *ValsetModule) installAndInitializeABv2(
+	vmenv *vm.EVM,
+	header *types.Header,
+	statedb *state.StateDB,
+) error {
+	config := v.Chain.Config()
+
+	// Read ABv2 implementation address from ABv2DataContract (pre-deployed by governance).
+	backend, err := backends.NewStateBlockchainContractBackend(v.Chain, statedb)
+	if err != nil {
+		return fmt.Errorf("create contract backend: %w", err)
+	}
+	// nil block number → caller uses CurrentBlock (parent), since the current
+	// block isn't committed yet.
+	implAddr, err := system.ReadABv2Implementation(backend, nil)
+	if err != nil {
+		logger.Error("Failed to read ABv2 implementation", "number", header.Number, "err", err)
+		return err
+	}
+
+	if err := system.InstallAddressBookV2(statedb, implAddr); err != nil {
+		logger.Error("Failed to install AddressBookV2", "number", header.Number, "err", err.Error())
+		return err
+	}
+	logger.Info("Installed AddressBookV2", "number", header.Number, "impl", implAddr.Hex())
+
+	// ABv2.initialize() reads all genesis data from ABv2DataContract via Registry(0x401).
+	from, msg, err := system.EncodeInitializeABv2(config.Rules(header.Number))
+	if err != nil {
+		logger.Error("Failed to encode initialize ABv2", "number", header.Number, "err", err.Error())
+		return err
+	}
+	if ret, evmErr := blockchain.SystemTxCall(msg, from, header, vmenv, statedb, config.Rules(header.Number)); evmErr != nil {
+		logger.Error("Failed to call initialize ABv2", "number", header.Number, "err", evmErr, "ret", common.Bytes2Hex(ret))
+		return evmErr
+	}
+
+	logger.Info("Initialized AddressBookV2", "number", header.Number)
+	return nil
+}

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -201,7 +201,7 @@ func (v *ValsetModule) writeTransitionToABv2(
 	}
 
 	config := v.Chain.Config()
-	from, msg, err := system.EncodeNodeStateUpdate(config.Rules(header.Number), diff, tr.epochVACountForWrite)
+	from, msg, err := system.EncodeProcessSystemTransition(config.Rules(header.Number), diff, tr.epochVACountForWrite)
 	if err != nil {
 		logger.Error("Failed to encode processSystemTransition", "number", header.Number.Uint64(), "err", err.Error(), "nodes", diff.String())
 		return err

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -242,8 +242,7 @@ func diffNodeStates(parent, current valset.NodeMap) valset.NodeMap {
 	for addr, cur := range current {
 		prev, exists := parent[addr]
 		if !exists || prev.State != cur.State || prev.IdleTimeout != cur.IdleTimeout || prev.PausedTimeout != cur.PausedTimeout {
-			copied := *cur
-			diff[addr] = &copied
+			diff[addr] = cur.Copy()
 		}
 	}
 	return diff

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -90,7 +90,7 @@ func (v *ValsetModule) applyTransition(header *types.Header, statedb *state.Stat
 	nextNum := headNum + 1
 
 	// ABv2 read from state `headNum`
-	abv2result, err := system.ReadNodeStates(statedb, v.Chain, header)
+	abv2result, err := system.ReadABv2Snapshot(statedb, v.Chain, header)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (v *ValsetModule) writeTransitionToABv2(
 	if parentHeader == nil {
 		return errParentHeaderNotFound(num)
 	}
-	parentRes, err := system.ReadNodeStates(statedb, v.Chain, parentHeader)
+	parentRes, err := system.ReadABv2Snapshot(statedb, v.Chain, parentHeader)
 	if err != nil {
 		return fmt.Errorf("failed to read ABv2(N-1): %w", err)
 	}

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -86,6 +86,7 @@ func (v *ValsetModule) getTransitionResult(num uint64, parentStatedb *state.Stat
 		return cached.(*TransitionResult), nil
 	}
 
+	// Read ABv2(N-1) + apply transitions for block N
 	parentHeader := v.Chain.GetHeaderByNumber(num - 1)
 	if parentHeader == nil {
 		return nil, errParentHeaderNotFound(num)

--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -60,7 +60,7 @@ type GovContext struct {
 	MinStake uint64 // Used by: epoch, violation
 }
 
-// ABv2Context is a subset of NodeStatesResult which holds values read from
+// ABv2Context is a subset of ABv2StateSnapshot which holds values read from
 // system.ReadNodeStates against the AddressBookV2 contract.
 type ABv2Context struct {
 	Nodes        valset.NodeMap // pipeline input. Used by: epoch, violation, timeout
@@ -89,12 +89,11 @@ type VRankContext struct {
 }
 
 // TransitionResult is the output of the orchestrator's transition pipeline.
-// EpochVACount is the count of ValActive after applyEpochTransition (before
-// violation); 0 for non-epoch blocks. The orchestrator writes it back to the
-// AddressBookV2 contract via processSystemTransition.
+// epochVACountForWrite is set only for epoch blocks, where it is written back
+// to AddressBookV2 via processSystemTransition.
 type TransitionResult struct {
-	Nodes        valset.NodeMap
-	EpochVACount uint64
+	Nodes                valset.NodeMap
+	epochVACountForWrite uint64
 }
 
 func NewTransitionContext() *TransitionContext {
@@ -114,9 +113,9 @@ func (ctx *TransitionContext) SetGovCtx(pset gov.ParamSet) {
 	}
 }
 
-func (ctx *TransitionContext) SetABv2Ctx(r *system.NodeStatesResult) {
+func (ctx *TransitionContext) SetABv2Ctx(r *system.ABv2StateSnapshot) {
 	ctx.ABv2Context = ABv2Context{
-		Nodes:                   r.Validators,
+		Nodes:                   r.Nodes,
 		EpochVACount:            r.EpochVACount,
 		PfsThreshold:            r.PfsThreshold,
 		CfsThreshold:            r.CfsThreshold,
@@ -151,24 +150,24 @@ func (ctx *TransitionContext) SetVRankCtx(cfs, pfs map[common.Address]uint64, pf
 // this call — the orchestrator pre-populates ctx and slot math is computed in
 // Go (see slot_math.go), so this method stays free of I/O.
 //
-// Returns the final NodeMap and the epoch VA count (0 on non-epoch blocks).
+// Returns the final NodeMap and, on epoch blocks, the epoch VA count to write.
 func (ctx *TransitionContext) ApplyAllTransitions() *TransitionResult {
 	nodes := ctx.Nodes
-	epochVACount := ctx.EpochVACount
+	epochVACountForWrite := uint64(0)
 
 	if ctx.IsEpoch {
 		nodes = ctx.applyEpochTransition(nodes)
 		// After the epoch transition the active-validator count changes, so
 		// slot limits must be recomputed before violation runs.
-		epochVACount = nodes.CountByState(valset.ValActive)
-		ctx.SetSlotsCtx(slotLimitsFor(epochVACount))
+		epochVACountForWrite = nodes.CountByState(valset.ValActive)
+		ctx.SetSlotsCtx(slotLimitsFor(epochVACountForWrite))
 	}
 	nodes = ctx.applyViolationTransition(nodes)
 	nodes = ctx.applyTimeoutTransition(nodes)
 
 	return &TransitionResult{
-		Nodes:        nodes,
-		EpochVACount: epochVACount,
+		Nodes:                nodes,
+		epochVACountForWrite: epochVACountForWrite,
 	}
 }
 
@@ -408,7 +407,8 @@ func (ctx *TransitionContext) applyTimeoutTransition(m valset.NodeMap) valset.No
 }
 
 // #region SlotMath
-// Slot limit calculations for validator state transitions. Go port of
+//
+// Slot limit calculations for node state transitions. Go port of
 // contracts_permissionless/contracts/libraries/SlotMath.sol — kept in lockstep
 // with that contract since the orchestrator and ABv2 must agree on slot math.
 //
@@ -423,7 +423,7 @@ func (ctx *TransitionContext) applyTimeoutTransition(m valset.NodeMap) valset.No
 //	minActiveCount   = n
 //	maxSlotAvailable = 0
 
-// minActiveCount returns the minimum number of active validators required for
+// minActiveCount returns the minimum number of active nodes required for
 // BFT liveness given epochVACount n.
 func minActiveCount(n uint64) uint64 {
 	if n < 4 {
@@ -432,7 +432,7 @@ func minActiveCount(n uint64) uint64 {
 	return (2*n + 2) / 3
 }
 
-// maxSlotAvailable returns the maximum number of validators allowed in
+// maxSlotAvailable returns the maximum number of nodes allowed in
 // ValPaused or ValExiting state each given epochVACount n.
 func maxSlotAvailable(n uint64) uint64 {
 	if n < 4 {

--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -35,7 +35,7 @@ import (
 // EpochTransitionContext is overwritten after epoch transition.
 //   - BlockContext           — header-derived
 //   - GovContext             — governance parameters
-//   - ABv2Context            — AddressBookV2 contract reads
+//   - ABv2TransitionParam    — AddressBookV2 transition parameters
 //   - EpochTransitionContext — slot limits derived from epochVACount; recomputed
 //     mid-pipeline at epoch boundaries by the orchestrator.
 //   - VRankContext           — vrank scores pre-fetched at orchestrator entry
@@ -44,7 +44,7 @@ import (
 type TransitionContext struct {
 	BlockContext
 	GovContext
-	ABv2Context
+	system.ABv2TransitionParam
 	EpochTransitionContext
 	VRankContext
 }
@@ -58,19 +58,6 @@ type BlockContext struct {
 // GovContext holds required governance parameters.
 type GovContext struct {
 	MinStake uint64 // Used by: epoch, violation
-}
-
-// ABv2Context is a subset of ABv2StateSnapshot which holds values read from
-// system.ReadNodeStates against the AddressBookV2 contract.
-type ABv2Context struct {
-	Nodes        valset.NodeMap // pipeline input. Used by: epoch, violation, timeout
-	EpochVACount uint64         // pipeline initial value. Used by: epoch (carried through on non-epoch blocks)
-
-	PfsThreshold            uint64        // Used by: violation
-	CfsThreshold            uint64        // Used by: epoch
-	IdleTimeout             time.Duration // Used by: epoch, violation, timeout
-	PauseTimeout            time.Duration // Used by: timeout
-	MaxValActivePausedCount uint64        // Used by: epoch
 }
 
 // EpochTransitionContext holds slot-limit values derived from the current
@@ -113,16 +100,8 @@ func (ctx *TransitionContext) SetGovCtx(pset gov.ParamSet) {
 	}
 }
 
-func (ctx *TransitionContext) SetABv2Ctx(r *system.ABv2StateSnapshot) {
-	ctx.ABv2Context = ABv2Context{
-		Nodes:                   r.Nodes,
-		EpochVACount:            r.EpochVACount,
-		PfsThreshold:            r.PfsThreshold,
-		CfsThreshold:            r.CfsThreshold,
-		IdleTimeout:             r.IdleTimeout,
-		PauseTimeout:            r.PauseTimeout,
-		MaxValActivePausedCount: r.MaxValActivePausedCount,
-	}
+func (ctx *TransitionContext) SetABv2TransitionParam(param system.ABv2TransitionParam) {
+	ctx.ABv2TransitionParam = param
 }
 
 func (ctx *TransitionContext) SetSlotsCtx(maxSlot, minActive uint64) {
@@ -151,8 +130,7 @@ func (ctx *TransitionContext) SetVRankCtx(cfs, pfs map[common.Address]uint64, pf
 // Go (see slot_math.go), so this method stays free of I/O.
 //
 // Returns the final NodeMap and, on epoch blocks, the epoch VA count to write.
-func (ctx *TransitionContext) ApplyAllTransitions() *TransitionResult {
-	nodes := ctx.Nodes
+func (ctx *TransitionContext) ApplyAllTransitions(nodes valset.NodeMap) *TransitionResult {
 	epochVACountForWrite := uint64(0)
 
 	if ctx.IsEpoch {
@@ -174,7 +152,7 @@ func (ctx *TransitionContext) ApplyAllTransitions() *TransitionResult {
 // applyEpochTransition returns a new NodeMap with the KIP-286 epoch transition
 // applied to m. Pure: m is not mutated.
 //
-// Reads from ABv2Context:  IdleTimeout, MaxValActivePausedCount, CfsThreshold.
+// Reads from ABv2TransitionParam: IdleTimeout, MaxValActivePausedCount, CfsThreshold.
 // Reads from GovContext:   MinStake.
 // Reads from BlockContext: BlockTime.
 // Reads from VRankContext: CFS (via isPassVrankTest).
@@ -266,7 +244,7 @@ func (ctx *TransitionContext) isPassVrankTest(addr common.Address) bool {
 // applyViolationTransition returns a new NodeMap with min-stake and PFS violation
 // transitions applied to m. Pure: m is not mutated. Runs every block.
 //
-// Reads from ABv2Context:            PfsThreshold, IdleTimeout.
+// Reads from ABv2TransitionParam:    PfsThreshold, IdleTimeout.
 // Reads from EpochTransitionContext: MaxSlotAvailable, MinActiveCount.
 // Reads from GovContext:             MinStake.
 // Reads from BlockContext:           BlockTime.
@@ -373,7 +351,7 @@ func (ctx *TransitionContext) applyViolationTransition(m valset.NodeMap) valset.
 // For nodes newly entering ValReady/ValInactive or ValPaused (timeout not yet
 // set), the timeout is initialized. Existing timeouts are preserved.
 //
-// Reads from ABv2Context:  IdleTimeout, PauseTimeout.
+// Reads from ABv2TransitionParam: IdleTimeout, PauseTimeout.
 // Reads from BlockContext: BlockTime.
 //
 // Internal use only — call via the orchestrator after applyViolationTransition.

--- a/kaiax/valset/impl/transition_context_test.go
+++ b/kaiax/valset/impl/transition_context_test.go
@@ -111,7 +111,7 @@ func buildCtx(t *testing.T, opts ctxOpts) *TransitionContext {
 	ctx := NewTransitionContext()
 	ctx.SetBlockCtx(header, false)
 	ctx.SetGovCtx(gov.ParamSet{MinimumStake: new(big.Int).SetUint64(opts.MinStake)})
-	ctx.SetABv2Ctx(&system.NodeStatesResult{
+	ctx.SetABv2Ctx(&system.ABv2StateSnapshot{
 		PfsThreshold:            opts.PfsThreshold,
 		CfsThreshold:            opts.CfsThreshold,
 		IdleTimeout:             opts.IdleTimeout,

--- a/kaiax/valset/impl/transition_context_test.go
+++ b/kaiax/valset/impl/transition_context_test.go
@@ -111,7 +111,7 @@ func buildCtx(t *testing.T, opts ctxOpts) *TransitionContext {
 	ctx := NewTransitionContext()
 	ctx.SetBlockCtx(header, false)
 	ctx.SetGovCtx(gov.ParamSet{MinimumStake: new(big.Int).SetUint64(opts.MinStake)})
-	ctx.SetABv2Ctx(&system.ABv2StateSnapshot{
+	ctx.SetABv2TransitionParam(system.ABv2TransitionParam{
 		PfsThreshold:            opts.PfsThreshold,
 		CfsThreshold:            opts.CfsThreshold,
 		IdleTimeout:             opts.IdleTimeout,

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -53,6 +53,26 @@ func TestGetNodesCache(t *testing.T) {
 		assert.Equal(t, cached, nodes)
 	})
 
+	t.Run("genesis reads genesis state", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		root := common.HexToHash("0x1234")
+		genesisHeader := &types.Header{Number: big.NewInt(0), Root: root}
+		stateErr := errors.New("state unavailable")
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().GetHeaderByNumber(uint64(0)).Return(genesisHeader)
+		mockChain.EXPECT().StateAt(root).Return(nil, stateErr)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		nodes, err := v.getNodes(0)
+		require.Nil(t, nodes)
+		require.ErrorIs(t, err, stateErr)
+	})
+
 	t.Run("no cache hit", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -90,6 +110,14 @@ func TestGetTransitionResultCache(t *testing.T) {
 		result, err := v.getTransitionResult(10, nil)
 		require.NoError(t, err)
 		require.Same(t, cached, result)
+	})
+
+	t.Run("genesis has no parent transition", func(t *testing.T) {
+		v := NewValsetModule()
+
+		result, err := v.getTransitionResult(0, nil)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "parent header not found for block 0")
 	})
 
 	t.Run("no cache hit", func(t *testing.T) {

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -39,17 +39,76 @@ func testPermissionlessConfig(permissionlessBlock int64, vrankEpoch uint64) *par
 	return config
 }
 
-func TestGetNodesCacheHit(t *testing.T) {
-	v := NewValsetModule()
-	cached := NodeMap{
-		addr1: {State: ValActive, StakingAmount: aboveMinStake},
-	}
-	v.transitionResultCache.Add(uint64(10), &TransitionResult{Nodes: cached})
+func TestGetNodesCache(t *testing.T) {
+	t.Run("cache hit", func(t *testing.T) {
+		v := NewValsetModule()
+		cached := NodeMap{
+			addr1: {State: ValActive, StakingAmount: aboveMinStake},
+		}
+		v.transitionResultCache.Add(uint64(10), &TransitionResult{Nodes: cached})
 
-	nodes, err := v.getNodes(10)
-	require.NoError(t, err)
-	require.Same(t, cached[addr1], nodes[addr1])
-	assert.Equal(t, cached, nodes)
+		nodes, err := v.getNodes(10)
+		require.NoError(t, err)
+		require.Same(t, cached[addr1], nodes[addr1])
+		assert.Equal(t, cached, nodes)
+	})
+
+	t.Run("no cache hit", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		root := common.HexToHash("0x1234")
+		parentHeader := &types.Header{Number: big.NewInt(9), Root: root}
+		stateErr := errors.New("state unavailable")
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(parentHeader)
+		mockChain.EXPECT().StateAt(root).Return(nil, stateErr)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		_, inCache := v.transitionResultCache.Get(uint64(10))
+		require.False(t, inCache, "cache must be cold before first call")
+
+		nodes, err := v.getNodes(10)
+		require.Nil(t, nodes)
+		require.ErrorIs(t, err, stateErr)
+	})
+}
+
+func TestGetTransitionResultCache(t *testing.T) {
+	t.Run("cache hit", func(t *testing.T) {
+		v := NewValsetModule()
+		cached := &TransitionResult{
+			Nodes: NodeMap{
+				addr1: {State: ValActive, StakingAmount: aboveMinStake},
+			},
+		}
+		v.transitionResultCache.Add(uint64(10), cached)
+
+		result, err := v.getTransitionResult(10, nil)
+		require.NoError(t, err)
+		require.Same(t, cached, result)
+	})
+
+	t.Run("no cache hit", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(nil)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		_, inCache := v.transitionResultCache.Get(uint64(10))
+		require.False(t, inCache, "cache must be cold before first call")
+
+		result, err := v.getTransitionResult(10, nil)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "parent header not found for block 10")
+	})
 }
 
 func TestGetNodesParentReadErrors(t *testing.T) {

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	vrank_mock "github.com/kaiachain/kaia/kaiax/vrank/mock"
+	"github.com/kaiachain/kaia/params"
+	chain_mock "github.com/kaiachain/kaia/work/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPermissionlessConfig(permissionlessBlock int64, vrankEpoch uint64) *params.ChainConfig {
+	config := params.TestChainConfig.Copy()
+	config.PermissionlessCompatibleBlock = big.NewInt(permissionlessBlock)
+	config.VRankEpoch = vrankEpoch
+	return config
+}
+
+func TestGetNodesCacheHit(t *testing.T) {
+	v := NewValsetModule()
+	cached := NodeMap{
+		addr1: {State: ValActive, StakingAmount: aboveMinStake},
+	}
+	v.transitionResultCache.Add(uint64(10), &TransitionResult{Nodes: cached})
+
+	nodes, err := v.getNodes(10)
+	require.NoError(t, err)
+	require.Same(t, cached[addr1], nodes[addr1])
+	assert.Equal(t, cached, nodes)
+}
+
+func TestGetNodesParentReadErrors(t *testing.T) {
+	t.Run("missing parent header", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(nil)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		nodes, err := v.getNodes(10)
+		require.Nil(t, nodes)
+		require.ErrorContains(t, err, "parent header not found for block 10")
+	})
+
+	t.Run("StateAt error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		root := common.HexToHash("0x1234")
+		parentHeader := &types.Header{Number: big.NewInt(9), Root: root}
+		stateErr := errors.New("state unavailable")
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(parentHeader)
+		mockChain.EXPECT().StateAt(root).Return(nil, stateErr)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		nodes, err := v.getNodes(10)
+		require.Nil(t, nodes)
+		require.ErrorIs(t, err, stateErr)
+	})
+}
+
+func TestWriteTransitionToABv2PreForkNoOp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10))
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+
+	err := v.WriteTransitionToABv2(nil, &types.Header{Number: big.NewInt(99)}, nil)
+	require.NoError(t, err)
+}
+
+func TestInstallABv2OutsideForkParentNoOp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10))
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+
+	err := v.InstallABv2(nil, &types.Header{Number: big.NewInt(98)}, nil)
+	require.NoError(t, err)
+}
+
+func TestFetchVRankCtx(t *testing.T) {
+	t.Run("epoch with pf report reads all vrank inputs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		cfs := map[common.Address]uint64{addr1: 1}
+		pfs := map[common.Address]uint64{addr1: 2}
+		pfReport := []common.Address{addr1}
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+
+		mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+		mockVRank.EXPECT().GetCFS(uint64(9)).Return(cfs, nil)
+		mockVRank.EXPECT().GetPfReport(uint64(9)).Return(pfReport, nil)
+		mockVRank.EXPECT().GetPFS(uint64(9)).Return(pfs, nil)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.VRankModule = mockVRank
+
+		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(9)
+		assert.Equal(t, cfs, gotCFS)
+		assert.Equal(t, pfs, gotPFS)
+		assert.Equal(t, pfReport, gotPfReport)
+	})
+
+	t.Run("non-epoch without pf report skips CFS and PFS", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+
+		mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+		mockVRank.EXPECT().GetPfReport(uint64(8)).Return(nil, nil)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.VRankModule = mockVRank
+
+		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(8)
+		assert.Nil(t, gotCFS)
+		assert.Nil(t, gotPFS)
+		assert.Nil(t, gotPfReport)
+	})
+
+	t.Run("errors fail open", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		pfReport := []common.Address{addr1}
+		vrankErr := errors.New("vrank unavailable")
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+
+		mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+		mockVRank.EXPECT().GetCFS(uint64(9)).Return(nil, vrankErr)
+		mockVRank.EXPECT().GetPfReport(uint64(9)).Return(pfReport, nil)
+		mockVRank.EXPECT().GetPFS(uint64(9)).Return(nil, vrankErr)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.VRankModule = mockVRank
+
+		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(9)
+		assert.Nil(t, gotCFS)
+		assert.Nil(t, gotPFS)
+		assert.Equal(t, pfReport, gotPfReport)
+	})
+}
+
+func TestDiffNodeStates(t *testing.T) {
+	oldIdleTimeout := time.Unix(100, 0)
+	newIdleTimeout := time.Unix(200, 0)
+
+	parent := NodeMap{
+		addr1: {State: ValActive, StakingAmount: highStake},
+		addr2: {State: ValPaused, PausedTimeout: oldIdleTimeout},
+		addr3: {State: ValReady, IdleTimeout: oldIdleTimeout},
+		addr4: {State: ValActive},
+	}
+	current := NodeMap{
+		addr1: {State: ValActive, StakingAmount: lowStake}, // staking amount is not written by this path
+		addr2: {State: ValActive},
+		addr3: {State: ValReady, IdleTimeout: newIdleTimeout},
+		addr4: {State: ValActive, Suspended: true}, // suspended is derived, not written
+		addr5: {State: CandReady},
+	}
+
+	diff := diffNodeStates(parent, current)
+	assert.Equal(t, []common.Address{addr2, addr3, addr5}, diff.Addresses())
+	assert.Equal(t, ValActive, diff[addr2].State)
+	assert.Equal(t, newIdleTimeout, diff[addr3].IdleTimeout)
+	assert.Equal(t, CandReady, diff[addr5].State)
+
+	diff[addr2].State = Registered
+	assert.Equal(t, ValActive, current[addr2].State, "diff must not alias current nodes")
+}

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -17,6 +17,9 @@
 package valset
 
 import (
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax"
 )
@@ -27,6 +30,7 @@ type ValsetModule interface {
 	kaiax.JsonRpcModule
 	kaiax.ExecutionModule
 	kaiax.RewindableModule
+	kaiax.BlockStateModule
 
 	GetCouncil(num uint64) ([]common.Address, error)
 	GetCommittee(num uint64, round uint64) ([]common.Address, error)
@@ -37,4 +41,8 @@ type ValsetModule interface {
 	// GetCandTesting returns nodes in the CandTesting state at block `num`.
 	// Stub until permissionless system contracts (AddressBookV2) land; currently returns an empty slice.
 	GetCandTesting(num uint64) ([]common.Address, error)
+
+	// Permissionless additions (post-fork; pre-fork these are no-ops).
+	WriteTransitionToABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
+	InstallABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 }

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -8,7 +8,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
+	vm "github.com/kaiachain/kaia/blockchain/vm"
 	common "github.com/kaiachain/kaia/common"
 	rpc "github.com/kaiachain/kaia/networks/rpc"
 )
@@ -48,6 +50,20 @@ func (m *MockValsetModule) APIs() []rpc.API {
 func (mr *MockValsetModuleMockRecorder) APIs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIs", reflect.TypeOf((*MockValsetModule)(nil).APIs))
+}
+
+// FinalizeState mocks base method.
+func (m *MockValsetModule) FinalizeState(arg0 *types.Header, arg1 *state.StateDB, arg2 []*types.Transaction, arg3 []*types.Receipt) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FinalizeState", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FinalizeState indicates an expected call of FinalizeState.
+func (mr *MockValsetModuleMockRecorder) FinalizeState(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeState", reflect.TypeOf((*MockValsetModule)(nil).FinalizeState), arg0, arg1, arg2, arg3)
 }
 
 // GetCandTesting mocks base method.
@@ -140,6 +156,32 @@ func (mr *MockValsetModuleMockRecorder) GetQualifiedValidators(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQualifiedValidators", reflect.TypeOf((*MockValsetModule)(nil).GetQualifiedValidators), arg0)
 }
 
+// InitializeState mocks base method.
+func (m *MockValsetModule) InitializeState(arg0 *types.Header, arg1 *state.StateDB) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InitializeState", arg0, arg1)
+}
+
+// InitializeState indicates an expected call of InitializeState.
+func (mr *MockValsetModuleMockRecorder) InitializeState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeState", reflect.TypeOf((*MockValsetModule)(nil).InitializeState), arg0, arg1)
+}
+
+// InstallABv2 mocks base method.
+func (m *MockValsetModule) InstallABv2(arg0 *vm.EVM, arg1 *types.Header, arg2 *state.StateDB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallABv2", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallABv2 indicates an expected call of InstallABv2.
+func (mr *MockValsetModuleMockRecorder) InstallABv2(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallABv2", reflect.TypeOf((*MockValsetModule)(nil).InstallABv2), arg0, arg1, arg2)
+}
+
 // PostInsertBlock mocks base method.
 func (m *MockValsetModule) PostInsertBlock(arg0 *types.Block) error {
 	m.ctrl.T.Helper()
@@ -202,4 +244,18 @@ func (m *MockValsetModule) Stop() {
 func (mr *MockValsetModuleMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockValsetModule)(nil).Stop))
+}
+
+// WriteTransitionToABv2 mocks base method.
+func (m *MockValsetModule) WriteTransitionToABv2(arg0 *vm.EVM, arg1 *types.Header, arg2 *state.StateDB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteTransitionToABv2", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteTransitionToABv2 indicates an expected call of WriteTransitionToABv2.
+func (mr *MockValsetModuleMockRecorder) WriteTransitionToABv2(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteTransitionToABv2", reflect.TypeOf((*MockValsetModule)(nil).WriteTransitionToABv2), arg0, arg1, arg2)
 }

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -145,12 +145,12 @@ type NodeMap map[common.Address]*Node
 func (v NodeMap) String() string {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return fmt.Sprintf("NodeStateMap error: %v", err)
+		return fmt.Sprintf("NodeMap error: %v", err)
 	}
 	return string(b)
 }
 
-// Copy returns a deep copy of the NodeStateMap. ValidatorState values are
+// Copy returns a deep copy of the NodeMap. Node values are
 // duplicated so that mutations through the returned map do not affect the
 // receiver. Pure transition methods rely on this property.
 func (v NodeMap) Copy() NodeMap {
@@ -204,7 +204,7 @@ func (v NodeMap) Addresses() []common.Address {
 	return addrs
 }
 
-// CountByState counts the number of validators in a given state.
+// CountByState counts the number of nodes in a given state.
 func (v NodeMap) CountByState(state NodeState) uint64 {
 	var count uint64
 	for _, val := range v {
@@ -215,8 +215,8 @@ func (v NodeMap) CountByState(state NodeState) uint64 {
 	return count
 }
 
-// MarkSuspended sets the Suspended flag on validators whose address is in the given list.
-// Mutates the receiver in place; the only in-place mutator on NodeStateMap.
+// MarkSuspended sets the Suspended flag on nodes whose address is in the given list.
+// Mutates the receiver in place; the only in-place mutator on NodeMap.
 func (v NodeMap) MarkSuspended(suspended []common.Address) {
 	set := make(map[common.Address]struct{}, len(suspended))
 	for _, addr := range suspended {
@@ -227,7 +227,7 @@ func (v NodeMap) MarkSuspended(suspended []common.Address) {
 	}
 }
 
-// ExcludeSuspended returns a new NodeStateMap without suspended validators.
+// ExcludeSuspended returns a new NodeMap without suspended nodes.
 func (v NodeMap) ExcludeSuspended() NodeMap {
 	filtered := make(NodeMap, len(v))
 	for addr, val := range v {
@@ -238,7 +238,7 @@ func (v NodeMap) ExcludeSuspended() NodeMap {
 	return filtered
 }
 
-// FilterByState returns a new NodeStateMap containing only validators in one of the given states.
+// FilterByState returns a new NodeMap containing only nodes in one of the given states.
 func (v NodeMap) FilterByState(states ...NodeState) NodeMap {
 	filtered := make(NodeMap)
 	for addr, val := range v {
@@ -249,20 +249,20 @@ func (v NodeMap) FilterByState(states ...NodeState) NodeMap {
 	return filtered
 }
 
-// Council returns validators committed to the Istanbul consensus cycle.
+// Council returns nodes committed to the Istanbul consensus cycle.
 // {ValActive, ValPaused}. ValReady excluded — voluntary standby, not consensus commitment.
 func (v NodeMap) Council() NodeMap {
 	return v.FilterByState(ValActive, ValPaused)
 }
 
-// Committee returns validators eligible for consensus signing and proposing.
-// {ValActive} excluding suspended validators.
+// Committee returns nodes eligible for consensus signing and proposing.
+// {ValActive} excluding suspended nodes.
 func (v NodeMap) Committee() NodeMap {
 	return v.FilterByState(ValActive).ExcludeSuspended()
 }
 
-// HeaderGovVoters returns validators eligible for governance header votes.
-// {ValActive} excluding suspended validators.
+// HeaderGovVoters returns nodes eligible for governance header votes.
+// {ValActive} excluding suspended nodes.
 func (v NodeMap) HeaderGovVoters() NodeMap {
 	return v.FilterByState(ValActive).ExcludeSuspended()
 }

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -139,6 +139,14 @@ type Node struct {
 	Suspended     bool      `json:"suspended"`
 }
 
+func (n *Node) Copy() *Node {
+	if n == nil {
+		return nil
+	}
+	copied := *n
+	return &copied
+}
+
 // NodeMap is the keyed collection of per-node records. Used for permissionless state transitions.
 type NodeMap map[common.Address]*Node
 
@@ -160,12 +168,7 @@ func (v NodeMap) Copy() NodeMap {
 
 	cp := make(NodeMap, len(v))
 	for key, value := range v {
-		if value == nil {
-			cp[key] = nil
-			continue
-		}
-		newValue := *value
-		cp[key] = &newValue
+		cp[key] = value.Copy()
 	}
 	return cp
 }

--- a/kaiax/valset/types_test.go
+++ b/kaiax/valset/types_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -146,6 +147,30 @@ func TestIsRewardEligible(t *testing.T) {
 	assert.False(t, CandReady.IsRewardEligible())
 	assert.False(t, CandTesting.IsRewardEligible())
 	assert.False(t, Registered.IsRewardEligible())
+}
+
+func TestNodeCopy(t *testing.T) {
+	var nilNode *Node
+	assert.Nil(t, nilNode.Copy())
+
+	t1 := time.Unix(1000, 0)
+	original := &Node{State: ValActive, StakingAmount: 5_000_000, IdleTimeout: t1, Suspended: false}
+
+	cp := original.Copy()
+	require.NotSame(t, original, cp)
+	assert.Equal(t, original, cp)
+
+	cp.State = ValPaused
+	cp.StakingAmount = 999
+	cp.IdleTimeout = time.Unix(2000, 0)
+	cp.PausedTimeout = time.Unix(3000, 0)
+	cp.Suspended = true
+
+	assert.Equal(t, ValActive, original.State)
+	assert.Equal(t, uint64(5_000_000), original.StakingAmount)
+	assert.Equal(t, t1, original.IdleTimeout)
+	assert.True(t, original.PausedTimeout.IsZero())
+	assert.False(t, original.Suspended)
 }
 
 // TestCopy_DeepCopy verifies the deep-copy property that pure transition methods

--- a/kaiax/vrank/README.md
+++ b/kaiax/vrank/README.md
@@ -73,7 +73,7 @@ On a cold start, the CP matrix is seeded from `GetCandTesting(N)` for the querie
 
 ### Scoring epoch
 
-Both scores are epoch-local. `epochStart(N) = N - (N % epoch)`. The epoch-start block itself (`N % epoch == 0`) always has an empty `header.VRank` and does not contribute to CFS.
+Both scores are epoch-local. `epochStart(N) = N - (N % epoch)`. The epoch-start block itself (`N % epoch == 0`) carries `RLPEncode(CandTesting(N))` in `header.VRank` and does not contribute to CFS.
 
 ### Checkpoints
 
@@ -176,7 +176,7 @@ Called when a `VRankCandidate` message is received. The handler does not try to 
 `VerifyHeader` checks the `VRank` field in committed headers:
 
 - before the permissionless fork, `header.VRank` must be empty
-- at epoch-start blocks, `header.VRank` must be empty
+- at epoch-start blocks, `header.VRank` must decode to `CandTesting(N)`
 - otherwise, `header(N).VRank` must decode to a sorted, deduplicated candidate list whose addresses are all in `GetCandTesting(N-1)`, because `header(N).VRank` reports failures observed while building block `N-1`
 
 ### Execution

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -38,6 +38,7 @@ var (
 
 	ErrUnexpectedVRankBeforePermissionless = errors.New("unexpected vrank before permissionless fork")
 	ErrUnexpectedVRankAtEpochStart         = errors.New("unexpected vrank at epoch start block")
+	ErrMismatchedEpochStartVRank           = errors.New("vrank at epoch start does not match CandTesting")
 	ErrInvalidVRankFormat                  = errors.New("invalid vrank format")
 	ErrInvalidVRankCandidate               = errors.New("invalid vrank: address is not a candidate")
 	ErrDuplicateVRankCandidate             = errors.New("invalid vrank: duplicate candidate address")

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -37,7 +37,7 @@ var (
 	ErrNotPermissionless      = errors.New("block is before the permissionless fork")
 
 	ErrUnexpectedVRankBeforePermissionless = errors.New("unexpected vrank before permissionless fork")
-	ErrMismatchedEpochStartVRank           = errors.New("vrank at epoch start does not match CandTesting")
+	ErrEpochStartVRankMismatch             = errors.New("vrank at epoch start does not match CandTesting")
 	ErrInvalidVRankFormat                  = errors.New("invalid vrank format")
 	ErrInvalidVRankCandidate               = errors.New("invalid vrank: address is not a candidate")
 	ErrDuplicateVRankCandidate             = errors.New("invalid vrank: duplicate candidate address")

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -37,7 +37,6 @@ var (
 	ErrNotPermissionless      = errors.New("block is before the permissionless fork")
 
 	ErrUnexpectedVRankBeforePermissionless = errors.New("unexpected vrank before permissionless fork")
-	ErrUnexpectedVRankAtEpochStart         = errors.New("unexpected vrank at epoch start block")
 	ErrMismatchedEpochStartVRank           = errors.New("vrank at epoch start does not match CandTesting")
 	ErrInvalidVRankFormat                  = errors.New("invalid vrank format")
 	ErrInvalidVRankCandidate               = errors.New("invalid vrank: address is not a candidate")

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -71,7 +71,7 @@ func (v *VRankModule) PrepareHeader(*types.Header) error { return nil }
 
 func validateEpochVRank(report, candidates []common.Address) error {
 	if !slices.Equal(report, candidates) {
-		return vrank.ErrMismatchedEpochStartVRank
+		return vrank.ErrEpochStartVRankMismatch
 	}
 	return nil
 }

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -19,6 +19,7 @@ package impl
 import (
 	"bytes"
 	"math/big"
+	"slices"
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
@@ -27,7 +28,7 @@ import (
 
 // VerifyHeader checks the VRank field in the header:
 //   - Before the permissionless fork: VRank must be empty.
-//   - At epoch-start blocks: VRank must be empty.
+//   - At epoch-start blocks: VRank must be RLPEncode(CandTesting(N)).
 //   - Otherwise: VRank must be a valid encoded report whose addresses are sorted,
 //     deduplicated, and all present in GetCandTesting(N-1), because header(N).VRank
 //     reports candidate failures observed while building block N-1.
@@ -42,11 +43,7 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 		return nil
 	}
 
-	if number%v.vrankEpoch() == 0 && len(header.VRank) > 0 {
-		return vrank.ErrUnexpectedVRankAtEpochStart
-	}
-
-	if len(header.VRank) == 0 {
+	if number%v.vrankEpoch() != 0 && len(header.VRank) == 0 {
 		return nil
 	}
 
@@ -55,34 +52,69 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 		return vrank.ErrInvalidVRankFormat
 	}
 
-	// Validate every address in the cfReport is an actual candidate for the
-	// reported block N-1. header(N).VRank is produced by TallyCfReport(N-1, ...),
-	// which checks GetCandTesting(N-1).
-	// This prevents a malicious proposer from injecting arbitrary addresses (e.g. validator
-	// addresses) into header.VRank to manipulate CFS scores.
-	candidates, err := v.Valset.GetCandTesting(number - 1)
-	if err != nil {
-		return err
-	}
-	candSet := make(map[common.Address]struct{}, len(candidates))
-	for _, c := range candidates {
-		candSet[c] = struct{}{}
-	}
-	for i, addr := range report {
-		if _, ok := candSet[addr]; !ok {
-			return vrank.ErrInvalidVRankCandidate
+	if number%v.vrankEpoch() == 0 {
+		candidates, err := v.Valset.GetCandTesting(number)
+		if err != nil {
+			return err
 		}
-		if i > 0 {
-			cmp := bytes.Compare(report[i-1].Bytes(), addr.Bytes())
-			if cmp == 0 {
-				return vrank.ErrDuplicateVRankCandidate
-			}
-			if cmp > 0 {
-				return vrank.ErrVRankNotSorted
-			}
+		return validateEpochVRank(report, candidates)
+	} else {
+		candidates, err := v.Valset.GetCandTesting(number - 1)
+		if err != nil {
+			return err
 		}
+		return validateNonEpochVRank(report, candidates)
+	}
+}
+
+func (v *VRankModule) PrepareHeader(*types.Header) error { return nil }
+
+func validateEpochVRank(report, candidates []common.Address) error {
+	if !slices.Equal(report, candidates) {
+		return vrank.ErrMismatchedEpochStartVRank
 	}
 	return nil
 }
 
-func (v *VRankModule) PrepareHeader(*types.Header) error { return nil }
+func validateNonEpochVRank(report, candidates []common.Address) error {
+	if isNonCandContained(report, candidates) {
+		return vrank.ErrInvalidVRankCandidate
+	}
+	if !isSorted(report) {
+		return vrank.ErrVRankNotSorted
+	}
+	if hasDuplicate(report) {
+		return vrank.ErrDuplicateVRankCandidate
+	}
+	return nil
+}
+
+func isNonCandContained(report, candidates []common.Address) bool {
+	candSet := make(map[common.Address]struct{}, len(candidates))
+	for _, c := range candidates {
+		candSet[c] = struct{}{}
+	}
+	for _, addr := range report {
+		if _, ok := candSet[addr]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isSorted(addrs []common.Address) bool {
+	sorted := append([]common.Address(nil), addrs...)
+	slices.SortFunc(sorted, func(a, b common.Address) int { return bytes.Compare(a.Bytes(), b.Bytes()) })
+	return slices.Equal(sorted, addrs)
+}
+
+func hasDuplicate(addrs []common.Address) bool {
+	seen := make(map[common.Address]struct{}, len(addrs))
+	for _, addr := range addrs {
+		if _, ok := seen[addr]; ok {
+			return true
+		}
+		seen[addr] = struct{}{}
+	}
+	return false
+}

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -66,13 +66,13 @@ func TestVerifyHeader(t *testing.T) {
 		v := newCN(t, withCandidates([]common.Address{C1, C2})).VRankModule
 		assert.NoError(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1, C2}), nil))
 		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C2, C1}), nil),
-			vrank.ErrMismatchedEpochStartVRank)
+			vrank.ErrEpochStartVRankMismatch)
 		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1, C1}), nil),
-			vrank.ErrMismatchedEpochStartVRank)
+			vrank.ErrEpochStartVRankMismatch)
 		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1, C3}), nil),
-			vrank.ErrMismatchedEpochStartVRank)
+			vrank.ErrEpochStartVRankMismatch)
 		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1}), nil),
-			vrank.ErrMismatchedEpochStartVRank)
+			vrank.ErrEpochStartVRankMismatch)
 		assert.ErrorIs(t, v.VerifyHeader(&types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}, nil),
 			vrank.ErrInvalidVRankFormat)
 	})

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -41,6 +41,13 @@ func makeVRankHeader(t *testing.T, number uint64, cfAddrs []common.Address) *typ
 	return h
 }
 
+func makeEpochStartVRankHeader(t *testing.T, number uint64, candidates []common.Address) *types.Header {
+	t.Helper()
+	encoded, err := vrank.EncodeAddressList(candidates)
+	require.NoError(t, err)
+	return &types.Header{Number: big.NewInt(int64(number)), VRank: encoded}
+}
+
 // TestVerifyHeader covers all branches of VRankModule.VerifyHeader.
 func TestVerifyHeader(t *testing.T) {
 	C1, C2, C3 := numToAddr(1), numToAddr(2), numToAddr(3)
@@ -55,16 +62,44 @@ func TestVerifyHeader(t *testing.T) {
 		assert.ErrorIs(t, v.VerifyHeader(h, nil), vrank.ErrUnexpectedVRankBeforePermissionless)
 	})
 
-	t.Run("epoch-start: VRank must be empty", func(t *testing.T) {
-		v := newCN(t).VRankModule
-		h := &types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}
-		assert.NoError(t, v.VerifyHeader(h, nil))
-		h = makeVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1})
-		assert.ErrorIs(t, v.VerifyHeader(h, nil), vrank.ErrUnexpectedVRankAtEpochStart)
+	t.Run("epoch-start: VRank must match CandTesting", func(t *testing.T) {
+		v := newCN(t, withCandidates([]common.Address{C1, C2})).VRankModule
+		assert.NoError(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1, C2}), nil))
+		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C2, C1}), nil),
+			vrank.ErrMismatchedEpochStartVRank)
+		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1, C1}), nil),
+			vrank.ErrMismatchedEpochStartVRank)
+		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1, C3}), nil),
+			vrank.ErrMismatchedEpochStartVRank)
+		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1}), nil),
+			vrank.ErrMismatchedEpochStartVRank)
+		assert.ErrorIs(t, v.VerifyHeader(&types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}, nil),
+			vrank.ErrInvalidVRankFormat)
 	})
 
-	t.Run("post-fork non-epoch: empty VRank passes", func(t *testing.T) {
-		v := newCN(t).VRankModule
+	t.Run("epoch-start: empty CandTesting is encoded as an RLP list", func(t *testing.T) {
+		v := newCN(t, withCandidates(nil)).VRankModule
+		assert.NoError(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, nil), nil))
+	})
+
+	t.Run("epoch-start: candidate membership is checked against block N", func(t *testing.T) {
+		headerNum := uint64(params.DefaultVRankEpoch)
+		cn := newCN(t, withoutStart())
+		cn.Valset.EXPECT().GetCandTesting(headerNum).Return(candidates, nil).Times(1)
+
+		assert.NoError(t, cn.VRankModule.VerifyHeader(makeEpochStartVRankHeader(t, headerNum, candidates), nil))
+	})
+
+	t.Run("epoch-start: candidate lookup failure is returned", func(t *testing.T) {
+		headerNum := uint64(params.DefaultVRankEpoch)
+		cn := newCN(t, withoutStart())
+		cn.Valset.EXPECT().GetCandTesting(headerNum).Return(nil, assert.AnError).Times(1)
+
+		assert.ErrorIs(t, cn.VRankModule.VerifyHeader(makeEpochStartVRankHeader(t, headerNum, candidates), nil), assert.AnError)
+	})
+
+	t.Run("post-fork non-epoch: empty VRank passes without reading candidates", func(t *testing.T) {
+		v := newCN(t, withoutStart()).VRankModule
 		h := &types.Header{Number: big.NewInt(100)}
 		assert.NoError(t, v.VerifyHeader(h, nil))
 	})
@@ -94,10 +129,18 @@ func TestVerifyHeader(t *testing.T) {
 			vrank.ErrVRankNotSorted)
 	})
 
-	t.Run("invalid encoding rejected", func(t *testing.T) {
-		v := newCN(t).VRankModule
+	t.Run("invalid encoding rejected before reading candidates", func(t *testing.T) {
+		v := newCN(t, withoutStart()).VRankModule
 		h := &types.Header{Number: big.NewInt(100), VRank: []byte{0xff, 0xfe}} // garbage
 		assert.ErrorIs(t, v.VerifyHeader(h, nil), vrank.ErrInvalidVRankFormat)
+	})
+
+	t.Run("non-epoch candidate lookup failure is returned", func(t *testing.T) {
+		headerNum := uint64(101)
+		cn := newCN(t, withoutStart())
+		cn.Valset.EXPECT().GetCandTesting(headerNum-1).Return(nil, assert.AnError).Times(1)
+
+		assert.ErrorIs(t, cn.VRankModule.VerifyHeader(makeVRankHeader(t, headerNum, []common.Address{C1}), nil), assert.AnError)
 	})
 
 	t.Run("candidate membership is checked against the reported block N-1", func(t *testing.T) {

--- a/kaiax/vrank/impl/scoring_test.go
+++ b/kaiax/vrank/impl/scoring_test.go
@@ -460,7 +460,7 @@ func TestGetCFS(t *testing.T) {
 		epochStart := uint64(params.DefaultVRankEpoch)
 		C1, C2, P1 := numToAddr(10), numToAddr(11), numToAddr(1)
 		headers := map[uint64]*types.Header{
-			epochStart: makeHeaderWithVRank(epochStart, 0, nil), // epoch start: VRank must be nil
+			epochStart: makeHeaderWithVRank(epochStart, 0, nil), // CFS ignores epoch-start VRank.
 		}
 		cn := newCN(t, withHeaders(headers), withCandidates([]common.Address{C1, C2}), withProposer(P1))
 
@@ -843,10 +843,10 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		randao := mock_randao.NewMockRandaoModule(ctrl)
 		v := newCN(t, withValset(valset), withRandao(randao), withGenesis()).VRankModule
 
-		// Only one block in the range: the epoch-start block with nil VRank.
+		// Only one block in the range: the epoch-start block, whose VRank is ignored by CFS.
 		v.Chain = &testChain{
 			headers: map[uint64]*types.Header{
-				0: makeHeaderWithRound(0, 0), // VRank is nil
+				0: makeHeaderWithRound(0, 0),
 			},
 		}
 		valset.EXPECT().GetCandTesting(uint64(0)).Return(candidates, nil)

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -103,7 +103,11 @@ func EncodeReport(report []common.Address) ([]byte, error) {
 		return nil, nil
 	}
 
-	return rlp.EncodeToBytes(report)
+	return EncodeAddressList(report)
+}
+
+func EncodeAddressList(addrs []common.Address) ([]byte, error) {
+	return rlp.EncodeToBytes(addrs)
 }
 
 func DecodeReport(data []byte) ([]common.Address, error) {

--- a/kaiax/vrank/types_test.go
+++ b/kaiax/vrank/types_test.go
@@ -52,3 +52,13 @@ func TestEncodeDecodeReport(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeAddressList_EmptyList(t *testing.T) {
+	enc, err := EncodeAddressList(nil)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, enc)
+
+	dec, err := DecodeReport(enc)
+	assert.NoError(t, err)
+	assert.Empty(t, dec)
+}


### PR DESCRIPTION
## Proposed changes

- Orchestrator (`kaiax/valset/impl/transition.go`): per-block pipeline that reads ABv2 + gov + vrank for the parent state, applies the KIP-286 transitions via `TransitionContext`, and caches the `TransitionResult` by block number.
- ABv2 writers:
  - `WriteTransitionToABv2` — every post-fork block, writes the diff of changed nodes via `processSystemTransition`.
  - `InstallABv2` — at the HF-1 block's Finalize step, deploys the ABv2 proxy and runs `initialize()`.
- `ValsetModule` now satisfies `kaiax.BlockStateModule` (`InitializeState` / `FinalizeState`). Registration in `node/cn` will be included in the future PR.
- Supporting infrastructure:
  - `blockchain.SystemTxCall` — shared helper for kaiax-driven system txs.
  - `backends.NewStateBlockchainContractBackend` — `ContractCaller` over an arbitrary statedb, used during init/finalize when `StateAt` isn't available (e.g., state from `Initialize()` after reboot).
- Type renames: `system.NodeStatesResult` → `ABv2StateSnapshot`, field `Validators` → `Nodes`; doc/log strings switched from "validator" to "node" where the value covers all node states.
  - Replace `ABv2Context` with `ABv2TransitionParam`
- Unit tests for the orchestrator: cache hit, parent-read errors, pre-fork no-op, `fetchVRankCtx` (epoch / non-epoch / fail-open), `diffNodeStates`.
- vrank: VerifyHeader validates that epoch-start block should contain `CandTesting(N)`


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

ApplyTransition(N):

```mermaid
flowchart TD
  ABV2["ABv2 contract states<br/>state(N-1)"]
  MC["MultiCallContractNodeStatesResult"]
  Snapshot["system.ABv2Snapshot"]
  Param["system.ABv2TransitionParam"]
  NodeMap0["valset.NodeMap<br/>ABv2(N-1)"]
  GovCtx["impl.GovContext"]
  VRankCtx["impl.VRankContext"]
  BlockCtx["impl.BlockContext"]
  EpochCtx["impl.EpochTransitionContext"]
  TCtx["impl.TransitionContext"]
  TResult["impl.TransitionResult"]
  NodeMap1["valset.NodeMap<br/>NodeStates(N)"]
  Diff["valset.NodeMap<br/>changed states/timeouts"]
  Tx["types.Transaction / types.Message"]
  StateDB["state.StateDB<br/>ABv2(N)"]

  ABV2 -->|"multiCallNodeStatesPermissionless"| MC
  MC -->|"ReadABv2Snapshot"| Snapshot
  Snapshot -->|"Nodes.MarkSuspended"| NodeMap0
  Snapshot -->|"TransitionParam"| Param

  BlockCtx -->|"SetBlockCtx"| TCtx
  GovCtx -->|"SetGovCtx"| TCtx
  Param -->|"SetABv2TransitionParam"| TCtx
  EpochCtx -->|"SetSlotsCtx"| TCtx
  VRankCtx -->|"SetVRankCtx"| TCtx

  TCtx -->|"ApplyAllTransitions"| TResult
  NodeMap0 -->|"ApplyAllTransitions"| TResult
  TResult -->|"Nodes"| NodeMap1

  NodeMap0 -->|"diffNodeStates"| Diff
  NodeMap1 -->|"diffNodeStates"| Diff

  Diff -->|"EncodeProcessSystemTransition"| Tx
  Tx -->|"SystemTxCall"| StateDB
```
