### PR TITLE
valset: permissionless core consensus

### DIFF
--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -241,6 +241,18 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		return nil
 	}
 
+	round, err := v.sealer.Round(header)
+	if err != nil {
+		return err
+	}
+	proposer, err := v.mValset.GetProposer(blockNum, uint64(round))
+	if err != nil {
+		return err
+	}
+	if author != proposer {
+		return consensus.ErrUnauthorized
+	}
+
 	qualified, err := v.mValset.GetQualifiedValidators(blockNum)
 	if err != nil {
 		return err

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -241,16 +241,18 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		return nil
 	}
 
-	round, err := v.sealer.Round(header)
-	if err != nil {
-		return err
-	}
-	proposer, err := v.mValset.GetProposer(blockNum, uint64(round))
-	if err != nil {
-		return err
-	}
-	if author != proposer {
-		return consensus.ErrUnauthorized
+	if v.config != nil && v.config.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) {
+		round, err := v.sealer.Round(header)
+		if err != nil {
+			return err
+		}
+		proposer, err := v.mValset.GetProposer(blockNum, uint64(round))
+		if err != nil {
+			return err
+		}
+		if author != proposer {
+			return consensus.ErrUnauthorized
+		}
 	}
 
 	qualified, err := v.mValset.GetQualifiedValidators(blockNum)

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -235,13 +235,14 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	}
 
 	blockNum := header.Number.Uint64()
+	isPermissionless := v.config != nil && v.config.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum))
 
 	// Skip module-dependent seal validation when gov/valset modules are not registered.
 	if v.mValset == nil || v.mGov == nil {
 		return nil
 	}
 
-	if v.config != nil && v.config.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) {
+	if isPermissionless {
 		round, err := v.sealer.Round(header)
 		if err != nil {
 			return err
@@ -259,25 +260,33 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	if err != nil {
 		return err
 	}
-	if !valset.NewAddressSet(qualified).Contains(author) {
+	qualifiedSet := valset.NewAddressSet(qualified)
+	if !qualifiedSet.Contains(author) {
 		return consensus.ErrUnauthorized
 	}
 
-	council, err := v.mValset.GetCouncil(blockNum)
-	if err != nil {
-		return err
+	signerSet := qualifiedSet.Copy()
+	if !isPermissionless {
+		council, err := v.mValset.GetCouncil(blockNum)
+		if err != nil {
+			return err
+		}
+		signerSet = valset.NewAddressSet(council).Copy()
 	}
-	councilSet := valset.NewAddressSet(council).Copy()
 	validSeal := 0
 	for _, addr := range committers {
-		if councilSet.Remove(addr) {
+		if signerSet.Remove(addr) {
 			validSeal++
 		} else {
 			return istanbul.ErrInvalidCommittedSeals
 		}
 	}
 
-	if validSeal < v.sealer.Quorum(blockNum, len(qualified), int(v.mGov.GetParamSet(blockNum).CommitteeSize)) {
+	committeeSize := len(qualified)
+	if !isPermissionless {
+		committeeSize = int(v.mGov.GetParamSet(blockNum).CommitteeSize)
+	}
+	if validSeal < v.sealer.Quorum(blockNum, len(qualified), committeeSize) {
 		return istanbul.ErrInvalidCommittedSeals
 	}
 	return nil

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -235,14 +235,18 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	}
 
 	blockNum := header.Number.Uint64()
-	isPermissionless := v.config != nil && v.config.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum))
+
+	var rules params.Rules
+	if v.config != nil {
+		rules = v.config.Rules(new(big.Int).SetUint64(blockNum))
+	}
 
 	// Skip module-dependent seal validation when gov/valset modules are not registered.
 	if v.mValset == nil || v.mGov == nil {
 		return nil
 	}
 
-	if isPermissionless {
+	if rules.IsPermissionless {
 		round, err := v.sealer.Round(header)
 		if err != nil {
 			return err
@@ -266,7 +270,7 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	}
 
 	signerSet := qualifiedSet.Copy()
-	if !isPermissionless {
+	if !rules.IsPermissionless {
 		council, err := v.mValset.GetCouncil(blockNum)
 		if err != nil {
 			return err
@@ -282,11 +286,12 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		}
 	}
 
-	committeeSize := len(qualified)
-	if !isPermissionless {
+	qualifiedLen := len(qualified)
+	committeeSize := qualifiedLen
+	if !gov.DeprecatedAt(gov.IstanbulCommitteeSize, rules) {
 		committeeSize = int(v.mGov.GetParamSet(blockNum).CommitteeSize)
 	}
-	if validSeal < v.sealer.Quorum(blockNum, len(qualified), committeeSize) {
+	if validSeal < v.sealer.Quorum(blockNum, qualifiedLen, committeeSize) {
 		return istanbul.ErrInvalidCommittedSeals
 	}
 	return nil

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/faker"
+	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	mock_gov "github.com/kaiachain/kaia/kaiax/gov/mock"
@@ -43,6 +44,33 @@ import (
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
 )
+
+type verifySealsTestSealer struct {
+	consensus.Sealer
+	author        common.Address
+	committers    []common.Address
+	quorum        int
+	qualifiedLen  int
+	committeeSize int
+}
+
+func (s *verifySealsTestSealer) Author(*types.Header) (common.Address, error) {
+	return s.author, nil
+}
+
+func (s *verifySealsTestSealer) Committers(*types.Header) ([]common.Address, error) {
+	return s.committers, nil
+}
+
+func (s *verifySealsTestSealer) Round(*types.Header) (byte, error) {
+	return 0, nil
+}
+
+func (s *verifySealsTestSealer) Quorum(_ uint64, qualifiedLen, committeeSize int) int {
+	s.qualifiedLen = qualifiedLen
+	s.committeeSize = committeeSize
+	return s.quorum
+}
 
 func TestValidateHeader(t *testing.T) {
 	testcases := []struct {
@@ -224,8 +252,6 @@ func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
 	mValset := mock_valset.NewMockValsetModule(ctrl)
 	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author}, nil)
-	mValset.EXPECT().GetCouncil(blockNum).Return([]common.Address{author}, nil)
-	mGov.EXPECT().GetParamSet(blockNum).Return(gov.ParamSet{CommitteeSize: 1})
 
 	validator := &BlockValidator{
 		config:  params.TestKaiaConfig("permissionless"),
@@ -235,6 +261,80 @@ func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
 	}
 
 	assert.NoError(t, validator.verifySeals(header))
+}
+
+func TestVerifySealsPermissionlessUsesQualifiedAsCommitteeSize(t *testing.T) {
+	var (
+		author    = common.HexToAddress("0x0001")
+		b         = common.HexToAddress("0x0002")
+		c         = common.HexToAddress("0x0003")
+		d         = common.HexToAddress("0x0004")
+		e         = common.HexToAddress("0x0005")
+		blockNum  = uint64(7)
+		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		qualified = []common.Address{author, b, c, d, e}
+		sealer    = &verifySealsTestSealer{
+			Sealer:     faker.NewFaker(),
+			author:     author,
+			committers: []common.Address{author, b, c, d},
+			quorum:     4,
+		}
+	)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
+	mValset.EXPECT().GetQualifiedValidators(blockNum).Return(qualified, nil)
+
+	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.NoError(t, validator.verifySeals(header))
+	assert.Equal(t, len(qualified), sealer.qualifiedLen)
+	assert.Equal(t, len(qualified), sealer.committeeSize)
+}
+
+func TestVerifySealsPermissionlessRejectsNonQualifiedCommitter(t *testing.T) {
+	var (
+		author    = common.HexToAddress("0x0001")
+		b         = common.HexToAddress("0x0002")
+		c         = common.HexToAddress("0x0003")
+		d         = common.HexToAddress("0x0004")
+		paused    = common.HexToAddress("0x0005")
+		blockNum  = uint64(7)
+		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		qualified = []common.Address{author, b, c, d}
+		sealer    = &verifySealsTestSealer{
+			Sealer:     faker.NewFaker(),
+			author:     author,
+			committers: []common.Address{author, b, paused},
+			quorum:     3,
+		}
+	)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
+	mValset.EXPECT().GetQualifiedValidators(blockNum).Return(qualified, nil)
+
+	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
 }
 
 func TestVerifyBlockBody(t *testing.T) {

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -171,12 +171,42 @@ func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
 	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(otherProposer, nil)
 
 	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
 		sealer:  sealer,
 		mGov:    mGov,
 		mValset: mValset,
 	}
 
 	assert.ErrorIs(t, validator.verifySeals(header), consensus.ErrUnauthorized)
+}
+
+func TestVerifySealsSkipsProposerAuthorCheckBeforePermissionless(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		blockNum = uint64(7)
+		header   = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		sealer   = faker.NewFakerWithFixedSealer(author)
+		config   = params.TestKaiaConfig("permissionless").Copy()
+	)
+	config.PermissionlessCompatibleBlock = big.NewInt(10)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author}, nil)
+	mValset.EXPECT().GetCouncil(blockNum).Return([]common.Address{author}, nil)
+	mGov.EXPECT().GetParamSet(blockNum).Return(gov.ParamSet{CommitteeSize: 1})
+
+	validator := &BlockValidator{
+		config:  config,
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.NoError(t, validator.verifySeals(header))
 }
 
 func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
@@ -198,6 +228,7 @@ func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
 	mGov.EXPECT().GetParamSet(blockNum).Return(gov.ParamSet{CommitteeSize: 1})
 
 	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
 		sealer:  sealer,
 		mGov:    mGov,
 		mValset: mValset,

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	mock_gov "github.com/kaiachain/kaia/kaiax/gov/mock"
+	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
@@ -151,6 +152,58 @@ func TestValidateHeader(t *testing.T) {
 			assert.ErrorIs(t, err, tc.expectedErr)
 		})
 	}
+}
+
+func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
+	var (
+		author        = common.HexToAddress("0x0001")
+		otherProposer = common.HexToAddress("0x0002")
+		blockNum      = uint64(7)
+		header        = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		sealer        = faker.NewFakerWithFixedSealer(author)
+	)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(otherProposer, nil)
+
+	validator := &BlockValidator{
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.ErrorIs(t, validator.verifySeals(header), consensus.ErrUnauthorized)
+}
+
+func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		blockNum = uint64(7)
+		header   = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		sealer   = faker.NewFakerWithFixedSealer(author)
+	)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
+	mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author}, nil)
+	mValset.EXPECT().GetCouncil(blockNum).Return([]common.Address{author}, nil)
+	mGov.EXPECT().GetParamSet(blockNum).Return(gov.ParamSet{CommitteeSize: 1})
+
+	validator := &BlockValidator{
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.NoError(t, validator.verifySeals(header))
 }
 
 func TestVerifyBlockBody(t *testing.T) {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -44,6 +44,9 @@ var logger = log.NewModuleLogger(log.ConsensusIstanbulCore)
 
 // getRoundCommitteeState fetches qualified, committee, proposer and derived values for the given sequence and round.
 func getRoundCommitteeState(c *core, seq, r uint64) (qualified *valset.AddressSet, committeeSet *valset.AddressSet, proposer common.Address, committeeSize uint64, requiredMsgCnt int, fNum int, err error) {
+	if c.valsetModule == nil || c.govModule == nil {
+		return nil, nil, common.Address{}, 0, 0, 0, istanbul.ErrNoEssentialModule
+	}
 	council, err := c.valsetModule.GetCouncil(seq)
 	if err != nil {
 		return nil, nil, common.Address{}, 0, 0, 0, err

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -66,7 +66,7 @@ func getRoundCommitteeState(c *core, seq, r uint64) (qualified *valset.AddressSe
 		return nil, nil, common.Address{}, 0, 0, 0, err
 	}
 	committeeSet = valset.NewAddressSet(committeeAddrs)
-	committeeSize = c.govModule.GetParamSet(seq).CommitteeSize
+	committeeSize = uint64(committeeSet.Len())
 
 	qLen := qualified.Len()
 	requiredMsgCnt = calcQuorumSize(qLen, committeeSize)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -133,6 +133,11 @@ func getTestCommitteeState(validatorAddrs []common.Address, committeeSize uint64
 	return qualified, committee, proposer, nonCommittee
 }
 
+func TestGetRoundCommitteeStateMissingModules(t *testing.T) {
+	_, _, _, _, _, _, err := getRoundCommitteeState(&core{}, 1, 0)
+	assert.ErrorIs(t, err, istanbul.ErrNoEssentialModule)
+}
+
 // genValidators returns a set of addresses and corresponding keys used for generating a validator set
 func genValidators(n int) ([]common.Address, map[common.Address]*ecdsa.PrivateKey) {
 	addrs := make([]common.Address, n)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -90,7 +90,7 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 		}).AnyTimes()
 	mockValsetModule.EXPECT().GetProposer(gomock.Any(), gomock.Any()).Return(validatorAddrs[0], nil).AnyTimes()
 
-	// Gov module: used by core for committee size
+	// Gov module: required by core registration checks.
 	mockGovModule.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{CommitteeSize: committeeSize}).AnyTimes()
 
 	// Consider the last proposal is "initBlock" and the owner of mockBackend is validatorAddrs[0]
@@ -116,6 +116,54 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 	mockBackend.EXPECT().Verify(gomock.Any()).Return(time.Duration(0), nil).AnyTimes()
 
 	return mockBackend, mockCtrl, mockValsetModule, mockGovModule
+}
+
+func TestGetRoundCommitteeStateUsesReturnedCommitteeSize(t *testing.T) {
+	validatorAddrs := []common.Address{
+		common.HexToAddress("0x0001"),
+		common.HexToAddress("0x0002"),
+		common.HexToAddress("0x0003"),
+		common.HexToAddress("0x0004"),
+		common.HexToAddress("0x0005"),
+	}
+	const (
+		round           = uint64(0)
+		govCommitteeLen = uint64(2)
+	)
+	proposer := validatorAddrs[0]
+
+	for _, tc := range []struct {
+		name              string
+		committee         []common.Address
+		expectedCommittee uint64
+	}{
+		{name: "subset committee keeps old effective size", committee: validatorAddrs[:int(govCommitteeLen)], expectedCommittee: govCommitteeLen},
+		{name: "full committee uses qualified length", committee: validatorAddrs, expectedCommittee: uint64(len(validatorAddrs))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const seq = uint64(7)
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+
+			mockValsetModule := valset_mock.NewMockValsetModule(mockCtrl)
+			mockGovModule := mock_gov.NewMockGovModule(mockCtrl)
+			mockValsetModule.EXPECT().GetCouncil(seq).Return(validatorAddrs, nil)
+			mockValsetModule.EXPECT().GetDemotedValidators(seq).Return([]common.Address{}, nil)
+			mockValsetModule.EXPECT().GetCommittee(seq, round).Return(tc.committee, nil)
+			mockValsetModule.EXPECT().GetProposer(seq, round).Return(proposer, nil)
+
+			c := &core{valsetModule: mockValsetModule, govModule: mockGovModule}
+			qualified, committee, gotProposer, committeeSize, requiredMsgCnt, fNum, err := getRoundCommitteeState(c, seq, round)
+			require.NoError(t, err)
+
+			assert.Equal(t, validatorAddrs, qualified.List())
+			assert.Equal(t, tc.committee, committee.List())
+			assert.Equal(t, proposer, gotProposer)
+			assert.Equal(t, tc.expectedCommittee, committeeSize)
+			assert.Equal(t, calcQuorumSize(len(validatorAddrs), tc.expectedCommittee), requiredMsgCnt)
+			assert.Equal(t, calcFaultTolerance(len(validatorAddrs), tc.expectedCommittee), fNum)
+		})
+	}
 }
 
 // getTestCommitteeState returns qualified, committee, proposer, nonCommittee for tests using the same logic as newMockBackend

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -100,10 +100,9 @@ func newTester(t *testing.T, confOverride func(*cn.Config)) *tester {
 	if err != nil {
 		t.Fatalf("failed to create node: %v", err)
 	}
-	cnConf := &cn.Config{
-		Genesis:            blockchain.DefaultTestGenesisBlock(),
-		ServiceChainSigner: common.HexToAddress(testAddress),
-	}
+	cnConf := cn.GetDefaultConfig()
+	cnConf.Genesis = blockchain.DefaultTestGenesisBlock()
+	cnConf.ServiceChainSigner = common.HexToAddress(testAddress)
 	if confOverride != nil {
 		confOverride(cnConf)
 	}

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -924,6 +924,12 @@ var klayMethods = [
 		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 	}),
 	new web3._extend.Method({
+		name: 'getNodesByState',
+		call: 'klay_getNodesByState',
+		params: 2,
+		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, null]
+	}),
+	new web3._extend.Method({
 		name: 'getCommittee',
 		call: 'klay_getCommittee',
 		params: 1,

--- a/kaiax/gov/param.go
+++ b/kaiax/gov/param.go
@@ -571,6 +571,16 @@ var AlwaysDeprecated = map[ParamName]struct{}{
 	RewardUseGiniCoeff:           {},
 }
 
+// PermissionlessDeprecated lists params that become disallowed for voting
+// after the Permissionless hardfork. Validator membership is governed by
+// AddressBookV2 (KIP-290) and the committee is derived from on-chain state,
+// so these governance levers no longer have an effect.
+var PermissionlessDeprecated = map[ParamName]struct{}{
+	AddValidator:          {},
+	RemoveValidator:       {},
+	IstanbulCommitteeSize: {},
+}
+
 // DeprecatedAt reports whether a governance parameter is deprecated (disallowed
 // for voting) given the current chain rules. Deprecation has two sources:
 //   - static: params that have always been deprecated regardless of fork state
@@ -581,7 +591,10 @@ func DeprecatedAt(name ParamName, rules params.Rules) bool {
 	if _, ok := AlwaysDeprecated[name]; ok {
 		return true
 	}
-
-	// TODO-Permissionless: fork-aware deprecation: extended in the permissionless branch.
+	if rules.IsPermissionless {
+		if _, ok := PermissionlessDeprecated[name]; ok {
+			return true
+		}
+	}
 	return false
 }

--- a/kaiax/gov/param_test.go
+++ b/kaiax/gov/param_test.go
@@ -199,29 +199,28 @@ func TestDeprecatedAt(t *testing.T) {
 
 	for _, rv := range rulesVariants {
 		t.Run(rv.desc, func(t *testing.T) {
-			expectedDeprecated := make(map[ParamName]struct{})
+			// Static deprecated: must return true regardless of fork.
 			for name := range AlwaysDeprecated {
-				expectedDeprecated[name] = struct{}{}
-			}
-			if rv.rules.IsPermissionless {
-				for name := range PermissionlessDeprecated {
-					expectedDeprecated[name] = struct{}{}
-				}
-			}
-
-			for name := range expectedDeprecated {
 				assert.True(t, DeprecatedAt(name, rv.rules), "expected %s to be deprecated", name)
 			}
 
-			// Every other known param in Params and ValidatorParams must return false.
+			// Permissionless-deprecated: true only when IsPermissionless.
+			for name := range PermissionlessDeprecated {
+				assert.Equal(t, rv.rules.IsPermissionless, DeprecatedAt(name, rv.rules), "permissionless deprecated %s", name)
+			}
+
+			// Every other known param must return false.
 			for name := range Params {
-				if _, ok := expectedDeprecated[name]; ok {
+				if _, ok := AlwaysDeprecated[name]; ok {
+					continue
+				}
+				if _, ok := PermissionlessDeprecated[name]; ok {
 					continue
 				}
 				assert.False(t, DeprecatedAt(name, rv.rules), "expected %s not deprecated", name)
 			}
 			for name := range ValidatorParams {
-				if _, ok := expectedDeprecated[name]; ok {
+				if _, ok := PermissionlessDeprecated[name]; ok {
 					continue
 				}
 				assert.False(t, DeprecatedAt(name, rv.rules), "expected %s not deprecated (validator param)", name)

--- a/kaiax/gov/param_test.go
+++ b/kaiax/gov/param_test.go
@@ -194,23 +194,36 @@ func TestDeprecatedAt(t *testing.T) {
 			IsKore: true, IsShanghai: true, IsCancun: true, IsKaia: true,
 			IsRandao: true, IsPrague: true, IsOsaka: true,
 		}},
+		{desc: "permissionless rules", rules: params.Rules{IsPermissionless: true}},
 	}
 
 	for _, rv := range rulesVariants {
 		t.Run(rv.desc, func(t *testing.T) {
-			// Static deprecated: must return true.
+			expectedDeprecated := make(map[ParamName]struct{})
 			for name := range AlwaysDeprecated {
+				expectedDeprecated[name] = struct{}{}
+			}
+			if rv.rules.IsPermissionless {
+				for name := range PermissionlessDeprecated {
+					expectedDeprecated[name] = struct{}{}
+				}
+			}
+
+			for name := range expectedDeprecated {
 				assert.True(t, DeprecatedAt(name, rv.rules), "expected %s to be deprecated", name)
 			}
 
 			// Every other known param in Params and ValidatorParams must return false.
 			for name := range Params {
-				if _, ok := AlwaysDeprecated[name]; ok {
+				if _, ok := expectedDeprecated[name]; ok {
 					continue
 				}
 				assert.False(t, DeprecatedAt(name, rv.rules), "expected %s not deprecated", name)
 			}
 			for name := range ValidatorParams {
+				if _, ok := expectedDeprecated[name]; ok {
+					continue
+				}
 				assert.False(t, DeprecatedAt(name, rv.rules), "expected %s not deprecated (validator param)", name)
 			}
 

--- a/kaiax/valset/impl/api.go
+++ b/kaiax/valset/impl/api.go
@@ -32,14 +32,14 @@ func NewValsetAPI(vs *ValsetModule) *ValsetAPI {
 	return &ValsetAPI{vs: vs}
 }
 
-// GetNodeByState retrieves nodes at the specified block filtered by state.
+// GetNodesByState retrieves nodes at the specified block filtered by state.
 // If no states are provided, it returns all nodes.
-func (api *ValsetAPI) GetNodeByState(number *rpc.BlockNumber, states []valset.NodeState) (map[string]any, error) {
+func (api *ValsetAPI) GetNodesByState(number *rpc.BlockNumber, states []valset.NodeState) (map[string]any, error) {
 	num, err := api.resolveRpcNumber(number, true)
 	if err != nil {
 		return nil, err
 	}
-	nodes, err := api.vs.GetNodeByState(num, states)
+	nodes, err := api.vs.GetNodesByState(num, states)
 	if err != nil {
 		return nil, err
 	}

--- a/kaiax/valset/impl/api.go
+++ b/kaiax/valset/impl/api.go
@@ -34,21 +34,12 @@ func NewValsetAPI(vs *ValsetModule) *ValsetAPI {
 
 // GetNodesByState retrieves nodes at the specified block filtered by state.
 // If no states are provided, it returns all nodes.
-func (api *ValsetAPI) GetNodesByState(number *rpc.BlockNumber, states []valset.NodeState) (map[string]any, error) {
+func (api *ValsetAPI) GetNodesByState(number *rpc.BlockNumber, states []valset.NodeState) (map[common.Address]*valset.Node, error) {
 	num, err := api.resolveRpcNumber(number, true)
 	if err != nil {
 		return nil, err
 	}
-	nodes, err := api.vs.GetNodesByState(num, states)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make(map[string]any, len(nodes))
-	for addr, node := range nodes {
-		result[addr.Hex()] = node
-	}
-	return result, nil
+	return api.vs.GetNodesByState(num, states)
 }
 
 // GetCouncil retrieves the list of authorized validators at the specified block.

--- a/kaiax/valset/impl/api.go
+++ b/kaiax/valset/impl/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain/system"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/networks/rpc"
 )
 
@@ -29,6 +30,25 @@ type ValsetAPI struct {
 
 func NewValsetAPI(vs *ValsetModule) *ValsetAPI {
 	return &ValsetAPI{vs: vs}
+}
+
+// GetNodeByState retrieves nodes at the specified block filtered by state.
+// If no states are provided, it returns all nodes.
+func (api *ValsetAPI) GetNodeByState(number *rpc.BlockNumber, states []valset.NodeState) (map[string]any, error) {
+	num, err := api.resolveRpcNumber(number, true)
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := api.vs.GetNodeByState(num, states)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]any, len(nodes))
+	for addr, node := range nodes {
+		result[addr.Hex()] = node
+	}
+	return result, nil
 }
 
 // GetCouncil retrieves the list of authorized validators at the specified block.

--- a/kaiax/valset/impl/blockstate.go
+++ b/kaiax/valset/impl/blockstate.go
@@ -25,7 +25,7 @@ import (
 
 // InitializeState writes the post-fork node-state diff into the
 // AddressBookV2 contract via a system tx. No-op pre-fork. Runs before user
-// transactions while statedb still represents parent state.
+// transactions.
 func (v *ValsetModule) InitializeState(header *types.Header, statedb *state.StateDB) {
 	config := v.Chain.Config()
 	if !config.IsPermissionlessForkEnabled(header.Number) {
@@ -38,9 +38,7 @@ func (v *ValsetModule) InitializeState(header *types.Header, statedb *state.Stat
 	}
 }
 
-// FinalizeState installs and initializes the AddressBookV2 proxy at the HF-1
-// block. Runs after user transactions so the install is the last thing in the
-// block's state root. No-op outside that single block.
+// FinalizeState installs and initializes the AddressBookV2 proxy at the HF-1 block.
 func (v *ValsetModule) FinalizeState(header *types.Header, statedb *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt) error {
 	config := v.Chain.Config()
 	if !config.IsPermissionlessForkBlockParent(header.Number) {

--- a/kaiax/valset/impl/consensus.go
+++ b/kaiax/valset/impl/consensus.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"slices"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+)
+
+// VerifyHeader checks that the validator set written into the header (via the
+// IstanbulSealer) matches the qualified validator set this node would compute.
+// This is enforced only after the permissionless hardfork.
+//
+// This guards against a malicious proposer writing an arbitrary validator set
+// into header.Extra and getting away with it because committed seals only
+// verify against whatever set the header itself declares.
+func (v *ValsetModule) VerifyHeader(header *types.Header, _ *types.Header) error {
+	if !v.Chain.Config().IsPermissionlessForkEnabled(header.Number) {
+		return nil
+	}
+	num := header.Number.Uint64()
+	headerVals, err := v.Chain.Sealer().Validators(header)
+	if err != nil {
+		return err
+	}
+	qualified, err := v.getQualifiedValidators(num)
+	if err != nil {
+		return err
+	}
+	if !slices.Equal(headerVals, qualified.List()) {
+		return errMismatchedValidators
+	}
+	return nil
+}
+
+// PrepareHeader is a no-op. The validator set is written by
+// blockchain.PrepareHeader via Sealer().WriteValidators, before this hook runs.
+func (v *ValsetModule) PrepareHeader(*types.Header) error { return nil }

--- a/kaiax/valset/impl/consensus_test.go
+++ b/kaiax/valset/impl/consensus_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/consensus/engine"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/params"
+	chain_mock "github.com/kaiachain/kaia/work/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyHeaderPrePermissionlessNoOp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	config := params.TestKaiaConfig("osaka")
+	config.PermissionlessCompatibleBlock = big.NewInt(10)
+
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(config)
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+
+	// Missing Istanbul extra validators would fail Sealer().Validators(header),
+	// so this confirms pre-HF headers bypass the permissionless check entirely.
+	header := &types.Header{Number: big.NewInt(9)}
+	assert.NoError(t, v.VerifyHeader(header, nil))
+}
+
+func TestVerifyHeaderPermissionlessValidatorOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	config := params.TestKaiaConfig("permissionless")
+	sealer := engine.NewSealer(nil, nil)
+
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(config).AnyTimes()
+	mockChain.EXPECT().Sealer().Return(sealer).AnyTimes()
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+	v.transitionResultCache.Add(uint64(1), &TransitionResult{
+		Nodes: valset.NodeMap{
+			numToAddr(1): &valset.Node{State: valset.ValActive},
+			numToAddr(2): &valset.Node{State: valset.ValActive},
+		},
+	})
+
+	valid := &types.Header{Number: big.NewInt(1)}
+	require.NoError(t, sealer.WriteValidators(valid, numsToAddrs(1, 2)))
+	assert.NoError(t, v.VerifyHeader(valid, nil))
+
+	reordered := &types.Header{Number: big.NewInt(1)}
+	require.NoError(t, sealer.WriteValidators(reordered, numsToAddrs(2, 1)))
+	assert.ErrorIs(t, v.VerifyHeader(reordered, nil), errMismatchedValidators)
+}

--- a/kaiax/valset/impl/consensus_test.go
+++ b/kaiax/valset/impl/consensus_test.go
@@ -32,8 +32,6 @@ import (
 
 func TestVerifyHeaderPrePermissionlessNoOp(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	config := params.TestKaiaConfig("osaka")
 	config.PermissionlessCompatibleBlock = big.NewInt(10)
 
@@ -51,8 +49,6 @@ func TestVerifyHeaderPrePermissionlessNoOp(t *testing.T) {
 
 func TestVerifyHeaderPermissionlessValidatorOrder(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	config := params.TestKaiaConfig("permissionless")
 	sealer := engine.NewSealer(nil, nil)
 

--- a/kaiax/valset/impl/error.go
+++ b/kaiax/valset/impl/error.go
@@ -29,6 +29,7 @@ var (
 	errNoBlock                = errors.New("no block found")
 	errNoLowestScannedNum     = errors.New("no lowest scanned validator vote num")
 	errNoVoteBlockNums        = errors.New("no validator vote block nums")
+	errMismatchedValidators   = errors.New("header extra validators do not match qualified validators")
 
 	// rpc related errors
 	errPendingNotAllowed       = errors.New("pending is not allowed")

--- a/kaiax/valset/impl/error.go
+++ b/kaiax/valset/impl/error.go
@@ -30,6 +30,7 @@ var (
 	errNoLowestScannedNum     = errors.New("no lowest scanned validator vote num")
 	errNoVoteBlockNums        = errors.New("no validator vote block nums")
 	errMismatchedValidators   = errors.New("header extra validators do not match qualified validators")
+	errPermissionlessDisabled = errors.New("permissionless fork is not enabled")
 
 	// rpc related errors
 	errPendingNotAllowed       = errors.New("pending is not allowed")

--- a/kaiax/valset/impl/execution.go
+++ b/kaiax/valset/impl/execution.go
@@ -41,7 +41,7 @@ func (v *ValsetModule) postInsertBlockPermissionless(block *types.Block) error {
 	if err != nil {
 		return err
 	}
-	_, err = v.getTransitionResult(nextNum, parentStatedb)
+	_, err = v.getTransitionResult(nextNum, parentStatedb) // to cache the transition result
 	return err
 }
 

--- a/kaiax/valset/impl/execution.go
+++ b/kaiax/valset/impl/execution.go
@@ -17,19 +17,40 @@
 package impl
 
 import (
+	"math/big"
+
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 )
 
 func (v *ValsetModule) PostInsertBlock(block *types.Block) error {
-	header := block.Header()
-	num := header.Number.Uint64()
+	num := block.Header().Number.Uint64()
 	if num == 0 {
 		return nil
 	}
+	if !v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.postInsertBlockPermissioned(block)
+	}
+	return v.postInsertBlockPermissionless(block)
+}
 
-	// Ingest validator vote
-	council, err := v.getCouncil(num)
+func (v *ValsetModule) postInsertBlockPermissionless(block *types.Block) error {
+	header := block.Header()
+	nextNum := header.Number.Uint64() + 1
+	parentStatedb, err := v.Chain.StateAt(header.Root)
+	if err != nil {
+		return err
+	}
+	_, err = v.getTransitionResult(nextNum, parentStatedb)
+	return err
+}
+
+// postInsertBlockPermissioned ingests the validator vote (if any) carried in
+// the block's header and persists the updated council to the DB.
+func (v *ValsetModule) postInsertBlockPermissioned(block *types.Block) error {
+	header := block.Header()
+	num := header.Number.Uint64()
+	council, err := v.getCouncilPermissioned(num)
 	if err != nil {
 		return err
 	}
@@ -39,13 +60,13 @@ func (v *ValsetModule) PostInsertBlock(block *types.Block) error {
 		writeCouncil(v.ChainKv, num, council.List())
 		v.validatorVoteBlockNumsCache = nil
 	}
-
 	return nil
 }
 
 func (v *ValsetModule) RewindTo(block *types.Block) {
 	trimValidatorVoteBlockNums(v.ChainKv, block.Header().Number.Uint64())
 	v.validatorVoteBlockNumsCache = nil
+	v.transitionResultCache.Purge()
 }
 
 func (v *ValsetModule) RewindDelete(hash common.Hash, num uint64) {

--- a/kaiax/valset/impl/execution.go
+++ b/kaiax/valset/impl/execution.go
@@ -66,7 +66,6 @@ func (v *ValsetModule) postInsertBlockPermissioned(block *types.Block) error {
 func (v *ValsetModule) RewindTo(block *types.Block) {
 	trimValidatorVoteBlockNums(v.ChainKv, block.Header().Number.Uint64())
 	v.validatorVoteBlockNumsCache = nil
-	v.transitionResultCache.Purge()
 }
 
 func (v *ValsetModule) RewindDelete(hash common.Hash, num uint64) {

--- a/kaiax/valset/impl/execution_test.go
+++ b/kaiax/valset/impl/execution_test.go
@@ -66,6 +66,7 @@ func TestPostInsertBlock(t *testing.T) {
 	writeCouncil(db, 0, genesisCouncil)
 	writeValidatorVoteBlockNums(db, []uint64{0})
 	writeLowestScannedVoteNum(db, 0)
+	mockChain.EXPECT().Config().Return(&params.ChainConfig{}).AnyTimes()
 	mockChain.EXPECT().GetHeaderByNumber(uint64(0)).Return(makeGenesisBlock(genesisCouncil).Header()).AnyTimes()
 	mockGov.EXPECT().GetParamSet(uint64(1)).Return(pset).AnyTimes()
 	mockGov.EXPECT().GetParamSet(uint64(2)).Return(pset).AnyTimes()
@@ -111,16 +112,19 @@ func Test_AddRemove(t *testing.T) {
 	for _, tc := range testcases {
 		ctrl := gomock.NewController(t)
 		db := database.NewMemDB()
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
 		mockGov := gov_mock.NewMockGovModule(ctrl)
 		mockStaking := staking_mock.NewMockStakingModule(ctrl)
 		v := &ValsetModule{InitOpts: InitOpts{
 			ChainKv:       db,
+			Chain:         mockChain,
 			GovModule:     mockGov,
 			StakingModule: mockStaking,
 		}}
 		writeCouncil(db, 0, genesisCouncil)
 		writeValidatorVoteBlockNums(db, []uint64{0})
 		writeLowestScannedVoteNum(db, 0)
+		mockChain.EXPECT().Config().Return(&params.ChainConfig{}).AnyTimes()
 		mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{GoverningNode: governingNode}).AnyTimes()
 
 		for i := 0; i < tc.length; i++ {

--- a/kaiax/valset/impl/execution_test.go
+++ b/kaiax/valset/impl/execution_test.go
@@ -82,6 +82,36 @@ func TestPostInsertBlock(t *testing.T) {
 	assert.Equal(t, numsToAddrs(1, 2, 3, 6), ReadCouncil(db, 2))
 }
 
+func TestPostInsertBlock_PermissionlessIgnoresVote(t *testing.T) {
+	var (
+		governingNode = numToAddr(3)
+		voteAdd6, _   = headergov.NewVoteData(governingNode, string(gov.AddValidator), numToAddr(6)).ToVoteBytes()
+		block1        = types.NewBlockWithHeader(&types.Header{
+			Number: big.NewInt(1),
+			Vote:   voteAdd6,
+		})
+	)
+
+	ctrl := gomock.NewController(t)
+
+	db := database.NewMemDB()
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+	mockChain.EXPECT().StateAt(gomock.Any()).Return(nil, nil)
+
+	v := NewValsetModule()
+	v.ChainKv = db
+	v.Chain = mockChain
+	v.transitionResultCache.Add(uint64(2), &TransitionResult{
+		Nodes: NodeMap{numToAddr(1): {State: ValActive}},
+	})
+
+	writeValidatorVoteBlockNums(db, []uint64{0})
+	assert.NoError(t, v.PostInsertBlock(block1))
+	assert.Equal(t, []uint64{0}, ReadValidatorVoteBlockNums(db))
+	assert.Nil(t, ReadCouncil(db, 1))
+}
+
 func Test_AddRemove(t *testing.T) {
 	type vote struct {
 		key   gov.ParamName
@@ -149,6 +179,5 @@ func Test_AddRemove(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, numsToAddrs(e.validators...), council)
 		}
-		ctrl.Finish()
 	}
 }

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -17,34 +17,30 @@
 package impl
 
 import (
+	"math/big"
+
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/valset"
 )
 
-// GetCandTesting returns nodes in the CandTesting state at block `num`.
-// TODO-kaia-permissionless: replace with a real implementation once AddressBookV2
-// and the permissionless node-state map land on dev.
-func (v *ValsetModule) GetCandTesting(num uint64) ([]common.Address, error) {
-	return []common.Address{}, nil
-}
-
 // GetCouncil returns the whole validator list for validating the block `num`.
 func (v *ValsetModule) GetCouncil(num uint64) ([]common.Address, error) {
-	council, err := v.getCouncil(num)
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getCouncil(num)
+	}
+	council, err := v.getCouncilPermissioned(num)
 	if err != nil {
 		return nil, err
-	} else {
-		return council.List(), nil
 	}
+	return council.List(), nil
 }
 
-// GetDemotedValidators are subtract of qualified from council(N)
+// GetDemotedValidators returns council − qualified at block `num`.
 func (v *ValsetModule) GetDemotedValidators(num uint64) ([]common.Address, error) {
-	council, err := v.getCouncil(num)
-	if err != nil {
-		return nil, err
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getDemoted(num)
 	}
-	demoted, err := v.getDemotedValidators(council, num)
+	demoted, err := v.getDemotedPermissioned(num)
 	if err != nil {
 		return nil, err
 	}
@@ -52,23 +48,19 @@ func (v *ValsetModule) GetDemotedValidators(num uint64) ([]common.Address, error
 }
 
 func (v *ValsetModule) GetQualifiedValidators(num uint64) ([]common.Address, error) {
-	qualified, err := v.getQualifiedValidators(num)
+	var (
+		qualified *valset.AddressSet
+		err       error
+	)
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		qualified, err = v.getQualifiedValidators(num)
+	} else {
+		qualified, err = v.getQualifiedPermissioned(num)
+	}
 	if err != nil {
 		return nil, err
 	}
 	return qualified.List(), nil
-}
-
-func (v *ValsetModule) getQualifiedValidators(num uint64) (*valset.AddressSet, error) {
-	council, err := v.getCouncil(num)
-	if err != nil {
-		return nil, err
-	}
-	demoted, err := v.getDemotedValidators(council, num)
-	if err != nil {
-		return nil, err
-	}
-	return council.Subtract(demoted), nil
 }
 
 // GetCommittee returns the current block's committee.
@@ -76,13 +68,16 @@ func (v *ValsetModule) GetCommittee(num uint64, round uint64) ([]common.Address,
 	if num == 0 {
 		return v.GetCouncil(0)
 	}
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getCommittee(num, round)
+	}
 
 	// TODO-kaiax: Sync blockContext
 	c, err := v.getBlockContext(num)
 	if err != nil {
 		return nil, err
 	}
-	return v.getCommittee(c, round)
+	return v.getCommitteePermissioned(c, round)
 }
 
 func (v *ValsetModule) GetProposer(num, round uint64) (common.Address, error) {
@@ -101,4 +96,42 @@ func (v *ValsetModule) GetProposer(num, round uint64) (common.Address, error) {
 		return common.Address{}, err
 	}
 	return v.getProposer(c, round)
+}
+
+// #region Permissionless-only public getters.
+//
+// Pre-fork they return permissioned
+// equivalents (council for peer/voter sets, empty for the post-fork-only
+// CandTesting / NodeByState).
+
+// GetCandTesting returns nodes in the CandTesting state. Empty pre-fork.
+func (v *ValsetModule) GetCandTesting(num uint64) ([]common.Address, error) {
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getCandTesting(num)
+	}
+	return []common.Address{}, nil
+}
+
+// GetCNPeers returns the CN-CN P2P peer set. Pre-fork: council.
+func (v *ValsetModule) GetCNPeers(num uint64) ([]common.Address, error) {
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getCNPeers(num)
+	}
+	return v.GetCouncil(num)
+}
+
+// GetHeaderGovVoters returns validators eligible for header governance votes. Pre-fork: council.
+func (v *ValsetModule) GetHeaderGovVoters(num uint64) ([]common.Address, error) {
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getHeaderGovVoters(num)
+	}
+	return v.GetCouncil(num)
+}
+
+// GetNodeByState filters NodeMap by state. Empty states means "all". Empty pre-fork.
+func (v *ValsetModule) GetNodeByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getNodeByState(num, states)
+	}
+	return nil, nil
 }

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -128,10 +128,10 @@ func (v *ValsetModule) GetHeaderGovVoters(num uint64) ([]common.Address, error) 
 	return v.GetCouncil(num)
 }
 
-// GetNodeByState filters NodeMap by state. Empty states means "all". Empty pre-fork.
-func (v *ValsetModule) GetNodeByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
+// GetNodesByState filters NodeMap by state. Empty states means "all". Empty pre-fork.
+func (v *ValsetModule) GetNodesByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		return v.getNodeByState(num, states)
+		return v.getNodesByState(num, states)
 	}
 	return nil, nil
 }

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -69,7 +69,7 @@ func (v *ValsetModule) GetCommittee(num uint64, round uint64) ([]common.Address,
 		return v.GetCouncil(0)
 	}
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		return v.getCommittee(num, round)
+		return v.getCommittee(num)
 	}
 
 	// TODO-kaiax: Sync blockContext

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -100,9 +100,8 @@ func (v *ValsetModule) GetProposer(num, round uint64) (common.Address, error) {
 
 // #region Permissionless-only public getters.
 //
-// Pre-fork they return permissioned
-// equivalents (council for peer/voter sets, empty for the post-fork-only
-// CandTesting / NodeByState).
+// Pre-fork they return permissioned equivalents for peer/voter sets, empty for
+// CandTesting, and an explicit fork-disabled error for NodesByState.
 
 // GetCandTesting returns nodes in the CandTesting state. Empty pre-fork.
 func (v *ValsetModule) GetCandTesting(num uint64) ([]common.Address, error) {
@@ -128,10 +127,8 @@ func (v *ValsetModule) GetHeaderGovVoters(num uint64) ([]common.Address, error) 
 	return v.GetCouncil(num)
 }
 
-// GetNodesByState filters NodeMap by state. Empty states means "all". Empty pre-fork.
+// GetNodesByState filters NodeMap by state. Empty states means "all".
+// Returns an explicit fork-disabled error pre-fork.
 func (v *ValsetModule) GetNodesByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
-	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		return v.getNodesByState(num, states)
-	}
-	return nil, nil
+	return v.getNodesByState(num, states)
 }

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -129,6 +129,10 @@ func (v *ValsetModule) GetHeaderGovVoters(num uint64) ([]common.Address, error) 
 
 // GetNodesByState filters NodeMap by state. Empty states means "all".
 // Returns an explicit fork-disabled error pre-fork.
-func (v *ValsetModule) GetNodesByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
-	return v.getNodesByState(num, states)
+func (v *ValsetModule) GetNodesByState(num uint64, states []valset.NodeState) (map[common.Address]*valset.Node, error) {
+	nodes, err := v.getNodesByState(num, states)
+	if err != nil {
+		return nil, err
+	}
+	return map[common.Address]*valset.Node(nodes), nil
 }

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -42,10 +42,36 @@ type blockContext struct {
 }
 
 func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
-	qualified, err := v.getQualifiedValidators(num)
-	if err != nil {
-		return nil, err
+	var (
+		qualified *valset.AddressSet
+		err       error
+	)
+
+	// Post-fork fast path: VerifyHeader guarantees that the header's stored
+	// validator list (Sealer().Validators) equals getQualifiedValidators(num)
+	// for committed canonical blocks. Read it directly to avoid an ABv2
+	// lookup. Falls back to recomputing when the block is not yet inserted
+	// (e.g. while mining or verifying the candidate header before insertion).
+	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		if header := v.Chain.GetHeaderByNumber(num); header != nil {
+			vals, err := v.Chain.Sealer().Validators(header)
+			if err != nil {
+				return nil, err
+			}
+			qualified = valset.NewAddressSet(vals)
+		} else {
+			qualified, err = v.getQualifiedValidators(num)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		qualified, err = v.getQualifiedPermissioned(num)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	prevHeader := v.Chain.GetHeaderByNumber(num - 1)
 	if prevHeader == nil {
 		return nil, errNoHeader
@@ -69,7 +95,7 @@ func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
 	}, nil
 }
 
-func (v *ValsetModule) getCommittee(c *blockContext, round uint64) ([]common.Address, error) {
+func (v *ValsetModule) getCommitteePermissioned(c *blockContext, round uint64) ([]common.Address, error) {
 	if c.num == 0 {
 		return c.qualified.List(), nil
 	}
@@ -178,7 +204,13 @@ func (v *ValsetModule) getProposer(c *blockContext, round uint64) (common.Addres
 		return selectStickyProposer(c.qualified, c.prevProposer, round), nil
 	case istanbul.WeightedRandom:
 		if c.rules.IsRandao {
-			committee := selectRandaoCommittee(c.qualified, c.pset.CommitteeSize, c.prevHeader.MixHash)
+			// CommitteeSize is deprecated post-fork: shuffle the full qualified
+			// set so the proposer is drawn from every active validator.
+			committeeSize := c.pset.CommitteeSize
+			if c.rules.IsPermissionless {
+				committeeSize = uint64(c.qualified.Len())
+			}
+			committee := selectRandaoCommittee(c.qualified, committeeSize, c.prevHeader.MixHash)
 			return selectRandaoProposer(committee, round), nil
 		} else {
 			list, sourceNum, err := v.getProposerList(c)

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -55,13 +55,11 @@ func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
 				return nil, err
 			}
 			qualified = valset.NewAddressSet(vals)
-		} else {
-			qualified, err = v.getQualifiedValidators(num)
-			if err != nil {
-				return nil, err
-			}
 		}
-	} else {
+	}
+
+	if qualified == nil {
+		// post-permissionless + future blocks, or pre-permissionless
 		qualified, err = v.getQualifiedPermissioned(num)
 		if err != nil {
 			return nil, err
@@ -200,10 +198,8 @@ func (v *ValsetModule) getProposer(c *blockContext, round uint64) (common.Addres
 		return selectStickyProposer(c.qualified, c.prevProposer, round), nil
 	case istanbul.WeightedRandom:
 		if c.rules.IsRandao {
-			// CommitteeSize is deprecated post-fork: shuffle the full qualified
-			// set so the proposer is drawn from every active validator.
 			committeeSize := c.pset.CommitteeSize
-			if c.rules.IsPermissionless {
+			if gov.DeprecatedAt(gov.IstanbulCommitteeSize, c.rules) {
 				committeeSize = uint64(c.qualified.Len())
 			}
 			committee := selectRandaoCommittee(c.qualified, committeeSize, c.prevHeader.MixHash)

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -47,11 +47,7 @@ func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
 		err       error
 	)
 
-	// Post-fork fast path: VerifyHeader guarantees that the header's stored
-	// validator list (Sealer().Validators) equals getQualifiedValidators(num)
-	// for committed canonical blocks. Read it directly to avoid an ABv2
-	// lookup. Falls back to recomputing when the block is not yet inserted
-	// (e.g. while mining or verifying the candidate header before insertion).
+	// After the fork, canonical headers already carry the verified validator set.
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
 		if header := v.Chain.GetHeaderByNumber(num); header != nil {
 			vals, err := v.Chain.Sealer().Validators(header)

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -59,7 +59,7 @@ func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
 	}
 
 	if qualified == nil {
-		// post-permissionless + future blocks, or pre-permissionless
+		// future blocks under post-permissionless, or pre-permissionless
 		qualified, err = v.getQualifiedPermissioned(num)
 		if err != nil {
 			return nil, err

--- a/kaiax/valset/impl/getter_context_test.go
+++ b/kaiax/valset/impl/getter_context_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestGetCommittee tests various branches of getCommittee().
+// TestGetCommittee tests various branches of getCommitteePermissioned().
 // Individual selectors are tested as separate tests.
 func TestGetCommittee(t *testing.T) {
 	var (
@@ -116,7 +116,7 @@ func TestGetCommittee(t *testing.T) {
 
 		v.proposerListCache.Purge()
 		v.removeVotesCache.Purge()
-		committee, err := v.getCommittee(c, 0)
+		committee, err := v.getCommitteePermissioned(c, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expected, committee, tc.desc)
 	}

--- a/kaiax/valset/impl/getter_council.go
+++ b/kaiax/valset/impl/getter_council.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/valset"
 )
 
-func (v *ValsetModule) getCouncil(num uint64) (*valset.AddressSet, error) {
+func (v *ValsetModule) getCouncilPermissioned(num uint64) (*valset.AddressSet, error) {
 	if num == 0 {
 		return v.getCouncilGenesis()
 	}

--- a/kaiax/valset/impl/getter_council_test.go
+++ b/kaiax/valset/impl/getter_council_test.go
@@ -38,7 +38,6 @@ func TestGetCouncilGenesis(t *testing.T) {
 		mockChain = chain_mock.NewMockBlockChain(ctrl)
 		v         = &ValsetModule{InitOpts: InitOpts{Chain: mockChain}}
 	)
-	defer ctrl.Finish()
 	// Kairos block 0
 	mockChain.EXPECT().GetHeaderByNumber(uint64(0)).Return(&types.Header{
 		Number: common.Big0,

--- a/kaiax/valset/impl/getter_demote.go
+++ b/kaiax/valset/impl/getter_demote.go
@@ -26,8 +26,8 @@ import (
 	"github.com/kaiachain/kaia/kaiax/valset"
 )
 
-// getDemotedValidators returns the demoted validators at the given block number.
-func (v *ValsetModule) getDemotedValidators(council *valset.AddressSet, num uint64) (*valset.AddressSet, error) {
+// getDemotedValidatorsPermissioned returns the demoted validators at the given block number.
+func (v *ValsetModule) getDemotedValidatorsPermissioned(council *valset.AddressSet, num uint64) (*valset.AddressSet, error) {
 	if num == 0 {
 		return valset.NewAddressSet(nil), nil
 	}
@@ -53,6 +53,26 @@ func (v *ValsetModule) getDemotedValidators(council *valset.AddressSet, num uint
 	default:
 		return nil, errInvalidProposerPolicy
 	}
+}
+
+func (v *ValsetModule) getDemotedPermissioned(num uint64) (*valset.AddressSet, error) {
+	council, err := v.getCouncilPermissioned(num)
+	if err != nil {
+		return nil, err
+	}
+	return v.getDemotedValidatorsPermissioned(council, num)
+}
+
+func (v *ValsetModule) getQualifiedPermissioned(num uint64) (*valset.AddressSet, error) {
+	council, err := v.getCouncilPermissioned(num)
+	if err != nil {
+		return nil, err
+	}
+	demoted, err := v.getDemotedValidatorsPermissioned(council, num)
+	if err != nil {
+		return nil, err
+	}
+	return council.Subtract(demoted), nil
 }
 
 func getDemotedValidatorsIstanbul(council *valset.AddressSet, si *staking.StakingInfo, pset gov.ParamSet) *valset.AddressSet {

--- a/kaiax/valset/impl/getter_demote_test.go
+++ b/kaiax/valset/impl/getter_demote_test.go
@@ -36,7 +36,6 @@ import (
 
 func newValsetModuleWithCouncil(t *testing.T, config *params.ChainConfig, council []common.Address) (*ValsetModule, *gov_mock.MockGovModule, *staking_mock.MockStakingModule) {
 	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
 
 	db := database.NewMemDB()
 	writeLowestScannedVoteNum(db, 0)
@@ -103,7 +102,6 @@ func TestGetDemotedValidators(t *testing.T) {
 			StakingModule: mockStaking,
 		}}
 	)
-	defer ctrl.Finish()
 	for _, tc := range testcases {
 		if tc.isIstanbul {
 			config.IstanbulCompatibleBlock = big.NewInt(1)

--- a/kaiax/valset/impl/getter_demote_test.go
+++ b/kaiax/valset/impl/getter_demote_test.go
@@ -114,7 +114,7 @@ func TestGetDemotedValidators(t *testing.T) {
 		mockGov.EXPECT().GetParamSet(gomock.Any()).Return(pset).Times(1)
 		mockStaking.EXPECT().GetStakingInfo(gomock.Any()).Return(si, nil).AnyTimes()
 
-		demoted, err := v.getDemotedValidators(valset.NewAddressSet(council), 1)
+		demoted, err := v.getDemotedValidatorsPermissioned(valset.NewAddressSet(council), 1)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.demoted, demoted.List(), tc.desc)
 	}

--- a/kaiax/valset/impl/getter_permissionless.go
+++ b/kaiax/valset/impl/getter_permissionless.go
@@ -105,9 +105,9 @@ func (v *ValsetModule) getHeaderGovVoters(num uint64) ([]common.Address, error) 
 	return nodes.HeaderGovVoters().Addresses(), nil
 }
 
-// getNodeByState filters nodes by state. Empty states means "all".
+// getNodesByState filters nodes by state. Empty states means "all".
 // Returns a defensive copy so callers can mutate the result freely.
-func (v *ValsetModule) getNodeByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
+func (v *ValsetModule) getNodesByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
 	nodes, err := v.getNodes(num)
 	if err != nil {
 		return nil, err

--- a/kaiax/valset/impl/getter_permissionless.go
+++ b/kaiax/valset/impl/getter_permissionless.go
@@ -59,7 +59,7 @@ func (v *ValsetModule) getQualifiedValidators(num uint64) (*valset.AddressSet, e
 }
 
 // getCommittee: committee: qualified = {VA} − suspended
-func (v *ValsetModule) getCommittee(num uint64, round uint64) ([]common.Address, error) {
+func (v *ValsetModule) getCommittee(num uint64) ([]common.Address, error) {
 	qualified, err := v.getQualifiedValidators(num)
 	if err != nil {
 		return nil, err

--- a/kaiax/valset/impl/getter_permissionless.go
+++ b/kaiax/valset/impl/getter_permissionless.go
@@ -31,7 +31,7 @@ func (v *ValsetModule) getCouncil(num uint64) ([]common.Address, error) {
 }
 
 // committeeWithFallback returns the committee at the given block.
-// Committee = {ValActive} - SuspendedSet.
+// Committee = {VA} - {Suspended}.
 //
 // Safety fallback: when len(committee)=0 due to {ValActive} ⊆ SuspendedSet, fallback to all VA.
 func committeeWithFallback(nodes valset.NodeMap) (committee valset.NodeMap, fellBack bool) {
@@ -44,7 +44,7 @@ func committeeWithFallback(nodes valset.NodeMap) (committee valset.NodeMap, fell
 	return nodes.FilterByState(valset.ValActive), true
 }
 
-// getQualifiedValidators: qualified = committee = {VA} − suspended (with safety fallback).
+// getQualifiedValidators: qualified = committee = {VA} − {Suspended} (with safety fallback).
 func (v *ValsetModule) getQualifiedValidators(num uint64) (*valset.AddressSet, error) {
 	nodes, err := v.getNodes(num)
 	if err != nil {
@@ -67,7 +67,7 @@ func (v *ValsetModule) getCommittee(num uint64, round uint64) ([]common.Address,
 	return qualified.List(), nil
 }
 
-// getDemoted: demoted = council − qualified = {VP} ∪ {suspended VA}.
+// getDemoted: demoted = council − qualified = {VP} ∪ {Suspended}.
 func (v *ValsetModule) getDemoted(num uint64) ([]common.Address, error) {
 	nodes, err := v.getNodes(num)
 	if err != nil {
@@ -96,7 +96,7 @@ func (v *ValsetModule) getCNPeers(num uint64) ([]common.Address, error) {
 	return nodes.CNPeers().Addresses(), nil
 }
 
-// getHeaderGovVoters: HeaderGovVoters = {ValActive} - SuspendedSet.
+// getHeaderGovVoters: HeaderGovVoters = {VA} - {Suspended}.
 func (v *ValsetModule) getHeaderGovVoters(num uint64) ([]common.Address, error) {
 	nodes, err := v.getNodes(num)
 	if err != nil {

--- a/kaiax/valset/impl/getter_permissionless.go
+++ b/kaiax/valset/impl/getter_permissionless.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/valset"
+)
+
+// getCouncil: Council = {ValActive, ValPaused}.
+func (v *ValsetModule) getCouncil(num uint64) ([]common.Address, error) {
+	nodes, err := v.getNodes(num)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Council().Addresses(), nil
+}
+
+// committeeWithFallback returns the committee at the given block.
+// Committee = {ValActive} - SuspendedSet.
+//
+// Safety fallback: when len(committee)=0 due to {ValActive} ⊆ SuspendedSet, fallback to all VA.
+func committeeWithFallback(nodes valset.NodeMap) (committee valset.NodeMap, fellBack bool) {
+	committee = nodes.Committee()
+	if len(committee) > 0 {
+		return committee, false
+	}
+
+	// ignore SuspendedSet
+	return nodes.FilterByState(valset.ValActive), true
+}
+
+// getQualifiedValidators: qualified = committee = {VA} − suspended (with safety fallback).
+func (v *ValsetModule) getQualifiedValidators(num uint64) (*valset.AddressSet, error) {
+	nodes, err := v.getNodes(num)
+	if err != nil {
+		return nil, err
+	}
+	committee, fellBack := committeeWithFallback(nodes)
+	if fellBack && v.lastSuspendFallbackLog != num {
+		logger.Warn("all ValActive are suspended, ignoring suspended set for committee", "num", num)
+		v.lastSuspendFallbackLog = num
+	}
+	return valset.NewAddressSet(committee.Addresses()), nil
+}
+
+// getCommittee: committee: qualified = {VA} − suspended
+func (v *ValsetModule) getCommittee(num uint64, round uint64) ([]common.Address, error) {
+	qualified, err := v.getQualifiedValidators(num)
+	if err != nil {
+		return nil, err
+	}
+	return qualified.List(), nil
+}
+
+// getDemoted: demoted = council − qualified = {VP} ∪ {suspended VA}.
+func (v *ValsetModule) getDemoted(num uint64) ([]common.Address, error) {
+	nodes, err := v.getNodes(num)
+	if err != nil {
+		return nil, err
+	}
+	council := valset.NewAddressSet(nodes.Council().Addresses())
+	committee, _ := committeeWithFallback(nodes)
+	return council.Subtract(valset.NewAddressSet(committee.Addresses())).List(), nil
+}
+
+// getCandTesting: CandTesting = {CT}
+func (v *ValsetModule) getCandTesting(num uint64) ([]common.Address, error) {
+	nodes, err := v.getNodes(num)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.FilterByState(valset.CandTesting).Addresses(), nil
+}
+
+// getCNPeers: CNPeers = {VA, VR, VP, CR, CT}.
+func (v *ValsetModule) getCNPeers(num uint64) ([]common.Address, error) {
+	nodes, err := v.getNodes(num)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.CNPeers().Addresses(), nil
+}
+
+// getHeaderGovVoters: HeaderGovVoters = {ValActive} - SuspendedSet.
+func (v *ValsetModule) getHeaderGovVoters(num uint64) ([]common.Address, error) {
+	nodes, err := v.getNodes(num)
+	if err != nil {
+		return nil, err
+	}
+	return nodes.HeaderGovVoters().Addresses(), nil
+}
+
+// getNodeByState filters nodes by state. Empty states means "all".
+// Returns a defensive copy so callers can mutate the result freely.
+func (v *ValsetModule) getNodeByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {
+	nodes, err := v.getNodes(num)
+	if err != nil {
+		return nil, err
+	}
+	if len(states) == 0 {
+		return nodes.Copy(), nil
+	}
+	return nodes.FilterByState(states...).Copy(), nil
+}

--- a/kaiax/valset/impl/getter_permissionless_test.go
+++ b/kaiax/valset/impl/getter_permissionless_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package impl
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/common"
+	chain_mock "github.com/kaiachain/kaia/work/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testGetterBlock = uint64(10)
+
+func TestPermissionlessPublicGetters(t *testing.T) {
+	addr6 := numToAddr(6)
+	addr7 := numToAddr(7)
+	v := newCachedPermissionlessValset(t, NodeMap{
+		addr1: {State: ValActive},
+		addr2: {State: ValActive, Suspended: true},
+		addr3: {State: ValPaused},
+		addr4: {State: ValReady},
+		addr5: {State: CandReady},
+		addr6: {State: CandTesting},
+		addr7: {State: Registered},
+	})
+
+	council, err := v.GetCouncil(testGetterBlock)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []common.Address{addr1, addr2, addr3}, council)
+
+	cnPeers, err := v.GetCNPeers(testGetterBlock)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []common.Address{addr1, addr2, addr3, addr4, addr5, addr6}, cnPeers)
+
+	headerGovVoters, err := v.GetHeaderGovVoters(testGetterBlock)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []common.Address{addr1}, headerGovVoters)
+
+	demoted, err := v.GetDemotedValidators(testGetterBlock)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []common.Address{addr2, addr3}, demoted)
+
+	committee, err := v.GetCommittee(testGetterBlock, 0)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []common.Address{addr1}, committee)
+
+	candTesting, err := v.GetCandTesting(testGetterBlock)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []common.Address{addr6}, candTesting)
+}
+
+func TestGetNodesByState(t *testing.T) {
+	addr6 := numToAddr(6)
+	nodes := NodeMap{
+		addr1: {State: ValActive},
+		addr2: {State: ValPaused},
+		addr3: {State: ValInactive},
+		addr4: {State: CandReady},
+		addr5: {State: ValExiting},
+		addr6: {State: ValActive, Suspended: true},
+	}
+	v := newCachedPermissionlessValset(t, nodes)
+
+	t.Run("filter single state", func(t *testing.T) {
+		result, err := v.GetNodesByState(testGetterBlock, []NodeState{ValActive})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []common.Address{addr1, addr6}, result.Addresses())
+	})
+
+	t.Run("filter multiple states", func(t *testing.T) {
+		result, err := v.GetNodesByState(testGetterBlock, []NodeState{ValActive, ValPaused})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []common.Address{addr1, addr2, addr6}, result.Addresses())
+	})
+
+	t.Run("empty states returns all", func(t *testing.T) {
+		result, err := v.GetNodesByState(testGetterBlock, []NodeState{})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, nodes.Addresses(), result.Addresses())
+	})
+
+	t.Run("nil states returns all", func(t *testing.T) {
+		result, err := v.GetNodesByState(testGetterBlock, nil)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, nodes.Addresses(), result.Addresses())
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		result, err := v.GetNodesByState(testGetterBlock, []NodeState{ValReady})
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("returns defensive copy", func(t *testing.T) {
+		result, err := v.GetNodesByState(testGetterBlock, nil)
+		require.NoError(t, err)
+		result[addr1].State = Registered
+
+		again, err := v.GetNodesByState(testGetterBlock, []NodeState{ValActive})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []common.Address{addr1, addr6}, again.Addresses())
+		assert.Equal(t, ValActive, again[addr1].State)
+	})
+}
+
+func TestSuspendedFallback(t *testing.T) {
+	t.Run("all ValActive suspended falls back to all ValActive", func(t *testing.T) {
+		v := newCachedPermissionlessValset(t, NodeMap{
+			addr1: {State: ValActive, Suspended: true},
+			addr2: {State: ValActive, Suspended: true},
+			addr3: {State: ValPaused, Suspended: true},
+		})
+
+		qualified, err := v.getQualifiedValidators(testGetterBlock)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []common.Address{addr1, addr2}, qualified.List())
+
+		committee, err := v.getCommittee(testGetterBlock)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []common.Address{addr1, addr2}, committee)
+	})
+
+	t.Run("some ValActive suspended excludes only suspended validators", func(t *testing.T) {
+		v := newCachedPermissionlessValset(t, NodeMap{
+			addr1: {State: ValActive, Suspended: true},
+			addr2: {State: ValActive},
+			addr3: {State: ValActive},
+		})
+
+		qualified, err := v.getQualifiedValidators(testGetterBlock)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []common.Address{addr2, addr3}, qualified.List())
+	})
+
+	t.Run("demoted is council minus qualified", func(t *testing.T) {
+		v := newCachedPermissionlessValset(t, NodeMap{
+			addr1: {State: ValActive, Suspended: true},
+			addr2: {State: ValActive},
+			addr3: {State: ValPaused},
+			addr4: {State: CandReady},
+		})
+
+		demoted, err := v.getDemoted(testGetterBlock)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []common.Address{addr1, addr3}, demoted)
+	})
+}
+
+func TestGetNodesByStatePreForkError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10))
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+
+	nodes, err := v.GetNodesByState(10, nil)
+	require.Nil(t, nodes)
+	require.ErrorIs(t, err, errPermissionlessDisabled)
+}
+
+func newCachedPermissionlessValset(t *testing.T, nodes NodeMap) *ValsetModule {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+	v.transitionResultCache.Add(testGetterBlock, &TransitionResult{Nodes: nodes})
+	return v
+}

--- a/kaiax/valset/impl/getter_permissionless_test.go
+++ b/kaiax/valset/impl/getter_permissionless_test.go
@@ -81,25 +81,25 @@ func TestGetNodesByState(t *testing.T) {
 	t.Run("filter single state", func(t *testing.T) {
 		result, err := v.GetNodesByState(testGetterBlock, []NodeState{ValActive})
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []common.Address{addr1, addr6}, result.Addresses())
+		assert.ElementsMatch(t, []common.Address{addr1, addr6}, NodeMap(result).Addresses())
 	})
 
 	t.Run("filter multiple states", func(t *testing.T) {
 		result, err := v.GetNodesByState(testGetterBlock, []NodeState{ValActive, ValPaused})
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []common.Address{addr1, addr2, addr6}, result.Addresses())
+		assert.ElementsMatch(t, []common.Address{addr1, addr2, addr6}, NodeMap(result).Addresses())
 	})
 
 	t.Run("empty states returns all", func(t *testing.T) {
 		result, err := v.GetNodesByState(testGetterBlock, []NodeState{})
 		require.NoError(t, err)
-		assert.ElementsMatch(t, nodes.Addresses(), result.Addresses())
+		assert.ElementsMatch(t, nodes.Addresses(), NodeMap(result).Addresses())
 	})
 
 	t.Run("nil states returns all", func(t *testing.T) {
 		result, err := v.GetNodesByState(testGetterBlock, nil)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, nodes.Addresses(), result.Addresses())
+		assert.ElementsMatch(t, nodes.Addresses(), NodeMap(result).Addresses())
 	})
 
 	t.Run("no match returns empty", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestGetNodesByState(t *testing.T) {
 
 		again, err := v.GetNodesByState(testGetterBlock, []NodeState{ValActive})
 		require.NoError(t, err)
-		assert.ElementsMatch(t, []common.Address{addr1, addr6}, again.Addresses())
+		assert.ElementsMatch(t, []common.Address{addr1, addr6}, NodeMap(again).Addresses())
 		assert.Equal(t, ValActive, again[addr1].State)
 	})
 }

--- a/kaiax/valset/impl/getter_proposers.go
+++ b/kaiax/valset/impl/getter_proposers.go
@@ -78,7 +78,7 @@ func (v *ValsetModule) getRemoveVotesInInterval(pUpdateNum, pUpdateInterval uint
 		}
 		if len(addresses) > 0 && voteKey == gov.RemoveValidator {
 			// demoted validators are not considered
-			qualified, err := v.getQualifiedValidators(num)
+			qualified, err := v.getQualifiedPermissioned(num)
 			if err != nil {
 				logger.Error("Failed to get qualified validators", "block", num, "err", err)
 				return nil

--- a/kaiax/valset/impl/getter_proposers_test.go
+++ b/kaiax/valset/impl/getter_proposers_test.go
@@ -142,7 +142,7 @@ func TestGetProposers_GetRemoveVotesInInterval(t *testing.T) {
 	}
 
 	for currentNum, mockQualified := range mockQualifiedValidators {
-		qualified, err := v.getQualifiedValidators(currentNum)
+		qualified, err := v.getQualifiedPermissioned(currentNum)
 		assert.NoError(t, err)
 		assert.Equal(t, mockQualified, qualified.List())
 	}

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -69,6 +69,8 @@ type ValsetModule struct {
 
 	validatorVoteBlockNumsCache []uint64
 	lowestScannedVoteNumCache   *uint64
+
+	lastSuspendFallbackLog uint64 // block number of the last suspend-set fallback warning
 }
 
 func NewValsetModule() *ValsetModule {

--- a/kaiax/valset/impl/init_test.go
+++ b/kaiax/valset/impl/init_test.go
@@ -179,7 +179,7 @@ func TestMigration(t *testing.T) {
 	// 3. Before migration, check GetCouncil() results
 	for _, tc := range expectedCouncils {
 		// council, _, err := v.replayFromIstanbulSnapshot(tc.num, false)
-		council, err := v.getCouncil(tc.num)
+		council, err := v.getCouncilPermissioned(tc.num)
 		require.NoError(t, err)
 		assert.Equal(t, tc.council, council.List(), tc.num)
 	}

--- a/kaiax/valset/impl/init_test.go
+++ b/kaiax/valset/impl/init_test.go
@@ -52,7 +52,6 @@ func TestStartStop(t *testing.T) {
 		mockStaking = staking_mock.NewMockStakingModule(ctrl) // not used in GetCouncil() stage.
 		v           = NewValsetModule()
 	)
-	defer ctrl.Finish()
 
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{}).AnyTimes()
 	mockChain.EXPECT().CurrentBlock().Return(current).AnyTimes()
@@ -148,7 +147,6 @@ func TestMigration(t *testing.T) {
 		mockStaking = staking_mock.NewMockStakingModule(ctrl) // not used in GetCouncil() stage.
 		v           = NewValsetModule()
 	)
-	defer ctrl.Finish()
 
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(pset).AnyTimes()
 	mockChain.EXPECT().CurrentBlock().Return(block2050).AnyTimes()

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -18,6 +18,7 @@ package impl
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
@@ -43,6 +44,9 @@ const (
 // Resolves parent state from chain (StateAt(parent.Root)). Use this for
 // post-commit reads (RPC, peer set queries).
 func (v *ValsetModule) getNodes(num uint64) (valset.NodeMap, error) {
+	if !v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return nil, errPermissionlessDisabled
+	}
 	if cached, ok := v.transitionResultCache.Get(num); ok {
 		return cached.(*TransitionResult).Nodes, nil
 	}

--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -387,7 +387,7 @@ func (ctx *TransitionContext) applyTimeoutTransition(m valset.NodeMap) valset.No
 // #region SlotMath
 //
 // Slot limit calculations for node state transitions. Go port of
-// contracts/contracts/system_contracts/consensus/AddressBookV2/libraries/SlotMath.sol — kept in lockstep
+// kaia-system-contracts/contracts-v3.0/src/libraries/SlotMath.sol — kept in lockstep
 // with that contract since the orchestrator and ABv2 must agree on slot math.
 //
 // For n >= 4 (standard BFT with f = floor(n/3) > 0):

--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -387,7 +387,7 @@ func (ctx *TransitionContext) applyTimeoutTransition(m valset.NodeMap) valset.No
 // #region SlotMath
 //
 // Slot limit calculations for node state transitions. Go port of
-// contracts_permissionless/contracts/libraries/SlotMath.sol — kept in lockstep
+// contracts/contracts/system_contracts/consensus/AddressBookV2/libraries/SlotMath.sol — kept in lockstep
 // with that contract since the orchestrator and ABv2 must agree on slot math.
 //
 // For n >= 4 (standard BFT with f = floor(n/3) > 0):

--- a/kaiax/valset/impl/transition_context_test.go
+++ b/kaiax/valset/impl/transition_context_test.go
@@ -705,3 +705,123 @@ func TestApplyTimeoutTransition_DefaultClearsAllTimeouts(t *testing.T) {
 }
 
 //#endregion
+
+//#region ApplyAllTransitions
+
+func TestApplyAllTransitions(t *testing.T) {
+	expiredTimeout := testBlockTime.Add(-1 * time.Hour)
+
+	cases := []struct {
+		name                 string
+		isEpoch              bool
+		input                NodeMap
+		expected             map[common.Address]NodeState
+		expectedEpochVACount uint64
+	}{
+		{
+			name:    "epoch pipeline demotes below-min before violation",
+			isEpoch: true,
+			input: NodeMap{
+				addr1: {State: ValActive, StakingAmount: belowMinStake},
+				addr2: {State: ValActive, StakingAmount: aboveMinStake},
+			},
+			expected: map[common.Address]NodeState{
+				addr1: ValInactive,
+				addr2: ValActive,
+			},
+			expectedEpochVACount: 1,
+		},
+		{
+			name:    "non-epoch violation fires while epoch transition is skipped",
+			isEpoch: false,
+			input: NodeMap{
+				addr1: {State: ValActive, StakingAmount: belowMinStake},
+				addr2: {State: ValActive, StakingAmount: aboveMinStake},
+			},
+			expected: map[common.Address]NodeState{
+				addr1: ValExiting,
+				addr2: ValActive,
+			},
+		},
+		{
+			name:    "non-epoch last ValActive protected by minActiveCount",
+			isEpoch: false,
+			input: NodeMap{
+				addr1: {State: ValActive, StakingAmount: belowMinStake},
+			},
+			expected: map[common.Address]NodeState{
+				addr1: ValActive,
+			},
+		},
+		{
+			name:    "candidate promotion only happens at epoch",
+			isEpoch: true,
+			input: NodeMap{
+				addr1: {State: CandReady, StakingAmount: aboveMinStake},
+			},
+			expected: map[common.Address]NodeState{
+				addr1: CandTesting,
+			},
+		},
+		{
+			name:    "mixed states at epoch run through epoch and timeout",
+			isEpoch: true,
+			input: NodeMap{
+				addr1: {State: ValActive, StakingAmount: belowMinStake},
+				addr2: {State: ValActive, StakingAmount: aboveMinStake},
+				addr3: {State: CandReady, StakingAmount: aboveMinStake},
+				addr4: {State: ValPaused, StakingAmount: aboveMinStake},
+				addr5: {State: CandReady, StakingAmount: belowMinStake},
+			},
+			expected: map[common.Address]NodeState{
+				addr1: ValInactive,
+				addr2: ValActive,
+				addr3: CandTesting,
+				addr4: ValPaused,
+				addr5: Registered,
+			},
+			expectedEpochVACount: 1,
+		},
+		{
+			name:    "timeout fires after transition pipeline",
+			isEpoch: true,
+			input: NodeMap{
+				addr1: {State: ValInactive, StakingAmount: aboveMinStake, IdleTimeout: expiredTimeout},
+			},
+			expected: map[common.Address]NodeState{
+				addr1: Registered,
+			},
+		},
+		{
+			name:    "expired pause transitions to ValInactive",
+			isEpoch: false,
+			input: NodeMap{
+				addr1: {State: ValPaused, StakingAmount: aboveMinStake, PausedTimeout: expiredTimeout},
+			},
+			expected: map[common.Address]NodeState{
+				addr1: ValInactive,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := buildCtx(t, ctxOpts{
+				MinStake:                testMinStake,
+				IdleTimeout:             testIdleTimeout,
+				PauseTimeout:            testPauseTimeout,
+				MaxValActivePausedCount: testMaxValCount,
+				MaxSlotAvailable:        noSlotLimit,
+				MinActiveCount:          1,
+			})
+			ctx.IsEpoch = tc.isEpoch
+
+			result := ctx.ApplyAllTransitions(tc.input)
+			for addr, expectedState := range tc.expected {
+				assert.Equal(t, expectedState, result.Nodes[addr].State, "addr=%s", addr.Hex())
+			}
+			assert.Equal(t, tc.expectedEpochVACount, result.epochVACountForWrite)
+		})
+	}
+}
+
+//#endregion

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -17,14 +17,30 @@
 package impl
 
 import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
 	"errors"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/accounts/abi/bind"
+	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/system"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/types/account"
+	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/contracts/bindings/abv2data"
+	addressbookv2contract "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
+	"github.com/kaiachain/kaia/contracts/bindings/cnstakingv4"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kaiax/gov"
+	gov_mock "github.com/kaiachain/kaia/kaiax/gov/mock"
 	vrank_mock "github.com/kaiachain/kaia/kaiax/vrank/mock"
 	"github.com/kaiachain/kaia/params"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
@@ -42,8 +58,6 @@ func testPermissionlessConfig(permissionlessBlock int64, vrankEpoch uint64) *par
 func TestGetNodesCache(t *testing.T) {
 	t.Run("cache hit", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
 		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10))
 
@@ -62,8 +76,6 @@ func TestGetNodesCache(t *testing.T) {
 
 	t.Run("genesis reads genesis state", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		root := common.HexToHash("0x1234")
 		genesisHeader := &types.Header{Number: big.NewInt(0), Root: root}
 		stateErr := errors.New("state unavailable")
@@ -83,8 +95,6 @@ func TestGetNodesCache(t *testing.T) {
 
 	t.Run("no cache hit", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		root := common.HexToHash("0x1234")
 		parentHeader := &types.Header{Number: big.NewInt(9), Root: root}
 		stateErr := errors.New("state unavailable")
@@ -107,8 +117,6 @@ func TestGetNodesCache(t *testing.T) {
 
 	t.Run("permissionless fork not enabled", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
 		mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10))
 
@@ -146,8 +154,6 @@ func TestGetTransitionResultCache(t *testing.T) {
 
 	t.Run("no cache hit", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
 		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(nil)
 
@@ -166,8 +172,6 @@ func TestGetTransitionResultCache(t *testing.T) {
 func TestGetNodesParentReadErrors(t *testing.T) {
 	t.Run("missing parent header", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
 		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10))
 		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(nil)
@@ -182,8 +186,6 @@ func TestGetNodesParentReadErrors(t *testing.T) {
 
 	t.Run("StateAt error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		root := common.HexToHash("0x1234")
 		parentHeader := &types.Header{Number: big.NewInt(9), Root: root}
 		stateErr := errors.New("state unavailable")
@@ -204,8 +206,6 @@ func TestGetNodesParentReadErrors(t *testing.T) {
 
 func TestWriteTransitionToABv2PreForkNoOp(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mockChain := chain_mock.NewMockBlockChain(ctrl)
 	mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10))
 
@@ -218,8 +218,6 @@ func TestWriteTransitionToABv2PreForkNoOp(t *testing.T) {
 
 func TestInstallABv2OutsideForkParentNoOp(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mockChain := chain_mock.NewMockBlockChain(ctrl)
 	mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10))
 
@@ -233,8 +231,6 @@ func TestInstallABv2OutsideForkParentNoOp(t *testing.T) {
 func TestFetchVRankCtx(t *testing.T) {
 	t.Run("epoch with pf report reads all vrank inputs", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		cfs := map[common.Address]uint64{addr1: 1}
 		pfs := map[common.Address]uint64{addr1: 2}
 		pfReport := []common.Address{addr1}
@@ -259,8 +255,6 @@ func TestFetchVRankCtx(t *testing.T) {
 
 	t.Run("non-epoch without pf report skips CFS and PFS", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
 		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
 
@@ -279,8 +273,6 @@ func TestFetchVRankCtx(t *testing.T) {
 
 	t.Run("errors fail open", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
 		pfReport := []common.Address{addr1}
 		vrankErr := errors.New("vrank unavailable")
 
@@ -329,4 +321,386 @@ func TestDiffNodeStates(t *testing.T) {
 
 	diff[addr2].State = Registered
 	assert.Equal(t, ValActive, current[addr2].State, "diff must not alias current nodes")
+}
+
+type testABv2GenesisNode struct {
+	NodeID          common.Address
+	Manager         common.Address
+	StakingContract common.Address
+	RewardAddress   common.Address
+	VoterAddress    common.Address
+}
+
+func TestInstallAndInitializeABv2(t *testing.T) {
+	h := newABv2Harness(t, withABv2ChainConfig(testPermissionlessConfig(3, 10)))
+	v, statedb, nodes := h.Valset, h.StateDB, h.Nodes
+	assert.Equal(t, system.ERC1967ProxyV5Code, statedb.GetCode(system.AddressBookAddr))
+
+	readBackend, err := backends.NewStateBlockchainContractBackend(v.Chain, statedb)
+	require.NoError(t, err)
+	caller, err := addressbookv2contract.NewAddressBookV2Caller(system.AddressBookAddr, readBackend)
+	require.NoError(t, err)
+	profiles, err := caller.GetAllProfiles(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.Len(t, profiles, len(nodes))
+
+	profilesByNodeID := make(map[common.Address]addressbookv2contract.Profile, len(profiles))
+	for _, profile := range profiles {
+		profilesByNodeID[profile.NodeId] = profile
+	}
+	for _, node := range nodes {
+		profile, ok := profilesByNodeID[node.NodeID]
+		require.True(t, ok)
+		assert.Equal(t, node.StakingContract, profile.StakingContract)
+		assert.Equal(t, node.RewardAddress, profile.RewardAddress)
+		assert.Equal(t, ValActive.ToUint8(), profile.State)
+		assert.Zero(t, profile.TimeoutAt.Sign())
+	}
+}
+
+func TestReadAndWriteABv2Snapshot(t *testing.T) {
+	h := newABv2Harness(t)
+	v, parentHeader, statedb, nodes := h.Valset, h.Header, h.StateDB, h.Nodes
+
+	snapshot, err := system.ReadABv2Snapshot(statedb, v.Chain, parentHeader)
+	require.NoError(t, err)
+	require.Len(t, snapshot.Nodes, len(nodes))
+	for _, node := range nodes {
+		require.Contains(t, snapshot.Nodes, node.NodeID)
+		got := snapshot.Nodes[node.NodeID]
+		assert.Equal(t, ValActive, got.State)
+		assert.Zero(t, got.StakingAmount)
+		assert.True(t, got.IdleTimeout.IsZero())
+		assert.True(t, got.PausedTimeout.IsZero())
+	}
+
+	pauseTimeout := time.Unix(9999, 0)
+	modified := snapshot.Nodes.Copy()
+	modified[nodes[0].NodeID].State = ValPaused
+	modified[nodes[0].NodeID].PausedTimeout = pauseTimeout
+
+	writeHeader := types.CopyHeader(parentHeader)
+	writeHeader.Number = new(big.Int).Add(parentHeader.Number, common.Big1)
+	writeHeader.Time = new(big.Int).Add(parentHeader.Time, common.Big1)
+
+	v.transitionResultCache.Add(writeHeader.Number.Uint64(), &TransitionResult{Nodes: modified})
+	blockCtx := blockchain.NewEVMBlockContext(writeHeader, v.Chain, nil)
+	vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, v.Chain.Config(), &vm.Config{})
+	require.NoError(t, v.WriteTransitionToABv2(vmenv, writeHeader, statedb))
+
+	updated, err := system.ReadABv2Snapshot(statedb, v.Chain, writeHeader)
+	require.NoError(t, err)
+	assert.Equal(t, ValPaused, updated.Nodes[nodes[0].NodeID].State)
+	assert.Equal(t, pauseTimeout, updated.Nodes[nodes[0].NodeID].PausedTimeout)
+	for _, node := range nodes[1:] {
+		assert.Equal(t, ValActive, updated.Nodes[node.NodeID].State)
+	}
+}
+
+func TestGetNodesExcludesUserTxAtCurrentBlock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	nodes, nodeKeys := testABv2GenesisNodesWithKeys(t, 4)
+	chainConfig := testPermissionlessConfig(0, 10)
+	h := newABv2Harness(t,
+		withABv2Nodes(nodes),
+		withABv2ChainConfig(chainConfig),
+	)
+	simBackend := h.Backend
+	chain := simBackend.BlockChain()
+
+	mockGov := gov_mock.NewMockGovModule(ctrl)
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		MinimumStake: common.Big0,
+	}).AnyTimes()
+	mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+	mockVRank.EXPECT().GetPfReport(gomock.Any()).Return(nil, nil).AnyTimes()
+
+	v := h.Valset
+	v.GovModule = mockGov
+	v.VRankModule = mockVRank
+
+	target := nodes[0].NodeID
+	pauseData, err := system.AddressBookV2ABI.Pack("pause", target)
+	require.NoError(t, err)
+	tx := types.NewTransaction(0, system.AddressBookAddr, common.Big0, 1_000_000, common.Big0, pauseData)
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(chainConfig.ChainID), nodeKeys[0])
+	require.NoError(t, err)
+	// userTx is sent at block 1.
+	require.NoError(t, simBackend.SendTransaction(context.Background(), signedTx))
+	simBackend.Commit()
+
+	receipt, err := simBackend.TransactionReceipt(context.Background(), signedTx.Hash())
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+
+	header1 := chain.GetHeaderByNumber(1)
+	require.NotNil(t, header1)
+	state1, err := chain.StateAt(header1.Root)
+	require.NoError(t, err)
+	snapshot1, err := system.ReadABv2Snapshot(state1, chain, header1)
+	require.NoError(t, err)
+	// ABv2(1): state is ValPaused.
+	require.Equal(t, ValPaused, snapshot1.Nodes[target].State)
+
+	nodesForBlock1, err := v.getNodes(1)
+	require.NoError(t, err)
+	// getNodes(1): state is ValActive.
+	assert.Equal(t, ValActive, nodesForBlock1[target].State, "block 1 production must exclude block 1 user tx")
+
+	nodesForBlock2, err := v.getNodes(2)
+	require.NoError(t, err)
+	// getNodes(2): state is ValPaused.
+	assert.Equal(t, ValPaused, nodesForBlock2[target].State, "block 2 production must include committed block 1 user tx")
+}
+
+type testABv2Harness struct {
+	Backend *backends.SimulatedBackend
+	Valset  *ValsetModule
+	Header  *types.Header
+	StateDB *state.StateDB
+	Nodes   []testABv2GenesisNode
+}
+
+type abv2HarnessOpt func(*abv2HarnessOpts)
+
+type abv2HarnessOpts struct {
+	nodes       []testABv2GenesisNode
+	chainConfig *params.ChainConfig
+}
+
+func withABv2Nodes(nodes []testABv2GenesisNode) abv2HarnessOpt {
+	return func(o *abv2HarnessOpts) { o.nodes = nodes }
+}
+
+func withABv2ChainConfig(config *params.ChainConfig) abv2HarnessOpt {
+	return func(o *abv2HarnessOpts) { o.chainConfig = config.Copy() }
+}
+
+func newABv2Harness(t *testing.T, options ...abv2HarnessOpt) *testABv2Harness {
+	t.Helper()
+
+	opts := &abv2HarnessOpts{
+		nodes:       testABv2GenesisNodes(),
+		chainConfig: testPermissionlessConfig(0, 10),
+	}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	deployerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	deployer := bind.NewKeyedTransactor(deployerKey)
+
+	alloc := testABv2Alloc(deployer.From, opts.nodes)
+
+	preinitializedGenesis := opts.chainConfig.IsPermissionlessForkEnabled(common.Big0)
+	installConfig := opts.chainConfig
+	if preinitializedGenesis {
+		installConfig = opts.chainConfig.Copy()
+		installConfig.PermissionlessCompatibleBlock = big.NewInt(3)
+	}
+
+	simBackend := backends.NewSimulatedBackendWithChainConfig(alloc, installConfig)
+	t.Cleanup(func() { _ = simBackend.Close() })
+
+	implAddr, _, _, err := addressbookv2contract.DeployAddressBookV2(deployer, simBackend, new(big.Int).SetUint64(opts.chainConfig.VRankEpoch))
+	require.NoError(t, err)
+	simBackend.Commit()
+
+	dataContractAddr, _, _, err := abv2data.DeployABv2DataContract(deployer, simBackend, implAddr, testABv2InitData(opts.nodes))
+	require.NoError(t, err)
+	simBackend.Commit()
+
+	chain := simBackend.BlockChain()
+	v := NewValsetModule()
+	v.Chain = chain
+
+	header := chain.CurrentHeader()
+	statedb, err := chain.StateAt(header.Root)
+	require.NoError(t, err)
+	require.NoError(t, system.InstallRegistry(statedb, &params.RegistryConfig{
+		Records: map[string]common.Address{
+			"ABv2DataContract": dataContractAddr,
+		},
+	}))
+	assert.Empty(t, statedb.GetCode(system.AddressBookAddr))
+
+	blockCtx := blockchain.NewEVMBlockContext(header, chain, nil)
+	vmenv := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, chain.Config(), &vm.Config{})
+	require.NoError(t, v.InstallABv2(vmenv, header, statedb))
+
+	if !preinitializedGenesis {
+		return &testABv2Harness{
+			Backend: simBackend,
+			Valset:  v,
+			Header:  header,
+			StateDB: statedb,
+			Nodes:   opts.nodes,
+		}
+	}
+
+	root, err := statedb.Commit(true)
+	require.NoError(t, err)
+	require.NoError(t, statedb.Database().TrieDB().Commit(root, false, header.Number.Uint64()))
+
+	initializedState, err := state.New(root, statedb.Database(), nil, nil)
+	require.NoError(t, err)
+	initializedAlloc := genesisAllocFromState(initializedState)
+
+	initializedBackend := backends.NewSimulatedBackendWithChainConfig(initializedAlloc, opts.chainConfig)
+	t.Cleanup(func() { _ = initializedBackend.Close() })
+	initializedChain := initializedBackend.BlockChain()
+	initializedHeader := initializedChain.CurrentHeader()
+	initializedStateDB, err := initializedChain.StateAt(initializedHeader.Root)
+	require.NoError(t, err)
+	initializedValset := NewValsetModule()
+	initializedValset.Chain = initializedChain
+
+	return &testABv2Harness{
+		Backend: initializedBackend,
+		Valset:  initializedValset,
+		Header:  initializedHeader,
+		StateDB: initializedStateDB,
+		Nodes:   opts.nodes,
+	}
+}
+
+func genesisAllocFromState(statedb *state.StateDB) blockchain.GenesisAlloc {
+	alloc := make(blockchain.GenesisAlloc)
+	statedb.ForEachAccount(func(addr common.Address, data account.Account) {
+		storage := make(map[common.Hash]common.Hash)
+		statedb.ForEachStorage(addr, func(key, value common.Hash) bool {
+			if value != (common.Hash{}) {
+				storage[key] = value
+			}
+			return true
+		})
+		code := statedb.GetCode(addr)
+		if len(code) > 0 {
+			code = append([]byte(nil), code...)
+		}
+		genesisAccount := blockchain.GenesisAccount{
+			Code:    code,
+			Balance: new(big.Int).Set(data.GetBalance()),
+			Nonce:   data.GetNonce(),
+		}
+		if len(storage) > 0 {
+			genesisAccount.Storage = storage
+		}
+		alloc[addr] = genesisAccount
+	})
+	return alloc
+}
+
+func testABv2GenesisNodes() []testABv2GenesisNode {
+	return []testABv2GenesisNode{
+		{
+			NodeID:          common.HexToAddress("0x1001"),
+			Manager:         common.HexToAddress("0x2001"),
+			StakingContract: common.HexToAddress("0x3001"),
+			RewardAddress:   common.HexToAddress("0x4001"),
+			VoterAddress:    common.HexToAddress("0x5001"),
+		},
+		{
+			NodeID:          common.HexToAddress("0x1002"),
+			Manager:         common.HexToAddress("0x2002"),
+			StakingContract: common.HexToAddress("0x3002"),
+			RewardAddress:   common.HexToAddress("0x4002"),
+			VoterAddress:    common.HexToAddress("0x5002"),
+		},
+		{
+			NodeID:          common.HexToAddress("0x1003"),
+			Manager:         common.HexToAddress("0x2003"),
+			StakingContract: common.HexToAddress("0x3003"),
+			RewardAddress:   common.HexToAddress("0x4003"),
+			VoterAddress:    common.HexToAddress("0x5003"),
+		},
+	}
+}
+
+func testABv2GenesisNodesWithKeys(t *testing.T, count int) ([]testABv2GenesisNode, []*ecdsa.PrivateKey) {
+	t.Helper()
+
+	nodes := make([]testABv2GenesisNode, count)
+	keys := make([]*ecdsa.PrivateKey, count)
+	for i := range count {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+
+		n := int64(i + 1)
+		keys[i] = key
+		nodes[i] = testABv2GenesisNode{
+			NodeID:          crypto.PubkeyToAddress(key.PublicKey),
+			Manager:         common.BigToAddress(big.NewInt(0x2000 + n)),
+			StakingContract: common.BigToAddress(big.NewInt(0x3000 + n)),
+			RewardAddress:   common.BigToAddress(big.NewInt(0x4000 + n)),
+			VoterAddress:    common.BigToAddress(big.NewInt(0x5000 + n)),
+		}
+	}
+	return nodes, keys
+}
+
+func testABv2Alloc(deployer common.Address, nodes []testABv2GenesisNode) blockchain.GenesisAlloc {
+	alloc := blockchain.GenesisAlloc{
+		deployer: {
+			Balance: new(big.Int).Mul(big.NewInt(100), big.NewInt(params.KAIA)),
+		},
+	}
+
+	cnStakingCode := common.FromHex("0x" + cnstakingv4.CnStakingV4BinRuntime)
+	for _, node := range nodes {
+		alloc[node.NodeID] = blockchain.GenesisAccount{
+			Balance: new(big.Int).Mul(big.NewInt(10), big.NewInt(params.KAIA)),
+		}
+		alloc[node.StakingContract] = blockchain.GenesisAccount{
+			Code:    cnStakingCode,
+			Balance: common.Big0,
+		}
+	}
+	return alloc
+}
+
+func testABv2InitData(nodes []testABv2GenesisNode) abv2data.IABv2DataContractInitData {
+	nodeIDs := make([]common.Address, len(nodes))
+	infos := make([]abv2data.NodeInfo, len(nodes))
+	for i, node := range nodes {
+		nodeIDs[i] = node.NodeID
+		infos[i] = abv2data.NodeInfo{
+			Manager:         node.Manager,
+			StakingContract: node.StakingContract,
+			RewardAddress:   node.RewardAddress,
+			VoterAddress:    node.VoterAddress,
+			TimeoutAt:       common.Big0,
+			GcId:            big.NewInt(int64(i + 1)),
+			BlsInfo:         testABv2BlsInfo(byte(i + 1)),
+			Name:            "genesis-node",
+			Metadata:        "{}",
+			State:           ValActive.ToUint8(),
+		}
+	}
+	return abv2data.IABv2DataContractInitData{
+		InitialOwner:            common.HexToAddress("0x9001"),
+		InitialSuspender:        common.HexToAddress("0x9002"),
+		InitialConfigurator:     common.HexToAddress("0x9003"),
+		PfsThreshold:            big.NewInt(10),
+		CfsThreshold:            big.NewInt(10),
+		PauseTimeout:            big.NewInt(3600),
+		IdleTimeout:             big.NewInt(7200),
+		MaxNodeCount:            big.NewInt(100),
+		MaxValActivePausedCount: big.NewInt(100),
+		MaxCandReadyCount:       big.NewInt(100),
+		KefAddress:              common.HexToAddress("0x9004"),
+		KifAddress:              common.HexToAddress("0x9005"),
+		KpfAddress:              common.HexToAddress("0x9006"),
+		NodeIds:                 nodeIDs,
+		Infos:                   infos,
+	}
+}
+
+func testABv2BlsInfo(seed byte) abv2data.BlsPublicKeyInfo {
+	return abv2data.BlsPublicKeyInfo{
+		PublicKey: bytes.Repeat([]byte{seed}, 48),
+		Pop:       bytes.Repeat([]byte{seed + 10}, 96),
+	}
 }

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -41,7 +41,14 @@ func testPermissionlessConfig(permissionlessBlock int64, vrankEpoch uint64) *par
 
 func TestGetNodesCache(t *testing.T) {
 	t.Run("cache hit", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10))
+
 		v := NewValsetModule()
+		v.Chain = mockChain
 		cached := NodeMap{
 			addr1: {State: ValActive, StakingAmount: aboveMinStake},
 		}
@@ -62,6 +69,7 @@ func TestGetNodesCache(t *testing.T) {
 		stateErr := errors.New("state unavailable")
 
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10))
 		mockChain.EXPECT().GetHeaderByNumber(uint64(0)).Return(genesisHeader)
 		mockChain.EXPECT().StateAt(root).Return(nil, stateErr)
 
@@ -82,6 +90,7 @@ func TestGetNodesCache(t *testing.T) {
 		stateErr := errors.New("state unavailable")
 
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10))
 		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(parentHeader)
 		mockChain.EXPECT().StateAt(root).Return(nil, stateErr)
 
@@ -94,6 +103,21 @@ func TestGetNodesCache(t *testing.T) {
 		nodes, err := v.getNodes(10)
 		require.Nil(t, nodes)
 		require.ErrorIs(t, err, stateErr)
+	})
+
+	t.Run("permissionless fork not enabled", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10))
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		nodes, err := v.getNodes(10)
+		require.Nil(t, nodes)
+		require.ErrorIs(t, err, errPermissionlessDisabled)
 	})
 }
 
@@ -145,6 +169,7 @@ func TestGetNodesParentReadErrors(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10))
 		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(nil)
 
 		v := NewValsetModule()
@@ -164,6 +189,7 @@ func TestGetNodesParentReadErrors(t *testing.T) {
 		stateErr := errors.New("state unavailable")
 
 		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10))
 		mockChain.EXPECT().GetHeaderByNumber(uint64(9)).Return(parentHeader)
 		mockChain.EXPECT().StateAt(root).Return(nil, stateErr)
 

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -45,7 +45,7 @@ type ValsetModule interface {
 	GetHeaderGovVoters(num uint64) ([]common.Address, error)
 	// GetNodesByState returns nodes filtered by state at block `num`.
 	// It returns an error before the permissionless fork.
-	GetNodesByState(num uint64, states []NodeState) (NodeMap, error)
+	GetNodesByState(num uint64, states []NodeState) (map[common.Address]*Node, error)
 
 	// Permissionless additions (post-fork; pre-fork these are no-ops).
 	WriteTransitionToABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -51,9 +51,8 @@ type ValsetModule interface {
 	InstallABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 }
 
-// ValsetModuleHost is implemented by the miner. The worker registers a
-// ValsetModule to read CandTesting at epoch-start blocks for header.VRank fill
-// (KIP-227).
+// ValsetModuleHost is implemented by the miner. The worker reads CandTesting
+// from it to fill header.VRank at epoch-start blocks.
 type ValsetModuleHost interface {
 	RegisterValsetModule(module ValsetModule)
 }

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -44,7 +44,7 @@ type ValsetModule interface {
 	GetCandTesting(num uint64) ([]common.Address, error)
 	GetCNPeers(num uint64) ([]common.Address, error)
 	GetHeaderGovVoters(num uint64) ([]common.Address, error)
-	GetNodeByState(num uint64, states []NodeState) (NodeMap, error)
+	GetNodesByState(num uint64, states []NodeState) (NodeMap, error)
 
 	// Permissionless additions (post-fork; pre-fork these are no-ops).
 	WriteTransitionToABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -40,10 +40,11 @@ type ValsetModule interface {
 	GetProposer(num uint64, round uint64) (common.Address, error)
 
 	// GetCandTesting returns nodes in the CandTesting state at block `num`.
-	// Stub until permissionless system contracts (AddressBookV2) land; currently returns an empty slice.
 	GetCandTesting(num uint64) ([]common.Address, error)
 	GetCNPeers(num uint64) ([]common.Address, error)
 	GetHeaderGovVoters(num uint64) ([]common.Address, error)
+	// GetNodesByState returns nodes filtered by state at block `num`.
+	// It returns an error before the permissionless fork.
 	GetNodesByState(num uint64, states []NodeState) (NodeMap, error)
 
 	// Permissionless additions (post-fork; pre-fork these are no-ops).

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -31,6 +31,7 @@ type ValsetModule interface {
 	kaiax.ExecutionModule
 	kaiax.RewindableModule
 	kaiax.BlockStateModule
+	kaiax.HeaderModule
 
 	GetCouncil(num uint64) ([]common.Address, error)
 	GetCommittee(num uint64, round uint64) ([]common.Address, error)
@@ -41,6 +42,9 @@ type ValsetModule interface {
 	// GetCandTesting returns nodes in the CandTesting state at block `num`.
 	// Stub until permissionless system contracts (AddressBookV2) land; currently returns an empty slice.
 	GetCandTesting(num uint64) ([]common.Address, error)
+	GetCNPeers(num uint64) ([]common.Address, error)
+	GetHeaderGovVoters(num uint64) ([]common.Address, error)
+	GetNodeByState(num uint64, states []NodeState) (NodeMap, error)
 
 	// Permissionless additions (post-fork; pre-fork these are no-ops).
 	WriteTransitionToABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -50,9 +50,3 @@ type ValsetModule interface {
 	WriteTransitionToABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 	InstallABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 }
-
-// ValsetModuleHost is implemented by the miner. The worker reads CandTesting
-// from it to fill header.VRank at epoch-start blocks.
-type ValsetModuleHost interface {
-	RegisterValsetModule(module ValsetModule)
-}

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -50,3 +50,10 @@ type ValsetModule interface {
 	WriteTransitionToABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 	InstallABv2(vmenv *vm.EVM, header *types.Header, state *state.StateDB) error
 }
+
+// ValsetModuleHost is implemented by the miner. The worker registers a
+// ValsetModule to read CandTesting at epoch-start blocks for header.VRank fill
+// (KIP-227).
+type ValsetModuleHost interface {
+	RegisterValsetModule(module ValsetModule)
+}

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -158,10 +158,10 @@ func (mr *MockValsetModuleMockRecorder) GetHeaderGovVoters(arg0 interface{}) *go
 }
 
 // GetNodesByState mocks base method.
-func (m *MockValsetModule) GetNodesByState(arg0 uint64, arg1 []valset.NodeState) (valset.NodeMap, error) {
+func (m *MockValsetModule) GetNodesByState(arg0 uint64, arg1 []valset.NodeState) (map[common.Address]*valset.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNodesByState", arg0, arg1)
-	ret0, _ := ret[0].(valset.NodeMap)
+	ret0, _ := ret[0].(map[common.Address]*valset.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -12,6 +12,7 @@ import (
 	types "github.com/kaiachain/kaia/blockchain/types"
 	vm "github.com/kaiachain/kaia/blockchain/vm"
 	common "github.com/kaiachain/kaia/common"
+	valset "github.com/kaiachain/kaia/kaiax/valset"
 	rpc "github.com/kaiachain/kaia/networks/rpc"
 )
 
@@ -64,6 +65,21 @@ func (m *MockValsetModule) FinalizeState(arg0 *types.Header, arg1 *state.StateDB
 func (mr *MockValsetModuleMockRecorder) FinalizeState(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeState", reflect.TypeOf((*MockValsetModule)(nil).FinalizeState), arg0, arg1, arg2, arg3)
+}
+
+// GetCNPeers mocks base method.
+func (m *MockValsetModule) GetCNPeers(arg0 uint64) ([]common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCNPeers", arg0)
+	ret0, _ := ret[0].([]common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCNPeers indicates an expected call of GetCNPeers.
+func (mr *MockValsetModuleMockRecorder) GetCNPeers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCNPeers", reflect.TypeOf((*MockValsetModule)(nil).GetCNPeers), arg0)
 }
 
 // GetCandTesting mocks base method.
@@ -124,6 +140,36 @@ func (m *MockValsetModule) GetDemotedValidators(arg0 uint64) ([]common.Address, 
 func (mr *MockValsetModuleMockRecorder) GetDemotedValidators(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDemotedValidators", reflect.TypeOf((*MockValsetModule)(nil).GetDemotedValidators), arg0)
+}
+
+// GetHeaderGovVoters mocks base method.
+func (m *MockValsetModule) GetHeaderGovVoters(arg0 uint64) ([]common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHeaderGovVoters", arg0)
+	ret0, _ := ret[0].([]common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHeaderGovVoters indicates an expected call of GetHeaderGovVoters.
+func (mr *MockValsetModuleMockRecorder) GetHeaderGovVoters(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderGovVoters", reflect.TypeOf((*MockValsetModule)(nil).GetHeaderGovVoters), arg0)
+}
+
+// GetNodeByState mocks base method.
+func (m *MockValsetModule) GetNodeByState(arg0 uint64, arg1 []valset.NodeState) (valset.NodeMap, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeByState", arg0, arg1)
+	ret0, _ := ret[0].(valset.NodeMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeByState indicates an expected call of GetNodeByState.
+func (mr *MockValsetModuleMockRecorder) GetNodeByState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeByState", reflect.TypeOf((*MockValsetModule)(nil).GetNodeByState), arg0, arg1)
 }
 
 // GetProposer mocks base method.
@@ -196,6 +242,20 @@ func (mr *MockValsetModuleMockRecorder) PostInsertBlock(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostInsertBlock", reflect.TypeOf((*MockValsetModule)(nil).PostInsertBlock), arg0)
 }
 
+// PrepareHeader mocks base method.
+func (m *MockValsetModule) PrepareHeader(arg0 *types.Header) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PrepareHeader indicates an expected call of PrepareHeader.
+func (mr *MockValsetModuleMockRecorder) PrepareHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHeader", reflect.TypeOf((*MockValsetModule)(nil).PrepareHeader), arg0)
+}
+
 // RewindDelete mocks base method.
 func (m *MockValsetModule) RewindDelete(arg0 common.Hash, arg1 uint64) {
 	m.ctrl.T.Helper()
@@ -244,6 +304,20 @@ func (m *MockValsetModule) Stop() {
 func (mr *MockValsetModuleMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockValsetModule)(nil).Stop))
+}
+
+// VerifyHeader mocks base method.
+func (m *MockValsetModule) VerifyHeader(arg0, arg1 *types.Header) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyHeader", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyHeader indicates an expected call of VerifyHeader.
+func (mr *MockValsetModuleMockRecorder) VerifyHeader(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyHeader", reflect.TypeOf((*MockValsetModule)(nil).VerifyHeader), arg0, arg1)
 }
 
 // WriteTransitionToABv2 mocks base method.

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -157,19 +157,19 @@ func (mr *MockValsetModuleMockRecorder) GetHeaderGovVoters(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderGovVoters", reflect.TypeOf((*MockValsetModule)(nil).GetHeaderGovVoters), arg0)
 }
 
-// GetNodeByState mocks base method.
-func (m *MockValsetModule) GetNodeByState(arg0 uint64, arg1 []valset.NodeState) (valset.NodeMap, error) {
+// GetNodesByState mocks base method.
+func (m *MockValsetModule) GetNodesByState(arg0 uint64, arg1 []valset.NodeState) (valset.NodeMap, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeByState", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetNodesByState", arg0, arg1)
 	ret0, _ := ret[0].(valset.NodeMap)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetNodeByState indicates an expected call of GetNodeByState.
-func (mr *MockValsetModuleMockRecorder) GetNodeByState(arg0, arg1 interface{}) *gomock.Call {
+// GetNodesByState indicates an expected call of GetNodesByState.
+func (mr *MockValsetModuleMockRecorder) GetNodesByState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeByState", reflect.TypeOf((*MockValsetModule)(nil).GetNodeByState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodesByState", reflect.TypeOf((*MockValsetModule)(nil).GetNodesByState), arg0, arg1)
 }
 
 // GetProposer mocks base method.

--- a/kaiax/vrank/README.md
+++ b/kaiax/vrank/README.md
@@ -24,12 +24,12 @@ during consensus of block N-1
                                        (committee collects VRankCandidate messages to produce the next block)
 
 when block N is proposed
-  proposer(N) ── TallyCfReport(N-1, round) ──▶ cfReport ──▶ header(N).VRank
+  proposer(N) ── EvaluateCandidates(N-1, round) ──▶ cfReport ──▶ header(N).VRank
 ```
 
 - `VRankPreprepare{Block, View, Sig}`: signed by `proposer(N-1)`; tells candidates a response is expected for `(N-1, view.Round)`.
 - `VRankCandidate{BlockNumber, Round, BlockHash, Sig, BlsSig}`: signed by each candidate; carries the block hash they observed.
-- `TallyCfReport(N-1, round)` lists every address in `GetCandTesting(N-1)` whose `VRankCandidate` did not arrive with the correct `BlockHash` before the timeout.
+- `EvaluateCandidates(N-1, round)` lists every address in `GetCandTesting(N-1)` whose `VRankCandidate` did not arrive with the correct `BlockHash` before the timeout.
 
 ### PFS
 
@@ -111,16 +111,16 @@ Calls `GetPFS(head)` and `getCPMatrix(head)` to warm both in-memory caches (PFS 
 #### Valset dependency
 
 - getters
-  - For all getters except `TallyCfReport`, `N` must exist in the header DB.
+  - For all getters except `EvaluateCandidates`, `N` must exist in the header DB.
   - `GetPfReport` and `GetPFS` call `GetProposer` for each block `x` in `[epochStart(N), N]`. In the valset module, `GetProposer` fast-paths committed historical blocks by returning `Chain.Sealer().Author(header)` when `header(x)` exists and its round matches the requested round; otherwise it falls back to block-context lookup.
   - `GetCFS(N)` calls `GetCandTesting(N)` to seed a fresh CP matrix when there is no cache or checkpoint seed, and `GetProposer(x, header(x).Round)` for every block `x ∈ [epochStart(N), N]`.
-  - `TallyCfReport(N, round)` is called by the proposer of block `N+1` to fill `header(N+1).VRank`; it queries `GetCandTesting(N)` because it validates messages collected for block `N`.
+  - `EvaluateCandidates(N, round)` is called by the proposer of block `N+1` to fill `header(N+1).VRank`; it queries `GetCandTesting(N)` because it validates messages collected for block `N`.
 
 | Function                  | Valset call                                                               | Notes                                                           |
 | ------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------- |
 | `GetPfReport(N)`          | `GetProposer(N, r)`; `r ∈ [0, header(N).Round)`                           | valset fast-paths committed headers via `Chain.Sealer().Author` |
 | `GetCfReport(N)`          | —                                                                         | —                                                               |
-| `TallyCfReport(N, round)` | `GetCandTesting(N)`                                                       | `N` is the reported block whose responses are being tallied     |
+| `EvaluateCandidates(N, round)` | `GetCandTesting(N)`                                                       | `N` is the reported block whose responses are being evaluated   |
 | `GetPFS(N)`               | `GetProposer(x, r)`; `x ∈ [epochStart(N), N]`, `r ∈ [0, header(x).Round)` | valset fast-paths committed headers via `Chain.Sealer().Author` |
 | `GetCFS(N)`               | `GetCandTesting(N)`                                                       | seeds `newCPMatrix` when no cache/checkpoint seed exists        |
 |                           | `GetProposer(x, header(x).Round)`; `x ∈ [epochStart(N), N]`               | reporter lookup per committed header                            |
@@ -128,7 +128,7 @@ Calls `GetPFS(head)` and `getCPMatrix(head)` to warm both in-memory caches (PFS 
 - handlers
   - During consensus of block N, block N is not yet committed, but its validator/candidate/proposer set is already determined — so `Get*(N)` is safe for proposer / candidate / committee identity checks tied to that live view.
   - `HandleVRankCandidate` deliberately does not perform canonical committee-membership or candidate-membership validation at receive time. It acts as a bounded inbox keyed by `(BlockNumber, Round)`: it requires a current preprepared view, drops stale messages, rejects overly-future messages, verifies ECDSA and BLS signatures, and ignores duplicate senders per view.
-  - Canonical semantic validation for candidate messages happens later in `TallyCfReport`, which checks the exact view's preprepare time, expected block hash, the candidate set from `GetCandTesting(N)`, and the timeout.
+  - Canonical semantic validation for candidate messages happens later in `EvaluateCandidates`, which checks the exact view's preprepare time, expected block hash, the candidate set from `GetCandTesting(N)`, and the timeout.
   - `VerifyHeader(N)` calls `GetCandTesting(N-1)` to confirm every address in `header(N).VRank` is an actual candidate for the reported block `N-1`, blocking malicious proposers from injecting arbitrary addresses to manipulate CFS scores.
 
 | Function                                  | Valset call                   | Notes                                                          |
@@ -167,9 +167,9 @@ Called when a `VRankCandidate` message is received. The handler does not try to 
 - drops stale messages for already-passed views
 - verifies the candidate's ECDSA and BLS signatures
 - ignores duplicate senders for the same `(blockNum, round)`
-- records the message in the collector for later tallying
+- records the message in the collector for later evaluation
 
-`TallyCfReport` is the stage that applies canonical checks such as expected block hash, candidate membership in `GetCandTesting(N)`, and the timeout rule.
+`EvaluateCandidates` is the stage that applies canonical checks such as expected block hash, candidate membership in `GetCandTesting(N)`, and the timeout rule.
 
 #### VerifyHeader
 
@@ -196,6 +196,6 @@ All getters return `ErrNotPermissionless` if the queried block is before the per
 
 - `GetPfReport(N)`: Returns the list of proposers who failed at block N (one per failed round).
 - `GetCfReport(N)`: Returns the raw cfReport committed in `header(N).VRank`.
-- `TallyCfReport(N, round)`: Computes the cfReport for block N at the given round from the in-memory collector, for use by the proposer of block N+1.
+- `EvaluateCandidates(N, round)`: Computes the cfReport for block N at the given round from the in-memory collector, for use by the proposer of block N+1.
 - `GetPFS(N)`: Returns the cumulative PFS map over `[epochStart(N), N]`.
 - `GetCFS(N)`: Returns the cumulative CFS map over `[epochStart(N), N]`. The byzantine-filter threshold is derived internally from `cpMatrix.ProposerCount()`, the number of distinct proposers seen so far in the epoch.

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -28,7 +28,7 @@ import (
 
 // VerifyHeader checks the VRank field in the header:
 //   - Before the permissionless fork: VRank must be empty.
-//   - At epoch-start blocks: VRank must be RLPEncode(CandTesting(N)), or empty when CandTesting(N) is empty.
+//   - At epoch-start blocks: VRank must be RLPEncode(CandTesting(N)) or RLPEncode([]).
 //   - Otherwise: VRank must be a valid encoded report whose addresses are sorted,
 //     deduplicated, and all present in GetCandTesting(N-1), because header(N).VRank
 //     reports candidate failures observed while building block N-1.
@@ -43,31 +43,23 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 		return nil
 	}
 
+	// Epoch-start block
 	if number%v.vrankEpoch() == 0 {
-		if len(header.VRank) == 0 {
-			candidates, err := v.Valset.GetCandTesting(number)
-			if err != nil {
-				return err
-			}
-			if len(candidates) == 0 {
-				return nil
-			}
-			return vrank.ErrEpochStartVRankMismatch
-		}
-		report, err := vrank.DecodeReport(header.VRank)
-		if err != nil {
-			return vrank.ErrInvalidVRankFormat
-		}
-		candidates, err := v.Valset.GetCandTesting(number)
+		expected, err := v.encodeEpochStartVRank(number)
 		if err != nil {
 			return err
 		}
-		return validateEpochVRank(report, candidates)
+		if !bytes.Equal(header.VRank, expected) {
+			return vrank.ErrEpochStartVRankMismatch
+		}
+		return nil
 	}
 
+	// Non-epoch-start block
 	if len(header.VRank) == 0 {
 		return nil
 	}
+
 	report, err := vrank.DecodeReport(header.VRank)
 	if err != nil {
 		return vrank.ErrInvalidVRankFormat
@@ -81,7 +73,7 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 
 // PrepareHeader fills header.VRank per KIP-227.
 //
-//   - At epoch-start blocks: VRank is CandTesting(N), or nil when there are no candidates.
+//   - At epoch-start blocks: VRank is CandTesting(N), encoded even when empty.
 //   - Otherwise: VRank is EvaluateCandidates(N-1, parentRound), or nil when the report is empty.
 func (v *VRankModule) PrepareHeader(header *types.Header) error {
 	number := header.Number.Uint64()
@@ -91,62 +83,66 @@ func (v *VRankModule) PrepareHeader(header *types.Header) error {
 	}
 
 	if number%v.vrankEpoch() == 0 {
-		candidates, err := v.Valset.GetCandTesting(number)
+		encoded, err := v.encodeEpochStartVRank(number)
 		if err != nil {
-			logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", number, "err", err)
-			return err
-		}
-		if len(candidates) == 0 {
-			header.VRank = nil
-			return nil
-		}
-		encoded, err := vrank.EncodeAddressList(candidates)
-		if err != nil {
-			logger.Error("epoch-start VRank fill: EncodeAddressList failed", "num", number, "err", err)
 			return err
 		}
 		header.VRank = encoded
-		return nil
+	} else {
+		encoded, err := v.encodeCandidateFailureVRank(number)
+		if err != nil {
+			return err
+		}
+		header.VRank = encoded
 	}
 
+	return nil
+}
+
+// encodeEpochStartVRank returns RLPEncode(CandTesting(N)) or RLPEncode([]) = 0xc0 when empty.
+func (v *VRankModule) encodeEpochStartVRank(number uint64) ([]byte, error) {
+	candidates, err := v.Valset.GetCandTesting(number)
+	if err != nil {
+		logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", number, "err", err)
+		return nil, err
+	}
+	encoded, err := vrank.EncodeAddressList(candidates)
+	if err != nil {
+		logger.Error("epoch-start VRank fill: EncodeAddressList failed", "num", number, "err", err)
+		return nil, err
+	}
+	return encoded, nil
+}
+
+func (v *VRankModule) encodeCandidateFailureVRank(number uint64) ([]byte, error) {
 	if number == 0 {
-		header.VRank = nil
-		return nil
+		return nil, nil
 	}
 	parentNum := number - 1
 	parent := v.Chain.GetHeaderByNumber(parentNum)
 	if parent == nil {
 		logger.Error("Failed to read parent header for VRank", "num", number, "parentNum", parentNum)
-		return vrank.ErrHeaderNotFound
+		return nil, vrank.ErrHeaderNotFound
 	}
 	parentRound, err := v.RoundReader.Round(parent)
 	if err != nil {
 		logger.Error("Failed to read parent round for VRank", "err", err, "parentNum", parentNum)
-		return err
+		return nil, err
 	}
 	report, err := v.EvaluateCandidates(parentNum, uint64(parentRound))
 	if err != nil {
 		logger.Error("Failed to evaluate VRank candidates", "err", err, "prevBlockNum", parentNum, "prevRound", parentRound)
-		return err
+		return nil, err
 	}
 	if len(report) == 0 {
-		header.VRank = nil
-		return nil
+		return nil, nil
 	}
 	encoded, err := vrank.EncodeReport(report)
 	if err != nil {
 		logger.Error("Failed to encode VRank report", "err", err, "report", report)
-		return err
+		return nil, err
 	}
-	header.VRank = encoded
-	return nil
-}
-
-func validateEpochVRank(report, candidates []common.Address) error {
-	if !slices.Equal(report, candidates) {
-		return vrank.ErrEpochStartVRankMismatch
-	}
-	return nil
+	return encoded, nil
 }
 
 func validateNonEpochVRank(report, candidates []common.Address) error {

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -28,7 +28,7 @@ import (
 
 // VerifyHeader checks the VRank field in the header:
 //   - Before the permissionless fork: VRank must be empty.
-//   - At epoch-start blocks: VRank must be RLPEncode(CandTesting(N)).
+//   - At epoch-start blocks: VRank must be RLPEncode(CandTesting(N)), or empty when CandTesting(N) is empty.
 //   - Otherwise: VRank must be a valid encoded report whose addresses are sorted,
 //     deduplicated, and all present in GetCandTesting(N-1), because header(N).VRank
 //     reports candidate failures observed while building block N-1.
@@ -43,31 +43,104 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 		return nil
 	}
 
-	if number%v.vrankEpoch() != 0 && len(header.VRank) == 0 {
-		return nil
-	}
-
-	report, err := vrank.DecodeReport(header.VRank)
-	if err != nil {
-		return vrank.ErrInvalidVRankFormat
-	}
-
 	if number%v.vrankEpoch() == 0 {
+		if len(header.VRank) == 0 {
+			candidates, err := v.Valset.GetCandTesting(number)
+			if err != nil {
+				return err
+			}
+			if len(candidates) == 0 {
+				return nil
+			}
+			return vrank.ErrEpochStartVRankMismatch
+		}
+		report, err := vrank.DecodeReport(header.VRank)
+		if err != nil {
+			return vrank.ErrInvalidVRankFormat
+		}
 		candidates, err := v.Valset.GetCandTesting(number)
 		if err != nil {
 			return err
 		}
 		return validateEpochVRank(report, candidates)
-	} else {
-		candidates, err := v.Valset.GetCandTesting(number - 1)
-		if err != nil {
-			return err
-		}
-		return validateNonEpochVRank(report, candidates)
 	}
+
+	if len(header.VRank) == 0 {
+		return nil
+	}
+	report, err := vrank.DecodeReport(header.VRank)
+	if err != nil {
+		return vrank.ErrInvalidVRankFormat
+	}
+	candidates, err := v.Valset.GetCandTesting(number - 1)
+	if err != nil {
+		return err
+	}
+	return validateNonEpochVRank(report, candidates)
 }
 
-func (v *VRankModule) PrepareHeader(*types.Header) error { return nil }
+// PrepareHeader fills header.VRank per KIP-227.
+//
+//   - At epoch-start blocks: VRank is CandTesting(N), or nil when there are no candidates.
+//   - Otherwise: VRank is EvaluateCandidates(N-1, parentRound), or nil when the report is empty.
+func (v *VRankModule) PrepareHeader(header *types.Header) error {
+	number := header.Number.Uint64()
+	if !v.ChainConfig.IsPermissionlessForkEnabled(header.Number) {
+		header.VRank = nil
+		return nil
+	}
+
+	if number%v.vrankEpoch() == 0 {
+		candidates, err := v.Valset.GetCandTesting(number)
+		if err != nil {
+			logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", number, "err", err)
+			return err
+		}
+		if len(candidates) == 0 {
+			header.VRank = nil
+			return nil
+		}
+		encoded, err := vrank.EncodeAddressList(candidates)
+		if err != nil {
+			logger.Error("epoch-start VRank fill: EncodeAddressList failed", "num", number, "err", err)
+			return err
+		}
+		header.VRank = encoded
+		return nil
+	}
+
+	if number == 0 {
+		header.VRank = nil
+		return nil
+	}
+	parentNum := number - 1
+	parent := v.Chain.GetHeaderByNumber(parentNum)
+	if parent == nil {
+		logger.Error("Failed to read parent header for VRank", "num", number, "parentNum", parentNum)
+		return vrank.ErrHeaderNotFound
+	}
+	parentRound, err := v.RoundReader.Round(parent)
+	if err != nil {
+		logger.Error("Failed to read parent round for VRank", "err", err, "parentNum", parentNum)
+		return err
+	}
+	report, err := v.EvaluateCandidates(parentNum, uint64(parentRound))
+	if err != nil {
+		logger.Error("Failed to evaluate VRank candidates", "err", err, "prevBlockNum", parentNum, "prevRound", parentRound)
+		return err
+	}
+	if len(report) == 0 {
+		header.VRank = nil
+		return nil
+	}
+	encoded, err := vrank.EncodeReport(report)
+	if err != nil {
+		logger.Error("Failed to encode VRank report", "err", err, "report", report)
+		return err
+	}
+	header.VRank = encoded
+	return nil
+}
 
 func validateEpochVRank(report, candidates []common.Address) error {
 	if !slices.Equal(report, candidates) {

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -19,6 +19,7 @@ package impl
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
@@ -74,12 +75,13 @@ func TestVerifyHeader(t *testing.T) {
 		assert.ErrorIs(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, []common.Address{C1}), nil),
 			vrank.ErrEpochStartVRankMismatch)
 		assert.ErrorIs(t, v.VerifyHeader(&types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}, nil),
-			vrank.ErrInvalidVRankFormat)
+			vrank.ErrEpochStartVRankMismatch)
 	})
 
-	t.Run("epoch-start: empty CandTesting is encoded as an RLP list", func(t *testing.T) {
+	t.Run("epoch-start: empty CandTesting accepts encoded or nil VRank", func(t *testing.T) {
 		v := newCN(t, withCandidates(nil)).VRankModule
 		assert.NoError(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, nil), nil))
+		assert.NoError(t, v.VerifyHeader(&types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}, nil))
 	})
 
 	t.Run("epoch-start: candidate membership is checked against block N", func(t *testing.T) {
@@ -154,5 +156,66 @@ func TestVerifyHeader(t *testing.T) {
 
 		assert.NoError(t, v.VerifyHeader(makeVRankHeader(t, headerNum, []common.Address{cand}), nil))
 		assert.ErrorIs(t, v.VerifyHeader(makeVRankHeader(t, headerNum, []common.Address{futureCand}), nil), vrank.ErrInvalidVRankCandidate)
+	})
+}
+
+func TestPrepareHeader(t *testing.T) {
+	C1, C2 := numToAddr(1), numToAddr(2)
+	candidates := []common.Address{C1, C2}
+
+	t.Run("pre-fork clears VRank", func(t *testing.T) {
+		v := newCN(t, withHardfork("osaka"), withoutStart()).VRankModule
+		header := makeVRankHeader(t, 100, []common.Address{C1})
+
+		require.NoError(t, v.PrepareHeader(header))
+		assert.Nil(t, header.VRank)
+	})
+
+	t.Run("epoch-start fills CandTesting", func(t *testing.T) {
+		v := newCN(t, withCandidates(candidates), withoutStart()).VRankModule
+		header := &types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}
+
+		require.NoError(t, v.PrepareHeader(header))
+		report, err := vrank.DecodeReport(header.VRank)
+		require.NoError(t, err)
+		assert.Equal(t, candidates, report)
+	})
+
+	t.Run("epoch-start with no candidates leaves VRank nil", func(t *testing.T) {
+		v := newCN(t, withCandidates(nil), withoutStart()).VRankModule
+		header := &types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}
+
+		require.NoError(t, v.PrepareHeader(header))
+		assert.Nil(t, header.VRank)
+		assert.NoError(t, v.VerifyHeader(header, nil))
+	})
+
+	t.Run("non-epoch empty evaluation leaves VRank nil", func(t *testing.T) {
+		parent := makeHeaderWithRound(10, 1)
+		v := newCN(t, withCandidates(candidates), withHeaders(map[uint64]*types.Header{10: parent}), withoutStart()).VRankModule
+		header := &types.Header{Number: big.NewInt(11)}
+
+		require.NoError(t, v.PrepareHeader(header))
+		assert.Nil(t, header.VRank)
+	})
+
+	t.Run("non-epoch fills evaluated candidate failures", func(t *testing.T) {
+		parent := makeHeaderWithRound(10, 1)
+		parentBlock := types.NewBlockWithHeader(parent)
+		v := newCN(t, withCandidates(candidates), withHeaders(map[uint64]*types.Header{10: parent}), withoutStart()).VRankModule
+		v.collector.AddPrepreparedTime(vrank.ViewKey{N: 10, R: 1}, time.Now(), parentBlock.Hash())
+		header := &types.Header{Number: big.NewInt(11)}
+
+		require.NoError(t, v.PrepareHeader(header))
+		report, err := vrank.DecodeReport(header.VRank)
+		require.NoError(t, err)
+		assert.Equal(t, candidates, report)
+	})
+
+	t.Run("non-epoch parent lookup failure is returned", func(t *testing.T) {
+		v := newCN(t, withoutStart()).VRankModule
+		header := &types.Header{Number: big.NewInt(11)}
+
+		assert.ErrorIs(t, v.PrepareHeader(header), vrank.ErrHeaderNotFound)
 	})
 }

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -78,10 +78,11 @@ func TestVerifyHeader(t *testing.T) {
 			vrank.ErrEpochStartVRankMismatch)
 	})
 
-	t.Run("epoch-start: empty CandTesting accepts encoded or nil VRank", func(t *testing.T) {
+	t.Run("epoch-start: empty CandTesting is encoded as an RLP list", func(t *testing.T) {
 		v := newCN(t, withCandidates(nil)).VRankModule
-		assert.NoError(t, v.VerifyHeader(makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, nil), nil))
-		assert.NoError(t, v.VerifyHeader(&types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}, nil))
+		h := makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, nil)
+		assert.Equal(t, []byte{0xc0}, h.VRank)
+		assert.NoError(t, v.VerifyHeader(h, nil))
 	})
 
 	t.Run("epoch-start: candidate membership is checked against block N", func(t *testing.T) {
@@ -151,7 +152,6 @@ func TestVerifyHeader(t *testing.T) {
 		cn := newCN(t, withoutStart())
 		v := cn.VRankModule
 
-		// headerNum must be generated with CandidateSet at headerNum-1
 		cn.Valset.EXPECT().GetCandTesting(headerNum-1).Return([]common.Address{cand}, nil).Times(2)
 
 		assert.NoError(t, v.VerifyHeader(makeVRankHeader(t, headerNum, []common.Address{cand}), nil))
@@ -179,14 +179,15 @@ func TestPrepareHeader(t *testing.T) {
 		report, err := vrank.DecodeReport(header.VRank)
 		require.NoError(t, err)
 		assert.Equal(t, candidates, report)
+		assert.NoError(t, v.VerifyHeader(header, nil))
 	})
 
-	t.Run("epoch-start with no candidates leaves VRank nil", func(t *testing.T) {
+	t.Run("epoch-start with no candidates writes encoded empty list", func(t *testing.T) {
 		v := newCN(t, withCandidates(nil), withoutStart()).VRankModule
 		header := &types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}
 
 		require.NoError(t, v.PrepareHeader(header))
-		assert.Nil(t, header.VRank)
+		assert.Equal(t, []byte{0xc0}, header.VRank)
 		assert.NoError(t, v.VerifyHeader(header, nil))
 	})
 

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -92,10 +92,10 @@ func (v *VRankModule) pfReport(blockNum uint64) ([]common.Address, error) {
 	return pfReport, nil
 }
 
-// TallyCfReport computes the cfReport for block blockNum at the given round from in-memory collector state.
-// To fill `header(N).VRank`, the proposer of block N must use `TallyCfReport(N-1, last round of N-1)`.
+// EvaluateCandidates computes the cfReport for block blockNum at the given round from in-memory collector state.
+// To fill `header(N).VRank`, the proposer of block N must use `EvaluateCandidates(N-1, last round of N-1)`.
 // Returns ErrNotPermissionless if header(blockNum+1) is before the permissionless fork.
-func (v *VRankModule) TallyCfReport(blockNum, round uint64) ([]common.Address, error) {
+func (v *VRankModule) EvaluateCandidates(blockNum, round uint64) ([]common.Address, error) {
 	if !v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum + 1)) {
 		return nil, vrank.ErrNotPermissionless
 	}

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -26,12 +26,22 @@ import (
 )
 
 // cfReport reads the committed cfReport for block blockNum from header.VRank.
-// Returns an empty report if header.VRank is nil (e.g. epoch-start block).
+// Returns an empty report if header.VRank is nil.
 // Returns ErrNotPermissionless if blockNum is before the permissionless fork.
+//
+// At epoch-start blocks (blockNum % VRankEpoch == 0), header.VRank carries
+// CandTesting(blockNum) per KIP-227, NOT cfReport. CFS aggregation must skip
+// these blocks — decoding the candidate list as a cfReport would credit every
+// candidate with a failure they didn't have. Returns an empty report at
+// epoch-start so applyBlocksForCPMatrix is a no-op for that block.
+//
 // Used by applyBlocksForCPMatrix so that catchUp can process pre-fork blocks without error.
 func (v *VRankModule) cfReport(blockNum uint64) ([]common.Address, error) {
 	if !v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) {
 		return nil, vrank.ErrNotPermissionless
+	}
+	if blockNum%v.vrankEpoch() == 0 {
+		return []common.Address{}, nil
 	}
 
 	header := v.Chain.GetHeaderByNumber(blockNum)

--- a/kaiax/vrank/impl/getter_test.go
+++ b/kaiax/vrank/impl/getter_test.go
@@ -174,9 +174,9 @@ func TestGetPfReport_Errors(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestTallyCfReport
+// TestEvaluateCandidates
 // ---------------------------------------------------------------------------
-func TestTallyCfReport(t *testing.T) {
+func TestEvaluateCandidates(t *testing.T) {
 	var (
 		ctrl   = gomock.NewController(t)
 		valset = mock_valset.NewMockValsetModule(ctrl)
@@ -249,7 +249,7 @@ func TestTallyCfReport(t *testing.T) {
 	}
 
 	for _, v := range validators {
-		report, err := v.VRankModule.TallyCfReport(2, 0)
+		report, err := v.VRankModule.EvaluateCandidates(2, 0)
 		assert.NoError(t, err)
 		assert.Len(t, report, 4, "cfReport: 2 liars + 2 late")
 		for _, addr := range ontimeCands {
@@ -264,13 +264,13 @@ func TestTallyCfReport(t *testing.T) {
 		for _, addr := range lateCands {
 			assert.True(t, slices.Contains(report, addr))
 		}
-		report2, err := v.VRankModule.TallyCfReport(2, 0)
+		report2, err := v.VRankModule.EvaluateCandidates(2, 0)
 		assert.NoError(t, err)
-		assert.Equal(t, report, report2, "TallyCfReport must be deterministic")
+		assert.Equal(t, report, report2, "EvaluateCandidates must be deterministic")
 	}
 }
 
-func TestTallyCfReport_Errors(t *testing.T) {
+func TestEvaluateCandidates_Errors(t *testing.T) {
 	block1 := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
 	view1_0 := &bft.View{Sequence: big.NewInt(1), Round: common.Big0}
 	candAddr := common.HexToAddress("0xc4nd1d473")
@@ -286,11 +286,11 @@ func TestTallyCfReport_Errors(t *testing.T) {
 	}
 
 	t.Run("pre-fork block returns ErrNotPermissionless", func(t *testing.T) {
-		// TallyCfReport(blockNum=0, ...) targets header(1).VRank; fork check is on blockNum+1=1.
+		// EvaluateCandidates(blockNum=0, ...) targets header(1).VRank; fork check is on blockNum+1=1.
 		// With osaka config, fork is never enabled, so block 1 is pre-fork.
 		v := newCN(t, withHardfork("osaka"), withoutStart()).VRankModule
 
-		report, err := v.TallyCfReport(0, 0)
+		report, err := v.EvaluateCandidates(0, 0)
 		assert.ErrorIs(t, err, vrank.ErrNotPermissionless)
 		assert.Nil(t, report)
 	})
@@ -299,7 +299,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		cn := newCNWithDefaults()
 		cn.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
-		report, err := cn.VRankModule.TallyCfReport(1, 0)
+		report, err := cn.VRankModule.EvaluateCandidates(1, 0)
 		require.NoError(t, err)
 		assert.True(t, slices.Contains(report, candAddr))
 	})
@@ -313,7 +313,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		cn.Valset.EXPECT().GetProposer(uint64(params.DefaultVRankEpoch-1), uint64(0)).Return(cn.Addr, nil).AnyTimes()
 		cn.VRankModule.HandleIstanbulPreprepare(block, view)
 
-		report, err := cn.VRankModule.TallyCfReport(params.DefaultVRankEpoch-1, 0)
+		report, err := cn.VRankModule.EvaluateCandidates(params.DefaultVRankEpoch-1, 0)
 		require.NoError(t, err)
 		assert.Empty(t, report)
 	})
@@ -322,11 +322,11 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		cn := newCNWithDefaults()
 		cn.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
-		report, err := cn.VRankModule.TallyCfReport(1, 11) // maxRound is 10
+		report, err := cn.VRankModule.EvaluateCandidates(1, 11) // maxRound is 10
 		require.ErrorIs(t, err, vrank.ErrRoundOutOfRange)
 		assert.Nil(t, report)
 
-		report, err = cn.VRankModule.TallyCfReport(1, 10)
+		report, err = cn.VRankModule.EvaluateCandidates(1, 10)
 		assert.NotErrorIs(t, err, vrank.ErrRoundOutOfRange)
 	})
 
@@ -340,7 +340,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(cn1.Addr, nil).AnyTimes()
 		cn1.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
-		report, err := cn2.VRankModule.TallyCfReport(1, 0)
+		report, err := cn2.VRankModule.EvaluateCandidates(1, 0)
 		require.NoError(t, err)
 		assert.Empty(t, report)
 	})
@@ -351,7 +351,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 
 		prepreparedTime, _, _ := val.VRankModule.collector.GetViewData(vrank.ViewKey{N: 1, R: 0})
 		assert.True(t, prepreparedTime.IsZero())
-		report, err := val.VRankModule.TallyCfReport(1, 0)
+		report, err := val.VRankModule.EvaluateCandidates(1, 0)
 		require.NoError(t, err)
 		assert.Empty(t, report)
 	})
@@ -364,7 +364,7 @@ func TestTallyCfReport_Errors(t *testing.T) {
 		valset.EXPECT().GetCandTesting(uint64(1)).Return(nil, assert.AnError).AnyTimes()
 		cn.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
-		report, err := cn.VRankModule.TallyCfReport(1, 0)
+		report, err := cn.VRankModule.EvaluateCandidates(1, 0)
 		require.ErrorIs(t, err, vrank.ErrGetCandidateFailed)
 		assert.Nil(t, report)
 	})

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -112,7 +112,7 @@ func (v *VRankModule) HandleVRankPreprepare(msg *vrank.VRankPreprepare) error {
 	return nil
 }
 
-// HandleVRankCandidate stores VRankCandidate from candidates. Verification is performed at TallyCfReport.
+// HandleVRankCandidate stores VRankCandidate from candidates. Verification is performed at EvaluateCandidates.
 func (v *VRankModule) HandleVRankCandidate(msg *vrank.VRankCandidate) error {
 	if !v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(msg.BlockNumber)) {
 		return nil

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -78,10 +78,10 @@ type VRankScenario struct {
 	Candidates        []string   // Candidates(1)
 	Proposer          string     // Proposer(1, 0)
 	UnresponsiveCands []string   // optional: candidates whose message is not delivered to validators
-	ExpectedCfReports [][]string // ExpectedCfReports[i] = expected TallyCfReport(1, 0) for Nodes[i]
+	ExpectedCfReports [][]string // ExpectedCfReports[i] = expected EvaluateCandidates(1, 0) for Nodes[i]
 }
 
-// runVRankScenario runs the full cycle for block 1 and asserts TallyCfReport(1, 0) for each node matches ExpectedCfReports[i].
+// runVRankScenario runs the full cycle for block 1 and asserts EvaluateCandidates(1, 0) for each node matches ExpectedCfReports[i].
 func runVRankScenario(t *testing.T, s VRankScenario) {
 	const blockNum = uint64(1)
 	require.Len(t, s.ExpectedCfReports, len(s.Nodes), "ExpectedCfReports must have one entry per node")
@@ -147,9 +147,9 @@ func runVRankScenario(t *testing.T, s VRankScenario) {
 		}
 	}
 
-	// 4. TallyCfReport(1, 0) from each node and assert ExpectedCfReports[i]
+	// 4. EvaluateCandidates(1, 0) from each node and assert ExpectedCfReports[i]
 	for i, nodeName := range s.Nodes {
-		report, err := nameToCN[nodeName].VRankModule.TallyCfReport(blockNum, 0)
+		report, err := nameToCN[nodeName].VRankModule.EvaluateCandidates(blockNum, 0)
 		require.NoError(t, err)
 		expectedNames := s.ExpectedCfReports[i]
 		expectedAddrs := make([]common.Address, 0, len(expectedNames))
@@ -552,7 +552,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 		assert.Nil(t, candMap, "stale messages should not be stored")
 	})
 
-	t.Run("epoch boundary future messages should be stored until tally", func(t *testing.T) {
+	t.Run("epoch boundary future messages should be stored until evaluation", func(t *testing.T) {
 		cns, valset, _ := newCNMulti(t, 2)
 		val, cand := cns[0], cns[1]
 		blockNum := params.DefaultVRankEpoch - 1

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -57,7 +57,7 @@ type VRankModule interface {
 	HandleIstanbulPreprepare(block *types.Block, view *bft.View)
 	HandleVRankPreprepare(msg *VRankPreprepare) error
 	HandleVRankCandidate(msg *VRankCandidate) error
-	TallyCfReport(blockNum, round uint64) ([]common.Address, error)
+	EvaluateCandidates(blockNum, round uint64) ([]common.Address, error)
 	GetPfReport(blockNum uint64) ([]common.Address, error)
 	GetPFS(blockNum uint64) (map[common.Address]uint64, error)
 	GetCFS(blockNum uint64) (map[common.Address]uint64, error)

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -64,7 +64,3 @@ type VRankModule interface {
 
 	SubscribeVRank(sink chan<- *VRankBroadcastEvent) event.Subscription
 }
-
-type VRankModuleHost interface {
-	RegisterVRankModule(module VRankModule)
-}

--- a/kaiax/vrank/mock/module.go
+++ b/kaiax/vrank/mock/module.go
@@ -38,6 +38,21 @@ func (m *MockVRankModule) EXPECT() *MockVRankModuleMockRecorder {
 	return m.recorder
 }
 
+// EvaluateCandidates mocks base method.
+func (m *MockVRankModule) EvaluateCandidates(arg0, arg1 uint64) ([]common.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvaluateCandidates", arg0, arg1)
+	ret0, _ := ret[0].([]common.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EvaluateCandidates indicates an expected call of EvaluateCandidates.
+func (mr *MockVRankModuleMockRecorder) EvaluateCandidates(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateCandidates", reflect.TypeOf((*MockVRankModule)(nil).EvaluateCandidates), arg0, arg1)
+}
+
 // GetCFS mocks base method.
 func (m *MockVRankModule) GetCFS(arg0 uint64) (map[common.Address]uint64, error) {
 	m.ctrl.T.Helper()
@@ -175,21 +190,6 @@ func (m *MockVRankModule) SubscribeVRank(arg0 chan<- *vrank.VRankBroadcastEvent)
 func (mr *MockVRankModuleMockRecorder) SubscribeVRank(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeVRank", reflect.TypeOf((*MockVRankModule)(nil).SubscribeVRank), arg0)
-}
-
-// TallyCfReport mocks base method.
-func (m *MockVRankModule) TallyCfReport(arg0, arg1 uint64) ([]common.Address, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TallyCfReport", arg0, arg1)
-	ret0, _ := ret[0].([]common.Address)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TallyCfReport indicates an expected call of TallyCfReport.
-func (mr *MockVRankModuleMockRecorder) TallyCfReport(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TallyCfReport", reflect.TypeOf((*MockVRankModule)(nil).TallyCfReport), arg0, arg1)
 }
 
 // VerifyHeader mocks base method.

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -58,6 +58,7 @@ import (
 	system_impl "github.com/kaiachain/kaia/kaiax/system/impl"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	valset_impl "github.com/kaiachain/kaia/kaiax/valset/impl"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	vrank_impl "github.com/kaiachain/kaia/kaiax/vrank/impl"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -93,6 +94,8 @@ type Miner interface {
 	PendingBlock() *types.Block
 	kaiax.ExecutionModuleHost  // Because miner executes blocks, inject ExecutionModule.
 	kaiax.TxBundlingModuleHost // Because miner bundle transactions, inject TxBundlingModule
+	vrank.VRankModuleHost      // Worker reads cfReports to fill header.VRank
+	valset.ValsetModuleHost    // Worker reads CandTesting to fill header.VRank at epoch-start
 }
 
 // BackendProtocolManager is an interface of cn.ProtocolManager used from cn.CN and cn.ServiceChain.
@@ -572,7 +575,6 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 		mVRank.Init(&vrank_impl.InitOpts{
 			Valset:      mValset,
 			Randao:      mRandao,
-			RoundReader: s.blockchain.Sealer(),
 			NodeKey:     ctx.NodeKey(),
 			BlsKey:      ctx.BlsNodeKey(),
 			ChainConfig: s.chainConfig,
@@ -590,7 +592,7 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	mTxPool := []kaiax.TxPoolModule{}
 	mJsonRpc := []kaiax.JsonRpcModule{s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao}
 	mRewindable := []kaiax.RewindableModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao}
-	mHeader := []kaiax.HeaderModule{mReward, s.govModule, mRandao, mValset}
+	mHeader := []kaiax.HeaderModule{mReward, s.govModule, mRandao, mValset, mVRank}
 	mBlockState := []kaiax.BlockStateModule{mReward, mSystem, mValset}
 
 	if !mGasless.IsDisabled() {
@@ -619,6 +621,8 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	s.RegisterJsonRpcModules(mJsonRpc...)
 	s.miner.RegisterExecutionModule(mExecution...)
 	s.miner.RegisterTxBundlingModule(mTxBundling...)
+	s.miner.RegisterVRankModule(mVRank)
+	s.miner.RegisterValsetModule(mValset)
 	s.blockchain.RegisterKaiaxModules(s.govModule, mValset, mExecution, mRewindable, mHeader, mBlockState)
 	s.txPool.RegisterTxPoolModule(mTxPool...)
 	s.engine.RegisterKaiaxModules(s.govModule, mValset)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -58,7 +58,6 @@ import (
 	system_impl "github.com/kaiachain/kaia/kaiax/system/impl"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	valset_impl "github.com/kaiachain/kaia/kaiax/valset/impl"
-	"github.com/kaiachain/kaia/kaiax/vrank"
 	vrank_impl "github.com/kaiachain/kaia/kaiax/vrank/impl"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -94,8 +93,6 @@ type Miner interface {
 	PendingBlock() *types.Block
 	kaiax.ExecutionModuleHost  // Because miner executes blocks, inject ExecutionModule.
 	kaiax.TxBundlingModuleHost // Because miner bundle transactions, inject TxBundlingModule
-	vrank.VRankModuleHost      // Worker reads candidate evaluations to fill header.VRank
-	valset.ValsetModuleHost    // Worker reads CandTesting to fill header.VRank at epoch-start
 }
 
 // BackendProtocolManager is an interface of cn.ProtocolManager used from cn.CN and cn.ServiceChain.
@@ -623,8 +620,6 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	s.RegisterJsonRpcModules(mJsonRpc...)
 	s.miner.RegisterExecutionModule(mExecution...)
 	s.miner.RegisterTxBundlingModule(mTxBundling...)
-	s.miner.RegisterVRankModule(mVRank)
-	s.miner.RegisterValsetModule(mValset)
 	s.blockchain.RegisterKaiaxModules(s.govModule, mValset, mExecution, mRewindable, mHeader, mBlockState)
 	s.txPool.RegisterTxPoolModule(mTxPool...)
 	s.engine.RegisterKaiaxModules(s.govModule, mValset)

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -412,6 +412,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	if err := cn.SetupKaiaxModules(ctx, mValset, mVRank); err != nil {
 		logger.Error("Failed to setup kaiax modules", "err", err)
+		return nil, err
 	}
 
 	// Fill the staking info cache for the recent blocks.
@@ -575,6 +576,7 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 		mVRank.Init(&vrank_impl.InitOpts{
 			Valset:      mValset,
 			Randao:      mRandao,
+			RoundReader: s.blockchain.Sealer(),
 			NodeKey:     ctx.NodeKey(),
 			BlsKey:      ctx.BlsNodeKey(),
 			ChainConfig: s.chainConfig,

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -94,7 +94,7 @@ type Miner interface {
 	PendingBlock() *types.Block
 	kaiax.ExecutionModuleHost  // Because miner executes blocks, inject ExecutionModule.
 	kaiax.TxBundlingModuleHost // Because miner bundle transactions, inject TxBundlingModule
-	vrank.VRankModuleHost      // Worker reads cfReports to fill header.VRank
+	vrank.VRankModuleHost      // Worker reads candidate evaluations to fill header.VRank
 	valset.ValsetModuleHost    // Worker reads CandTesting to fill header.VRank at epoch-start
 }
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -58,6 +58,7 @@ import (
 	system_impl "github.com/kaiachain/kaia/kaiax/system/impl"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	valset_impl "github.com/kaiachain/kaia/kaiax/valset/impl"
+	vrank_impl "github.com/kaiachain/kaia/kaiax/vrank/impl"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/node"
@@ -236,6 +237,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		mGov     = gov_impl.NewGovModule()
 		mValset  = valset_impl.NewValsetModule()
 		mStaking = staking_impl.NewStakingModule()
+		mVRank   = vrank_impl.NewVRankModule()
 	)
 	cn := &CN{
 		config:            config,
@@ -307,7 +309,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 
 	cn.blockchain = bc
 
-	if err := cn.InitGovModule(mStaking, mGov, mValset); err != nil {
+	if err := cn.InitGovModule(mStaking, mGov, mValset, mVRank); err != nil {
 		return nil, err
 	}
 
@@ -405,7 +407,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	cn.addComponent(cn.ChainDB())
 	cn.addComponent(cn.engine)
 
-	if err := cn.SetupKaiaxModules(ctx, mValset); err != nil {
+	if err := cn.SetupKaiaxModules(ctx, mValset, mVRank); err != nil {
 		logger.Error("Failed to setup kaiax modules", "err", err)
 	}
 
@@ -491,7 +493,7 @@ func (s *CN) SetComponents(component []interface{}) {
 	// do nothing
 }
 
-func (s *CN) InitGovModule(mStaking *staking_impl.StakingModule, mGov *gov_impl.GovModule, mValset *valset_impl.ValsetModule,
+func (s *CN) InitGovModule(mStaking *staking_impl.StakingModule, mGov *gov_impl.GovModule, mValset *valset_impl.ValsetModule, mVRank *vrank_impl.VRankModule,
 ) error {
 	// Initialize modules
 	return errors.Join(
@@ -512,11 +514,12 @@ func (s *CN) InitGovModule(mStaking *staking_impl.StakingModule, mGov *gov_impl.
 			Chain:         s.blockchain,
 			GovModule:     mGov,
 			StakingModule: mStaking,
+			VRankModule:   mVRank,
 		}),
 	)
 }
 
-func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetModule) error {
+func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetModule, mVRank *vrank_impl.VRankModule) error {
 	var (
 		mRandao  = randao_impl.NewRandaoModule()
 		mReward  = reward_impl.NewRewardModule()
@@ -566,6 +569,16 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 			Downloader:    s.protocolManager.Downloader(),
 			NodeKey:       ctx.NodeKey(),
 		}),
+		mVRank.Init(&vrank_impl.InitOpts{
+			Valset:      mValset,
+			Randao:      mRandao,
+			RoundReader: s.blockchain.Sealer(),
+			NodeKey:     ctx.NodeKey(),
+			BlsKey:      ctx.BlsNodeKey(),
+			ChainConfig: s.chainConfig,
+			Chain:       s.blockchain,
+			ChainKv:     s.chainDB.GetMiscDB(),
+		}),
 	)
 	if err != nil {
 		return err
@@ -577,8 +590,8 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	mTxPool := []kaiax.TxPoolModule{}
 	mJsonRpc := []kaiax.JsonRpcModule{s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao}
 	mRewindable := []kaiax.RewindableModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao}
-	mHeader := []kaiax.HeaderModule{mReward, s.govModule, mRandao}
-	mBlockState := []kaiax.BlockStateModule{mReward, mSystem}
+	mHeader := []kaiax.HeaderModule{mReward, s.govModule, mRandao, mValset}
+	mBlockState := []kaiax.BlockStateModule{mReward, mSystem, mValset}
 
 	if !mGasless.IsDisabled() {
 		mExecution = append(mExecution, mGasless)

--- a/node/cn/mocks/miner_mock.go
+++ b/node/cn/mocks/miner_mock.go
@@ -11,6 +11,8 @@ import (
 	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	kaiax "github.com/kaiachain/kaia/kaiax"
+	valset "github.com/kaiachain/kaia/kaiax/valset"
+	vrank "github.com/kaiachain/kaia/kaiax/vrank"
 )
 
 // MockMiner is a mock of Miner interface.
@@ -110,6 +112,30 @@ func (m *MockMiner) RegisterTxBundlingModule(arg0 ...kaiax.TxBundlingModule) {
 func (mr *MockMinerMockRecorder) RegisterTxBundlingModule(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTxBundlingModule", reflect.TypeOf((*MockMiner)(nil).RegisterTxBundlingModule), arg0...)
+}
+
+// RegisterVRankModule mocks base method.
+func (m *MockMiner) RegisterVRankModule(arg0 vrank.VRankModule) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterVRankModule", arg0)
+}
+
+// RegisterVRankModule indicates an expected call of RegisterVRankModule.
+func (mr *MockMinerMockRecorder) RegisterVRankModule(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterVRankModule", reflect.TypeOf((*MockMiner)(nil).RegisterVRankModule), arg0)
+}
+
+// RegisterValsetModule mocks base method.
+func (m *MockMiner) RegisterValsetModule(arg0 valset.ValsetModule) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterValsetModule", arg0)
+}
+
+// RegisterValsetModule indicates an expected call of RegisterValsetModule.
+func (mr *MockMinerMockRecorder) RegisterValsetModule(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterValsetModule", reflect.TypeOf((*MockMiner)(nil).RegisterValsetModule), arg0)
 }
 
 // SetExtra mocks base method.

--- a/node/cn/mocks/miner_mock.go
+++ b/node/cn/mocks/miner_mock.go
@@ -11,8 +11,6 @@ import (
 	state "github.com/kaiachain/kaia/blockchain/state"
 	types "github.com/kaiachain/kaia/blockchain/types"
 	kaiax "github.com/kaiachain/kaia/kaiax"
-	valset "github.com/kaiachain/kaia/kaiax/valset"
-	vrank "github.com/kaiachain/kaia/kaiax/vrank"
 )
 
 // MockMiner is a mock of Miner interface.
@@ -112,30 +110,6 @@ func (m *MockMiner) RegisterTxBundlingModule(arg0 ...kaiax.TxBundlingModule) {
 func (mr *MockMinerMockRecorder) RegisterTxBundlingModule(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTxBundlingModule", reflect.TypeOf((*MockMiner)(nil).RegisterTxBundlingModule), arg0...)
-}
-
-// RegisterVRankModule mocks base method.
-func (m *MockMiner) RegisterVRankModule(arg0 vrank.VRankModule) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterVRankModule", arg0)
-}
-
-// RegisterVRankModule indicates an expected call of RegisterVRankModule.
-func (mr *MockMinerMockRecorder) RegisterVRankModule(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterVRankModule", reflect.TypeOf((*MockMiner)(nil).RegisterVRankModule), arg0)
-}
-
-// RegisterValsetModule mocks base method.
-func (m *MockMiner) RegisterValsetModule(arg0 valset.ValsetModule) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterValsetModule", arg0)
-}
-
-// RegisterValsetModule indicates an expected call of RegisterValsetModule.
-func (mr *MockMinerMockRecorder) RegisterValsetModule(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterValsetModule", reflect.TypeOf((*MockMiner)(nil).RegisterValsetModule), arg0)
 }
 
 // SetExtra mocks base method.

--- a/work/work.go
+++ b/work/work.go
@@ -40,7 +40,6 @@ import (
 	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/valset"
-	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -216,18 +215,6 @@ func (self *Miner) RegisterTxBundlingModule(txBundlingModules ...kaiax.TxBundlin
 		modules[i] = module.(builder.TxBundlingModule)
 	}
 	self.worker.RegisterTxBundlingModule(modules...)
-}
-
-// RegisterVRankModule registers vrank.VRankModule to underlying worker. The
-// worker reads candidate evaluations from it to fill header.VRank at block creation.
-func (self *Miner) RegisterVRankModule(module vrank.VRankModule) {
-	self.worker.RegisterVRankModule(module)
-}
-
-// RegisterValsetModule registers valset.ValsetModule to underlying worker.
-// The worker reads CandTesting from it to fill header.VRank at epoch-start blocks.
-func (self *Miner) RegisterValsetModule(module valset.ValsetModule) {
-	self.worker.RegisterValsetModule(module)
 }
 
 // BlockChain is an interface of blockchain.BlockChain used by ProtocolManager.

--- a/work/work.go
+++ b/work/work.go
@@ -219,7 +219,7 @@ func (self *Miner) RegisterTxBundlingModule(txBundlingModules ...kaiax.TxBundlin
 }
 
 // RegisterVRankModule registers vrank.VRankModule to underlying worker. The
-// worker reads cfReports from it to fill header.VRank at block creation.
+// worker reads candidate evaluations from it to fill header.VRank at block creation.
 func (self *Miner) RegisterVRankModule(module vrank.VRankModule) {
 	self.worker.RegisterVRankModule(module)
 }

--- a/work/work.go
+++ b/work/work.go
@@ -225,8 +225,7 @@ func (self *Miner) RegisterVRankModule(module vrank.VRankModule) {
 }
 
 // RegisterValsetModule registers valset.ValsetModule to underlying worker.
-// The worker reads CandTesting from it to fill header.VRank at epoch-start
-// blocks (KIP-227).
+// The worker reads CandTesting from it to fill header.VRank at epoch-start blocks.
 func (self *Miner) RegisterValsetModule(module valset.ValsetModule) {
 	self.worker.RegisterValsetModule(module)
 }

--- a/work/work.go
+++ b/work/work.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
@@ -215,6 +216,19 @@ func (self *Miner) RegisterTxBundlingModule(txBundlingModules ...kaiax.TxBundlin
 		modules[i] = module.(builder.TxBundlingModule)
 	}
 	self.worker.RegisterTxBundlingModule(modules...)
+}
+
+// RegisterVRankModule registers vrank.VRankModule to underlying worker. The
+// worker reads cfReports from it to fill header.VRank at block creation.
+func (self *Miner) RegisterVRankModule(module vrank.VRankModule) {
+	self.worker.RegisterVRankModule(module)
+}
+
+// RegisterValsetModule registers valset.ValsetModule to underlying worker.
+// The worker reads CandTesting from it to fill header.VRank at epoch-start
+// blocks (KIP-227).
+func (self *Miner) RegisterValsetModule(module valset.ValsetModule) {
+	self.worker.RegisterValsetModule(module)
 }
 
 // BlockChain is an interface of blockchain.BlockChain used by ProtocolManager.

--- a/work/worker.go
+++ b/work/worker.go
@@ -40,6 +40,8 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/kaiax/gov"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/kerrors"
 	kaiametrics "github.com/kaiachain/kaia/metrics"
 	"github.com/kaiachain/kaia/params"
@@ -162,6 +164,8 @@ type worker struct {
 	chain             BlockChain
 	chainDB           database.DBManager
 	govModule         gov.GovModule
+	valsetModule      valset.ValsetModule // optional, nil before permissionless fork
+	vrankModule       vrank.VRankModule   // optional, nil before permissionless fork
 	executionModules  []kaiax.ExecutionModule
 	txBundlingModules []builder.TxBundlingModule
 
@@ -403,6 +407,9 @@ func (self *worker) commitNewWork() {
 		logger.Error("Failed to prepare header for mining", "err", err)
 		return
 	}
+	if self.config.IsPermissionlessForkEnabled(header.Number) {
+		header.VRank = self.generateVRankField(parent)
+	}
 	// Apply KIP-279.
 	if self.config.IsOsakaForkEnabled(header.Number) {
 		// In KIP-279, ExcessBlobGas is defined as follows:
@@ -605,6 +612,75 @@ func (self *worker) RegisterExecutionModule(modules ...kaiax.ExecutionModule) {
 
 func (self *worker) RegisterTxBundlingModule(modules ...builder.TxBundlingModule) {
 	self.txBundlingModules = append(self.txBundlingModules, modules...)
+}
+
+func (self *worker) RegisterVRankModule(module vrank.VRankModule) {
+	self.vrankModule = module
+}
+
+func (self *worker) RegisterValsetModule(module valset.ValsetModule) {
+	self.valsetModule = module
+}
+
+// generateVRankField fills `header(num).VRank` per KIP-227.
+//
+//	num % VRankEpoch != 0:  RLPEncode(cfReport(num)), or nil if empty.
+//	num % VRankEpoch == 0:  RLPEncode(CandTesting(num)), MUST NOT be nil.
+//
+// Returns nil on error; consensus rules permit nil only when num is non-epoch
+// AND cfReport is empty. At epoch-start, nil produces an invalid header — the
+// proposer will fail VerifyHeader, which is the desired behavior over silently
+// emitting a malformed block.
+func (self *worker) generateVRankField(parent *types.Block) []byte {
+	if self.vrankModule == nil {
+		return nil
+	}
+	prevBlockNum := parent.Number().Uint64()
+	num := prevBlockNum + 1
+	if num%self.config.VRankEpoch == 0 {
+		return self.encodeCandTestingForEpochStart(num)
+	}
+	prevRound, err := self.chain.Sealer().Round(parent.Header())
+	if err != nil {
+		logger.Error("Failed to read parent round for vrank", "err", err, "prevBlockNum", prevBlockNum)
+		return nil
+	}
+	cfReport, err := self.vrankModule.TallyCfReport(prevBlockNum, uint64(prevRound))
+	if err != nil {
+		logger.Error("Failed to tally cfReport", "err", err, "prevBlockNum", prevBlockNum, "prevRound", prevRound)
+		return nil
+	}
+	if len(cfReport) == 0 {
+		return nil
+	}
+	encoded, err := vrank.EncodeReport(cfReport)
+	if err != nil {
+		logger.Error("Failed to encode cfReport", "err", err, "cfReport", cfReport)
+		return nil
+	}
+	return encoded
+}
+
+// encodeCandTestingForEpochStart returns RLPEncode(CandTesting(num)) for an
+// epoch-start block. Per KIP-227 the field MUST NOT be nil at epoch-start, so
+// any error here will fail header verification downstream rather than silently
+// emit a malformed block.
+func (self *worker) encodeCandTestingForEpochStart(num uint64) []byte {
+	if self.valsetModule == nil {
+		logger.Error("epoch-start VRank fill: valsetModule unavailable", "num", num)
+		return nil
+	}
+	candidates, err := self.valsetModule.GetCandTesting(num)
+	if err != nil {
+		logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", num, "err", err)
+		return nil
+	}
+	encoded, err := vrank.EncodeReport(candidates)
+	if err != nil {
+		logger.Error("epoch-start VRank fill: EncodeReport failed", "num", num, "err", err)
+		return nil
+	}
+	return encoded
 }
 
 // Return the balance of the address in KAIA, in int64. If the balance is greater (often happens in private net), return MaxInt64.

--- a/work/worker.go
+++ b/work/worker.go
@@ -40,8 +40,6 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/kaiax/gov"
-	"github.com/kaiachain/kaia/kaiax/valset"
-	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/kerrors"
 	kaiametrics "github.com/kaiachain/kaia/metrics"
 	"github.com/kaiachain/kaia/params"
@@ -164,8 +162,6 @@ type worker struct {
 	chain             BlockChain
 	chainDB           database.DBManager
 	govModule         gov.GovModule
-	valsetModule      valset.ValsetModule
-	vrankModule       vrank.VRankModule
 	executionModules  []kaiax.ExecutionModule
 	txBundlingModules []builder.TxBundlingModule
 
@@ -407,9 +403,6 @@ func (self *worker) commitNewWork() {
 		logger.Error("Failed to prepare header for mining", "err", err)
 		return
 	}
-	if self.config.IsPermissionlessForkEnabled(header.Number) {
-		header.VRank = self.generateVRankField(parent)
-	}
 	// Apply KIP-279.
 	if self.config.IsOsakaForkEnabled(header.Number) {
 		// In KIP-279, ExcessBlobGas is defined as follows:
@@ -612,66 +605,6 @@ func (self *worker) RegisterExecutionModule(modules ...kaiax.ExecutionModule) {
 
 func (self *worker) RegisterTxBundlingModule(modules ...builder.TxBundlingModule) {
 	self.txBundlingModules = append(self.txBundlingModules, modules...)
-}
-
-func (self *worker) RegisterVRankModule(module vrank.VRankModule) {
-	self.vrankModule = module
-}
-
-func (self *worker) RegisterValsetModule(module valset.ValsetModule) {
-	self.valsetModule = module
-}
-
-// generateVRankField fills `header(num).VRank` per KIP-227.
-//
-//	num % VRankEpoch != 0:  RLPEncode(EvaluateCandidates(num-1, parentRound)), or nil if empty.
-//	num % VRankEpoch == 0:  RLPEncode(CandTesting(num)).
-func (self *worker) generateVRankField(parent *types.Block) []byte {
-	if self.vrankModule == nil {
-		return nil
-	}
-	prevBlockNum := parent.Number().Uint64()
-	num := prevBlockNum + 1
-	if num%self.config.VRankEpoch == 0 {
-		return self.encodeCandTestingForEpochStart(num)
-	}
-	prevRound, err := self.chain.Sealer().Round(parent.Header())
-	if err != nil {
-		logger.Error("Failed to read parent round for vrank", "err", err, "prevBlockNum", prevBlockNum)
-		return nil
-	}
-	cfReport, err := self.vrankModule.EvaluateCandidates(prevBlockNum, uint64(prevRound))
-	if err != nil {
-		logger.Error("Failed to evaluate VRank candidates", "err", err, "prevBlockNum", prevBlockNum, "prevRound", prevRound)
-		return nil
-	}
-	if len(cfReport) == 0 {
-		return nil
-	}
-	encoded, err := vrank.EncodeReport(cfReport)
-	if err != nil {
-		logger.Error("Failed to encode cfReport", "err", err, "cfReport", cfReport)
-		return nil
-	}
-	return encoded
-}
-
-func (self *worker) encodeCandTestingForEpochStart(num uint64) []byte {
-	if self.valsetModule == nil {
-		logger.Error("epoch-start VRank fill: valsetModule unavailable", "num", num)
-		return nil
-	}
-	candidates, err := self.valsetModule.GetCandTesting(num)
-	if err != nil {
-		logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", num, "err", err)
-		return nil
-	}
-	encoded, err := vrank.EncodeAddressList(candidates)
-	if err != nil {
-		logger.Error("epoch-start VRank fill: EncodeAddressList failed", "num", num, "err", err)
-		return nil
-	}
-	return encoded
 }
 
 // Return the balance of the address in KAIA, in int64. If the balance is greater (often happens in private net), return MaxInt64.

--- a/work/worker.go
+++ b/work/worker.go
@@ -164,7 +164,7 @@ type worker struct {
 	chain             BlockChain
 	chainDB           database.DBManager
 	govModule         gov.GovModule
-	valsetModule      valset.ValsetModule // optional, nil before permissionless fork
+	valsetModule      valset.ValsetModule // optional, used for epoch-start VRank fill
 	vrankModule       vrank.VRankModule   // optional, nil before permissionless fork
 	executionModules  []kaiax.ExecutionModule
 	txBundlingModules []builder.TxBundlingModule
@@ -625,12 +625,7 @@ func (self *worker) RegisterValsetModule(module valset.ValsetModule) {
 // generateVRankField fills `header(num).VRank` per KIP-227.
 //
 //	num % VRankEpoch != 0:  RLPEncode(cfReport(num)), or nil if empty.
-//	num % VRankEpoch == 0:  RLPEncode(CandTesting(num)), MUST NOT be nil.
-//
-// Returns nil on error; consensus rules permit nil only when num is non-epoch
-// AND cfReport is empty. At epoch-start, nil produces an invalid header — the
-// proposer will fail VerifyHeader, which is the desired behavior over silently
-// emitting a malformed block.
+//	num % VRankEpoch == 0:  RLPEncode(CandTesting(num)).
 func (self *worker) generateVRankField(parent *types.Block) []byte {
 	if self.vrankModule == nil {
 		return nil
@@ -661,10 +656,6 @@ func (self *worker) generateVRankField(parent *types.Block) []byte {
 	return encoded
 }
 
-// encodeCandTestingForEpochStart returns RLPEncode(CandTesting(num)) for an
-// epoch-start block. Per KIP-227 the field MUST NOT be nil at epoch-start, so
-// any error here will fail header verification downstream rather than silently
-// emit a malformed block.
 func (self *worker) encodeCandTestingForEpochStart(num uint64) []byte {
 	if self.valsetModule == nil {
 		logger.Error("epoch-start VRank fill: valsetModule unavailable", "num", num)
@@ -675,9 +666,9 @@ func (self *worker) encodeCandTestingForEpochStart(num uint64) []byte {
 		logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", num, "err", err)
 		return nil
 	}
-	encoded, err := vrank.EncodeReport(candidates)
+	encoded, err := vrank.EncodeAddressList(candidates)
 	if err != nil {
-		logger.Error("epoch-start VRank fill: EncodeReport failed", "num", num, "err", err)
+		logger.Error("epoch-start VRank fill: EncodeAddressList failed", "num", num, "err", err)
 		return nil
 	}
 	return encoded

--- a/work/worker.go
+++ b/work/worker.go
@@ -164,8 +164,8 @@ type worker struct {
 	chain             BlockChain
 	chainDB           database.DBManager
 	govModule         gov.GovModule
-	valsetModule      valset.ValsetModule // optional, used for epoch-start VRank fill
-	vrankModule       vrank.VRankModule   // optional, nil before permissionless fork
+	valsetModule      valset.ValsetModule
+	vrankModule       vrank.VRankModule
 	executionModules  []kaiax.ExecutionModule
 	txBundlingModules []builder.TxBundlingModule
 

--- a/work/worker.go
+++ b/work/worker.go
@@ -640,9 +640,9 @@ func (self *worker) generateVRankField(parent *types.Block) []byte {
 		logger.Error("Failed to read parent round for vrank", "err", err, "prevBlockNum", prevBlockNum)
 		return nil
 	}
-	cfReport, err := self.vrankModule.TallyCfReport(prevBlockNum, uint64(prevRound))
+	cfReport, err := self.vrankModule.EvaluateCandidates(prevBlockNum, uint64(prevRound))
 	if err != nil {
-		logger.Error("Failed to tally cfReport", "err", err, "prevBlockNum", prevBlockNum, "prevRound", prevRound)
+		logger.Error("Failed to evaluate VRank candidates", "err", err, "prevBlockNum", prevBlockNum, "prevRound", prevRound)
 		return nil
 	}
 	if len(cfReport) == 0 {

--- a/work/worker.go
+++ b/work/worker.go
@@ -624,7 +624,7 @@ func (self *worker) RegisterValsetModule(module valset.ValsetModule) {
 
 // generateVRankField fills `header(num).VRank` per KIP-227.
 //
-//	num % VRankEpoch != 0:  RLPEncode(cfReport(num)), or nil if empty.
+//	num % VRankEpoch != 0:  RLPEncode(EvaluateCandidates(num-1, parentRound)), or nil if empty.
 //	num % VRankEpoch == 0:  RLPEncode(CandTesting(num)).
 func (self *worker) generateVRankField(parent *types.Block) []byte {
 	if self.vrankModule == nil {

--- a/work/worker_fake.go
+++ b/work/worker_fake.go
@@ -22,6 +22,8 @@ import (
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/kaiax"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 )
 
 type FakeWorker struct{}
@@ -41,3 +43,5 @@ func (*FakeWorker) Pending() (*types.Block, types.Receipts, *state.StateDB)    {
 func (*FakeWorker) PendingBlock() *types.Block                                 { return nil }
 func (*FakeWorker) RegisterExecutionModule(modules ...kaiax.ExecutionModule)   {}
 func (*FakeWorker) RegisterTxBundlingModule(modules ...kaiax.TxBundlingModule) {}
+func (*FakeWorker) RegisterVRankModule(module vrank.VRankModule)               {}
+func (*FakeWorker) RegisterValsetModule(module valset.ValsetModule)            {}

--- a/work/worker_fake.go
+++ b/work/worker_fake.go
@@ -22,8 +22,6 @@ import (
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/kaiax"
-	"github.com/kaiachain/kaia/kaiax/valset"
-	"github.com/kaiachain/kaia/kaiax/vrank"
 )
 
 type FakeWorker struct{}
@@ -43,5 +41,3 @@ func (*FakeWorker) Pending() (*types.Block, types.Receipts, *state.StateDB)    {
 func (*FakeWorker) PendingBlock() *types.Block                                 { return nil }
 func (*FakeWorker) RegisterExecutionModule(modules ...kaiax.ExecutionModule)   {}
 func (*FakeWorker) RegisterTxBundlingModule(modules ...kaiax.TxBundlingModule) {}
-func (*FakeWorker) RegisterVRankModule(module vrank.VRankModule)               {}
-func (*FakeWorker) RegisterValsetModule(module valset.ValsetModule)            {}


### PR DESCRIPTION
## Proposed changes

### Permissionless Valset Getters

- `kaiax/valset/impl/getter.go`
  - Adds fork-aware dispatch for council, demoted, qualified, committee, and permissionless-only getters.
- `kaiax/valset/impl/getter_permissionless.go`
  - Implements permissionless node-state based getter semantics.
- `kaiax/valset/interface.go`, `kaiax/valset/mock/module.go`
  - Extends the valset module interface and mocks for new getters.

### Header Verification

- `kaiax/valset/impl/consensus.go`
  - Adds valset `VerifyHeader`: post-HF, checks `header.Extra` validators exactly match computed qualified validators.
- `kaiax/vrank/impl/consensus.go`
  - Verifies `header.VRank`.
  - Pre-HF: VRank must be empty.
  - Epoch-start: VRank must equal `RLPEncode(CandTesting(N))`.
  - Non-epoch: VRank must be sorted, deduplicated, and contain only candidates from `N-1`.
- `blockchain/block_validator.go`
  - Verifies post-HF block author equals `GetProposer(N, round)`.
  - Verifies post-HF committed seals against qualified validators.
- `node/cn/backend.go`
  - Registers valset and VRank as header modules.

### Consensus Committee/Seal Semantics

- `consensus/istanbul/core/core.go`
  - Deprecates `istanbul.committeesize`; uses committee length as effective committee size.
  - Preserves pre-HF subset committee behavior and post-HF full-qualified committee behavior.
- `blockchain/block_validator.go`
  - Post-HF quorum and signer validation are based on qualified validators, not council or stale gov `CommitteeSize`.

### VRank Production

- `kaiax/vrank/impl/consensus.go`
  - Implements `PrepareHeader` to fill `header.VRank` after permissionless HF.
  - Epoch-start uses `RLPEncode(CandTesting(N))`, including `RLPEncode([])` when empty.
  - Non-epoch uses `EvaluateCandidates(N-1, parentRound)`, or nil when empty.
- `node/cn/backend.go`
  - Initializes VRank with valset, randao, round reader, chain config, chain, and ChainKv.
  - Registers valset and VRank as blockchain header modules.

### VRank Semantics

- `kaiax/vrank/impl/getter.go`
  - Renames `TallyCfReport` to `EvaluateCandidates`.
  - Skips epoch-start VRank when computing CFS because epoch-start VRank carries candidate list, not cfReport.
- `kaiax/vrank/interface.go`, `kaiax/vrank/mock/module.go`
  - Updates interface and mocks for `EvaluateCandidates`.
- `kaiax/vrank/README.md`, tests
  - Updates terminology and expected behavior.

### Permissionless Valset Lifecycle

- `kaiax/valset/impl/execution.go`
  - Pre-HF keeps validator headergov vote.
  - Post-HF caches next-block transition results from ABv2 state.
- `kaiax/valset/impl/blockstate.go`
  - Wires permissionless ABv2 install/update hooks into block-state processing.
- `kaiax/valset/impl/init.go`
  - Adds VRank dependency and transition-result cache.

### Governance Deprecation

- `kaiax/gov/param.go`
  - Deprecates validator add/remove votes and `istanbul.committeesize` after permissionless HF.
- `kaiax/gov/param_test.go`
  - Covers permissionless deprecation behavior.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
