### PR TITLE
p2p: implement KIP-311 permissionless networking

### DIFF
--- a/cmd/kbn/config.go
+++ b/cmd/kbn/config.go
@@ -62,10 +62,6 @@ type bootnodeConfig struct {
 	natm         nat.Interface
 	listenAddr   string
 
-	// Authorized Nodes are used as pre-configured nodes list which are only
-	// bonded with this bootnode.
-	AuthorizedNodes []*discover.Node
-
 	// DataDir is the file system folder the node should use for any data storage
 	// requirements. The configured data directory will not be directly shared with
 	// registered services, instead those can use utility methods to create/access
@@ -161,23 +157,6 @@ func splitAndTrim(input string) []string {
 		result[i] = strings.TrimSpace(r)
 	}
 	return result
-}
-
-func setAuthorizedNodes(ctx *cli.Context, cfg *bootnodeConfig) {
-	if !ctx.IsSet(utils.AuthorizedNodesFlag.Name) {
-		return
-	}
-	urls := ctx.String(utils.AuthorizedNodesFlag.Name)
-	splitedUrls := strings.Split(urls, ",")
-	cfg.AuthorizedNodes = make([]*discover.Node, 0, len(splitedUrls))
-	for _, url := range splitedUrls {
-		node, err := discover.ParseNode(url)
-		if err != nil {
-			logger.Error("URL is invalid", "kni", url, "err", err)
-			continue
-		}
-		cfg.AuthorizedNodes = append(cfg.AuthorizedNodes, node)
-	}
 }
 
 // setHTTP creates the HTTP RPC listener interface string from the set

--- a/cmd/kbn/main.go
+++ b/cmd/kbn/main.go
@@ -93,7 +93,6 @@ func bootnode(ctx *cli.Context) error {
 	setHTTP(ctx, &bcfg)
 	setWS(ctx, &bcfg)
 	setgRPC(ctx, &bcfg)
-	setAuthorizedNodes(ctx, &bcfg)
 
 	// Check exit condition
 	switch bcfg.checkCMDState() {
@@ -139,16 +138,15 @@ func bootnode(ctx *cli.Context) error {
 	}
 
 	cfg := discover.Config{
-		NetworkID:       bcfg.networkID,
-		PrivateKey:      bcfg.nodeKey,
-		AnnounceAddr:    realaddr,
-		NetRestrict:     bcfg.restrictList,
-		Conn:            conn,
-		Addr:            realaddr,
-		Id:              discover.PubkeyID(&bcfg.nodeKey.PublicKey),
-		NodeType:        p2p.ConvertNodeType(common.BOOTNODE),
-		AuthorizedNodes: bcfg.AuthorizedNodes,
-		DiscoverTypes:   discover.DiscoverTypesConfig{CN: true, PN: true, EN: true},
+		NetworkID:     bcfg.networkID,
+		PrivateKey:    bcfg.nodeKey,
+		AnnounceAddr:  realaddr,
+		NetRestrict:   bcfg.restrictList,
+		Conn:          conn,
+		Addr:          realaddr,
+		Id:            discover.PubkeyID(&bcfg.nodeKey.PublicKey),
+		NodeType:      p2p.ConvertNodeType(common.BOOTNODE),
+		DiscoverTypes: discover.DiscoverTypesConfig{CN: true, PN: true, EN: true},
 	}
 
 	disc, err := discover.NewDiscovery2(&cfg)

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -249,8 +249,8 @@ func setDefaultDiscoverTypes(cfg *p2p.Config) {
 }
 
 const (
-	defaultCNMaxPhysicalConnections = 103 // peerTargets[CN][CN] + peerTargets[CN][EN]
-	defaultENMaxPhysicalConnections = 12  // peerTargets[EN][CN] + peerTargets[EN][EN]
+	defaultCNMaxPhysicalConnections = 103 // MaxNodeCount + peerTargets[CN][EN]
+	defaultENMaxPhysicalConnections = node.DefaultMaxPhysicalConnections
 )
 
 func setDefaultMaxPhysicalConnections(cfg *p2p.Config) {

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -186,6 +186,8 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 
 	if ctx.IsSet(MaxConnectionsFlag.Name) {
 		cfg.MaxPhysicalConnections = ctx.Int(MaxConnectionsFlag.Name)
+	} else {
+		setDefaultMaxPhysicalConnections(cfg)
 	}
 	logger.Info("Setting MaxPhysicalConnections", "MaxPhysicalConnections", cfg.MaxPhysicalConnections)
 
@@ -243,6 +245,20 @@ func setDefaultDiscoverTypes(cfg *p2p.Config) {
 	} else { // PN is EN-equivalent under KIP-311.
 		cfg.DiscoverTypes.CN = true
 		cfg.DiscoverTypes.EN = true
+	}
+}
+
+const (
+	defaultCNMaxPhysicalConnections = 103 // peerTargets[CN][CN] + peerTargets[CN][EN]
+	defaultENMaxPhysicalConnections = 12  // peerTargets[EN][CN] + peerTargets[EN][EN]
+)
+
+func setDefaultMaxPhysicalConnections(cfg *p2p.Config) {
+	switch cfg.ConnectionType {
+	case common.CONSENSUSNODE:
+		cfg.MaxPhysicalConnections = defaultCNMaxPhysicalConnections
+	case common.ENDPOINTNODE, common.PROXYNODE:
+		cfg.MaxPhysicalConnections = defaultENMaxPhysicalConnections
 	}
 }
 

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -239,8 +239,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 func setDefaultDiscoverTypes(cfg *p2p.Config) {
 	if cfg.ConnectionType == common.CONSENSUSNODE {
 		cfg.DiscoverTypes.CN = true
-	} else { // PN or EN
-		cfg.DiscoverTypes.PN = true
+		cfg.DiscoverTypes.EN = true
+	} else { // PN is EN-equivalent under KIP-311.
+		cfg.DiscoverTypes.CN = true
 		cfg.DiscoverTypes.EN = true
 	}
 }

--- a/cmd/utils/config_test.go
+++ b/cmd/utils/config_test.go
@@ -228,7 +228,6 @@ func TestLoadYaml(t *testing.T) {
 		"genkey":                                    false,
 		"writeaddress":                              true,
 		"bnaddr":                                    true,
-		"authorized-nodes":                          false,
 		"rewardbase":                                false,
 		"mainnet":                                   true,
 		"kairos":                                    true,

--- a/cmd/utils/config_test.go
+++ b/cmd/utils/config_test.go
@@ -18,6 +18,8 @@ package utils
 import (
 	"testing"
 
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
@@ -290,5 +292,25 @@ func TestLoadYaml(t *testing.T) {
 	err := app.Run([]string{"testApp", "--conf", "nodecmd/testdata/test-config.yaml"})
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestSetDefaultMaxPhysicalConnections(t *testing.T) {
+	tests := []struct {
+		name     string
+		connType common.ConnType
+		want     int
+	}{
+		{name: "CN", connType: common.CONSENSUSNODE, want: defaultCNMaxPhysicalConnections},
+		{name: "EN", connType: common.ENDPOINTNODE, want: defaultENMaxPhysicalConnections},
+		{name: "PN", connType: common.PROXYNODE, want: defaultENMaxPhysicalConnections},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &p2p.Config{ConnectionType: tt.connType}
+			setDefaultMaxPhysicalConnections(cfg)
+			assert.Equal(t, tt.want, cfg.MaxPhysicalConnections)
+		})
 	}
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1291,14 +1291,6 @@ var (
 		EnvVars:  []string{"KLAYTN_BAOBAB", "KAIA_BAOBAB", "KAIA_KAIROS"}, // TODO: remove baobab
 		Category: "NETWORK",
 	}
-	// Bootnode's settings
-	AuthorizedNodesFlag = &cli.StringFlag{
-		Name:    "authorized-nodes",
-		Usage:   "Comma separated kni URLs for authorized nodes list",
-		Value:   "",
-		Aliases: []string{"common.authorized-nodes"},
-		EnvVars: []string{"KLAYTN_AUTHORIZED_NODES", "KAIA_AUTHORIZED_NODES"},
-	}
 	// TODO-Kaia-Bootnode the boodnode flags should be updated when it is implemented
 	BNAddrFlag = &cli.StringFlag{
 		Name:    "bnaddr",

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -343,7 +343,6 @@ var BNFlags = []cli.Flag{
 	altsrc.NewBoolFlag(MetricsEnabledFlag),
 	altsrc.NewBoolFlag(PrometheusExporterFlag),
 	altsrc.NewIntFlag(PrometheusExporterPortFlag),
-	altsrc.NewStringFlag(AuthorizedNodesFlag),
 	altsrc.NewUint64Flag(NetworkIdFlag),
 }
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -111,13 +111,21 @@ func (sb *backend) ValidatePeerType(addr common.Address) error {
 	if sb.valsetModule == nil {
 		return errInvalidPeerAddress
 	}
-	council, err := sb.valsetModule.GetCouncil(sb.chain.CurrentHeader().Number.Uint64() + 1)
+	num := sb.chain.CurrentHeader().Number.Uint64() + 1
+	cnPeers, err := sb.valsetModule.GetCNPeers(num)
 	if err != nil {
+		sb.logger.Trace("Failed to read CN peers for peer type validation", "addr", addr, "num", num, "err", err)
 		return errInvalidPeerAddress
 	}
-	if valset.NewAddressSet(council).Contains(addr) {
+	if cnPeers == nil {
+		sb.logger.Trace("CN peer validation disabled", "addr", addr, "num", num)
 		return nil
 	}
+	if valset.NewAddressSet(cnPeers).Contains(addr) {
+		sb.logger.Trace("CN peer type validation accepted", "addr", addr, "num", num)
+		return nil
+	}
+	sb.logger.Trace("CN peer type validation rejected", "addr", addr, "num", num)
 	return errInvalidPeerAddress
 }
 

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -115,7 +115,7 @@ func (v *ValsetModule) GetCandTesting(num uint64) ([]common.Address, error) {
 func (v *ValsetModule) GetCNPeers(num uint64) ([]common.Address, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
 		cnPeers, err := v.getCNPeers(num)
-		if err == nil && len(cnPeers) > 0 {
+		if len(cnPeers) > 0 {
 			return cnPeers, nil
 		}
 		if err != nil {

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -125,7 +125,12 @@ func (v *ValsetModule) GetCNPeers(num uint64) ([]common.Address, error) {
 		}
 		return nil, nil // allow all CN peers as fallback
 	}
-	return v.GetCouncil(num)
+	cnPeers, err := v.GetCouncil(num)
+	if err != nil {
+		logger.Warn("GetCNPeers: disabling CN peer filter after pre-fork GetCouncil failed", "num", num, "err", err)
+		return nil, nil
+	}
+	return cnPeers, nil
 }
 
 // GetHeaderGovVoters returns validators eligible for header governance votes. Pre-fork: council.

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -114,7 +114,16 @@ func (v *ValsetModule) GetCandTesting(num uint64) ([]common.Address, error) {
 // GetCNPeers returns the CN-CN P2P peer set. Pre-fork: council.
 func (v *ValsetModule) GetCNPeers(num uint64) ([]common.Address, error) {
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		return v.getCNPeers(num)
+		cnPeers, err := v.getCNPeers(num)
+		if err == nil && len(cnPeers) > 0 {
+			return cnPeers, nil
+		}
+		if err != nil {
+			logger.Warn("GetCNPeers: disabling CN peer filter after post-fork read failed", "num", num, "err", err)
+		} else {
+			logger.Warn("GetCNPeers: disabling CN peer filter after post-fork read returned empty", "num", num)
+		}
+		return nil, nil // allow all CN peers as fallback
 	}
 	return v.GetCouncil(num)
 }

--- a/kaiax/valset/impl/getter_permissionless_test.go
+++ b/kaiax/valset/impl/getter_permissionless_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/storage/database"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -174,6 +175,55 @@ func TestGetNodesByStatePreForkError(t *testing.T) {
 	nodes, err := v.GetNodesByState(10, nil)
 	require.Nil(t, nodes)
 	require.ErrorIs(t, err, errPermissionlessDisabled)
+}
+
+func TestGetCNPeersFilterFallback(t *testing.T) {
+	t.Run("pre-fork returns council", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10)).AnyTimes()
+
+		db := database.NewMemDB()
+		writeCouncil(db, 0, numsToAddrs(2, 1))
+		writeValidatorVoteBlockNums(db, []uint64{0})
+		writeLowestScannedVoteNum(db, 0)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.ChainKv = db
+
+		cnPeers, err := v.GetCNPeers(11)
+		require.NoError(t, err)
+		assert.Equal(t, numsToAddrs(1, 2), cnPeers)
+	})
+
+	t.Run("post-fork read failure returns nil to disable filtering", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+		mockChain.EXPECT().GetHeaderByNumber(uint64(10)).Return(nil)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		cnPeers, err := v.GetCNPeers(11)
+		require.NoError(t, err)
+		assert.Nil(t, cnPeers)
+	})
+
+	t.Run("post-fork empty peer set returns nil to disable filtering", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.transitionResultCache.Add(uint64(11), &TransitionResult{Nodes: NodeMap{}})
+
+		cnPeers, err := v.GetCNPeers(11)
+		require.NoError(t, err)
+		assert.Nil(t, cnPeers)
+	})
 }
 
 func newCachedPermissionlessValset(t *testing.T, nodes NodeMap) *ValsetModule {

--- a/kaiax/valset/impl/getter_permissionless_test.go
+++ b/kaiax/valset/impl/getter_permissionless_test.go
@@ -197,6 +197,20 @@ func TestGetCNPeersFilterFallback(t *testing.T) {
 		assert.Equal(t, numsToAddrs(1, 2), cnPeers)
 	})
 
+	t.Run("pre-fork GetCouncil failure returns nil to disable filtering", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(100, 10)).AnyTimes()
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.ChainKv = database.NewMemDB()
+
+		cnPeers, err := v.GetCNPeers(11)
+		require.NoError(t, err)
+		assert.Nil(t, cnPeers)
+	})
+
 	t.Run("post-fork read failure returns nil to disable filtering", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockChain := chain_mock.NewMockBlockChain(ctrl)

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -60,14 +60,13 @@ type DialConfig struct {
 
 	// target number of outbound connections for each node type.
 	// Set connTargets[T] = 0 to disable dynamic dial of node type T (i.e. only accept inbound connections).
-	// Set connTargets = nil to use the default value based on the selfType and maxDynDials.
+	// Set connTargets = nil to use the KIP-311 defaults (with maxENToENDynDials override) based on the selfType.
 	// See also: discover.table.discoverTargets.
 	connTarget map[discover.NodeType]int
 
-	// maxDynDials is the maximum number of dynamic (discovery-based) outbound connections.
-	// Used only when connTarget is nil, to compute the default EN-EN target.
+	// maxENToENDynDials overrides the default EN-to-EN target when connTarget is nil.
 	// Pass the result of Server.maxDialedConns() here.
-	maxDynDials int
+	maxENToENDynDials *int
 
 	// maxPeers is the total peer capacity (inbound + outbound).
 	// Dynamic dials are suppressed when connectedAll reaches this limit,
@@ -292,11 +291,10 @@ func (ds *DialSched) dialLoop() {
 // If there are too many static nodes, the dynamic candidate dialing can be delayed. But it is reasonable and expected.
 // - You don't need dynamic candidates when you have enough static nodes.
 //
-// If there are too many dynamic CN/PN candidates, EN dialing can be delayed. But it is unlikely under the connTarget settings.
+// If there are too many dynamic CN candidates, EN dialing can be delayed. But it is unlikely under the connTarget settings.
 // - CN's connTarget = {CN: 100}. No starvation possible.
-// - PN's connTarget = {PN: 1}. No starvation possible.
-// - EN's connTarget = {PN: 2, EN: maxDynDials}.
-// EN dialing is delayed only if there are [8+ undialing/unconnected static nodes] + [2*4 dynamic PN candidates] = 16 dialable candidates.
+// - EN's connTarget = {CN: 2, EN: maxENToENDynDials}.
+// EN dialing is delayed only if static nodes and CN candidates fill maxConcurrentDials first.
 // But in reality, there are much less static nodes, and even so they will be filtered out by shouldDial() in later iterations quite soon.
 func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh bool) {
 	ds.mu.RLock()
@@ -446,7 +444,7 @@ func (ds *DialSched) refillCandidates() {
 	for targetType := range ds.connTarget {
 		if len(ds.candidateQueue[targetType]) == 0 {
 			buf := make([]*discover.Node, candidateQueueSize)
-			n := ds.tab.RandomNodes(buf, targetType)
+			n := ds.tab.RandomNodes(buf, discover.EffectiveNodeType(targetType))
 			ds.candidateQueue[targetType] = buf[:n]
 		}
 	}

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -62,13 +62,13 @@ type DialConfig struct {
 
 	// target number of outbound connections for each node type.
 	// Set connTargets[T] = 0 to disable dynamic dial of node type T (i.e. only accept inbound connections).
-	// Set connTargets = nil to use the KIP-311 defaults (with maxENToENDynDials override) based on the selfType.
+	// Set connTargets = nil to use the KIP-311 defaults based on the selfType.
 	// See also: discover.table.discoverTargets.
 	connTarget map[discover.NodeType]int
 
-	// maxENToENDynDials overrides the default EN-to-EN target when connTarget is nil.
+	// maxENToENDialTarget is the EN-to-EN target derived from MaxPhysicalConnections / DialRatio.
 	// Pass the result of Server.maxDialedConns() here.
-	maxENToENDynDials *int
+	maxENToENDialTarget *int
 
 	// maxPeers is the total peer capacity (inbound + outbound).
 	// Dynamic dials are suppressed when connectedAll reaches this limit,
@@ -316,7 +316,7 @@ func (ds *DialSched) dialLoop() {
 //
 // If there are too many dynamic CN candidates, EN dialing can be delayed. But it is unlikely under the connTarget settings.
 // - CN's connTarget = {CN: 100}. No starvation possible.
-// - EN's connTarget = {CN: 2, EN: maxENToENDynDials}.
+// - EN's connTarget = {CN: 2, EN: maxENToENDialTarget}.
 // EN dialing is delayed only if static nodes and CN candidates fill maxConcurrentDials first.
 // But in reality, there are much less static nodes, and even so they will be filtered out by shouldDial() in later iterations quite soon.
 func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh bool) {

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -20,10 +20,12 @@ package p2p
 
 import (
 	"net"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/networks/p2p/netutil"
 )
@@ -108,6 +110,7 @@ type DialConfig struct {
 type DialSched struct {
 	mu         sync.RWMutex
 	selfID     discover.NodeID
+	selfType   discover.NodeType
 	connTarget map[discover.NodeType]int // Number of outbound connections to maintain for each node type
 	maxPeers   int                       // Total peer capacity (inbound + outbound). 0 = no limit.
 	dialer     NodeDialer
@@ -132,6 +135,7 @@ type DialSched struct {
 	connectedAll      typedNodeSet            // All connected peers, inbound + outbound.
 	connectedOutbound typedNodeSet            // Outbound connected peers only.
 	connFails         map[discover.NodeID]int // For static nodes, count the consecutive connection failures to limit retries.
+	cnPeerAddrs       map[common.Address]struct{}
 
 	// Coordination
 	started  atomic.Bool
@@ -156,6 +160,7 @@ func NewDialSched(cfg DialConfig, tab discovery, backend DialBackend) *DialSched
 
 	ds := &DialSched{
 		selfID:            cfg.selfID,
+		selfType:          discover.EffectiveNodeType(cfg.selfType),
 		connTarget:        connTarget,
 		maxPeers:          cfg.maxPeers,
 		dialer:            dialer,
@@ -212,6 +217,24 @@ func (ds *DialSched) AddStatic(n *discover.Node) {
 
 func (ds *DialSched) RemoveStatic(id discover.NodeID) {
 	ds.removeStatic(id)
+	ds.signalDial()
+}
+
+// SetCNPeers replaces the CN dynamic dial allowlist.
+// nil disables filtering; an empty list rejects all dynamic CN candidates.
+func (ds *DialSched) SetCNPeers(addrs []common.Address) {
+	ds.mu.Lock()
+	if addrs == nil {
+		ds.cnPeerAddrs = nil
+	} else {
+		cnPeerAddrs := make(map[common.Address]struct{}, len(addrs))
+		for _, addr := range addrs {
+			cnPeerAddrs[addr] = struct{}{}
+		}
+		ds.cnPeerAddrs = cnPeerAddrs
+	}
+	ds.mu.Unlock()
+
 	ds.signalDial()
 }
 
@@ -333,19 +356,23 @@ func (ds *DialSched) getDynamicCandidates(targetType discover.NodeType, need int
 	if ds.tab == nil || need <= 0 {
 		return nil, false
 	}
-
 	// Try to refill from the table if the queue can't satisfy the demand.
 	// The table may already have nodes (e.g. from local nodeDB) without needing a refresh
 	if len(ds.candidateQueue[targetType]) < need {
 		ds.refillCandidates()
 	}
 
-	// Pop up to `need` candidates from the queue.
+	// Disallowed CNs are discarded so they do not keep occupying the dynamic candidate queue.
 	q := ds.candidateQueue[targetType]
+	q = slices.DeleteFunc(q, func(n *discover.Node) bool {
+		return !ds.dynamicCandidateAllowed(targetType, n)
+	})
+
+	// Pop up to `need` candidates from the filtered queue.
 	end := min(need, len(q))
 	nodes, ds.candidateQueue[targetType] = q[:end], q[end:]
 	// If the queue is short even after a refill, signal the dial loop to run a discovery refresh.
-	return nodes, len(q) < need
+	return nodes, len(nodes) < need
 }
 
 // #region dial task
@@ -448,6 +475,25 @@ func (ds *DialSched) refillCandidates() {
 			ds.candidateQueue[targetType] = buf[:n]
 		}
 	}
+}
+
+func (ds *DialSched) dynamicCandidateAllowed(targetType discover.NodeType, n *discover.Node) bool {
+	if ds.selfType != discover.NodeTypeCN || discover.EffectiveNodeType(targetType) != discover.NodeTypeCN {
+		return true
+	}
+
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	if ds.cnPeerAddrs == nil {
+		return true
+	}
+
+	addr, err := addressFromNodeID(n.ID)
+	if err != nil {
+		return false
+	}
+	_, ok := ds.cnPeerAddrs[addr]
+	return ok
 }
 
 // #region internal variable accessors

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -135,17 +135,17 @@ func TestDialSched_StaticNode_RedialImmediatelyAfterReAdd(t *testing.T) {
 // Updates accounting for inbound and outbound peers.
 func TestDialSched_OnPeerConnected(t *testing.T) {
 	var (
-		candidate = testNode(1, "10.0.0.1", discover.NodeTypePN)
+		candidate = testNode(1, "10.0.0.1", discover.NodeTypeEN)
 		inbound   = testNode(2, "10.0.0.2", discover.NodeTypePN)
 		outbound  = testNode(3, "10.0.0.3", discover.NodeTypePN)
 		tab       = &mockTable{
 			nodesByType: map[discover.NodeType][]*discover.Node{
-				discover.NodeTypePN: {candidate},
+				discover.NodeTypeEN: {candidate},
 			},
 		}
 		ds = NewDialSched(DialConfig{
 			connTarget: map[discover.NodeType]int{
-				discover.NodeTypePN: 1,
+				discover.NodeTypeEN: 1,
 			},
 		}, tab, nil)
 	)
@@ -154,14 +154,14 @@ func TestDialSched_OnPeerConnected(t *testing.T) {
 	assert.False(t, ds.connectedOutbound.contains(inbound.ID), "inbound peer should not be counted as connected outbound")
 	assert.True(t, ds.connectedAll.contains(inbound.ID), "inbound peer should be counted as connected")
 	cands, _ := ds.getCandidates()
-	require.Len(t, cands, 1, "expected one outbound candidate for PN when only inbound PN exists")
+	require.Len(t, cands, 1, "expected one outbound EN candidate when only inbound legacy PN exists")
 	assert.Equal(t, candidate.ID, cands[0].ID)
 
 	ds.OnPeerConnected(outbound.ID, outbound.NType, false)
 	assert.True(t, ds.connectedOutbound.contains(outbound.ID), "outbound peer should be counted as connected outbound")
 	assert.True(t, ds.connectedAll.contains(outbound.ID), "outbound peer should be counted as connected")
 	cands, _ = ds.getCandidates()
-	assert.Len(t, cands, 0, "expected no outbound candidate when outbound PN target is already met")
+	assert.Len(t, cands, 0, "expected no outbound candidate when outbound legacy PN fulfills EN target")
 }
 
 // Correctly enforces discovery table refresh throttling.
@@ -218,6 +218,51 @@ func TestDialSched_Candidates_StaticNodes(t *testing.T) {
 // Dynamic nodes are candidates if connTarget is not met.
 func TestDialSched_GetCandidates_FromDiscovery(t *testing.T) {
 	var (
+		cn  = testNode(201, "10.0.0.201", discover.NodeTypeCN)
+		tab = &mockTable{
+			nodesByType: map[discover.NodeType][]*discover.Node{
+				discover.NodeTypeCN: {cn},
+			},
+		}
+		ds = NewDialSched(DialConfig{
+			connTarget: map[discover.NodeType]int{
+				discover.NodeTypeCN: 1,
+			},
+		}, tab, nil)
+	)
+
+	cands, needRefresh := ds.getCandidates()
+
+	assert.True(t, hasNodeID(cands, cn.ID), "CN candidates should include discovery result")
+	assert.False(t, needRefresh, "No need to refresh when candidates are enough")
+}
+
+func TestDialSched_GetCandidates_ENTargetDoesNotQueryLegacyPN(t *testing.T) {
+	var (
+		pn  = testNode(201, "10.0.0.201", discover.NodeTypePN)
+		en  = testNode(202, "10.0.0.202", discover.NodeTypeEN)
+		tab = &mockTable{
+			nodesByType: map[discover.NodeType][]*discover.Node{
+				discover.NodeTypePN: {pn},
+				discover.NodeTypeEN: {en},
+			},
+		}
+		ds = NewDialSched(DialConfig{
+			connTarget: map[discover.NodeType]int{
+				discover.NodeTypeEN: 1,
+			},
+		}, tab, nil)
+	)
+
+	cands, needRefresh := ds.getCandidates()
+
+	assert.True(t, hasNodeID(cands, en.ID), "EN candidates should fill the EN target")
+	assert.False(t, hasNodeID(cands, pn.ID), "upgraded nodes should not dial PN candidates dynamically")
+	assert.False(t, needRefresh)
+}
+
+func TestDialSched_GetCandidates_LegacyPNTargetUsesEffectiveEN(t *testing.T) {
+	var (
 		pn  = testNode(201, "10.0.0.201", discover.NodeTypePN)
 		en  = testNode(202, "10.0.0.202", discover.NodeTypeEN)
 		tab = &mockTable{
@@ -229,16 +274,15 @@ func TestDialSched_GetCandidates_FromDiscovery(t *testing.T) {
 		ds = NewDialSched(DialConfig{
 			connTarget: map[discover.NodeType]int{
 				discover.NodeTypePN: 1,
-				discover.NodeTypeEN: 1,
 			},
 		}, tab, nil)
 	)
 
 	cands, needRefresh := ds.getCandidates()
 
-	assert.True(t, hasNodeID(cands, pn.ID), "PN candidates should include GetNodes result")
-	assert.True(t, hasNodeID(cands, en.ID), "EN candidates should include ReadRandomNodes result")
-	assert.False(t, needRefresh, "No need to refresh when candidates are enough")
+	assert.True(t, hasNodeID(cands, en.ID), "legacy PN target should include EN candidates")
+	assert.False(t, hasNodeID(cands, pn.ID), "legacy PN target should not query PN candidates")
+	assert.False(t, needRefresh)
 }
 
 // Skips discovery when connTarget is met.

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/networks/p2p/netutil"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +43,12 @@ func testNodeID(i uint32) discover.NodeID {
 
 func testNode(i uint32, ip string, nType discover.NodeType) *discover.Node {
 	return discover.NewNode(testNodeID(i), net.ParseIP(ip), 30303, 30303, nil, nType)
+}
+
+func testNodeWithAddress(ip string, nType discover.NodeType) (*discover.Node, common.Address) {
+	key := newkey()
+	return discover.NewNode(discover.PubkeyID(&key.PublicKey), net.ParseIP(ip), 30303, 30303, nil, nType),
+		crypto.PubkeyToAddress(key.PublicKey)
 }
 
 func hasNodeID(nodes []*discover.Node, id discover.NodeID) bool {
@@ -258,6 +266,97 @@ func TestDialSched_GetCandidates_ENTargetDoesNotQueryLegacyPN(t *testing.T) {
 
 	assert.True(t, hasNodeID(cands, en.ID), "EN candidates should fill the EN target")
 	assert.False(t, hasNodeID(cands, pn.ID), "upgraded nodes should not dial PN candidates dynamically")
+	assert.False(t, needRefresh)
+}
+
+func TestDialSched_GetCandidates_CNPeerAllowlist(t *testing.T) {
+	allowed, allowedAddr := testNodeWithAddress("10.0.0.201", discover.NodeTypeCN)
+	blocked, _ := testNodeWithAddress("10.0.0.202", discover.NodeTypeCN)
+	tab := &mockTable{
+		nodesByType: map[discover.NodeType][]*discover.Node{
+			discover.NodeTypeCN: {allowed, blocked},
+		},
+	}
+	ds := NewDialSched(DialConfig{
+		selfType: discover.NodeTypeCN,
+		connTarget: map[discover.NodeType]int{
+			discover.NodeTypeCN: 2,
+		},
+	}, tab, nil)
+	ds.SetCNPeers([]common.Address{allowedAddr})
+
+	cands, needRefresh := ds.getCandidates()
+
+	assert.True(t, hasNodeID(cands, allowed.ID), "CN peer in allowlist should remain dialable")
+	assert.False(t, hasNodeID(cands, blocked.ID), "CN peer outside allowlist should be filtered")
+	assert.True(t, needRefresh, "filtering below target should request discovery refresh")
+}
+
+func TestDialSched_GetCandidates_CNPeerAllowlistNilAndEmpty(t *testing.T) {
+	cn, _ := testNodeWithAddress("10.0.0.201", discover.NodeTypeCN)
+	tab := &mockTable{
+		nodesByType: map[discover.NodeType][]*discover.Node{
+			discover.NodeTypeCN: {cn},
+		},
+	}
+
+	nilFilter := NewDialSched(DialConfig{
+		selfType: discover.NodeTypeCN,
+		connTarget: map[discover.NodeType]int{
+			discover.NodeTypeCN: 1,
+		},
+	}, tab, nil)
+	nilFilter.SetCNPeers(nil)
+	cands, needRefresh := nilFilter.getCandidates()
+	assert.True(t, hasNodeID(cands, cn.ID), "nil allowlist should disable CN filtering")
+	assert.False(t, needRefresh)
+
+	emptyFilter := NewDialSched(DialConfig{
+		selfType: discover.NodeTypeCN,
+		connTarget: map[discover.NodeType]int{
+			discover.NodeTypeCN: 1,
+		},
+	}, tab, nil)
+	emptyFilter.SetCNPeers([]common.Address{})
+	cands, needRefresh = emptyFilter.getCandidates()
+	assert.False(t, hasNodeID(cands, cn.ID), "empty allowlist should reject dynamic CN candidates")
+	assert.True(t, needRefresh)
+}
+
+func TestDialSched_GetCandidates_CNPeerAllowlistStaticBypass(t *testing.T) {
+	staticCN, _ := testNodeWithAddress("10.0.0.201", discover.NodeTypeCN)
+	ds := NewDialSched(DialConfig{
+		selfType:    discover.NodeTypeCN,
+		staticNodes: []*discover.Node{staticCN},
+		connTarget: map[discover.NodeType]int{
+			discover.NodeTypeCN: 1,
+		},
+	}, &mockTable{}, nil)
+	ds.SetCNPeers([]common.Address{})
+
+	cands, _ := ds.getCandidates()
+
+	assert.True(t, hasNodeID(cands, staticCN.ID), "static outbound CN should bypass dynamic CN filtering")
+}
+
+func TestDialSched_GetCandidates_CNPeerAllowlistOnlyAppliesToCN(t *testing.T) {
+	cn, _ := testNodeWithAddress("10.0.0.201", discover.NodeTypeCN)
+	tab := &mockTable{
+		nodesByType: map[discover.NodeType][]*discover.Node{
+			discover.NodeTypeCN: {cn},
+		},
+	}
+	ds := NewDialSched(DialConfig{
+		selfType: discover.NodeTypeEN,
+		connTarget: map[discover.NodeType]int{
+			discover.NodeTypeCN: 1,
+		},
+	}, tab, nil)
+	ds.SetCNPeers([]common.Address{})
+
+	cands, needRefresh := ds.getCandidates()
+
+	assert.True(t, hasNodeID(cands, cn.ID), "EN dynamic CN dials should not use CN peer allowlist")
 	assert.False(t, needRefresh)
 }
 

--- a/networks/p2p/dialsched_util.go
+++ b/networks/p2p/dialsched_util.go
@@ -99,5 +99,11 @@ func (t *typedNodeSet) contains(id discover.NodeID) bool {
 }
 
 func (t *typedNodeSet) count(nType discover.NodeType) int {
+	// PN is a legacy wire value. For target accounting, PN and EN share
+	// the same effective role bucket.
+	nType = discover.EffectiveNodeType(nType)
+	if nType == discover.NodeTypeEN {
+		return t.counts[discover.NodeTypeEN] + t.counts[discover.NodeTypePN]
+	}
 	return t.counts[nType]
 }

--- a/networks/p2p/dialsched_util.go
+++ b/networks/p2p/dialsched_util.go
@@ -22,26 +22,28 @@ import (
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 )
 
+// dialTargets from KIP-311
+var dialTargets = map[discover.NodeType]map[discover.NodeType]int{
+	discover.NodeTypeCN: {discover.NodeTypeCN: 100, discover.NodeTypeEN: 1},
+	discover.NodeTypeEN: {discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
+}
+
+// defaultConnTarget = KIP-311 dialTargets + maxENToENDynDials override
 func defaultConnTarget(cfg DialConfig) map[discover.NodeType]int {
-	switch cfg.selfType {
-	case discover.NodeTypeCN:
-		// CN attempts to connect to all other CNs.
-		return map[discover.NodeType]int{
-			discover.NodeTypeCN: 100,
-		}
-	case discover.NodeTypePN:
-		// PN attempts to connect to at most 1 PN, if not statically configured.
-		return map[discover.NodeType]int{
-			discover.NodeTypePN: 1,
-		}
-	case discover.NodeTypeEN:
-		return map[discover.NodeType]int{
-			discover.NodeTypePN: 2,
-			discover.NodeTypeEN: cfg.maxDynDials,
-		}
-	default:
-		return map[discover.NodeType]int{}
+	targets := dialTargets[discover.EffectiveNodeType(cfg.selfType)]
+	targets = cloneTargets(targets)
+	if discover.EffectiveNodeType(cfg.selfType) == discover.NodeTypeEN && cfg.maxENToENDynDials != nil {
+		targets[discover.NodeTypeEN] = *cfg.maxENToENDynDials
 	}
+	return targets
+}
+
+func cloneTargets(targets map[discover.NodeType]int) map[discover.NodeType]int {
+	cloned := make(map[discover.NodeType]int, len(targets))
+	for nType, target := range targets {
+		cloned[nType] = target
+	}
+	return cloned
 }
 
 // typedNodeSet is a set of discover.Nodes, which are counted by NodeType.

--- a/networks/p2p/dialsched_util.go
+++ b/networks/p2p/dialsched_util.go
@@ -22,18 +22,19 @@ import (
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 )
 
-// dialTargets from KIP-311
+// dialTargets from KIP-311.
 var dialTargets = map[discover.NodeType]map[discover.NodeType]int{
 	discover.NodeTypeCN: {discover.NodeTypeCN: 100, discover.NodeTypeEN: 1},
 	discover.NodeTypeEN: {discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
 }
 
-// defaultConnTarget = KIP-311 dialTargets + maxENToENDynDials override
+// defaultConnTarget applies KIP-311 dialTargets. EN-to-EN preserves the legacy
+// DialRatio semantics by using maxENToENDialTarget when provided.
 func defaultConnTarget(cfg DialConfig) map[discover.NodeType]int {
 	targets := dialTargets[discover.EffectiveNodeType(cfg.selfType)]
 	targets = cloneTargets(targets)
-	if discover.EffectiveNodeType(cfg.selfType) == discover.NodeTypeEN && cfg.maxENToENDynDials != nil {
-		targets[discover.NodeTypeEN] = *cfg.maxENToENDynDials
+	if discover.EffectiveNodeType(cfg.selfType) == discover.NodeTypeEN && cfg.maxENToENDialTarget != nil {
+		targets[discover.NodeTypeEN] = *cfg.maxENToENDialTarget
 	}
 	return targets
 }

--- a/networks/p2p/dialsched_util_test.go
+++ b/networks/p2p/dialsched_util_test.go
@@ -53,8 +53,8 @@ func TestTypedNodeSet_BasicOps(t *testing.T) {
 	set.add(n2)
 
 	assert.Equal(t, 2, set.len())
-	assert.Equal(t, 1, set.count(discover.NodeTypePN))
-	assert.Equal(t, 1, set.count(discover.NodeTypeEN))
+	assert.Equal(t, 2, set.count(discover.NodeTypePN))
+	assert.Equal(t, 2, set.count(discover.NodeTypeEN))
 	assert.Equal(t, 0, set.count(discover.NodeTypeCN))
 	assert.True(t, set.contains(n1.ID))
 	assert.True(t, set.contains(n2.ID))
@@ -67,6 +67,21 @@ func TestTypedNodeSet_BasicOps(t *testing.T) {
 	assert.True(t, hasNode(all, n2.ID))
 }
 
+func TestTypedNodeSet_CountTreatsPNAsEN(t *testing.T) {
+	set := newTypedNodeSet()
+	pn := typedSetNode(1, "10.0.0.1", discover.NodeTypePN)
+	en := typedSetNode(2, "10.0.0.2", discover.NodeTypeEN)
+	cn := typedSetNode(3, "10.0.0.3", discover.NodeTypeCN)
+
+	set.add(pn)
+	set.add(en)
+	set.add(cn)
+
+	assert.Equal(t, 2, set.count(discover.NodeTypePN))
+	assert.Equal(t, 2, set.count(discover.NodeTypeEN))
+	assert.Equal(t, 1, set.count(discover.NodeTypeCN))
+}
+
 func TestTypedNodeSet_RetypeSameID(t *testing.T) {
 	set := newTypedNodeSet()
 	n1 := typedSetNode(1, "10.0.0.1", discover.NodeTypePN)
@@ -76,7 +91,7 @@ func TestTypedNodeSet_RetypeSameID(t *testing.T) {
 	set.add(n2)
 
 	assert.Equal(t, 1, set.len())
-	assert.Equal(t, 0, set.count(discover.NodeTypePN))
+	assert.Equal(t, 0, set.counts[discover.NodeTypePN])
 	assert.Equal(t, 1, set.count(discover.NodeTypeEN))
 	assert.Equal(t, n2, set.get(n1.ID))
 }

--- a/networks/p2p/dialsched_util_test.go
+++ b/networks/p2p/dialsched_util_test.go
@@ -124,11 +124,11 @@ func TestDefaultConnTarget(t *testing.T) {
 	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
 		defaultConnTarget(DialConfig{selfType: discover.NodeTypePN}))
 
-	maxENToENDynDials := 5
+	maxENToENDialTarget := 5
 	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 5},
-		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDynDials: &maxENToENDynDials}))
+		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDialTarget: &maxENToENDialTarget}))
 
-	maxENToENDynDials = 0
+	maxENToENDialTarget = 0
 	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 0},
-		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDynDials: &maxENToENDynDials}))
+		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDialTarget: &maxENToENDialTarget}))
 }

--- a/networks/p2p/dialsched_util_test.go
+++ b/networks/p2p/dialsched_util_test.go
@@ -115,3 +115,20 @@ func TestTypedNodeSet_RemoveNoopAndNilAdd(t *testing.T) {
 	assert.False(t, set.contains(n.ID))
 	assert.Nil(t, set.get(n.ID))
 }
+
+func TestDefaultConnTarget(t *testing.T) {
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 100, discover.NodeTypeEN: 1},
+		defaultConnTarget(DialConfig{selfType: discover.NodeTypeCN}))
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
+		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN}))
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
+		defaultConnTarget(DialConfig{selfType: discover.NodeTypePN}))
+
+	maxENToENDynDials := 5
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 5},
+		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDynDials: &maxENToENDynDials}))
+
+	maxENToENDynDials = 0
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 0},
+		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDynDials: &maxENToENDynDials}))
+}

--- a/networks/p2p/discover/discovery.go
+++ b/networks/p2p/discover/discovery.go
@@ -34,9 +34,6 @@ type Discovery2 interface {
 	// Serve discovered nodes. Used by p2p.DialSched.
 	RandomNodes(buf []*Node, nType NodeType) int
 
-	// Update authorized nodes. To be used by permless.
-	PutAuthorizedNodes(nodes []*Node)
-
 	// APIs returns the RPC APIs for the discovery service.
 	APIs() []rpc.API
 }
@@ -61,7 +58,6 @@ type Config struct {
 
 	// These settings are required for discovery packet control
 	MaxNeighborsNode uint
-	AuthorizedNodes  []*Node
 
 	// DiscoverNodetype is list of node type to enable discovery.
 	DiscoverTypes DiscoverTypesConfig
@@ -78,7 +74,6 @@ type Config struct {
 //   - refreshLoop         -> findNodesOnce()      -> udp.findnode()
 //
 // UDP -> Table calls (originating from udp.readLoop dispatching packet handlers):
-//   - incoming PING     -> ping.preverify()     -> tab.IsAuthorized()  works even before tab.Start or after tab.Close
 //   - incoming FINDNODE -> findnode.preverify() -> tab.IsBonded()      same as above
 //   - incoming FINDNODE -> findnode.handle()    -> tab.ClosestNodes()  same as above
 //   - incoming PING     -> go t.bond(...)       -> go tab.Bond()       no-op before tab.Start or after tab.Close
@@ -109,8 +104,4 @@ func (d *discovery2) Refresh() {
 
 func (d *discovery2) RandomNodes(buf []*Node, nType NodeType) int {
 	return d.tab.RandomNodes(buf, nType)
-}
-
-func (d *discovery2) PutAuthorizedNodes(nodes []*Node) {
-	d.tab.PutAuthorizedNodes(nodes)
 }

--- a/networks/p2p/discover/discovery_api.go
+++ b/networks/p2p/discover/discovery_api.go
@@ -17,7 +17,6 @@
 package discover
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -86,42 +85,4 @@ func (api *DiscoveryAPI) DeleteNode(kni string) error {
 	}
 	api.tab.deleteNode(n)
 	return api.tab.db.deleteNode(n.ID)
-}
-
-// GetAuthorizedNodes returns the list of authorized nodes.
-func (api *DiscoveryAPI) GetAuthorizedNodes() []*Node {
-	return api.tab.GetAuthorizedNodes()
-}
-
-// PutAuthorizedNodes adds nodes to the authorized list. knis is a comma-separated list of KNI URIs.
-func (api *DiscoveryAPI) PutAuthorizedNodes(knis string) error {
-	nodes, err := parseNodeList(knis)
-	if err != nil {
-		return err
-	}
-	api.tab.PutAuthorizedNodes(nodes)
-	return nil
-}
-
-// DeleteAuthorizedNodes removes nodes from the authorized list. knis is a comma-separated list of KNI URIs.
-func (api *DiscoveryAPI) DeleteAuthorizedNodes(knis string) error {
-	nodes, err := parseNodeList(knis)
-	if err != nil {
-		return err
-	}
-	api.tab.DeleteAuthorizedNodes(nodes)
-	return nil
-}
-
-func parseNodeList(knis string) ([]*Node, error) {
-	kniList := strings.Split(knis, ",")
-	nodes := make([]*Node, 0, len(kniList))
-	for _, kni := range kniList {
-		n, err := ParseNode(strings.TrimSpace(kni))
-		if err != nil {
-			return nil, fmt.Errorf("invalid KNI: %s: %v", kni, err)
-		}
-		nodes = append(nodes, n)
-	}
-	return nodes, nil
 }

--- a/networks/p2p/discover/table_data.go
+++ b/networks/p2p/discover/table_data.go
@@ -36,42 +36,6 @@ func (tab *Table2) ClosestNodes(targetID NodeID, targetType NodeType, max int) [
 	}
 }
 
-func (tab *Table2) PutAuthorizedNodes(nodes []*Node) {
-	tab.authMu.Lock()
-	defer tab.authMu.Unlock()
-	for _, n := range nodes {
-		tab.authNodes[n.ID] = n
-	}
-}
-
-func (tab *Table2) DeleteAuthorizedNodes(nodes []*Node) {
-	tab.authMu.Lock()
-	defer tab.authMu.Unlock()
-	for _, n := range nodes {
-		delete(tab.authNodes, n.ID)
-	}
-}
-
-func (tab *Table2) GetAuthorizedNodes() []*Node {
-	tab.authMu.RLock()
-	defer tab.authMu.RUnlock()
-	nodes := make([]*Node, 0, len(tab.authNodes))
-	for _, n := range tab.authNodes {
-		nodes = append(nodes, n)
-	}
-	return nodes
-}
-
-func (tab *Table2) IsAuthorized(id NodeID, nType NodeType) bool {
-	tab.authMu.RLock()
-	defer tab.authMu.RUnlock()
-	if len(tab.authNodes) == 0 {
-		return true // no authorized nodes means no restriction
-	}
-	_, ok := tab.authNodes[id]
-	return ok
-}
-
 func (tab *Table2) IsBonded(id NodeID) bool {
 	return tab.bondAge(id) < nodeDBNodeExpiration
 }

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -19,7 +19,6 @@ package discover
 import (
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"sync/atomic"
 
@@ -149,43 +148,14 @@ func (tab *Table2) initialized() bool {
 	return tab.init.Load()
 }
 
-// Returns the number of nodes to actively discover depending of self node type.
-// Note that this number is NOT the number of connections to maintain.
-// The connection counts (or peer counts) are regulated by the p2p.Server and p2p.DialSched.
+// getDiscoverTargets returns this node's discovery goals by remote node type.
+// These targets are not connection counts; p2p.Server and p2p.DialSched regulate peers.
 func getDiscoverTargets(cfg *Config) map[NodeType]int {
-	switch cfg.NodeType {
-	case NodeTypeCN:
-		// CN discovers each other in a mesh structure. Assuming up to 100 validators.
-		return map[NodeType]int{
-			NodeTypeCN: 100,
-			NodeTypeBN: 3,
-		}
-	case NodeTypePN:
-		// PN discovers at least one neighboring PN. However, in production, PN connections are usually specified via static nodes
-		// to make up a certain network structure, in which case this number is irrelevant.
-		return map[NodeType]int{
-			NodeTypePN: 1,
-			NodeTypeBN: 3,
-		}
-	case NodeTypeEN:
-		// EN discovers to up to 2 PNs for high availability.
-		// EN try to learn as many ENs as possible via Kademlia algorithm.
-		return map[NodeType]int{
-			NodeTypeEN: math.MaxInt32,
-			NodeTypePN: 2,
-			NodeTypeBN: 3,
-		}
-	case NodeTypeBN:
-		// BN has to learn every CN and PN.
-		return map[NodeType]int{
-			NodeTypeCN: 100,
-			NodeTypePN: 100,
-			NodeTypeBN: 3,
-		}
-	default:
+	targets := discoverTargets[EffectiveNodeType(cfg.NodeType)]
+	if len(targets) == 0 {
 		logger.Error("Unsupported node type", "NodeType", cfg.NodeType)
-		return map[NodeType]int{}
 	}
+	return cloneNodeTypeTargets(targets)
 }
 
 // Filter bootnodes to be used as initial seeds.

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -49,10 +49,6 @@ type Table2 struct {
 	nursery  []*Node
 	storages map[NodeType]tableStorage
 
-	// Authorized nodes (in-memory only)
-	authMu    sync.RWMutex
-	authNodes map[NodeID]*Node
-
 	// target number of nodes to obtain for each node type.
 	// set discoverTargets[T] = 0 to disable discovery of node type T (i.e. only accept inbound connections).
 	// see also: p2p.DialSched.connTargets.
@@ -96,11 +92,6 @@ func newTable2(cfg *Config, udp transport) (*Table2, error) {
 		bondslots <- struct{}{}
 	}
 
-	authNodes := make(map[NodeID]*Node, len(cfg.AuthorizedNodes))
-	for _, n := range cfg.AuthorizedNodes {
-		authNodes[n.ID] = n
-	}
-
 	tab := &Table2{
 		rand:            rand,
 		db:              db,
@@ -111,7 +102,6 @@ func newTable2(cfg *Config, udp transport) (*Table2, error) {
 		storages:        storages,
 		discoverTargets: discoverTargets,
 		bondslots:       bondslots,
-		authNodes:       authNodes,
 	}
 
 	// Insert the initial seeds into storages.

--- a/networks/p2p/discover/table_init_test.go
+++ b/networks/p2p/discover/table_init_test.go
@@ -17,6 +17,7 @@
 package discover
 
 import (
+	"math"
 	"net"
 	"testing"
 
@@ -63,6 +64,17 @@ func Test_Table_getBootnodes_netRestrict(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, nursery, 1, "node outside netrestrict subnet should be filtered")
 	assert.Equal(t, inside.ID, nursery[0].ID)
+}
+
+func Test_Table_getDiscoverTargets(t *testing.T) {
+	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypeEN: 1, NodeTypeBN: 3},
+		getDiscoverTargets(&Config{NodeType: NodeTypeCN}))
+	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypeEN: math.MaxInt32, NodeTypeBN: 3},
+		getDiscoverTargets(&Config{NodeType: NodeTypeEN}))
+	assert.Equal(t, getDiscoverTargets(&Config{NodeType: NodeTypeEN}),
+		getDiscoverTargets(&Config{NodeType: NodeTypePN}))
+	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypeBN: 3},
+		getDiscoverTargets(&Config{NodeType: NodeTypeBN}))
 }
 
 func Test_Table_StartClose(t *testing.T) {

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -51,7 +51,6 @@ var (
 	errTimeout          = errors.New("RPC timeout")
 	errClockWarp        = errors.New("reply deadline too far in the future")
 	errClosed           = errors.New("socket closed")
-	errUnauthorized     = errors.New("unauthorized node")
 	errMismatchNetwork  = errors.New("mismatch network id")
 )
 
@@ -346,10 +345,6 @@ func (t *udp) close() {
 	close(t.closing) // shuts down the loop()
 	t.conn.Close()   // shuts down the readLoop()
 	t.wg.Wait()
-}
-
-func (t *udp) isAuthorized(fromID NodeID, nType NodeType) bool {
-	return t.tab.IsAuthorized(fromID, nType)
 }
 
 func (t *udp) hasBond(fromID NodeID) bool {
@@ -733,11 +728,6 @@ func (req *ping) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 		mismatchNetworkCounter.Mark(1)
 		return errMismatchNetwork
 	}
-	if !t.isAuthorized(fromID, req.From.NType) {
-		logger.Trace("unauthorized node.", "nodeid", fromID, "nodetype", req.From.NType)
-		return errUnauthorized
-	}
-	logger.Trace("authorized node.", "nodeid", fromID, "nodetype", req.From.NType)
 	return nil
 }
 

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -836,22 +836,12 @@ func (req *neighbors) handle(t *udp, from *net.UDPAddr, fromID NodeID, mac []byt
 
 func (req *neighbors) name() string { return "NEIGHBORS/v4" }
 
+// findnodeRetrieveSize caps one FINDNODE response. It is responder-side packet
+// sizing, not the requester's long-term discovery goal from getDiscoverTargets.
 func findnodeRetrieveSize(nType NodeType) int {
 	// Returning too small value will make CNs unable to find each other.
 	if nType == NodeTypeCN {
 		return 100
-	}
-	// Return at most 2 PNs.
-	// 1. Under current CN-PN-EN 3-tier operating practices, findnode(type=PN) packet originates only from EN.
-	//    CNs only connect to other CNs via CNBN. PNs are connected to PNs and CNs via static-nodes.json.
-	// 2. Giving 16 PNs to ENs will lead to uneven PN connection distribution.
-	//    ENs will choose 2 PNs from 16 PNs based on the ping-pong latency. Given that PNs and ENs are geographically
-	//    unevenly distributed, the EN's PN choice should be concentrated to a small number of PNs, even if the 16 is random.
-	// Returning up to 2 PNs will force EN to connect to random PNs that may not necessarily be the geographically closest ones.
-	// ENs may suffer some latency if it connected to faraway PN, but distributing the p2p workload across PNs is more important
-	// for the network stability.
-	if nType == NodeTypePN {
-		return 2
 	}
 	return bucketSize
 }

--- a/networks/p2p/discover/udp_test.go
+++ b/networks/p2p/discover/udp_test.go
@@ -354,6 +354,12 @@ func TestUDP_findnode_CN_overfill(t *testing.T) {
 	}
 }
 
+func TestFindnodeRetrieveSize(t *testing.T) {
+	assert.Equal(t, discoverTargets[NodeTypeCN][NodeTypeCN], findnodeRetrieveSize(NodeTypeCN))
+	assert.Equal(t, bucketSize, findnodeRetrieveSize(NodeTypeEN))
+	assert.Equal(t, bucketSize, findnodeRetrieveSize(NodeTypePN))
+}
+
 func TestUDP_findnodeMultiReply(t *testing.T) {
 	test := newUDPTest(t)
 	defer test.table.Close()

--- a/networks/p2p/discover/utils.go
+++ b/networks/p2p/discover/utils.go
@@ -241,6 +241,14 @@ func nodeTypeName(nt NodeType) string { // TODO-Kaia-Node Consolidate p2p.NodeTy
 	}
 }
 
+// EffectiveNodeType returns the KIP-311 role bucket for a wire-level node type.
+func EffectiveNodeType(nt NodeType) NodeType {
+	if nt == NodeTypePN {
+		return NodeTypeEN
+	}
+	return nt
+}
+
 func ParseNodeType(nt string) NodeType {
 	switch nt {
 	case "cn":

--- a/networks/p2p/discover/utils.go
+++ b/networks/p2p/discover/utils.go
@@ -22,6 +22,8 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"maps"
+	"math"
 	"math/rand"
 	"sort"
 	"sync"
@@ -247,6 +249,19 @@ func EffectiveNodeType(nt NodeType) NodeType {
 		return NodeTypeEN
 	}
 	return nt
+}
+
+// KIP-311 discoverTargets
+var discoverTargets = map[NodeType]map[NodeType]int{
+	NodeTypeCN: {NodeTypeCN: 100, NodeTypeEN: 1, NodeTypeBN: 3},
+	NodeTypeEN: {NodeTypeCN: 100, NodeTypeEN: math.MaxInt32, NodeTypeBN: 3},
+	NodeTypeBN: {NodeTypeCN: 100, NodeTypeBN: 3},
+}
+
+func cloneNodeTypeTargets(targets map[NodeType]int) map[NodeType]int {
+	cloned := make(map[NodeType]int, len(targets))
+	maps.Copy(cloned, targets)
+	return cloned
 }
 
 func ParseNodeType(nt string) NodeType {

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -209,6 +209,10 @@ type Server interface {
 	Name() string
 	GetListenAddress() []string
 	MaxPeers() int // returns MaxPhysicalConnections
+
+	// SetCNPeers replaces the address-keyed CN admission allowlist.
+	// nil disables filtering; an empty list rejects all CN claims.
+	SetCNPeers(addrs []common.Address)
 }
 
 // NewServer returns a new Server interface.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -68,6 +68,7 @@ type BaseServer struct {
 	outboundCount int
 	trusted       map[discover.NodeID]bool
 	dialSched     *DialSched
+	cnPeerAddrs   map[common.Address]struct{} // KIP-311 peerNodes allowlist for CN-CN connections.
 }
 
 // SingleChannelServer is a server that uses a single channel.
@@ -284,7 +285,7 @@ func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inbou
 	case c.id == srv.selfID:
 		return DiscSelf
 	default:
-		return nil
+		return srv.admitByCNPeers(c)
 	}
 }
 
@@ -307,6 +308,27 @@ func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *con
 		}
 	}
 	return count >= target
+}
+
+func (srv *BaseServer) admitByCNPeers(c *conn) error {
+	if EffectiveConnType(c.conntype) != common.CONSENSUSNODE {
+		return nil
+	}
+	if c.is(trustedConn | staticDialedConn) {
+		return nil
+	}
+	if srv.cnPeerAddrs == nil {
+		return nil
+	}
+
+	addr, err := addressFromNodeID(c.id)
+	if err != nil {
+		return err
+	}
+	if _, ok := srv.cnPeerAddrs[addr]; !ok {
+		return DiscUselessPeer
+	}
+	return nil
 }
 
 func (srv *BaseServer) maxInboundConns() int {
@@ -582,6 +604,24 @@ func (srv *BaseServer) reportPeerMetric() {
 	connectionCountGauge.Update(int64(srv.outboundCount + srv.inboundCount))
 	connectionInCountGauge.Update(int64(srv.inboundCount))
 	connectionOutCountGauge.Update(int64(srv.outboundCount))
+}
+
+// SetCNPeers replaces the address-keyed CN admission allowlist.
+// nil disables filtering; an empty list rejects all CN claims.
+func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
+	srv.lock.Lock()
+	defer srv.lock.Unlock()
+
+	if addrs == nil {
+		srv.cnPeerAddrs = nil
+		return
+	}
+
+	cnPeerAddrs := make(map[common.Address]struct{}, len(addrs))
+	for _, addr := range addrs {
+		cnPeerAddrs[addr] = struct{}{}
+	}
+	srv.cnPeerAddrs = cnPeerAddrs
 }
 
 // Disconnect tries to disconnect peer.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -612,6 +612,9 @@ func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
 	srv.lock.Lock()
 	if addrs == nil {
 		srv.cnPeerAddrs = nil
+		if srv.dialSched != nil {
+			srv.dialSched.SetCNPeers(nil)
+		}
 		srv.lock.Unlock()
 		return
 	}
@@ -621,6 +624,9 @@ func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
 		cnPeerAddrs[addr] = struct{}{}
 	}
 	srv.cnPeerAddrs = cnPeerAddrs
+	if srv.dialSched != nil {
+		srv.dialSched.SetCNPeers(addrs)
+	}
 	drops := srv.peersOutsideCNPeerAddrs(cnPeerAddrs)
 	srv.lock.Unlock()
 

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -26,7 +26,9 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"errors"
+	"maps"
 	"net"
+	"slices"
 	"sync"
 
 	"github.com/kaiachain/kaia/common"
@@ -147,15 +149,15 @@ func (srv *BaseServer) Start() (err error) {
 	}
 
 	if !srv.NoDial {
-		maxENToENDynDials := srv.maxDialedConns()
+		maxENToENDialTarget := srv.maxDialedConns()
 		srv.dialSched = NewDialSched(DialConfig{
-			selfID:            srv.selfID,
-			selfType:          ConvertNodeType(srv.ConnectionType),
-			staticNodes:       srv.StaticNodes,
-			netrestrict:       srv.NetRestrict,
-			maxENToENDynDials: &maxENToENDynDials,
-			maxPeers:          srv.MaxPeers(),
-			dialer:            srv.Dialer,
+			selfID:              srv.selfID,
+			selfType:            ConvertNodeType(srv.ConnectionType),
+			staticNodes:         srv.StaticNodes,
+			netrestrict:         srv.NetRestrict,
+			maxENToENDialTarget: &maxENToENDialTarget,
+			maxPeers:            srv.MaxPeers(),
+			dialer:              srv.Dialer,
 		}, srv.ntab, srv)
 		srv.dialSched.Start()
 	}
@@ -301,13 +303,10 @@ func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *con
 		return false
 	}
 
-	count := 0
-	for _, p := range peers {
-		if EffectiveConnType(p.ConnType()) == peerType {
-			count++
-		}
-	}
-	return count >= target
+	peersByType := slices.DeleteFunc(slices.Collect(maps.Values(peers)), func(p *Peer) bool {
+		return EffectiveConnType(p.ConnType()) != peerType
+	})
+	return len(peersByType) >= target
 }
 
 func (srv *BaseServer) admitByCNPeers(c *conn) error {

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -277,6 +277,8 @@ func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inbou
 		return DiscTooManyPeers
 	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
 		return DiscTooManyPeers
+	case srv.exceedsPeerTarget(peers, c):
+		return DiscTooManyPeers
 	case peers[c.id] != nil:
 		return DiscAlreadyConnected
 	case c.id == srv.selfID:
@@ -284,6 +286,27 @@ func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inbou
 	default:
 		return nil
 	}
+}
+
+func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *conn) bool {
+	if c.is(trustedConn | staticDialedConn) {
+		return false
+	}
+
+	selfType := EffectiveConnType(srv.ConnectionType)
+	peerType := EffectiveConnType(c.conntype)
+	target, ok := peerTargets[selfType][peerType]
+	if !ok {
+		return false
+	}
+
+	count := 0
+	for _, p := range peers {
+		if EffectiveConnType(p.ConnType()) == peerType {
+			count++
+		}
+	}
+	return count >= target
 }
 
 func (srv *BaseServer) maxInboundConns() int {

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -610,10 +610,9 @@ func (srv *BaseServer) reportPeerMetric() {
 // nil disables filtering; an empty list rejects all CN claims.
 func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
 	srv.lock.Lock()
-	defer srv.lock.Unlock()
-
 	if addrs == nil {
 		srv.cnPeerAddrs = nil
+		srv.lock.Unlock()
 		return
 	}
 
@@ -622,6 +621,33 @@ func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
 		cnPeerAddrs[addr] = struct{}{}
 	}
 	srv.cnPeerAddrs = cnPeerAddrs
+	drops := srv.peersOutsideCNPeerAddrs(cnPeerAddrs)
+	srv.lock.Unlock()
+
+	for _, p := range drops {
+		srv.logger.Info("Disconnecting CN peer outside allowlist", "id", p.ID())
+		p.Disconnect(DiscRequested)
+	}
+}
+
+func (srv *BaseServer) peersOutsideCNPeerAddrs(cnPeerAddrs map[common.Address]struct{}) []*Peer {
+	drops := make([]*Peer, 0)
+	for id, p := range srv.peers {
+		if p == nil || EffectiveConnType(p.ConnType()) != common.CONSENSUSNODE {
+			continue
+		}
+		if p.rws[ConnDefault].is(trustedConn | staticDialedConn) {
+			continue
+		}
+		addr, err := addressFromNodeID(id)
+		if err != nil {
+			continue
+		}
+		if _, ok := cnPeerAddrs[addr]; !ok {
+			drops = append(drops, p)
+		}
+	}
+	return drops
 }
 
 // Disconnect tries to disconnect peer.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -146,14 +146,15 @@ func (srv *BaseServer) Start() (err error) {
 	}
 
 	if !srv.NoDial {
+		maxENToENDynDials := srv.maxDialedConns()
 		srv.dialSched = NewDialSched(DialConfig{
-			selfID:      srv.selfID,
-			selfType:    ConvertNodeType(srv.ConnectionType),
-			staticNodes: srv.StaticNodes,
-			netrestrict: srv.NetRestrict,
-			maxDynDials: srv.maxDialedConns(),
-			maxPeers:    srv.MaxPeers(),
-			dialer:      srv.Dialer,
+			selfID:            srv.selfID,
+			selfType:          ConvertNodeType(srv.ConnectionType),
+			staticNodes:       srv.StaticNodes,
+			netrestrict:       srv.NetRestrict,
+			maxENToENDynDials: &maxENToENDynDials,
+			maxPeers:          srv.MaxPeers(),
+			dialer:            srv.Dialer,
 		}, srv.ntab, srv)
 		srv.dialSched.Start()
 	}

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -338,9 +338,7 @@ func (srv *BaseServer) maxDialedConns() int {
 	switch srv.ConnectionType {
 	case common.CONSENSUSNODE:
 		return 0
-	case common.PROXYNODE:
-		return 0
-	case common.ENDPOINTNODE:
+	case common.PROXYNODE, common.ENDPOINTNODE:
 		if srv.NoDiscovery || srv.NoDial {
 			return 0
 		}
@@ -626,7 +624,7 @@ func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
 	if srv.dialSched != nil {
 		srv.dialSched.SetCNPeers(addrs)
 	}
-	drops := srv.peersOutsideCNPeerAddrs(cnPeerAddrs)
+	drops := srv.peersOutsideCNPeerAddrs()
 	srv.lock.Unlock()
 
 	for _, p := range drops {
@@ -635,7 +633,7 @@ func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
 	}
 }
 
-func (srv *BaseServer) peersOutsideCNPeerAddrs(cnPeerAddrs map[common.Address]struct{}) []*Peer {
+func (srv *BaseServer) peersOutsideCNPeerAddrs() []*Peer {
 	drops := make([]*Peer, 0)
 	for id, p := range srv.peers {
 		if p == nil || EffectiveConnType(p.ConnType()) != common.CONSENSUSNODE {
@@ -648,7 +646,7 @@ func (srv *BaseServer) peersOutsideCNPeerAddrs(cnPeerAddrs map[common.Address]st
 		if err != nil {
 			continue
 		}
-		if _, ok := cnPeerAddrs[addr]; !ok {
+		if _, ok := srv.cnPeerAddrs[addr]; !ok {
 			drops = append(drops, p)
 		}
 	}

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -120,15 +120,15 @@ func (srv *MultiChannelServer) Start() (err error) {
 	}
 
 	if !srv.NoDial {
-		maxENToENDynDials := srv.maxDialedConns()
+		maxENToENDialTarget := srv.maxDialedConns()
 		srv.dialSched = NewDialSched(DialConfig{
-			selfID:            srv.selfID,
-			selfType:          ConvertNodeType(srv.ConnectionType),
-			staticNodes:       srv.StaticNodes,
-			netrestrict:       srv.NetRestrict,
-			maxENToENDynDials: &maxENToENDynDials,
-			maxPeers:          srv.MaxPeers(),
-			dialer:            srv.Dialer,
+			selfID:              srv.selfID,
+			selfType:            ConvertNodeType(srv.ConnectionType),
+			staticNodes:         srv.StaticNodes,
+			netrestrict:         srv.NetRestrict,
+			maxENToENDialTarget: &maxENToENDialTarget,
+			maxPeers:            srv.MaxPeers(),
+			dialer:              srv.Dialer,
 		}, srv.ntab, srv)
 		srv.dialSched.Start()
 	}

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -120,14 +120,15 @@ func (srv *MultiChannelServer) Start() (err error) {
 	}
 
 	if !srv.NoDial {
+		maxENToENDynDials := srv.maxDialedConns()
 		srv.dialSched = NewDialSched(DialConfig{
-			selfID:      srv.selfID,
-			selfType:    ConvertNodeType(srv.ConnectionType),
-			staticNodes: srv.StaticNodes,
-			netrestrict: srv.NetRestrict,
-			maxDynDials: srv.maxDialedConns(),
-			maxPeers:    srv.MaxPeers(),
-			dialer:      srv.Dialer,
+			selfID:            srv.selfID,
+			selfType:          ConvertNodeType(srv.ConnectionType),
+			staticNodes:       srv.StaticNodes,
+			netrestrict:       srv.NetRestrict,
+			maxENToENDynDials: &maxENToENDynDials,
+			maxPeers:          srv.MaxPeers(),
+			dialer:            srv.Dialer,
 		}, srv.ntab, srv)
 		srv.dialSched.Start()
 	}

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -379,6 +379,10 @@ func TestServerPeerTargets(t *testing.T) {
 	}
 
 	cnSrv := &BaseServer{Config: Config{ConnectionType: common.CONSENSUSNODE}}
+	cnMeshPeers := newPeers(common.CONSENSUSNODE, common.CONSENSUSNODE, common.CONSENSUSNODE)
+	if cnSrv.exceedsPeerTarget(cnMeshPeers, &conn{conntype: common.CONSENSUSNODE}) {
+		t.Fatal("CN should not apply an extra per-role cap to CN peers")
+	}
 	cnPeers := newPeers(common.ENDPOINTNODE, common.PROXYNODE, common.ENDPOINTNODE)
 	if !cnSrv.exceedsPeerTarget(cnPeers, &conn{conntype: common.ENDPOINTNODE}) {
 		t.Fatal("CN should reject EN when EN-equivalent peer target is full")
@@ -397,6 +401,10 @@ func TestServerPeerTargets(t *testing.T) {
 	}
 
 	enSrv := &BaseServer{Config: Config{ConnectionType: common.ENDPOINTNODE}}
+	enMeshPeers := newPeers(common.ENDPOINTNODE, common.PROXYNODE, common.ENDPOINTNODE)
+	if enSrv.exceedsPeerTarget(enMeshPeers, &conn{conntype: common.ENDPOINTNODE}) {
+		t.Fatal("EN should not apply an extra per-role cap to EN-equivalent peers")
+	}
 	enPeers := newPeers(common.CONSENSUSNODE, common.CONSENSUSNODE)
 	if !enSrv.exceedsPeerTarget(enPeers, &conn{conntype: common.CONSENSUSNODE}) {
 		t.Fatal("EN should reject CN when CN peer target is full")

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -497,6 +497,31 @@ func TestServerSetCNPeersReconcilesConnectedCNPeers(t *testing.T) {
 	assertNotDisconnected(t, en)
 }
 
+func TestServerSetCNPeersUpdatesDialSched(t *testing.T) {
+	allowedKey := newkey()
+	blockedKey := newkey()
+	allowed := discover.NewNode(discover.PubkeyID(&allowedKey.PublicKey), net.ParseIP("10.0.0.1"), 30303, 30303, nil, discover.NodeTypeCN)
+	blocked := discover.NewNode(discover.PubkeyID(&blockedKey.PublicKey), net.ParseIP("10.0.0.2"), 30303, 30303, nil, discover.NodeTypeCN)
+	ds := NewDialSched(DialConfig{selfType: discover.NodeTypeCN}, nil, nil)
+	srv := &BaseServer{
+		dialSched: ds,
+		peers:     make(map[discover.NodeID]*Peer),
+	}
+
+	srv.SetCNPeers([]common.Address{crypto.PubkeyToAddress(allowedKey.PublicKey)})
+	if !ds.dynamicCandidateAllowed(discover.NodeTypeCN, allowed) {
+		t.Fatal("allowed CN should remain dialable")
+	}
+	if ds.dynamicCandidateAllowed(discover.NodeTypeCN, blocked) {
+		t.Fatal("blocked CN should not remain dialable")
+	}
+
+	srv.SetCNPeers(nil)
+	if !ds.dynamicCandidateAllowed(discover.NodeTypeCN, blocked) {
+		t.Fatal("nil CN peer allowlist should disable dynamic dial filtering")
+	}
+}
+
 func TestServerSetupConn(t *testing.T) {
 	var (
 		id     = discover.PubkeyID(&newkey().PublicKey)

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -403,6 +403,45 @@ func TestServerPeerTargets(t *testing.T) {
 	}
 }
 
+func TestServerCNPeersAdmission(t *testing.T) {
+	key := newkey()
+	id := discover.PubkeyID(&key.PublicKey)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	srv := &BaseServer{}
+
+	c := &conn{conntype: common.CONSENSUSNODE, id: id}
+	srv.SetCNPeers(nil)
+	if err := srv.admitByCNPeers(c); err != nil {
+		t.Fatalf("nil CN peers should disable CN filtering: %v", err)
+	}
+
+	srv.SetCNPeers([]common.Address{})
+	if err := srv.admitByCNPeers(c); err != DiscUselessPeer {
+		t.Fatalf("empty CN peers should reject CN claims, got %v", err)
+	}
+
+	if err := srv.admitByCNPeers(&conn{conntype: common.ENDPOINTNODE, id: id}); err != nil {
+		t.Fatalf("EN should bypass CN peer admission: %v", err)
+	}
+	if err := srv.admitByCNPeers(&conn{conntype: common.PROXYNODE, id: id}); err != nil {
+		t.Fatalf("legacy PN should bypass CN peer admission as EN-equivalent: %v", err)
+	}
+	if err := srv.admitByCNPeers(&conn{conntype: common.CONSENSUSNODE, id: id, flags: trustedConn}); err != nil {
+		t.Fatalf("trusted CN should bypass CN peer admission: %v", err)
+	}
+	if err := srv.admitByCNPeers(&conn{conntype: common.CONSENSUSNODE, id: id, flags: staticDialedConn}); err != nil {
+		t.Fatalf("static outbound CN should bypass CN peer admission: %v", err)
+	}
+	if err := srv.admitByCNPeers(&conn{conntype: common.CONSENSUSNODE, id: id, flags: inboundConn}); err != DiscUselessPeer {
+		t.Fatalf("inbound CN should not bypass CN peer admission, got %v", err)
+	}
+
+	srv.SetCNPeers([]common.Address{addr})
+	if err := srv.admitByCNPeers(c); err != nil {
+		t.Fatalf("CN in CN peers should pass admission: %v", err)
+	}
+}
+
 func TestServerSetupConn(t *testing.T) {
 	var (
 		id     = discover.PubkeyID(&newkey().PublicKey)

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -442,6 +442,61 @@ func TestServerCNPeersAdmission(t *testing.T) {
 	}
 }
 
+func TestServerSetCNPeersReconcilesConnectedCNPeers(t *testing.T) {
+	newPeerWithKey := func(key *ecdsa.PrivateKey, connType common.ConnType, flags connFlag) *Peer {
+		return &Peer{
+			rws:  []*conn{{id: discover.PubkeyID(&key.PublicKey), conntype: connType, flags: flags}},
+			disc: make(chan DiscReason, 1),
+		}
+	}
+	assertNotDisconnected := func(t *testing.T, p *Peer) {
+		t.Helper()
+		select {
+		case reason := <-p.disc:
+			t.Fatalf("peer should remain connected, got disconnect %v", reason)
+		default:
+		}
+	}
+
+	allowedKey := newkey()
+	dropKey := newkey()
+	trustedKey := newkey()
+	staticKey := newkey()
+	enKey := newkey()
+
+	allowed := newPeerWithKey(allowedKey, common.CONSENSUSNODE, inboundConn)
+	drop := newPeerWithKey(dropKey, common.CONSENSUSNODE, inboundConn)
+	trusted := newPeerWithKey(trustedKey, common.CONSENSUSNODE, inboundConn|trustedConn)
+	staticOutbound := newPeerWithKey(staticKey, common.CONSENSUSNODE, staticDialedConn)
+	en := newPeerWithKey(enKey, common.ENDPOINTNODE, inboundConn)
+
+	srv := &BaseServer{
+		logger: logger.NewWith(),
+		peers: map[discover.NodeID]*Peer{
+			allowed.ID():        allowed,
+			drop.ID():           drop,
+			trusted.ID():        trusted,
+			staticOutbound.ID(): staticOutbound,
+			en.ID():             en,
+		},
+	}
+
+	srv.SetCNPeers([]common.Address{crypto.PubkeyToAddress(allowedKey.PublicKey)})
+
+	select {
+	case reason := <-drop.disc:
+		if reason != DiscRequested {
+			t.Fatalf("wrong disconnect reason: %v", reason)
+		}
+	default:
+		t.Fatal("CN peer outside allowlist should be disconnected")
+	}
+	assertNotDisconnected(t, allowed)
+	assertNotDisconnected(t, trusted)
+	assertNotDisconnected(t, staticOutbound)
+	assertNotDisconnected(t, en)
+}
+
 func TestServerSetupConn(t *testing.T) {
 	var (
 		id     = discover.PubkeyID(&newkey().PublicKey)

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -366,6 +366,43 @@ func TestServerAtCap(t *testing.T) {
 	}
 }
 
+func TestServerPeerTargets(t *testing.T) {
+	newPeerWithType := func(connType common.ConnType) *Peer {
+		return &Peer{rws: []*conn{{conntype: connType}}}
+	}
+	newPeers := func(connTypes ...common.ConnType) map[discover.NodeID]*Peer {
+		peers := make(map[discover.NodeID]*Peer, len(connTypes))
+		for _, connType := range connTypes {
+			peers[randomID()] = newPeerWithType(connType)
+		}
+		return peers
+	}
+
+	cnSrv := &BaseServer{Config: Config{ConnectionType: common.CONSENSUSNODE}}
+	cnPeers := newPeers(common.ENDPOINTNODE, common.PROXYNODE, common.ENDPOINTNODE)
+	if !cnSrv.exceedsPeerTarget(cnPeers, &conn{conntype: common.ENDPOINTNODE}) {
+		t.Fatal("CN should reject EN when EN-equivalent peer target is full")
+	}
+	if !cnSrv.exceedsPeerTarget(cnPeers, &conn{conntype: common.PROXYNODE}) {
+		t.Fatal("CN should count PN against the EN-equivalent peer target")
+	}
+	if cnSrv.exceedsPeerTarget(cnPeers, &conn{conntype: common.ENDPOINTNODE, flags: trustedConn}) {
+		t.Fatal("trusted peer should bypass peer target")
+	}
+	if cnSrv.exceedsPeerTarget(cnPeers, &conn{conntype: common.ENDPOINTNODE, flags: staticDialedConn}) {
+		t.Fatal("static outbound peer should bypass peer target")
+	}
+	if !cnSrv.exceedsPeerTarget(cnPeers, &conn{conntype: common.ENDPOINTNODE, flags: inboundConn}) {
+		t.Fatal("static/dynamic inbound peer should not bypass peer target unless trusted")
+	}
+
+	enSrv := &BaseServer{Config: Config{ConnectionType: common.ENDPOINTNODE}}
+	enPeers := newPeers(common.CONSENSUSNODE, common.CONSENSUSNODE)
+	if !enSrv.exceedsPeerTarget(enPeers, &conn{conntype: common.CONSENSUSNODE}) {
+		t.Fatal("EN should reject CN when CN peer target is full")
+	}
+}
+
 func TestServerSetupConn(t *testing.T) {
 	var (
 		id     = discover.PubkeyID(&newkey().PublicKey)

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -194,6 +194,14 @@ func ConvertNodeType(ct common.ConnType) discover.NodeType {
 	}
 }
 
+// EffectiveConnType returns the KIP-311 role bucket for a wire-level connection type.
+func EffectiveConnType(ct common.ConnType) common.ConnType {
+	if ct == common.PROXYNODE {
+		return common.ENDPOINTNODE
+	}
+	return ct
+}
+
 func ConvertConnType(nt discover.NodeType) common.ConnType {
 	switch nt {
 	case discover.NodeTypeCN:

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -31,6 +31,18 @@ import (
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 )
 
+// peerTargets from KIP-311.
+var peerTargets = map[common.ConnType]map[common.ConnType]int{
+	common.CONSENSUSNODE: {
+		common.CONSENSUSNODE: 100,
+		common.ENDPOINTNODE:  3,
+	},
+	common.ENDPOINTNODE: {
+		common.CONSENSUSNODE: 2,
+		common.ENDPOINTNODE:  10,
+	},
+}
+
 type peerDrop struct {
 	*Peer
 	err       error

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -32,15 +32,14 @@ import (
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 )
 
-// peerTargets from KIP-311.
+// Finite peerTargets from KIP-311. Missing entries mean no per-role cap beyond
+// MaxPhysicalConnections and inbound capacity.
 var peerTargets = map[common.ConnType]map[common.ConnType]int{
 	common.CONSENSUSNODE: {
-		common.CONSENSUSNODE: 100,
-		common.ENDPOINTNODE:  3,
+		common.ENDPOINTNODE: 3,
 	},
 	common.ENDPOINTNODE: {
 		common.CONSENSUSNODE: 2,
-		common.ENDPOINTNODE:  10,
 	},
 }
 

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 )
 
@@ -58,6 +59,8 @@ const (
 type connFlag int
 
 const (
+	// inbound/dyndial/staticdial are mutually exclusive origins.
+	// trusted is an independent overlay added after identity is known.
 	dynDialedConn connFlag = 1 << iota
 	staticDialedConn
 	inboundConn
@@ -212,6 +215,14 @@ func EffectiveConnType(ct common.ConnType) common.ConnType {
 		return common.ENDPOINTNODE
 	}
 	return ct
+}
+
+func addressFromNodeID(id discover.NodeID) (common.Address, error) {
+	pub, err := id.Pubkey()
+	if err != nil {
+		return common.Address{}, err
+	}
+	return crypto.PubkeyToAddress(*pub), nil
 }
 
 func ConvertConnType(nt discover.NodeType) common.ConnType {

--- a/networks/p2p/server_util_test.go
+++ b/networks/p2p/server_util_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/networks/p2p/discover"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEffectiveConnTypeTreatsPNAsEN(t *testing.T) {
+	assert.Equal(t, common.ENDPOINTNODE, EffectiveConnType(common.PROXYNODE))
+	assert.Equal(t, common.ENDPOINTNODE, EffectiveConnType(common.ENDPOINTNODE))
+	assert.Equal(t, common.CONSENSUSNODE, EffectiveConnType(common.CONSENSUSNODE))
+	assert.Equal(t, common.BOOTNODE, EffectiveConnType(common.BOOTNODE))
+}
+
+func TestEffectiveNodeTypeTreatsPNAsEN(t *testing.T) {
+	assert.Equal(t, discover.NodeTypeEN, discover.EffectiveNodeType(discover.NodeTypePN))
+	assert.Equal(t, discover.NodeTypeEN, discover.EffectiveNodeType(discover.NodeTypeEN))
+	assert.Equal(t, discover.NodeTypeCN, discover.EffectiveNodeType(discover.NodeTypeCN))
+	assert.Equal(t, discover.NodeTypeBN, discover.EffectiveNodeType(discover.NodeTypeBN))
+}

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -154,7 +154,12 @@ type CN struct {
 
 	components []interface{}
 
-	govModule gov.GovModule
+	govModule    gov.GovModule
+	valsetModule valset.ValsetModule
+
+	cnPeerHeadSub event.Subscription
+	cnPeerSyncWg  sync.WaitGroup
+	cnPeerUpdater *cnPeerUpdater
 
 	// kaiax modules
 	baseModules    []kaiax.BaseModule
@@ -253,6 +258,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 		closeBloomHandler: make(chan struct{}),
 		govModule:         mGov,
 		stakingModule:     mStaking,
+		valsetModule:      mValset,
 	}
 
 	// Derive and set node's address using nodekey
@@ -905,6 +911,8 @@ func (s *CN) Start(srvr p2p.Server) error {
 	// Start the RPC service
 	s.p2pServer = srvr
 
+	s.startCNPeerSync(srvr)
+
 	// Figure out a max peers count based on the server limits
 	maxPeers := srvr.MaxPeers()
 	// Start the networking layer and the light server if requested
@@ -920,6 +928,7 @@ func (s *CN) Start(srvr p2p.Server) error {
 // Kaia protocol.
 func (s *CN) Stop() error {
 	// Stop all the peer-related stuff first.
+	s.stopCNPeerSync()
 	s.protocolManager.Stop()
 	if s.lesServer != nil {
 		s.lesServer.Stop()

--- a/node/cn/cnpeers.go
+++ b/node/cn/cnpeers.go
@@ -1,0 +1,139 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package cn
+
+import (
+	"github.com/kaiachain/kaia/blockchain"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/event"
+	"github.com/kaiachain/kaia/networks/p2p"
+	"github.com/kaiachain/kaia/rlp"
+)
+
+const cnPeerHeadChanSize = 16
+
+type cnPeerReader interface {
+	GetCNPeers(num uint64) ([]common.Address, error)
+}
+
+type cnPeerSink interface {
+	SetCNPeers(addrs []common.Address)
+}
+
+type cnPeerUpdater struct {
+	reader cnPeerReader
+	sink   cnPeerSink
+
+	lastHash *common.Hash // Last hashed SetCNPeers input; nil means never pushed.
+}
+
+type cnPeerInput struct {
+	AllCNPeersAllowed bool
+	Addrs             []common.Address
+}
+
+func newCNPeerUpdater(reader cnPeerReader, sink cnPeerSink) *cnPeerUpdater {
+	return &cnPeerUpdater{
+		reader: reader,
+		sink:   sink,
+	}
+}
+
+func (u *cnPeerUpdater) syncHead(head *types.Block) {
+	if head == nil {
+		return
+	}
+	u.sync(head.NumberU64() + 1)
+}
+
+func (u *cnPeerUpdater) sync(num uint64) {
+	if u == nil || u.reader == nil || u.sink == nil {
+		return
+	}
+	addrs, err := u.reader.GetCNPeers(num)
+	if err != nil {
+		logger.Warn("syncCNPeers: disabling CN peer filter after initial GetCNPeers failed", "num", num, "err", err)
+		u.setCNPeersIfChanged(nil)
+		return
+	}
+	u.setCNPeersIfChanged(addrs)
+}
+
+func (u *cnPeerUpdater) setCNPeersIfChanged(addrs []common.Address) {
+	hash := hashCNPeerInput(addrs)
+	if u.lastHash != nil && hash == *u.lastHash {
+		return
+	}
+	u.lastHash = &hash
+	u.sink.SetCNPeers(addrs)
+}
+
+// hashCNPeerInput hashes `AllCNPeersAllowed || addrs`. The order of `addrs` matters.
+func hashCNPeerInput(addrs []common.Address) common.Hash {
+	input := cnPeerInput{AllCNPeersAllowed: addrs == nil}
+	if addrs != nil {
+		input.Addrs = addrs
+	}
+	encoded, err := rlp.EncodeToBytes(input)
+	if err != nil {
+		panic(err)
+	}
+	return crypto.Keccak256Hash(encoded)
+}
+
+func (s *CN) startCNPeerSync(srvr p2p.Server) {
+	if srvr == nil || s.valsetModule == nil || s.blockchain == nil {
+		return
+	}
+	s.cnPeerUpdater = newCNPeerUpdater(s.valsetModule, srvr)
+
+	ch := make(chan blockchain.ChainHeadEvent, cnPeerHeadChanSize)
+	sub := s.blockchain.SubscribeChainHeadEvent(ch)
+	s.cnPeerHeadSub = sub
+
+	s.cnPeerUpdater.syncHead(s.blockchain.CurrentBlock())
+
+	s.cnPeerSyncWg.Add(1)
+	go s.cnPeerSyncLoop(ch, sub)
+}
+
+func (s *CN) cnPeerSyncLoop(ch <-chan blockchain.ChainHeadEvent, sub event.Subscription) {
+	defer s.cnPeerSyncWg.Done()
+
+	for {
+		select {
+		case ev := <-ch:
+			s.cnPeerUpdater.syncHead(ev.Block)
+		case err, ok := <-sub.Err():
+			if ok && err != nil {
+				logger.Warn("CN peer sync stopped", "err", err)
+			}
+			return
+		}
+	}
+}
+
+func (s *CN) stopCNPeerSync() {
+	if s.cnPeerHeadSub != nil {
+		s.cnPeerHeadSub.Unsubscribe()
+		s.cnPeerHeadSub = nil
+	}
+	s.cnPeerSyncWg.Wait()
+	s.cnPeerUpdater = nil
+}

--- a/node/cn/cnpeers.go
+++ b/node/cn/cnpeers.go
@@ -17,12 +17,15 @@
 package cn
 
 import (
+	"math/big"
+
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/networks/p2p"
+	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
 )
 
@@ -37,8 +40,9 @@ type cnPeerSink interface {
 }
 
 type cnPeerUpdater struct {
-	reader cnPeerReader
-	sink   cnPeerSink
+	reader      cnPeerReader
+	sink        cnPeerSink
+	chainConfig *params.ChainConfig
 
 	lastHash *common.Hash // Last hashed SetCNPeers input; nil means never pushed.
 }
@@ -48,10 +52,11 @@ type cnPeerInput struct {
 	Addrs             []common.Address
 }
 
-func newCNPeerUpdater(reader cnPeerReader, sink cnPeerSink) *cnPeerUpdater {
+func newCNPeerUpdater(reader cnPeerReader, sink cnPeerSink, chainConfig *params.ChainConfig) *cnPeerUpdater {
 	return &cnPeerUpdater{
-		reader: reader,
-		sink:   sink,
+		reader:      reader,
+		sink:        sink,
+		chainConfig: chainConfig,
 	}
 }
 
@@ -59,7 +64,21 @@ func (u *cnPeerUpdater) syncHead(head *types.Block) {
 	if head == nil {
 		return
 	}
-	u.sync(head.NumberU64() + 1)
+	num := head.NumberU64() + 1
+	if !u.shouldSync(num) {
+		u.setCNPeersIfChanged(nil)
+		return
+	}
+	u.sync(num)
+}
+
+func (u *cnPeerUpdater) shouldSync(num uint64) bool {
+	if u == nil || u.chainConfig == nil || u.chainConfig.PermissionlessCompatibleBlock == nil {
+		return false
+	}
+	// Avoid next-block ABv2 reads until the HF block has been committed.
+	syncAfter := new(big.Int).Add(u.chainConfig.PermissionlessCompatibleBlock, common.Big1)
+	return new(big.Int).SetUint64(num).Cmp(syncAfter) >= 0
 }
 
 func (u *cnPeerUpdater) sync(num uint64) {
@@ -101,7 +120,7 @@ func (s *CN) startCNPeerSync(srvr p2p.Server) {
 	if srvr == nil || s.valsetModule == nil || s.blockchain == nil {
 		return
 	}
-	s.cnPeerUpdater = newCNPeerUpdater(s.valsetModule, srvr)
+	s.cnPeerUpdater = newCNPeerUpdater(s.valsetModule, srvr, s.chainConfig)
 
 	ch := make(chan blockchain.ChainHeadEvent, cnPeerHeadChanSize)
 	sub := s.blockchain.SubscribeChainHeadEvent(ch)

--- a/node/cn/cnpeers_test.go
+++ b/node/cn/cnpeers_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package cn
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cnPeerReadResult struct {
+	addrs []common.Address
+	err   error
+}
+
+type fakeCNPeerReader struct {
+	results []cnPeerReadResult
+	calls   []uint64
+}
+
+func (r *fakeCNPeerReader) GetCNPeers(num uint64) ([]common.Address, error) {
+	r.calls = append(r.calls, num)
+	if len(r.results) == 0 {
+		return nil, nil
+	}
+	result := r.results[0]
+	if len(r.results) > 1 {
+		r.results = r.results[1:]
+	}
+	return result.addrs, result.err
+}
+
+type recordCNPeerSink struct {
+	calls [][]common.Address
+}
+
+func (s *recordCNPeerSink) SetCNPeers(addrs []common.Address) {
+	if addrs == nil {
+		s.calls = append(s.calls, nil)
+		return
+	}
+	cp := make([]common.Address, len(addrs))
+	copy(cp, addrs)
+	s.calls = append(s.calls, cp)
+}
+
+func TestCNPeerUpdaterSyncHeadUsesNextBlockNumber(t *testing.T) {
+	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{addrs: cnTestAddrs(1)}}}
+	sink := &recordCNPeerSink{}
+	updater := newCNPeerUpdater(reader, sink)
+
+	updater.syncHead(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(10)}))
+
+	require.Equal(t, []uint64{11}, reader.calls)
+	require.Len(t, sink.calls, 1)
+	assert.Equal(t, cnTestAddrs(1), sink.calls[0])
+}
+
+func TestCNPeerUpdaterSkipsDuplicatePushes(t *testing.T) {
+	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{addrs: cnTestAddrs(1, 2)}}}
+	sink := &recordCNPeerSink{}
+	updater := newCNPeerUpdater(reader, sink)
+
+	updater.sync(11)
+	updater.sync(12)
+
+	require.Len(t, sink.calls, 1)
+	assert.Equal(t, cnTestAddrs(1, 2), sink.calls[0])
+}
+
+func TestCNPeerUpdaterNilDisablesFiltering(t *testing.T) {
+	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{addrs: nil}}}
+	sink := &recordCNPeerSink{}
+	updater := newCNPeerUpdater(reader, sink)
+
+	updater.sync(11)
+	updater.sync(12)
+
+	require.Len(t, sink.calls, 1)
+	assert.Nil(t, sink.calls[0])
+}
+
+func TestCNPeerUpdaterNilAndEmptyInputsAreDistinct(t *testing.T) {
+	reader := &fakeCNPeerReader{results: []cnPeerReadResult{
+		{addrs: nil},
+		{addrs: []common.Address{}},
+	}}
+	sink := &recordCNPeerSink{}
+	updater := newCNPeerUpdater(reader, sink)
+
+	updater.sync(11)
+	updater.sync(12)
+
+	require.Len(t, sink.calls, 2)
+	assert.Nil(t, sink.calls[0])
+	assert.NotNil(t, sink.calls[1])
+	assert.Empty(t, sink.calls[1])
+}
+
+func TestCNPeerUpdaterFailureDisablesBeforeFirstPush(t *testing.T) {
+	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{err: errors.New("missing cn peers")}}}
+	sink := &recordCNPeerSink{}
+	updater := newCNPeerUpdater(reader, sink)
+
+	updater.sync(11)
+
+	require.Len(t, sink.calls, 1)
+	assert.Nil(t, sink.calls[0])
+}
+
+func TestCNPeerUpdaterFailureDisablesFilteringAfterPreviousPush(t *testing.T) {
+	reader := &fakeCNPeerReader{results: []cnPeerReadResult{
+		{addrs: cnTestAddrs(1)},
+		{err: errors.New("temporary read failure")},
+	}}
+	sink := &recordCNPeerSink{}
+	updater := newCNPeerUpdater(reader, sink)
+
+	updater.sync(11)
+	updater.sync(12)
+
+	require.Len(t, sink.calls, 2)
+	assert.Equal(t, cnTestAddrs(1), sink.calls[0])
+	assert.Nil(t, sink.calls[1])
+}
+
+func cnTestAddrs(n ...int) []common.Address {
+	addrs := make([]common.Address, len(n))
+	for i, num := range n {
+		addrs[i] = common.BigToAddress(big.NewInt(int64(num)))
+	}
+	return addrs
+}

--- a/node/cn/cnpeers_test.go
+++ b/node/cn/cnpeers_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,84 +64,128 @@ func (s *recordCNPeerSink) SetCNPeers(addrs []common.Address) {
 	s.calls = append(s.calls, cp)
 }
 
-func TestCNPeerUpdaterSyncHeadUsesNextBlockNumber(t *testing.T) {
-	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{addrs: cnTestAddrs(1)}}}
+type cnPeerUpdaterOpt func(*cnPeerUpdaterOpts)
+
+type cnPeerUpdaterOpts struct {
+	results []cnPeerReadResult
+	fork    uint64
+}
+
+func withCNPeerReadResults(results ...cnPeerReadResult) cnPeerUpdaterOpt {
+	return func(o *cnPeerUpdaterOpts) { o.results = results }
+}
+
+func withPermissionlessFork(fork uint64) cnPeerUpdaterOpt {
+	return func(o *cnPeerUpdaterOpts) { o.fork = fork }
+}
+
+type cnPeerUpdaterTest struct {
+	updater *cnPeerUpdater
+	reader  *fakeCNPeerReader
+	sink    *recordCNPeerSink
+}
+
+func newCNPeerUpdaterTest(t *testing.T, options ...cnPeerUpdaterOpt) *cnPeerUpdaterTest {
+	t.Helper()
+
+	opts := &cnPeerUpdaterOpts{fork: 1}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	reader := &fakeCNPeerReader{results: opts.results}
 	sink := &recordCNPeerSink{}
-	updater := newCNPeerUpdater(reader, sink)
+	return &cnPeerUpdaterTest{
+		updater: newCNPeerUpdater(reader, sink, &params.ChainConfig{
+			PermissionlessCompatibleBlock: new(big.Int).SetUint64(opts.fork),
+		}),
+		reader: reader,
+		sink:   sink,
+	}
+}
 
-	updater.syncHead(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(10)}))
+func TestCNPeerUpdaterSyncHeadUsesNextBlockNumber(t *testing.T) {
+	cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(cnPeerReadResult{addrs: cnTestAddrs(1)}))
 
-	require.Equal(t, []uint64{11}, reader.calls)
-	require.Len(t, sink.calls, 1)
-	assert.Equal(t, cnTestAddrs(1), sink.calls[0])
+	cn.updater.syncHead(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(10)}))
+
+	require.Equal(t, []uint64{11}, cn.reader.calls)
+	require.Len(t, cn.sink.calls, 1)
+	assert.Equal(t, cnTestAddrs(1), cn.sink.calls[0])
+}
+
+func TestCNPeerUpdaterSyncHeadWaitsUntilPermissionlessPlusOne(t *testing.T) {
+	cn := newCNPeerUpdaterTest(t,
+		withPermissionlessFork(30),
+		withCNPeerReadResults(cnPeerReadResult{addrs: cnTestAddrs(1)}),
+	)
+
+	cn.updater.syncHead(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(28)})) // target 29
+	cn.updater.syncHead(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(29)})) // target 30
+	cn.updater.syncHead(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(30)})) // target 31
+
+	require.Equal(t, []uint64{31}, cn.reader.calls)
+	require.Len(t, cn.sink.calls, 2)
+	assert.Nil(t, cn.sink.calls[0])
+	assert.Equal(t, cnTestAddrs(1), cn.sink.calls[1])
 }
 
 func TestCNPeerUpdaterSkipsDuplicatePushes(t *testing.T) {
-	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{addrs: cnTestAddrs(1, 2)}}}
-	sink := &recordCNPeerSink{}
-	updater := newCNPeerUpdater(reader, sink)
+	cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(cnPeerReadResult{addrs: cnTestAddrs(1, 2)}))
 
-	updater.sync(11)
-	updater.sync(12)
+	cn.updater.sync(11)
+	cn.updater.sync(12)
 
-	require.Len(t, sink.calls, 1)
-	assert.Equal(t, cnTestAddrs(1, 2), sink.calls[0])
+	require.Len(t, cn.sink.calls, 1)
+	assert.Equal(t, cnTestAddrs(1, 2), cn.sink.calls[0])
 }
 
 func TestCNPeerUpdaterNilDisablesFiltering(t *testing.T) {
-	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{addrs: nil}}}
-	sink := &recordCNPeerSink{}
-	updater := newCNPeerUpdater(reader, sink)
+	cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(cnPeerReadResult{addrs: nil}))
 
-	updater.sync(11)
-	updater.sync(12)
+	cn.updater.sync(11)
+	cn.updater.sync(12)
 
-	require.Len(t, sink.calls, 1)
-	assert.Nil(t, sink.calls[0])
+	require.Len(t, cn.sink.calls, 1)
+	assert.Nil(t, cn.sink.calls[0])
 }
 
 func TestCNPeerUpdaterNilAndEmptyInputsAreDistinct(t *testing.T) {
-	reader := &fakeCNPeerReader{results: []cnPeerReadResult{
-		{addrs: nil},
-		{addrs: []common.Address{}},
-	}}
-	sink := &recordCNPeerSink{}
-	updater := newCNPeerUpdater(reader, sink)
+	cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(
+		cnPeerReadResult{addrs: nil},
+		cnPeerReadResult{addrs: []common.Address{}},
+	))
 
-	updater.sync(11)
-	updater.sync(12)
+	cn.updater.sync(11)
+	cn.updater.sync(12)
 
-	require.Len(t, sink.calls, 2)
-	assert.Nil(t, sink.calls[0])
-	assert.NotNil(t, sink.calls[1])
-	assert.Empty(t, sink.calls[1])
+	require.Len(t, cn.sink.calls, 2)
+	assert.Nil(t, cn.sink.calls[0])
+	assert.NotNil(t, cn.sink.calls[1])
+	assert.Empty(t, cn.sink.calls[1])
 }
 
 func TestCNPeerUpdaterFailureDisablesBeforeFirstPush(t *testing.T) {
-	reader := &fakeCNPeerReader{results: []cnPeerReadResult{{err: errors.New("missing cn peers")}}}
-	sink := &recordCNPeerSink{}
-	updater := newCNPeerUpdater(reader, sink)
+	cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(cnPeerReadResult{err: errors.New("missing cn peers")}))
 
-	updater.sync(11)
+	cn.updater.sync(11)
 
-	require.Len(t, sink.calls, 1)
-	assert.Nil(t, sink.calls[0])
+	require.Len(t, cn.sink.calls, 1)
+	assert.Nil(t, cn.sink.calls[0])
 }
 
 func TestCNPeerUpdaterFailureDisablesFilteringAfterPreviousPush(t *testing.T) {
-	reader := &fakeCNPeerReader{results: []cnPeerReadResult{
-		{addrs: cnTestAddrs(1)},
-		{err: errors.New("temporary read failure")},
-	}}
-	sink := &recordCNPeerSink{}
-	updater := newCNPeerUpdater(reader, sink)
+	cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(
+		cnPeerReadResult{addrs: cnTestAddrs(1)},
+		cnPeerReadResult{err: errors.New("temporary read failure")},
+	))
 
-	updater.sync(11)
-	updater.sync(12)
+	cn.updater.sync(11)
+	cn.updater.sync(12)
 
-	require.Len(t, sink.calls, 2)
-	assert.Equal(t, cnTestAddrs(1), sink.calls[0])
-	assert.Nil(t, sink.calls[1])
+	require.Len(t, cn.sink.calls, 2)
+	assert.Equal(t, cnTestAddrs(1), cn.sink.calls[0])
+	assert.Nil(t, cn.sink.calls[1])
 }
 
 func cnTestAddrs(n ...int) []common.Address {


### PR DESCRIPTION
## Proposed changes

This PR implements the [KIP-311](https://kips.kaia.io/KIPs/kip-311) P2P networking changes for permissionless CN admission and peer budgeting.

## Main Behavior
- PN is treated as EN-equivalent for compatibility.
- BN no longer filters discovery by `AuthorizedNodes`.
- CN dynamic outbound CN dials are filtered by `peerNodes`.
- CN-claimed peers are admitted only if they are in `peerNodes`, except trusted/static outbound peers.
- Static inbound is not an authorization bypass.
- CNs reconcile already-connected CN peers after `peerNodes` changes.
- Pre-HF `GetCNPeers` uses council when available; if council read fails, filtering is disabled.
- Post-HF `GetCNPeers` uses ABv2; if read fails or returns empty during startup/transition, filtering is disabled.

## Implementation Details
- Discovery/dial targets:
  - `discoverTargets` and `dialTargets` are updated for CN/EN/BN KIP-311 topology.
  - EN→EN dial target preserves `DialRatio`: `MaxPhysicalConnections / DialRatio`.
  - Dynamic CN candidates are filtered by the current CN allowlist.

- Peer budgets:
  - Existing `MaxPhysicalConnections` and inbound capacity checks remain.
  - Adds finite per-role caps (`peerTargets`) only where needed:
    - CN caps EN peers.
    - EN caps CN peers.
  - Trusted peers and static outbound peers keep existing exemptions.

- CN peer allowlist:
  - Adds `p2p.Server.SetCNPeers([]common.Address)`.
  - `nil` means allow all CN peers, used for fallback/disabled filtering; on the other hand, empty slice means reject all non-exempt CN peers.
  - Updates disconnect non-exempt connected CN peers outside the new set.

- CN wiring:
  - CN owns syncing the allowlist.
  - On startup and chain-head events, CN pushes `GetCNPeers(head+1)` into the P2P server.
  - Duplicate pushes are suppressed by hashing the input.

- Istanbul validation:
  - CN protocol registration validates peer identity against `GetCNPeers`.
  - `nil` CN peer set disables validation, matching fallback semantics.

- Removed/deprecated pieces:
  - Removes BN `AuthorizedNodes` discovery filtering from this path.
  - Removes related config/RPC/CLI surface for authorized-node discovery filtering.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Further comments

<details>

<summary>Previous P2P logic</summary>

```
Parameters:
- M = MaxPhysicalConnections (default 10)
- R = DialRatio (default 3)

CN/PN:
- maxDialedConns = 0
- maxInboundConns = M = 10

EN:
- maxDialedConns = M / R = 3 by default
- maxInboundConns = M - maxDialedConns = 7 by default

Admission:
- [total cap] total peers <= MaxPhysicalConnections
- [inbound cap] inbound peers <= maxInboundConns
- Exemptions:
  - trusted: exempt from total and inbound cap
  - static (outbound): exempt from total cap

Dial budget:
- CN: { CN: 100 }
- PN: { PN: 100 }
- EN: { PN: 2, EN: maxDialedConns }
```

</details>

<details>

<summary>This PR</summary>

```
Parameters:
- M = MaxPhysicalConnections (CN default 103, PN/EN default 12)
- R = DialRatio (default 3)
- peerTargets (for minimum CN-CN, CN-EN connection guarantee): CN->EN:3, EN->CN:2
- cnPeers ([]address): allowlist for CN-CN connections

CN/PN:
- maxDialedConns = 0
- maxInboundConns = M

EN:
- maxDialedConns = M / R = 4 by default
- maxInboundConns = M - maxDialedConns = 8 by default

Admission: new policies are peer cap, whitelist check
- [total cap] total peers <= MaxPhysicalConnections
- [inbound cap] inbound peers <= maxInboundConns
- [peer cap] peer-type peers <= peerTargets[selfType][peerType]
- [whitelist check] CN peers must pass cnPeers allowlist when enabled
- Exemptions:
  - trusted: exempt from total cap, inbound cap, peer cap, whitelist check
  - static (outbound): exempt from total cap, peer cap, whitelist admission

Dial budget (dialTargets):
- CN: { CN: 100, EN: 1 }
- EN: { CN: 2,   EN: 3 or maxENToENDynDials }
- PN: treated as EN
- BN: {}
```

</details>

