### PR TITLE
valset: fix permissionless HF boundary valset reads

### DIFF
--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -59,8 +59,11 @@ func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
 	}
 
 	if qualified == nil {
-		// future blocks under post-permissionless, or pre-permissionless
-		qualified, err = v.getQualifiedPermissioned(num)
+		if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+			qualified, err = v.getQualifiedValidators(num)
+		} else {
+			qualified, err = v.getQualifiedPermissioned(num)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/kaiax/valset/impl/getter_context_test.go
+++ b/kaiax/valset/impl/getter_context_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kaiachain/kaia/storage/database"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestGetCommittee tests various branches of getCommitteePermissioned().
@@ -140,6 +141,35 @@ func TestRandaoCommittee(t *testing.T) {
 	)
 	assert.Equal(t, numsToAddrs(8), selectRandaoCommittee(qualified, 1, mixHash))
 	assert.Equal(t, numsToAddrs(8, 3, 5, 1, 0, 9), selectRandaoCommittee(qualified, 6, mixHash))
+}
+
+func TestGetBlockContextPermissionlessFutureBlockUsesTransitionedNodes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockGov := gov_mock.NewMockGovModule(ctrl)
+
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+	mockChain.EXPECT().GetHeaderByNumber(uint64(1)).Return(nil)
+	mockChain.EXPECT().GetHeaderByNumber(uint64(0)).Return(&types.Header{Number: big.NewInt(0)})
+	mockGov.EXPECT().GetParamSet(uint64(1)).Return(gov.ParamSet{
+		CommitteeSize:  4,
+		ProposerPolicy: uint64(istanbul.RoundRobin),
+	})
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+	v.GovModule = mockGov
+	v.transitionResultCache.Add(uint64(1), &TransitionResult{
+		Nodes: NodeMap{
+			addr1: {State: ValActive},
+			addr2: {State: ValPaused},
+			addr3: {State: ValActive},
+		},
+	})
+
+	c, err := v.getBlockContext(1)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []common.Address{addr1, addr3}, c.qualified.List())
 }
 
 // TestGetProposer tests various branches of getProposer().

--- a/kaiax/valset/impl/getter_context_test.go
+++ b/kaiax/valset/impl/getter_context_test.go
@@ -143,7 +143,7 @@ func TestRandaoCommittee(t *testing.T) {
 	assert.Equal(t, numsToAddrs(8, 3, 5, 1, 0, 9), selectRandaoCommittee(qualified, 6, mixHash))
 }
 
-func TestGetBlockContextPermissionlessFutureBlockUsesTransitionedNodes(t *testing.T) {
+func TestGetBlockContext_FutureBlockPostFork(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockChain := chain_mock.NewMockBlockChain(ctrl)
 	mockGov := gov_mock.NewMockGovModule(ctrl)

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -146,6 +146,11 @@ func (v *ValsetModule) fetchVRankCtx(num uint64) (cfs, pfs map[common.Address]ui
 		logger.Error("VRankModule is nil")
 		return nil, nil, nil
 	}
+	// Pre-HF blocks have no VRank evidence. Keep applyTr(HF-1) as a no-op
+	// for VRank-dependent transitions by returning an empty VRank context.
+	if !v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return nil, nil, nil
+	}
 	if nextNum := num + 1; v.isVrankEpoch(nextNum) {
 		c, err := v.VRankModule.GetCFS(num)
 		if err != nil {

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -293,6 +293,21 @@ func TestFetchVRankCtx(t *testing.T) {
 		assert.Nil(t, gotPFS)
 		assert.Equal(t, pfReport, gotPfReport)
 	})
+
+	t.Run("pre-fork block returns empty context without vrank reads", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(30, 10)).AnyTimes()
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.VRankModule = vrank_mock.NewMockVRankModule(ctrl)
+
+		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(29)
+		assert.Nil(t, gotCFS)
+		assert.Nil(t, gotPFS)
+		assert.Nil(t, gotPfReport)
+	})
 }
 
 func TestDiffNodeStates(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

- Use the permissionless qualified validator set when computing `getBlockContext` for future post-HF blocks (i.e., for block that is being mined).
  - This prevents `GetProposer(N, round)` from falling back to the old permissioned validator set when header N is not inserted yet.
  - Fixes the case where a paused validator can still be selected as proposer, which happened because `getBlockContext` uses the permissioned qualified validator set.
- Treat pre-HF VRank data as empty when applying transition for the HF block.
  - `applyTr(HF-1)` still runs normally.
  - `fetchVRankCtx(HF-1)` returns empty CFS/PFS/PfReport instead of calling VRank APIs for a pre-permissionless block.
  - This removes expected boundary errors such as `block is before the permissionless fork`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
