### PR TITLE
txpool: introduce txpool optimizations

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1326,9 +1326,7 @@ func (pool *TxPool) HandleTxMsg(txs types.Transactions) {
 	// Filter spam txs based on to-address of failed txs
 	spamThrottler := GetSpamThrottler()
 	if spamThrottler != nil {
-		pool.mu.RLock()
 		poolSize := uint64(pool.all.Count())
-		pool.mu.RUnlock()
 
 		// Activate spam throttler when pool has enough txs
 		if poolSize > uint64(spamThrottler.config.ActivateTxPoolSize) {
@@ -1464,10 +1462,7 @@ func (pool *TxPool) AddLocal(tx *types.Transaction) error {
 		return errNotAllowedAnchoringTx
 	}
 
-	pool.mu.RLock()
-	poolSize := uint64(pool.all.Count())
-	pool.mu.RUnlock()
-	if poolSize >= pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll {
+	if poolSize := uint64(pool.all.Count()); poolSize >= pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll {
 		return fmt.Errorf("txpool is full: %d", poolSize)
 	}
 	return pool.addTx(tx, !pool.config.NoLocals)
@@ -1498,9 +1493,7 @@ func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
 // If given transactions exceed the capacity of TxPool, it slices the given transactions
 // so it can fit into TxPool's capacity.
 func (pool *TxPool) checkAndAddTxs(txs []*types.Transaction, local bool) []error {
-	pool.mu.RLock()
 	poolSize := uint64(pool.all.Count())
-	pool.mu.RUnlock()
 	poolCapacity := int(pool.config.ExecSlotsAll + pool.config.NonExecSlotsAll - poolSize)
 	numTxs := len(txs)
 

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -251,6 +251,11 @@ type TxPool struct {
 	all     *txLookup                    // All transactions to allow lookups
 	priced  *txPricedList                // All transactions sorted by price
 
+	// Running totals of |pending| and |queue| txs across all senders.
+	// Protected by the same locks as pending/queue.
+	pendingCount uint64
+	queuedCount  uint64
+
 	wg sync.WaitGroup // for shutdown sync
 
 	txMsgCh  chan types.Transactions // A buffer for async tx intake via AddRemotes
@@ -640,6 +645,8 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 		pool.gasPrice = price
 		pool.pending = make(map[common.Address]*txList)
 		pool.queue = make(map[common.Address]*txList)
+		pool.pendingCount = 0
+		pool.queuedCount = 0
 		pool.beats = make(map[common.Address]time.Time)
 		pool.all = newTxLookup()
 		pool.pendingNonce = make(map[common.Address]uint64)
@@ -1250,6 +1257,8 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 		pool.all.Remove(old.Hash())
 		pool.priced.Removed()
 		queuedReplaceCounter.Inc(1)
+	} else {
+		pool.queuedCount++
 	}
 	if pool.all.Get(hash) == nil {
 		pool.all.Add(tx)
@@ -1303,6 +1312,8 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 		pool.priced.Removed()
 
 		pendingReplaceCounter.Inc(1)
+	} else {
+		pool.pendingCount++
 	}
 	// Failsafe to work around direct pending inserts (tests)
 	if pool.all.Get(hash) == nil {
@@ -1656,11 +1667,13 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 	// Remove the transaction from the pending lists and reset the account nonce
 	if pending := pool.pending[addr]; pending != nil {
 		if removed, invalids := pending.Remove(tx); removed {
+			// strict-mode Remove also strips invalidated higher-nonce txs from pending.
+			pool.pendingCount -= uint64(1 + len(invalids))
 			// If no more pending transactions are left, remove the list
 			if pending.Empty() {
 				delete(pool.pending, addr)
 			}
-			// Postpone any invalidated transactions
+			// Postpone any invalidated transactions (re-enqueue bumps queuedCount).
 			for _, tx := range invalids {
 				pool.enqueueTx(tx.Hash(), tx)
 			}
@@ -1670,7 +1683,9 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 	}
 	// Transaction is in the future queue
 	if future := pool.queue[addr]; future != nil {
-		future.Remove(tx)
+		if removed, _ := future.Remove(tx); removed {
+			pool.queuedCount--
+		}
 		if future.Empty() {
 			delete(pool.queue, addr)
 		}
@@ -1701,14 +1716,18 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			continue // Just in case someone calls with a non existing account
 		}
 		// Drop all transactions that are deemed too old (low nonce)
-		for _, tx := range list.Forward(pool.getNonce(addr)) {
+		forwarded := list.Forward(pool.getNonce(addr))
+		pool.queuedCount -= uint64(len(forwarded))
+		for _, tx := range forwarded {
 			hash := tx.Hash()
 			logger.Trace("Removed old queued transaction", "hash", hash)
 			pool.all.Remove(hash)
 			pool.priced.Removed()
 		}
-		// Drop all transactions that are too costly (low balance)
+		// Drop all transactions that are too costly (low balance). Queue is non-strict
+		// so the second return value is always empty.
 		drops, _ := list.Filter(addr, pool)
+		pool.queuedCount -= uint64(len(drops))
 		for _, tx := range drops {
 			hash := tx.Hash()
 			logger.Trace("Removed unpayable queued transaction", "hash", hash)
@@ -1717,13 +1736,15 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			queuedNofundsCounter.Inc(1)
 		}
 
-		// Gather all executable transactions and promote them
+		// Gather all executable transactions and promote them. Ready / ReadyWithGasPrice
+		// already removed them from the queue list.
 		var readyTxs types.Transactions
 		if pool.rules.IsMagma {
 			readyTxs = list.ReadyWithGasPrice(pool.getPendingNonce(addr), pool.gasPrice, pool.modules)
 		} else {
 			readyTxs = list.Ready(pool.getPendingNonce(addr))
 		}
+		pool.queuedCount -= uint64(len(readyTxs))
 		for _, tx := range readyTxs {
 			hash := tx.Hash()
 			if pool.promoteTx(addr, hash, tx) {
@@ -1734,7 +1755,9 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 
 		// Drop all transactions over the allowed limit
 		if !pool.locals.contains(addr) {
-			for _, tx := range list.Cap(int(pool.config.NonExecSlotsAccount)) {
+			capped := list.Cap(int(pool.config.NonExecSlotsAccount))
+			pool.queuedCount -= uint64(len(capped))
+			for _, tx := range capped {
 				hash := tx.Hash()
 				pool.all.Remove(hash)
 				pool.priced.Removed()
@@ -1751,11 +1774,9 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 	if len(promoted) > 0 {
 		pool.txFeedCh <- promoted
 	}
-	// If the pending limit is overflown, start equalizing allowances
-	pending := uint64(0)
-	for _, list := range pool.pending {
-		pending += uint64(list.Len())
-	}
+	// If the pending limit is overflown, start equalizing allowances. The running
+	// total is maintained incrementally so this is O(1) instead of O(N_senders).
+	pending := pool.pendingCount
 
 	if pending > pool.config.ExecSlotsAll {
 		pendingBeforeCap := pending
@@ -1783,7 +1804,9 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 				for pending > pool.config.ExecSlotsAll && pool.pending[offenders[len(offenders)-2]].Len() > threshold {
 					for i := 0; i < len(offenders)-1; i++ {
 						list := pool.pending[offenders[i]]
-						for _, tx := range list.Cap(list.Len() - 1) {
+						capped := list.Cap(list.Len() - 1)
+						pool.pendingCount -= uint64(len(capped))
+						for _, tx := range capped {
 							// Drop the transaction from the global pools too
 							hash := tx.Hash()
 							pool.all.Remove(hash)
@@ -1803,7 +1826,9 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			for pending > pool.config.ExecSlotsAll && uint64(pool.pending[offenders[len(offenders)-1]].Len()) > pool.config.ExecSlotsAccount {
 				for _, addr := range offenders {
 					list := pool.pending[addr]
-					for _, tx := range list.Cap(list.Len() - 1) {
+					capped := list.Cap(list.Len() - 1)
+					pool.pendingCount -= uint64(len(capped))
+					for _, tx := range capped {
 						// Drop the transaction from the global pools too
 						hash := tx.Hash()
 						pool.all.Remove(hash)
@@ -1819,11 +1844,9 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 		}
 		pendingRateLimitCounter.Inc(int64(pendingBeforeCap - pending))
 	}
-	// If we've queued more transactions than the hard limit, drop oldest ones
-	queued := uint64(0)
-	for _, list := range pool.queue {
-		queued += uint64(list.Len())
-	}
+	// If we've queued more transactions than the hard limit, drop oldest ones.
+	// Read the incrementally maintained running total instead of summing every list.
+	queued := pool.queuedCount
 
 	if queued > pool.config.NonExecSlotsAll {
 		// Sort all accounts with queued transactions by heartbeat
@@ -1877,7 +1900,9 @@ func (pool *TxPool) demoteUnexecutables() {
 		var drops, invalids types.Transactions
 
 		// Drop all transactions that are deemed too old (low nonce)
-		for _, tx := range list.Forward(nonce) {
+		forwarded := list.Forward(nonce)
+		pool.pendingCount -= uint64(len(forwarded))
+		for _, tx := range forwarded {
 			hash := tx.Hash()
 			logger.Trace("Removed old pending transaction", "hash", hash)
 			pool.all.Remove(hash)
@@ -1892,6 +1917,9 @@ func (pool *TxPool) demoteUnexecutables() {
 		} else {
 			drops, invalids = list.FilterUnexecutable()
 		}
+		// Filter / FilterUnexecutable strip both drops and invalids from the pending
+		// list. Invalids are re-enqueued to the queue below (queuedCount bumps via enqueueTx).
+		pool.pendingCount -= uint64(len(drops) + len(invalids))
 
 		// Drop all transactions that are unexecutable, and queue any invalids back for later
 		for _, tx := range drops {
@@ -1909,7 +1937,9 @@ func (pool *TxPool) demoteUnexecutables() {
 		}
 		// If there's a gap in front, warn (should never happen) and postpone all transactions
 		if list.Len() > 0 && list.txs.Get(nonce) == nil {
-			for _, tx := range list.Cap(0) {
+			capped := list.Cap(0)
+			pool.pendingCount -= uint64(len(capped))
+			for _, tx := range capped {
 				hash := tx.Hash()
 				logger.Error("Demoting invalidated transaction", "hash", hash)
 				pool.enqueueTx(hash, tx)
@@ -1925,6 +1955,9 @@ func (pool *TxPool) demoteUnexecutables() {
 					logger.Trace("Demoting the tx that is lower than the baseFee and those greater than the nonce of the tx.", "txhash", hash)
 					removed, invalids := list.Remove(tx) // delete all transactions satisfying the nonce value > tx.Nonce()
 					if removed {
+						// Both `tx` and `invalids` were stripped from pending; the re-enqueue
+						// below bumps queuedCount per tx via enqueueTx.
+						pool.pendingCount -= uint64(1 + len(invalids))
 						for _, invalidTx := range invalids {
 							pool.enqueueTx(invalidTx.Hash(), invalidTx)
 						}
@@ -2282,5 +2315,7 @@ func (pool *TxPool) Clear() {
 	pool.priced = newTxPricedList(pool.all)
 	pool.pending = make(map[common.Address]*txList)
 	pool.queue = make(map[common.Address]*txList)
+	pool.pendingCount = 0
+	pool.queuedCount = 0
 	pool.pendingNonce = make(map[common.Address]uint64)
 }

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -706,7 +706,7 @@ func (pool *TxPool) Pending() (map[common.Address]types.Transactions, error) {
 
 // pendingUnlocked must be protected by pool.mu AND pool.txMu by the caller.
 func (pool *TxPool) pendingUnlocked() (map[common.Address]types.Transactions, error) {
-	pending := make(map[common.Address]types.Transactions)
+	pending := make(map[common.Address]types.Transactions, len(pool.pending))
 	for addr, list := range pool.pending {
 		pending[addr] = list.Flatten()
 	}
@@ -715,7 +715,7 @@ func (pool *TxPool) pendingUnlocked() (map[common.Address]types.Transactions, er
 
 // queueUnlocked must be protected by pool.mu AND pool.txMu by the caller.
 func (pool *TxPool) queueUnlocked() (map[common.Address]types.Transactions, error) {
-	queue := make(map[common.Address]types.Transactions)
+	queue := make(map[common.Address]types.Transactions, len(pool.queue))
 	for addr, list := range pool.queue {
 		queue[addr] = list.Flatten()
 	}
@@ -1493,6 +1493,12 @@ func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
 // If given transactions exceed the capacity of TxPool, it slices the given transactions
 // so it can fit into TxPool's capacity.
 func (pool *TxPool) checkAndAddTxs(txs []*types.Transaction, local bool) []error {
+	// Single-tx fast path: bypass the slot pre-check so add()'s existing
+	// missing-nonce admission can run even when the pool is at cap.
+	if len(txs) == 1 {
+		return []error{pool.addTx(txs[0], local)}
+	}
+
 	poolSize := uint64(pool.all.Count())
 	poolCapacity := int(pool.config.ExecSlotsAll + pool.config.NonExecSlotsAll - poolSize)
 	numTxs := len(txs)

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -56,11 +56,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	// testTxPoolConfig is a transaction pool configuration without stateful disk
-	// sideeffects used during testing.
-	testTxPoolConfig TxPoolConfig
-)
+// testTxPoolConfig is a transaction pool configuration without stateful disk
+// sideeffects used during testing.
+var testTxPoolConfig TxPoolConfig
 
 type dummyGovModule struct {
 	chainConfig *params.ChainConfig
@@ -4348,5 +4346,257 @@ func TestTxPool_saveAndPruneBlobStorage(t *testing.T) {
 			}
 			tc.verify(t, pool, block)
 		})
+	}
+}
+
+// sumPendingQueued recomputes pendingCount/queuedCount from the source-of-truth
+// per-sender lists. It runs under pool.mu RLock to keep the snapshot consistent.
+func sumPendingQueued(pool *TxPool) (uint64, uint64) {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+	pool.txMu.RLock()
+	defer pool.txMu.RUnlock()
+	var p, q uint64
+	for _, list := range pool.pending {
+		p += uint64(list.Len())
+	}
+	for _, list := range pool.queue {
+		q += uint64(list.Len())
+	}
+	return p, q
+}
+
+func assertCountsMatch(t *testing.T, pool *TxPool, label string) {
+	t.Helper()
+	wantP, wantQ := sumPendingQueued(pool)
+	pool.mu.RLock()
+	gotP, gotQ := pool.pendingCount, pool.queuedCount
+	pool.mu.RUnlock()
+	if gotP != wantP {
+		t.Fatalf("%s: pendingCount drift: counter=%d actual=%d", label, gotP, wantP)
+	}
+	if gotQ != wantQ {
+		t.Fatalf("%s: queuedCount drift: counter=%d actual=%d", label, gotQ, wantQ)
+	}
+}
+
+// largeCapTxPool wires a TxPool with high slot caps so multi-sender benchmarks
+// don't trip the global limit before the workload begins.
+func largeCapTxPool(execAll, nonExecAll uint64) *TxPool {
+	cfg := testTxPoolConfig
+	cfg.ExecSlotsAll = execAll
+	cfg.NonExecSlotsAll = nonExecAll
+	cfg.ExecSlotsAccount = 64
+	cfg.NonExecSlotsAccount = 64
+
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	chain := &testBlockChain{
+		statedb:       statedb,
+		gasLimit:      1_000_000_000,
+		chainHeadFeed: new(event.Feed),
+		txMap:         make(map[common.Hash]*types.Transaction),
+	}
+	return NewTxPool(cfg, params.TestChainConfig, chain, &dummyGovModule{chainConfig: params.TestChainConfig})
+}
+
+// TestTxPoolPendingQueuedCountInvariant exercises the full mutation surface of
+// pool.pending / pool.queue and checks the running counters track the actual
+// per-sender list sums after every operation. Covers: queue inserts, pending
+// promotion via reset, replacement, eviction by balance drop, gap-induced
+// demotion, removeTx, cap-overflow (per-account + global), GasPrice reset,
+// and Clear.
+func TestTxPoolPendingQueuedCountInvariant(t *testing.T) {
+	t.Parallel()
+
+	cfg := testTxPoolConfig
+	cfg.ExecSlotsAll = 256
+	cfg.NonExecSlotsAll = 64
+	cfg.ExecSlotsAccount = 8
+	cfg.NonExecSlotsAccount = 8
+
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	chain := &testBlockChain{
+		statedb:       statedb,
+		gasLimit:      1_000_000_000,
+		chainHeadFeed: new(event.Feed),
+		txMap:         make(map[common.Hash]*types.Transaction),
+	}
+	pool := NewTxPool(cfg, params.TestChainConfig, chain, &dummyGovModule{chainConfig: params.TestChainConfig})
+	defer pool.Stop()
+	assertCountsMatch(t, pool, "init")
+
+	const numKeys = 80
+	keys := make([]*ecdsa.PrivateKey, numKeys)
+	accs := make([]common.Address, numKeys)
+	for i := range keys {
+		keys[i], _ = crypto.GenerateKey()
+		accs[i] = crypto.PubkeyToAddress(keys[i].PublicKey)
+		testAddBalance(pool, accs[i], new(big.Int).Mul(big.NewInt(1_000_000_000), big.NewInt(1_000_000)))
+	}
+
+	rng := rand.New(rand.NewSource(0xC0FFEE))
+
+	// Phase 1: contiguous-nonce inserts from many senders — they should all flow
+	// straight into pending after the addTx promotion pass.
+	for i, key := range keys {
+		for n := 0; n < 3; n++ {
+			tx := transaction(uint64(n), 21000, key)
+			if err := pool.AddRemote(tx); err != nil {
+				t.Fatalf("phase1 sender %d nonce %d: %v", i, n, err)
+			}
+		}
+	}
+	assertCountsMatch(t, pool, "phase1 contiguous adds")
+
+	// Phase 2: gapped-nonce inserts that should land in queue.
+	for i, key := range keys[:numKeys/2] {
+		tx := transaction(uint64(10+rng.Intn(4)), 21000, key)
+		if err := pool.AddRemote(tx); err != nil {
+			t.Fatalf("phase2 sender %d: %v", i, err)
+		}
+	}
+	assertCountsMatch(t, pool, "phase2 gapped adds")
+
+	// Phase 3: replacements (same nonce, higher price for the eth-replace path).
+	for i, key := range keys[:10] {
+		tx := pricedTransaction(0, 21000, big.NewInt(2), key)
+		// Replacement may return ErrAlreadyNonceExistInPool if priceBump not met;
+		// pre-Magma config requires strictly higher gasPrice, which 2>1 satisfies.
+		_ = pool.AddRemote(tx)
+		_ = i
+	}
+	assertCountsMatch(t, pool, "phase3 replacements")
+
+	// Phase 4: state-nonce bump triggers demoteUnexecutables on next reset, which
+	// strips low-nonce pending txs and may push trailing ones back to queue.
+	for _, addr := range accs[:numKeys/4] {
+		testSetNonce(pool, addr, 2)
+	}
+	pool.lockedReset(nil, nil)
+	assertCountsMatch(t, pool, "phase4 nonce bump + reset")
+
+	// Phase 5: balance crash on some senders — Filter() drops in promote/demote.
+	for _, addr := range accs[numKeys/4 : numKeys/2] {
+		pool.mu.Lock()
+		pool.currentState.SetBalance(addr, big.NewInt(0))
+		pool.mu.Unlock()
+	}
+	pool.lockedReset(nil, nil)
+	assertCountsMatch(t, pool, "phase5 balance crash + reset")
+
+	// Phase 6: direct removeTx for some still-alive hashes — exercises both the
+	// pending strict-Remove (with invalidated trailing txs) and the queue branch.
+	pool.mu.Lock()
+	victims := []common.Hash{}
+	for _, addr := range accs {
+		if list := pool.pending[addr]; list != nil {
+			for _, tx := range list.Flatten() {
+				if rng.Intn(4) == 0 {
+					victims = append(victims, tx.Hash())
+				}
+			}
+		}
+		if list := pool.queue[addr]; list != nil {
+			for _, tx := range list.Flatten() {
+				if rng.Intn(3) == 0 {
+					victims = append(victims, tx.Hash())
+				}
+			}
+		}
+	}
+	for _, h := range victims {
+		pool.removeTx(h, true)
+	}
+	pool.mu.Unlock()
+	assertCountsMatch(t, pool, "phase6 removeTx")
+
+	// Phase 7: per-account cap-overflow — load >ExecSlotsAccount contiguous txs
+	// from one fresh sender. The per-account cap fires inside promoteExecutables
+	// for the queue side via list.Cap(NonExecSlotsAccount).
+	bulkKey, _ := crypto.GenerateKey()
+	bulkAddr := crypto.PubkeyToAddress(bulkKey.PublicKey)
+	testAddBalance(pool, bulkAddr, new(big.Int).Mul(big.NewInt(1_000_000_000), big.NewInt(1_000_000)))
+	for n := 0; n < int(cfg.NonExecSlotsAccount)+20; n++ {
+		// Use a nonce gap so they pile into the queue, not pending.
+		_ = pool.AddRemote(transaction(uint64(100+n), 21000, bulkKey))
+	}
+	assertCountsMatch(t, pool, "phase7 per-account cap")
+
+	// Phase 8: global cap-overflow — keep pumping fresh senders until
+	// ExecSlotsAll trips and the spammer-equalize path runs.
+	for i := 0; i < 200; i++ {
+		k, _ := crypto.GenerateKey()
+		a := crypto.PubkeyToAddress(k.PublicKey)
+		testAddBalance(pool, a, new(big.Int).Mul(big.NewInt(1_000_000_000), big.NewInt(1_000_000)))
+		for n := 0; n < 4; n++ {
+			_ = pool.AddRemote(transaction(uint64(n), 21000, k))
+		}
+	}
+	assertCountsMatch(t, pool, "phase8 global cap")
+
+	// Phase 9: SetGasPrice on a non-Magma chain wipes the pool entirely.
+	pool.SetGasPrice(big.NewInt(1000000))
+	assertCountsMatch(t, pool, "phase9 SetGasPrice")
+
+	// Phase 10: Clear() must zero both counters.
+	for n := 0; n < 5; n++ {
+		_ = pool.AddRemote(pricedTransaction(uint64(n), 21000, big.NewInt(1000000), keys[0]))
+	}
+	pool.Clear()
+	assertCountsMatch(t, pool, "phase10 Clear")
+}
+
+// BenchmarkAddTxManySenders measures addTx cost when the pool already holds
+// txs from many senders. With the O(N_senders) sum gone from promoteExecutables,
+// per-op time should be roughly flat across N. Without the fix it scales linearly.
+func BenchmarkAddTxManySenders1k(b *testing.B)   { benchmarkAddTxManySenders(b, 1_000) }
+func BenchmarkAddTxManySenders10k(b *testing.B)  { benchmarkAddTxManySenders(b, 10_000) }
+func BenchmarkAddTxManySenders100k(b *testing.B) { benchmarkAddTxManySenders(b, 100_000) }
+
+func benchmarkAddTxManySenders(b *testing.B, numSenders int) {
+	pool := largeCapTxPool(uint64(numSenders*4), uint64(numSenders*4))
+	defer pool.Stop()
+
+	// Preload pool.pending with one tx from each of numSenders different senders.
+	// Use promoteTx + currentState fiddling directly to keep preload time bounded;
+	// going through AddRemote would also pay O(N_senders) per preload step.
+	pool.mu.Lock()
+	for i := 0; i < numSenders; i++ {
+		key, _ := crypto.GenerateKey()
+		addr := crypto.PubkeyToAddress(key.PublicKey)
+		pool.currentState.AddBalance(addr, new(big.Int).Mul(big.NewInt(1_000_000_000), big.NewInt(1_000_000)))
+		tx := transaction(0, 21000, key)
+		pool.all.Add(tx)
+		pool.priced.Put(tx)
+		pool.promoteTx(addr, tx.Hash(), tx)
+	}
+	pool.mu.Unlock()
+
+	// Dedicated sender we'll spam addTx from; nonce advances each iteration.
+	senderKey, _ := crypto.GenerateKey()
+	senderAddr := crypto.PubkeyToAddress(senderKey.PublicKey)
+	testAddBalance(pool, senderAddr, new(big.Int).Mul(big.NewInt(1_000_000_000), big.NewInt(1_000_000)))
+
+	txs := make([]*types.Transaction, b.N)
+	for i := range txs {
+		txs[i] = transaction(uint64(i), 21000, senderKey)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := pool.AddRemote(txs[i]); err != nil {
+			b.Fatalf("AddRemote %d: %v", i, err)
+		}
+	}
+	b.StopTimer()
+
+	// Post-bench correctness sanity check on the counters.
+	wantP, wantQ := sumPendingQueued(pool)
+	pool.mu.RLock()
+	gotP, gotQ := pool.pendingCount, pool.queuedCount
+	pool.mu.RUnlock()
+	if gotP != wantP || gotQ != wantQ {
+		b.Fatalf("counter drift after bench: pending counter=%d actual=%d, queued counter=%d actual=%d",
+			gotP, wantP, gotQ, wantQ)
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces multiple txpool optimizations.

- Remove redundant lock for txLookup
- Do not drop nonce-gap filling txs from remote peers
- Track pending/queue counts to avoid expensive re-calculation

## Benchmark

`BenchmarkAddTxManySenders`

| Preloaded senders (N) | Before (ns/op) | After (ns/op) | Speedup |    Δ |
| --------------------- | -------------: | ------------: | ------: | ---: |
| 1,000                 |         48,372 |        39,558 |   1.22× | −18% |
| 10,000                |        138,587 |        39,031 |   3.55× | −72% |
| 100,000               |      4,045,756 |        42,515 |   95.2× | −99% |

## Stress test

- 4 CN, 4 PN, 4 EN networks
- 8k RPS, 10k users

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| On-chain TPS | 3,977 | 5,610 | +41% |
| Tx in a block (avg) | ≈ 4.0 K | ≈ 6.0 K | +50% |
| Pending tx in CN | 3,846 | 12,720 | +231% |
| Locust latency — p50 | 9 ms | 5 ms | −44% |
| Locust latency — p95 | 12 ms | 10 ms | −17% |
| Locust latency — p99 | 78 ms | 81 ms | ~flat |
| Locust latency — avg | 9 ms | 8 ms | −11% |
| Failure rate (`txpool is full`) | 43.2% | 29.3% | −13.9 pp |
| Locust aggregate RPS | 7,391.8 | 7,229.9 | ~flat |
| Block interval | 1.000 s | 0.998 s | ~flat |

<details><summary>Before (latest dev)</summary>

<img width="1784" height="1274" alt="image" src="https://github.com/user-attachments/assets/ca8e3073-d286-415f-8f58-0b1436a1e5f7" />

<img width="1015" height="882" alt="image" src="https://github.com/user-attachments/assets/8bb121ca-f4a5-4ca3-834f-8c18a1b165c5" />

<img width="523" height="249" alt="image" src="https://github.com/user-attachments/assets/eee1c949-e814-4e15-b017-0860d7494089" />

<img width="530" height="248" alt="image" src="https://github.com/user-attachments/assets/5de29a30-bb2c-4590-a115-26dfd39606a1" />

<img width="1348" height="1597" alt="image" src="https://github.com/user-attachments/assets/72b40efc-87b2-4ef7-9bdf-f816770b382f" />

</details>

<details><summary>After (PR)</summary>

<img width="1784" height="1263" alt="image" src="https://github.com/user-attachments/assets/f9d93f16-46a0-4f3e-9740-c8209bbd58b9" />

<img width="1009" height="877" alt="image" src="https://github.com/user-attachments/assets/2eeaff8c-ca60-4c14-8772-a1ae699b27a9" />

<img width="324" height="256" alt="image" src="https://github.com/user-attachments/assets/62343701-7fa5-4c7c-bbd6-d19b44a63bf1" />

<img width="323" height="254" alt="image" src="https://github.com/user-attachments/assets/fe074289-63cb-45a6-bc9b-ce2e14db5f08" />

<img width="1345" height="1600" alt="image" src="https://github.com/user-attachments/assets/7e5fb327-b2c6-4ad4-a250-29fa41b580e6" />

</details>

<details><summary>TxPool comparison</summary>

<img width="320" height="254" alt="image" src="https://github.com/user-attachments/assets/bb5a8715-d127-4fc5-bb69-ba8d989aeba6" />

<img width="323" height="255" alt="image" src="https://github.com/user-attachments/assets/2b2f986a-efef-42f5-a7e1-96f7b6dde810" />

</details>

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
