### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -30,6 +30,7 @@ import (
 	mrand "math/rand"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1246,8 +1247,7 @@ func (bc *BlockChain) Rollback(chain []common.Hash) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
-	for i := len(chain) - 1; i >= 0; i-- {
-		hash := chain[i]
+	for _, hash := range slices.Backward(chain) {
 
 		currentHeader := bc.CurrentHeader()
 		if currentHeader.Hash() == hash {
@@ -2550,12 +2550,12 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	}
 	// Insert the new chain, taking care of the proper incremental order
 	var addedTxs types.Transactions
-	for i := len(newChain) - 1; i >= 0; i-- {
+	for _, n := range slices.Backward(newChain) {
 		// insert the block in the canonical way, re-writing history
-		bc.insert(newChain[i])
+		bc.insert(n)
 		// write lookup entries for hash based transaction/receipt searches
-		bc.db.WriteTxLookupEntries(newChain[i])
-		addedTxs = append(addedTxs, newChain[i].Transactions()...)
+		bc.db.WriteTxLookupEntries(n)
+		addedTxs = append(addedTxs, n.Transactions()...)
 	}
 	// calculate the difference between deleted and added transactions
 	diff := types.TxDifference(deletedTxs, addedTxs)

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"maps"
 	"math/big"
+	"slices"
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
@@ -245,8 +246,8 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 
 		if len(log.Stack) > 0 {
 			fmt.Fprintln(writer, "Stack:")
-			for i := len(log.Stack) - 1; i >= 0; i-- {
-				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(log.Stack[i], 32))
+			for i, v := range slices.Backward(log.Stack) {
+				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(v, 32))
 			}
 		}
 		if len(log.Memory) > 0 {

--- a/crypto/bn256/cloudflare/curve.go
+++ b/crypto/bn256/cloudflare/curve.go
@@ -2,6 +2,7 @@ package bn256
 
 import (
 	"math/big"
+	"slices"
 )
 
 // curvePoint implements the elliptic curve y²=x³+3. Points are kept in Jacobian
@@ -195,12 +196,12 @@ func (c *curvePoint) Mul(a *curvePoint, scalar *big.Int) {
 	sum.SetInfinity()
 	t := &curvePoint{}
 
-	for i := len(multiScalar) - 1; i >= 0; i-- {
+	for _, m := range slices.Backward(multiScalar) {
 		t.Double(sum)
-		if multiScalar[i] == 0 {
+		if m == 0 {
 			sum.Set(t)
 		} else {
-			sum.Add(t, precomp[multiScalar[i]])
+			sum.Add(t, precomp[m])
 		}
 	}
 	c.Set(sum)

--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -875,14 +876,14 @@ func (d *Downloader) findAncestor(p *peerConnection, height uint64) (uint64, err
 			}
 			// Check if a common ancestor was found
 			finished = true
-			for i := len(headers) - 1; i >= 0; i-- {
+			for i, header := range slices.Backward(headers) {
 				// Skip any headers that underflow/overflow our requested set
-				if headers[i].Number.Int64() < from || headers[i].Number.Uint64() > ceil {
+				if header.Number.Int64() < from || header.Number.Uint64() > ceil {
 					continue
 				}
 				// Otherwise check if we already know the header or not
-				if (mode == FullSync && d.blockchain.HasBlock(headers[i].Hash(), headers[i].Number.Uint64())) || (mode != FullSync && d.lightchain.HasHeader(headers[i].Hash(), headers[i].Number.Uint64())) {
-					number, hash = headers[i].Number.Uint64(), headers[i].Hash()
+				if (mode == FullSync && d.blockchain.HasBlock(header.Hash(), header.Number.Uint64())) || (mode != FullSync && d.lightchain.HasHeader(header.Hash(), header.Number.Uint64())) {
+					number, hash = header.Number.Uint64(), header.Hash()
 
 					// If every header is known, even future ones, the peer straight out lied about its head
 					if number > height && i == limit-1 {

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -376,8 +377,8 @@ func (dl *downloadTester) CurrentHeader() *types.Header {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
-	for i := len(dl.ownHashes) - 1; i >= 0; i-- {
-		if header := dl.ownHeaders[dl.ownHashes[i]]; header != nil {
+	for _, v := range slices.Backward(dl.ownHashes) {
+		if header := dl.ownHeaders[v]; header != nil {
 			return header
 		}
 	}
@@ -389,8 +390,8 @@ func (dl *downloadTester) CurrentBlock() *types.Block {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
-	for i := len(dl.ownHashes) - 1; i >= 0; i-- {
-		if block := dl.ownBlocks[dl.ownHashes[i]]; block != nil {
+	for _, v := range slices.Backward(dl.ownHashes) {
+		if block := dl.ownBlocks[v]; block != nil {
 			if has, _ := dl.stateDb.HasTrieNode(block.Root().ExtendZero()); has {
 				return block
 			}
@@ -409,8 +410,8 @@ func (dl *downloadTester) CurrentFastBlock() *types.Block {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
-	for i := len(dl.ownHashes) - 1; i >= 0; i-- {
-		if block := dl.ownBlocks[dl.ownHashes[i]]; block != nil {
+	for _, v := range slices.Backward(dl.ownHashes) {
+		if block := dl.ownBlocks[v]; block != nil {
 			return block
 		}
 	}
@@ -539,15 +540,15 @@ func (dl *downloadTester) Rollback(hashes []common.Hash) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 
-	for i := len(hashes) - 1; i >= 0; i-- {
-		if dl.ownHashes[len(dl.ownHashes)-1] == hashes[i] {
+	for _, hash := range slices.Backward(hashes) {
+		if dl.ownHashes[len(dl.ownHashes)-1] == hashe {
 			dl.ownHashes = dl.ownHashes[:len(dl.ownHashes)-1]
 		}
-		delete(dl.ownChainTd, hashes[i])
-		delete(dl.ownHeaders, hashes[i])
-		delete(dl.ownReceipts, hashes[i])
-		delete(dl.ownBlocks, hashes[i])
-		delete(dl.ownStakingInfo, hashes[i])
+		delete(dl.ownChainTd, hashe)
+		delete(dl.ownHeaders, hashe)
+		delete(dl.ownReceipts, hashe)
+		delete(dl.ownBlocks, hashe)
+		delete(dl.ownStakingInfo, hashe)
 	}
 }
 

--- a/datasync/fetcher/fetcher_test.go
+++ b/datasync/fetcher/fetcher_test.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"maps"
 	"math/big"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -449,9 +450,9 @@ func testRandomArrivalImport(t *testing.T, protocol int) {
 	imported := make(chan *types.Block, len(hashes)-1)
 	tester.fetcher.importedHook = func(block *types.Block) { imported <- block }
 
-	for i := len(hashes) - 1; i >= 0; i-- {
+	for i, hash := range slices.Backward(hashes) {
 		if i != skip {
-			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+			tester.fetcher.Notify("valid", hashe, uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
 			time.Sleep(time.Millisecond)
 		}
 	}
@@ -482,9 +483,9 @@ func testQueueGapFill(t *testing.T, protocol int) {
 	imported := make(chan *types.Block, len(hashes)-1)
 	tester.fetcher.importedHook = func(block *types.Block) { imported <- block }
 
-	for i := len(hashes) - 1; i >= 0; i-- {
+	for i, hash := range slices.Backward(hashes) {
 		if i != skip {
-			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+			tester.fetcher.Notify("valid", hashe, uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
 			time.Sleep(time.Millisecond)
 		}
 	}

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -31,6 +31,7 @@ import (
 	"io"
 	"math/big"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -121,8 +122,8 @@ func (err *decodeError) Error() string {
 	ctx := ""
 	if len(err.ctx) > 0 {
 		ctx = ", decoding into "
-		for i := len(err.ctx) - 1; i >= 0; i-- {
-			ctx += err.ctx[i]
+		for _, v := range slices.Backward(err.ctx) {
+			ctx += v
 		}
 	}
 	return fmt.Sprintf("rlp: %s for %v%s", err.msg, err.typ, ctx)

--- a/storage/database/db_manager.go
+++ b/storage/database/db_manager.go
@@ -2915,10 +2915,10 @@ func (dbm *databaseManager) ReadGovernanceAtNumber(num uint64, epoch uint64) (ui
 		minimum -= epoch
 	}
 	totalIdx, _ := dbm.ReadRecentGovernanceIdx(0)
-	for i := len(totalIdx) - 1; i >= 0; i-- {
-		if totalIdx[i] <= minimum {
-			result, err := dbm.ReadGovernance(totalIdx[i])
-			return totalIdx[i], result, err
+	for _, t := range slices.Backward(totalIdx) {
+		if t <= minimum {
+			result, err := dbm.ReadGovernance(t)
+			return t, result, err
 		}
 	}
 	return 0, nil, errors.New("No governance data found")


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward) added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see https://github.com/golang/go/issues/61899


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
