### PR TITLE
consensus: reject out-of-range roundchange rounds

### DIFF
--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -46,6 +46,11 @@ func (c *core) checkMessage(msgCode uint64, view *bft.View) error {
 	}
 
 	if msgCode == bft.MsgRoundChange {
+		// Round-change buckets are keyed by uint64 round in roundChangeSet.
+		// Reject out-of-range round values early to avoid truncation collisions.
+		if !view.Round.IsUint64() {
+			return bft.ErrInvalidMessage
+		}
 		if view.Sequence.Cmp(c.currentView().Sequence) > 0 {
 			return errFutureMessage
 		} else if view.Cmp(c.currentView()) < 0 {


### PR DESCRIPTION
## Proposed changes

This PR adds a guard in checkMessage to reject `ROUND CHANGE` messages whose view.Round does not fit in uint64.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
