### PR TITLE
blockchain/vm: fix typo in opCLZ comment (bytes -> bits)

### DIFF
--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -341,7 +341,7 @@ func opBlobBaseFee(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	return nil, nil
 }
 
-// opCLZ implements the CLZ opcode (count leading zero bytes)
+// opCLZ implements the CLZ opcode (count leading zero bits)
 func opCLZ(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	x := scope.Stack.peek()
 	x.SetUint64(256 - uint64(x.BitLen()))

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -64,8 +64,8 @@ var (
 	ShanghaiInstructionSet       = newShanghaiInstructionSet()
 	CancunInstructionSet         = newCancunInstructionSet()
 	PragueInstructionSet         = newPragueInstructionSet()
-	PermissionlessInstructionSet = newPermissionlessInstructionSet()
 	OsakaInstructionSet          = newOsakaInstructionSet()
+	PermissionlessInstructionSet = newPermissionlessInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.


### PR DESCRIPTION
## Proposed changes

- Fix a typo in the `opCLZ` comment: `bytes` → `bits`
- Reorder `InstructionSet` vars in chronological fork order (`OsakaInstructionSet` before `PermissionlessInstructionSet`)

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

PR #916