### PR TITLE
refactor(gasless): move uniswap bytecode regression from system const…

### DIFF
--- a/blockchain/system/constant.go
+++ b/blockchain/system/constant.go
@@ -32,8 +32,6 @@ import (
 	proxyv5contract "github.com/kaiachain/kaia/contracts/bindings/proxyv5"
 	"github.com/kaiachain/kaia/contracts/bindings/testing/reward"
 	testcontract "github.com/kaiachain/kaia/contracts/bindings/testing/system_contracts"
-	uniswapFactoryContracts "github.com/kaiachain/kaia/contracts/bindings/uniswap/factory"
-	uniswapRouterContracts "github.com/kaiachain/kaia/contracts/bindings/uniswap/router"
 	"github.com/kaiachain/kaia/log"
 )
 
@@ -104,10 +102,6 @@ var (
 	RegistryMockZero          = hexutil.MustDecode("0x" + reward.RegistryMockZeroBinRuntime)
 	CLRegistryMockThreeCLCode = hexutil.MustDecode("0x" + reward.CLRegistryMockThreeCLBinRuntime)
 	WrappedKaiaMockCode       = hexutil.MustDecode("0x" + reward.WrappedKaiaMockBinRuntime)
-
-	// Uniswap contracts for Gasless test
-	UniswapV2FactoryCode  = hexutil.MustDecode("0x" + uniswapFactoryContracts.UniswapV2FactoryBinRuntime)
-	UniswapV2Router02Code = hexutil.MustDecode("0x" + uniswapRouterContracts.UniswapV2Router02BinRuntime)
 
 	// Errors
 	ErrRegistryNotInstalled      = errors.New("Registry contract not installed")

--- a/blockchain/system/constant_test.go
+++ b/blockchain/system/constant_test.go
@@ -44,8 +44,6 @@ func TestRuntimeCodeRegression(t *testing.T) {
 		{Kip113Code, "0x236841ea654b0f18e83e934ba0f69b4ab215f0b6ffbeee288797ce67c89aea25"},
 		{ERC1967ProxyCode, "0x7bd49b148f3b1ffd97fb2ef2fdc773271822fa8306d3bcba626fbd412ed21c12"},
 		{ERC1967ProxyV5Code, "0xea418405ca57c8c6b4cbef32defcf1a8e86a5dc8e2a1ec0c4a0941285483cfcb"},
-		{UniswapV2FactoryCode, "0xbab145d02e7005f0d84c6c1639d39b799b0ea16df99ebbdaf5a14d9da820b4e0"},
-		{UniswapV2Router02Code, "0x8078c0090b05e0bee0587064947604e217146cc295dcb119a2c0217d6e88dac5"},
 	}
 
 	for _, tc := range tcs {

--- a/tests/gasless_test.go
+++ b/tests/gasless_test.go
@@ -40,6 +40,7 @@ import (
 	testingGaslessContracts "github.com/kaiachain/kaia/contracts/bindings/testing/system_contracts/gasless"
 	uniswapFactoryContracts "github.com/kaiachain/kaia/contracts/bindings/uniswap/factory"
 	uniswapRouterContracts "github.com/kaiachain/kaia/contracts/bindings/uniswap/router"
+	"github.com/kaiachain/kaia/crypto"
 	gaslessImpl "github.com/kaiachain/kaia/kaiax/gasless/impl"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -55,6 +56,13 @@ var (
 
 func TestGasless(t *testing.T) {
 	log.EnableLogForTest(log.LvlError, log.LvlError)
+
+	// Bytecode regression: pin the keccak256 of Uniswap runtime bytecode used in gasless.
+	// DO NOT MODIFY THE EXPECTED HASHES BELOW.
+	assert.Equal(t, "0xbab145d02e7005f0d84c6c1639d39b799b0ea16df99ebbdaf5a14d9da820b4e0",
+		crypto.Keccak256Hash(common.Hex2Bytes(uniswapFactoryContracts.UniswapV2FactoryBinRuntime)).Hex())
+	assert.Equal(t, "0x8078c0090b05e0bee0587064947604e217146cc295dcb119a2c0217d6e88dac5",
+		crypto.Keccak256Hash(common.Hex2Bytes(uniswapRouterContracts.UniswapV2Router02BinRuntime)).Hex())
 
 	// prepare chain configuration
 	config := params.MainnetChainConfig.Copy()


### PR DESCRIPTION
## Proposed changes

`UniswapV2Factory` and `UniswapV2Router02` are not system contracts deployed at well-known addresses, so their bytecode hash pins don't belong in `blockchain/system`.

This PR moves the uniswap bytecode regression check out of `TestRuntimeCodeRegression` (which is reserved for chain-level system contracts) and into `TestGasless`, where these contracts are actually exercised.

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

N/A

## Further comments

- `blockchain/system/constant_test.go`'s `TestRuntimeCodeRegression` is scoped to contracts deployed at well-known addresses at hardfork. Uniswap contracts are deployed dynamically by tests and do not meet that criteria.
- The hash assertions are placed at the top of `TestGasless` as a single natural entry point whenever gasless integration tests execute.