### PR TITLE
worker: Fix deflated mining-related metrics

### DIFF
--- a/work/worker.go
+++ b/work/worker.go
@@ -41,7 +41,6 @@ import (
 	"github.com/kaiachain/kaia/kaiax"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kerrors"
-	kaiametrics "github.com/kaiachain/kaia/metrics"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/kaiachain/kaia/work/builder"
@@ -77,20 +76,20 @@ var (
 
 	blockBaseFee              = metrics.NewRegisteredGauge("miner/block/mining/basefee", nil)
 	blobsGauge                = metrics.NewRegisteredGauge("miner/block/mining/blobs", nil)
-	blockMiningTimer          = kaiametrics.NewRegisteredHybridTimer("miner/block/mining/time", nil)
-	blockMiningExecuteTxTimer = kaiametrics.NewRegisteredHybridTimer("miner/block/execute/time", nil)
-	blockMiningCommitTxTimer  = kaiametrics.NewRegisteredHybridTimer("miner/block/commit/time", nil)
-	blockMiningFinalizeTimer  = kaiametrics.NewRegisteredHybridTimer("miner/block/finalize/time", nil)
+	blockMiningTimer          = metrics.NewRegisteredTimer("miner/block/mining/time", nil)
+	blockMiningExecuteTxTimer = metrics.NewRegisteredTimer("miner/block/execute/time", nil)
+	blockMiningCommitTxTimer  = metrics.NewRegisteredTimer("miner/block/commit/time", nil)
+	blockMiningFinalizeTimer  = metrics.NewRegisteredTimer("miner/block/finalize/time", nil)
 
-	accountReadTimer   = kaiametrics.NewRegisteredHybridTimer("miner/block/account/reads", nil)
-	accountHashTimer   = kaiametrics.NewRegisteredHybridTimer("miner/block/account/hashes", nil)
-	accountUpdateTimer = kaiametrics.NewRegisteredHybridTimer("miner/block/account/updates", nil)
-	accountCommitTimer = kaiametrics.NewRegisteredHybridTimer("miner/block/account/commits", nil)
+	accountReadTimer   = metrics.NewRegisteredTimer("miner/block/account/reads", nil)
+	accountHashTimer   = metrics.NewRegisteredTimer("miner/block/account/hashes", nil)
+	accountUpdateTimer = metrics.NewRegisteredTimer("miner/block/account/updates", nil)
+	accountCommitTimer = metrics.NewRegisteredTimer("miner/block/account/commits", nil)
 
-	storageReadTimer   = kaiametrics.NewRegisteredHybridTimer("miner/block/storage/reads", nil)
-	storageHashTimer   = kaiametrics.NewRegisteredHybridTimer("miner/block/storage/hashes", nil)
-	storageUpdateTimer = kaiametrics.NewRegisteredHybridTimer("miner/block/storage/updates", nil)
-	storageCommitTimer = kaiametrics.NewRegisteredHybridTimer("miner/block/storage/commits", nil)
+	storageReadTimer   = metrics.NewRegisteredTimer("miner/block/storage/reads", nil)
+	storageHashTimer   = metrics.NewRegisteredTimer("miner/block/storage/hashes", nil)
+	storageUpdateTimer = metrics.NewRegisteredTimer("miner/block/storage/updates", nil)
+	storageCommitTimer = metrics.NewRegisteredTimer("miner/block/storage/commits", nil)
 
 	snapshotAccountReadTimer = metrics.NewRegisteredTimer("miner/snapshot/account/reads", nil)
 	snapshotStorageReadTimer = metrics.NewRegisteredTimer("miner/snapshot/storage/reads", nil)


### PR DESCRIPTION
## Proposed changes

## Problem

The KaiaBFT consensus refactor moved metric updates into `handleFinalizedBlock`, which early-returns on `result == nil`, so only the proposer updates the `miner/block/*` timers. Given how `HybridTimer` is exported, Grafana panels show values that are much smaller than the per-block durations printed in the "Prepared new block" log.

## Root cause

`HybridTimer.Update(d)` calls `Meter.Mark(int64(d))`, and the Prometheus exporter emits `Rate1()` (EWMA-smoothed `Σd/Δt_wall`), not a per-event mean. With proposer-only updates, the value deflates by ~1/N — e.g. 4 CNs round-robin → 0.25×.

It seems the `HybridTimer` was originally introduced to capture the mean and max values simultaneously, which can be replaced with `p9999` when using `go-metrics`.

## Fix

Swap 12 `kaiametrics.NewRegisteredHybridTimer` registrations in `work/worker.go` to `metrics.NewRegisteredTimer` at the same names. The exporter then dispatches to `case metrics.Timer:` and emits `Mean()` plus percentile series. `hybrid_timer.go` is untouched.

Affected: `miner/block/{mining,execute,commit,finalize}/time` and `miner/block/{account,storage}/{reads,hashes,updates,commits}`.

## Effect on Grafana

- Bare-name series jumps up ~N× — pre-adjust alerts if any.
- New `_0_5 / _0_75 / _0_95 / _0_99 / _0_999 / _0_9999` percentile
series appear automatically.
- `_maxgauge` companion disappears. Use `_0_9999` as the approximate peak (sample-reservoir near-max, slightly smoothed vs the old per-flush reset).

Please note that Grafana still shows a lower tx execution count than the `Prepared new block` log, because it excludes trie access time from its metrics. This will be discussed separately and fixed if needed.

## Data

- Environment: 4 CN network, 2.5k RPS with ERC20

You can see the key metrics, such as `block mining time - xxx`, have been correctly recorded after this PR.

<details><summary>v2.2.2</summary>

<img width="2870" height="922" alt="image" src="https://github.com/user-attachments/assets/317363b0-ecad-45e3-a07b-1f25e4104deb" />
<img width="3262" height="1300" alt="image" src="https://github.com/user-attachments/assets/7aab8f6b-63c5-44c3-bdff-ae28dad86806" />

```
INFO[05/19,06:06:14 Z] [51] Commit new mining work                    number=1386 hash=463ffa…7d9524                                                      txs=2496 elapsed=236.668ms   commitTime=197.389ms finalizeTime=39.267ms
INFO[05/19,06:06:15 Z] [51] Commit new mining work                    number=1387 hash=9a9897…6fcc5b                                                      txs=2496 elapsed=226.351ms   commitTime=188.937ms finalizeTime=37.406ms
INFO[05/19,06:06:16 Z] [51] Commit new mining work                    number=1388 hash=888142…97cb8c                                                      txs=2496 elapsed=223.596ms   commitTime=188.252ms finalizeTime=35.337ms
INFO[05/19,06:06:17 Z] [51] Commit new mining work                    number=1389 hash=22190c…7f1242                                                      txs=2496 elapsed=229.044ms   commitTime=192.142ms finalizeTime=36.894ms
INFO[05/19,06:06:18 Z] [51] Commit new mining work                    number=1390 hash=25883f…b01619                                                      txs=2496 elapsed=246.005ms   commitTime=195.323ms finalizeTime=50.673ms
```

</details>

<details><summary>dev (refactored)</summary>

<img width="2862" height="912" alt="image" src="https://github.com/user-attachments/assets/e7a7cffb-7d40-4e9b-a838-49f7601c0293" />
<img width="3264" height="1302" alt="image" src="https://github.com/user-attachments/assets/38ec4bcd-7406-4ac7-ae49-de5ce213dfe2" />

```
INFO[05/19,05:04:51 Z] [51] Prepared new block                        number=2799 hash=7219e6…72dd9c txs=2500 elapsed=160.618ms   executeTime=136.056ms finalizeTime=24.562ms
INFO[05/19,05:04:52 Z] [51] Prepared new block                        number=2800 hash=bdc40a…bf242a txs=2500 elapsed=157.650ms   executeTime=134.285ms finalizeTime=23.365ms
INFO[05/19,05:04:53 Z] [51] Prepared new block                        number=2801 hash=2052b4…17bc4c txs=2500 elapsed=161.652ms   executeTime=136.630ms finalizeTime=25.022ms
INFO[05/19,05:04:54 Z] [51] Prepared new block                        number=2802 hash=c05a35…b015ed txs=2500 elapsed=159.770ms   executeTime=135.373ms finalizeTime=24.397ms
INFO[05/19,05:04:55 Z] [51] Prepared new block                        number=2803 hash=a3ec6d…cc29ac txs=2500 elapsed=156.866ms   executeTime=133.024ms finalizeTime=23.842ms
```

</details>

<details><summary>PR</summary>

<img width="3262" height="1282" alt="image" src="https://github.com/user-attachments/assets/8c81d8f9-35df-4a81-95ee-e13c633639a8" />
<img width="2874" height="920" alt="image" src="https://github.com/user-attachments/assets/e8eceb4c-e10f-4ee4-8dcf-0a5dba7c62fa" />

```
INFO[05/19,06:31:02 Z] [51] Prepared new block                        number=2221 hash=081cd4…64a222                                                      txs=2496 elapsed=186.572ms   executeTime=155.472ms finalizeTime=31.100ms
INFO[05/19,06:31:03 Z] [51] Prepared new block                        number=2222 hash=db086e…74195d                                                      txs=2496 elapsed=186.926ms   executeTime=152.615ms finalizeTime=34.310ms
INFO[05/19,06:31:04 Z] [51] Prepared new block                        number=2223 hash=393eb9…7e978c                                                      txs=2496 elapsed=188.782ms   executeTime=153.261ms finalizeTime=35.521ms
INFO[05/19,06:31:05 Z] [51] Prepared new block                        number=2224 hash=532e03…113507                                                      txs=2496 elapsed=192.618ms   executeTime=155.597ms finalizeTime=37.020ms
INFO[05/19,06:31:06 Z] [51] Prepared new block                        number=2225 hash=463004…ffc191                                                      txs=2496 elapsed=198.308ms   executeTime=159.928ms finalizeTime=38.380ms
```

</details>

<details><summary>p9999</summary>

<img width="3822" height="1984" alt="image" src="https://github.com/user-attachments/assets/ced052c7-79cb-4b4d-8d54-2292ebf11d8a" />

</details

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
