### PR TITLE
vm: add CLZ computation cost

### DIFF
--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -408,6 +408,10 @@ func enableCancunComputationCostModification(jt *JumpTable) {
 	jt[LOG4].computationCost = params.Log4ComputationCostCancun
 }
 
+func enablePermissionlessComputationCostModification(jt *JumpTable) {
+	jt[CLZ].computationCost = params.ClzComputationCost
+}
+
 func ChangeGasCostForTest(jt *JumpTable) {
 	// EIP-1052 must be activated for backward compatibility on Kaia. But EIP-2929 is activated instead of it on Ethereum
 	jt[EXTCODEHASH].constantGas = params.WarmStorageReadCostEIP2929

--- a/blockchain/vm/instructions_test.go
+++ b/blockchain/vm/instructions_test.go
@@ -704,6 +704,11 @@ func BenchmarkOpIsZero(b *testing.B) {
 	opBenchmark(b, opIszero, x)
 }
 
+func BenchmarkOpCLZ(b *testing.B) {
+	x := "FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"
+	opBenchmark(b, opCLZ, x)
+}
+
 func TestOpMstore(t *testing.T) {
 	var (
 		env            = NewEVM(BlockContext{}, TxContext{}, nil, params.TestChainConfig, &Config{})

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -104,6 +104,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	if cfg.JumpTable[STOP] == nil {
 		var jt JumpTable
 		switch {
+		case evm.chainRules.IsPermissionless:
+			jt = PermissionlessInstructionSet
 		case evm.chainRules.IsOsaka:
 			jt = OsakaInstructionSet
 		case evm.chainRules.IsPrague:

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -64,11 +64,18 @@ var (
 	ShanghaiInstructionSet       = newShanghaiInstructionSet()
 	CancunInstructionSet         = newCancunInstructionSet()
 	PragueInstructionSet         = newPragueInstructionSet()
+	PermissionlessInstructionSet = newPermissionlessInstructionSet()
 	OsakaInstructionSet          = newOsakaInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]*operation
+
+func newPermissionlessInstructionSet() JumpTable {
+	instructionSet := newOsakaInstructionSet()
+	enablePermissionlessComputationCostModification(&instructionSet)
+	return instructionSet
+}
 
 func newOsakaInstructionSet() JumpTable {
 	instructionSet := newPragueInstructionSet()

--- a/params/computation_cost_params.go
+++ b/params/computation_cost_params.go
@@ -212,7 +212,11 @@ const (
 	Bls12381MapG1ComputationCost          = 275000
 	Bls12381MapG2ComputationCost          = 1190000
 
+	// computation cost added at OsakaCompatible
 	P256VerifyComputationCost = 235000
+
+	// computation cost added at PermissionlessCompatible
+	ClzComputationCost = 165
 
 	OpcodeComputationCostLimit         = 100000000      // 100ms
 	OpcodeComputationCostLimitCancun   = 150000000      // 150ms


### PR DESCRIPTION
## Proposed changes

This PR adds computation cost at CLZ opcode. It will be activated after permissionless hardfork.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
