### PR TITLE
docs: document git submodule usage and add make submodules target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ FIXTURE_TEST_REGEX?=^(TestExecutionSpecBlockTestSuite|TestExecutionSpecStateTest
 
 OBJECTS=kcn kpn ken kscn kspn ksen kbn kgen homi
 
-.PHONY: all test clean ${OBJECTS}
+.PHONY: all submodules test clean ${OBJECTS}
 
 all: ${OBJECTS}
 
@@ -61,6 +61,9 @@ clean:
 
 # The devtools target installs tools required for 'go generate'.
 # You need to put $BIN (or $GOPATH/bin) in your PATH to use 'go generate'.
+
+submodules:
+	git submodule update --init
 
 devtools:
 	env GOFLAGS= GOBIN= go install golang.org/x/tools/cmd/stringer@latest

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ both a Go and a C compiler. You can install them using your favorite package man
 
     make all (or make {kcn, kpn, ken, kbn, kscn, kspn, ksen, kgen, homi, abigen})
 
+This repository uses Git submodules. The submodule (`contracts/kaia-system-contracts`) is only needed if you want to regenerate Go contract bindings via `go generate`. For normal builds, the pre-generated bindings are already included. To initialize the submodule, run `make submodules`.
+
 ## Executables
 
 After successful build, executable binaries are installed at `build/bin/`.


### PR DESCRIPTION
## Proposed changes

Add \`make submodules\` target (\`git submodule update --init\`) and document in README that the \`contracts/kaia-system-contracts\` submodule is only needed for \`go generate\`, not for normal builds.

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [x] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment \`I have read the CLA Document and I hereby sign the CLA\` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (\`\$ make test\`)

## Related issues

## Further comments