### PR TITLE
kaiax/auction: Re-check bidWinnerMap and duplicates in #insertBid

### DIFF
--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -275,10 +275,8 @@ func (bp *BidPool) insertBid(bid *auction.Bid) error {
 	if _, ok := bp.bidMap[bid.Hash()]; ok {
 		return auction.ErrBidAlreadyExists
 	}
-	if existingHash, ok := bp.bidWinnerMap[blockNumber][sender]; ok {
-		if !bid.Equals(bp.bidMap[existingHash]) {
-			return auction.ErrBidSenderExists
-		}
+	if bp.senderHasDifferentWinner(bid) {
+		return auction.ErrBidSenderExists
 	}
 
 	// If same block number, same target tx hash exists, replace it if it's better
@@ -322,9 +320,18 @@ func (bp *BidPool) initializeBidMap(num uint64) {
 	}
 }
 
+// senderHasDifferentWinner reports whether a different bid from the same sender
+// already exists in the winner list for this block. Caller must hold bidMu.
+func (bp *BidPool) senderHasDifferentWinner(bid *auction.Bid) bool {
+	hash, ok := bp.bidWinnerMap[bid.BlockNumber][bid.Sender]
+	if !ok {
+		return false
+	}
+	return !bid.Equals(bp.bidMap[hash])
+}
+
 func (bp *BidPool) validateBid(bid *auction.Bid) error {
 	blockNumber := bid.BlockNumber
-	sender := bid.Sender
 
 	bp.bidMu.RLock()
 
@@ -335,11 +342,9 @@ func (bp *BidPool) validateBid(bid *auction.Bid) error {
 	}
 
 	// 1. The `bid.Sender` must not be in the winner list of the same block number if the new bid isn't equal to the previous bid.
-	if hash, ok := bp.bidWinnerMap[blockNumber][sender]; ok {
-		if !bid.Equals(bp.bidMap[hash]) {
-			bp.bidMu.RUnlock()
-			return auction.ErrBidSenderExists
-		}
+	if bp.senderHasDifferentWinner(bid) {
+		bp.bidMu.RUnlock()
+		return auction.ErrBidSenderExists
 	}
 	bp.bidMu.RUnlock()
 

--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -271,15 +271,20 @@ func (bp *BidPool) insertBid(bid *auction.Bid) error {
 		sender       = bid.Sender
 	)
 
+	// Re-check bidWinnerMap here — two concurrent bids can pass validateBid together.
+	if _, ok := bp.bidMap[bid.Hash()]; ok {
+		return auction.ErrBidAlreadyExists
+	}
+	if existingHash, ok := bp.bidWinnerMap[blockNumber][sender]; ok {
+		if !bid.Equals(bp.bidMap[existingHash]) {
+			return auction.ErrBidSenderExists
+		}
+	}
+
 	// If same block number, same target tx hash exists, replace it if it's better
 	if existingBid, ok := bp.bidTargetMap[blockNumber][targetTxHash]; ok {
 		// FCFS if the bid is the same.
 		if existingBid.Bid.Cmp(bid.Bid) >= 0 {
-			// Since we allow the parallel bid validation, the previous duplicate bid check at #validateBid might be skipped.
-			// So we need to check the bid map again to return the correct error.
-			if _, ok := bp.bidMap[bid.Hash()]; ok {
-				return auction.ErrBidAlreadyExists
-			}
 			return auction.ErrLowBid
 		}
 

--- a/kaiax/auction/impl/bid_pool_test.go
+++ b/kaiax/auction/impl/bid_pool_test.go
@@ -655,7 +655,7 @@ func TestBidPool_ConcurrentAddBid_OneWinnerPerSender(t *testing.T) {
 			pool.bidMu.RUnlock()
 
 			require.False(t, errA == nil && errB == nil && gotA && gotB,
-				"iter %d: both bids accepted; rule 1a violated", i)
+				"iter %d: both same-sender bids accepted", i)
 		}()
 	}
 }

--- a/kaiax/auction/impl/bid_pool_test.go
+++ b/kaiax/auction/impl/bid_pool_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/big"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -603,4 +604,58 @@ func benchmarkAddBidParallel(b *testing.B, numBids int) {
 			bidIndex++
 		}
 	})
+}
+
+// Two concurrent same-sender bids with different targets must not both succeed.
+func TestBidPool_ConcurrentAddBid_OneWinnerPerSender(t *testing.T) {
+	bidA, bidB := testBids[0], testBids[4]
+	require.Equal(t, bidA.Sender, bidB.Sender)
+	require.Equal(t, bidA.BlockNumber, bidB.BlockNumber)
+	require.NotEqual(t, bidA.TargetTxHash, bidB.TargetTxHash)
+
+	for i := 0; i < 10; i++ {
+		func() {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			chain := chain_mock.NewMockBlockChain(mockCtrl)
+			chain.EXPECT().CurrentBlock().Return(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})).AnyTimes()
+
+			pool := NewBidPool(testChainConfig, chain, &auction.AuctionConfig{MaxBidPoolSize: 1024})
+			require.NotNil(t, pool)
+			pool.start()
+			atomic.StoreUint32(&pool.running, 1)
+			defer pool.stop()
+			pool.auctioneer = testAuctioneer
+			pool.auctionEntryPoint = testAuctionEntryPoint
+
+			var (
+				wg         sync.WaitGroup
+				errA, errB error
+			)
+			startGate := make(chan struct{})
+
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				<-startGate
+				_, errA = pool.AddBid(bidA)
+			}()
+			go func() {
+				defer wg.Done()
+				<-startGate
+				_, errB = pool.AddBid(bidB)
+			}()
+			close(startGate)
+			wg.Wait()
+
+			pool.bidMu.RLock()
+			_, gotA := pool.bidMap[bidA.Hash()]
+			_, gotB := pool.bidMap[bidB.Hash()]
+			pool.bidMu.RUnlock()
+
+			require.False(t, errA == nil && errB == nil && gotA && gotB,
+				"iter %d: both bids accepted; rule 1a violated", i)
+		}()
+	}
 }


### PR DESCRIPTION
## Proposed changes

- Fix: `validateBid` runs the duplicate and `bidWinnerMap` checks under RLock, so two concurrent `AddBid` calls from the same sender with different targets could both pass. Re-check in `insertBid` under the write lock. The duplicate check added in e5c880676 is absorbed into the new entry-point check.
- Refactor: extract `senderHasDifferentWinner` helper to remove the duplicated nested check between `validateBid` and `insertBid`.
- Test: add regression test `TestBidPool_ConcurrentAddBid_OneWinnerPerSender`.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
