### PR TITLE
api: add tracecall prestate diffmode

### DIFF
--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/kzg4844"
 	"github.com/kaiachain/kaia/kerrors"
 	"github.com/kaiachain/kaia/params"
@@ -471,6 +472,32 @@ func (st *StateTransition) preCheck() error {
 	return st.buyGas()
 }
 
+func (st *StateTransition) captureTxStartPreCheck() {
+	if !st.evm.Config.Debug {
+		return
+	}
+	tracer, ok := st.evm.Config.Tracer.(vm.TxPrestateTracer)
+	if !ok {
+		return
+	}
+
+	tx := st.msg
+	from := tx.ValidatedSender()
+	feePayer := tx.ValidatedFeePayer()
+	to := from
+	create := (tx.Type().IsEthereumTransaction() && tx.To() == nil) || tx.Type().IsContractDeploy()
+	if create {
+		if tx.To() != nil {
+			to = *tx.To()
+		} else {
+			to = crypto.CreateAddress(from, st.state.GetNonce(from))
+		}
+	} else if tx.To() != nil {
+		to = *tx.To()
+	}
+	tracer.CaptureTxStartPreCheck(st.evm, from, feePayer, to, create, tx.Data(), tx.Value())
+}
+
 // TransitionDb will transition the state by applying the current message and
 // returning the evm execution result with following fields.
 //
@@ -495,6 +522,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// 4. the purchased gas is enough to cover intrinsic usage
 	// 5. there is no overflow when calculating intrinsic gas
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
+
+	st.captureTxStartPreCheck()
 
 	// Check clauses 1-3, buy gas if everything is correct
 	if err := st.preCheck(); err != nil {

--- a/blockchain/state_transition.go
+++ b/blockchain/state_transition.go
@@ -495,7 +495,7 @@ func (st *StateTransition) captureTxStartPreCheck() {
 	} else if tx.To() != nil {
 		to = *tx.To()
 	}
-	tracer.CaptureTxStartPreCheck(st.evm, from, feePayer, to, create, tx.Data(), tx.Value())
+	tracer.CaptureTxStartPreCheck(st.evm, from, feePayer, to, create, tx.Data(), tx.Value(), tx.AuthList())
 }
 
 // TransitionDb will transition the state by applying the current message and

--- a/blockchain/vm/call_tracer.go
+++ b/blockchain/vm/call_tracer.go
@@ -19,6 +19,7 @@
 package vm
 
 import (
+	"encoding/json"
 	"errors"
 	"math/big"
 	"sync/atomic"
@@ -29,6 +30,14 @@ import (
 )
 
 var _ Tracer = (*CallTracer)(nil)
+
+type CallLog struct {
+	Address  common.Address `json:"address"`
+	Topics   []common.Hash  `json:"topics"`
+	Data     hexutil.Bytes  `json:"data"`
+	Index    hexutil.Uint   `json:"index"`
+	Position hexutil.Uint   `json:"position"`
+}
 
 //go:generate gencodec -type CallFrame -field-override callFrameMarshaling -out gen_callframe_json.go
 type CallFrame struct {
@@ -43,6 +52,7 @@ type CallFrame struct {
 	RevertReason string          `json:"revertReason,omitempty"` // decoded revert message in geth style.
 	Reverted     *RevertedInfo   `json:"reverted,omitempty"`     // decoded revert message and reverted contract address in klaytn style.
 	Calls        []CallFrame     `json:"calls,omitempty"`        // child calls
+	Logs         []CallLog       `json:"logs,omitempty"`
 	Value        *big.Int        `json:"value,omitempty"`
 }
 
@@ -93,6 +103,11 @@ type callFrameMarshaling struct {
 	Output     hexutil.Bytes
 }
 
+type CallTracerConfig struct {
+	OnlyTopCall bool `json:"onlyTopCall"`
+	WithLog     bool `json:"withLog"`
+}
+
 // Populate output, error, and revert-related fields
 // 1. no error: {output}
 // 2. non-revert error: {to: nil if CREATE, error}
@@ -131,7 +146,9 @@ func (c *CallFrame) processOutput(output []byte, err error) {
 // Implements vm.Tracer interface
 type CallTracer struct {
 	callstack       []CallFrame
+	config          CallTracerConfig
 	gasLimit        uint64 // saved tx.gasLimit
+	logIndex        uint
 	interrupt       atomic.Bool
 	interruptReason error
 }
@@ -140,6 +157,18 @@ func NewCallTracer() *CallTracer {
 	return &CallTracer{
 		callstack: make([]CallFrame, 1), // empty top-level frame
 	}
+}
+
+func NewCallTracerWithConfig(cfg json.RawMessage) (*CallTracer, error) {
+	var config CallTracerConfig
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &config); err != nil {
+			return nil, err
+		}
+	}
+	tracer := NewCallTracer()
+	tracer.config = config
+	return tracer, nil
 }
 
 // Transaction start
@@ -172,11 +201,14 @@ func (t *CallTracer) CaptureStart(env *EVM, from common.Address, to common.Addre
 func (t *CallTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {
 	// gasUsed will be filled by CaptureTxEnd; just process the output
 	t.callstack[0].processOutput(output, err)
+	if t.config.WithLog {
+		t.logIndex -= uint(clearFailedLogs(&t.callstack[0], false))
+	}
 }
 
 // Enter nested call frame
 func (t *CallTracer) CaptureEnter(typ OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
-	if t.interrupt.Load() {
+	if t.interrupt.Load() || t.config.OnlyTopCall {
 		return
 	}
 
@@ -203,6 +235,9 @@ func (t *CallTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	call := t.callstack[size-1]
 	call.GasUsed = gasUsed
 	call.processOutput(output, err)
+	if t.config.WithLog {
+		t.logIndex -= uint(clearFailedLogs(&call, false))
+	}
 
 	// pop current frame
 	t.callstack = t.callstack[:size-1]
@@ -213,6 +248,34 @@ func (t *CallTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 
 // Each opcode
 func (t *CallTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost, ccLeft, ccOpcode uint64, scope *ScopeContext, depth int, err error) {
+	if err != nil || !t.config.WithLog || t.interrupt.Load() {
+		return
+	}
+	if t.config.OnlyTopCall && depth > 0 {
+		return
+	}
+	if op < LOG0 || op > LOG4 || len(t.callstack) == 0 {
+		return
+	}
+	topics := int(op - LOG0)
+	stackData := scope.Stack.Data()
+	if len(stackData) < 2+topics {
+		return
+	}
+	mStart := stackData[len(stackData)-1].Uint64()
+	mSize := stackData[len(stackData)-2].Uint64()
+	log := CallLog{
+		Address:  scope.Contract.Address(),
+		Topics:   make([]common.Hash, topics),
+		Data:     scope.Memory.GetCopy(int64(mStart), int64(mSize)),
+		Index:    hexutil.Uint(t.logIndex),
+		Position: hexutil.Uint(len(t.callstack[len(t.callstack)-1].Calls)),
+	}
+	for i := 0; i < topics; i++ {
+		log.Topics[i] = stackData[len(stackData)-3-i].Bytes32()
+	}
+	t.callstack[len(t.callstack)-1].Logs = append(t.callstack[len(t.callstack)-1].Logs, log)
+	t.logIndex++
 }
 
 // Fault during opcode execution
@@ -233,4 +296,21 @@ func (t *CallTracer) GetResult() (CallFrame, error) {
 func (t *CallTracer) Stop(err error) {
 	t.interrupt.Store(true)
 	t.interruptReason = err
+}
+
+func (f *CallFrame) failed() bool {
+	return f.Error != ""
+}
+
+func clearFailedLogs(frame *CallFrame, parentFailed bool) int {
+	failed := parentFailed || frame.failed()
+	cleared := 0
+	if failed && len(frame.Logs) > 0 {
+		cleared += len(frame.Logs)
+		frame.Logs = nil
+	}
+	for i := range frame.Calls {
+		cleared += clearFailedLogs(&frame.Calls[i], failed)
+	}
+	return cleared
 }

--- a/blockchain/vm/gen_callframe_json.go
+++ b/blockchain/vm/gen_callframe_json.go
@@ -26,6 +26,7 @@ func (c CallFrame) MarshalJSON() ([]byte, error) {
 		RevertReason string          `json:"revertReason,omitempty"`
 		Reverted     *RevertedInfo   `json:"reverted,omitempty"`
 		Calls        []CallFrame     `json:"calls,omitempty"`
+		Logs         []CallLog       `json:"logs,omitempty"`
 		Value        *hexutil.Big    `json:"value,omitempty"`
 		TypeString   string          `json:"type"`
 	}
@@ -41,6 +42,7 @@ func (c CallFrame) MarshalJSON() ([]byte, error) {
 	enc.RevertReason = c.RevertReason
 	enc.Reverted = c.Reverted
 	enc.Calls = c.Calls
+	enc.Logs = c.Logs
 	enc.Value = (*hexutil.Big)(c.Value)
 	enc.TypeString = c.TypeString()
 	return json.Marshal(&enc)
@@ -60,6 +62,7 @@ func (c *CallFrame) UnmarshalJSON(input []byte) error {
 		RevertReason *string         `json:"revertReason,omitempty"`
 		Reverted     *RevertedInfo   `json:"reverted,omitempty"`
 		Calls        []CallFrame     `json:"calls,omitempty"`
+		Logs         []CallLog       `json:"logs,omitempty"`
 		Value        *hexutil.Big    `json:"value,omitempty"`
 	}
 	var dec CallFrame0
@@ -98,6 +101,9 @@ func (c *CallFrame) UnmarshalJSON(input []byte) error {
 	}
 	if dec.Calls != nil {
 		c.Calls = dec.Calls
+	}
+	if dec.Logs != nil {
+		c.Logs = dec.Logs
 	}
 	if dec.Value != nil {
 		c.Value = (*big.Int)(dec.Value)

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -118,6 +118,14 @@ type Tracer interface {
 	CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost, ccLeft, ccOpcode uint64, scope *ScopeContext, depth int, err error)
 }
 
+// TxPrestateTracer is implemented by tracers that need to snapshot top-level
+// transaction state before StateTransition preCheck and subsequent execution
+// mutate balances, nonces, or access lists. It is optional so existing tracers
+// do not need to implement it.
+type TxPrestateTracer interface {
+	CaptureTxStartPreCheck(env *EVM, from common.Address, feePayer common.Address, to common.Address, create bool, input []byte, value *big.Int)
+}
+
 // StructLogger is an EVM state logger and implements Tracer.
 //
 // StructLogger can capture state based on the given Log configuration and also keeps

--- a/blockchain/vm/logger.go
+++ b/blockchain/vm/logger.go
@@ -123,7 +123,7 @@ type Tracer interface {
 // mutate balances, nonces, or access lists. It is optional so existing tracers
 // do not need to implement it.
 type TxPrestateTracer interface {
-	CaptureTxStartPreCheck(env *EVM, from common.Address, feePayer common.Address, to common.Address, create bool, input []byte, value *big.Int)
+	CaptureTxStartPreCheck(env *EVM, from common.Address, feePayer common.Address, to common.Address, create bool, input []byte, value *big.Int, authList []types.SetCodeAuthorization)
 }
 
 // StructLogger is an EVM state logger and implements Tracer.

--- a/blockchain/vm/prestate_tracer.go
+++ b/blockchain/vm/prestate_tracer.go
@@ -1,0 +1,330 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+
+package vm
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"sync/atomic"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/kaiachain/kaia/crypto"
+)
+
+var _ Tracer = (*PrestateTracer)(nil)
+var _ TxPrestateTracer = (*PrestateTracer)(nil)
+
+// PrestateAccount captures account state for the prestate tracer.
+type PrestateAccount struct {
+	Balance *big.Int                    `json:"balance,omitempty"`
+	Nonce   uint64                      `json:"nonce,omitempty"`
+	Code    []byte                      `json:"code,omitempty"`
+	Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
+}
+
+func (a *PrestateAccount) MarshalJSON() ([]byte, error) {
+	type accountJSON struct {
+		Balance *hexutil.Big                `json:"balance,omitempty"`
+		Nonce   uint64                      `json:"nonce,omitempty"`
+		Code    *hexutil.Bytes              `json:"code,omitempty"`
+		Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
+	}
+	enc := accountJSON{Nonce: a.Nonce}
+	if a.Balance != nil {
+		enc.Balance = (*hexutil.Big)(a.Balance)
+	}
+	if a.Code != nil {
+		code := hexutil.Bytes(a.Code)
+		enc.Code = &code
+	}
+	if a.Storage != nil {
+		enc.Storage = a.Storage
+	}
+	return json.Marshal(enc)
+}
+
+func (a *PrestateAccount) empty() bool {
+	return (a.Balance == nil || a.Balance.Sign() == 0) && a.Nonce == 0 && len(a.Code) == 0 && len(a.Storage) == 0
+}
+
+type prestateState = map[common.Address]*PrestateAccount
+
+// PrestateTracerConfig is parsed from the JSON tracer config.
+type PrestateTracerConfig struct {
+	DiffMode       bool `json:"diffMode"`
+	DisableCode    bool `json:"disableCode"`
+	DisableStorage bool `json:"disableStorage"`
+}
+
+// PrestateTracer records the prestate, and optionally the post-tx diff, of all
+// accounts and storage slots touched during a transaction.
+type PrestateTracer struct {
+	env *EVM
+
+	pre    prestateState
+	post   prestateState
+	config PrestateTracerConfig
+
+	created map[common.Address]bool
+
+	synthAddr   common.Address
+	synthAmount *big.Int
+
+	interrupt atomic.Bool
+	reason    error
+}
+
+// NewPrestateTracer constructs a PrestateTracer. cfg may be nil.
+func NewPrestateTracer(cfg json.RawMessage) (*PrestateTracer, error) {
+	var config PrestateTracerConfig
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &config); err != nil {
+			return nil, err
+		}
+	}
+	return &PrestateTracer{
+		pre:     prestateState{},
+		post:    prestateState{},
+		config:  config,
+		created: make(map[common.Address]bool),
+	}, nil
+}
+
+// SetSyntheticBalance records balance that debug_traceCall added only to make
+// simulation executable. The tracer subtracts it from prestate snapshots so the
+// output reflects the state selected by the caller plus stateOverrides.
+func (t *PrestateTracer) SetSyntheticBalance(addr common.Address, amount *big.Int) {
+	t.synthAddr = addr
+	if amount != nil {
+		t.synthAmount = new(big.Int).Set(amount)
+	}
+}
+
+func (t *PrestateTracer) CaptureTxStartPreCheck(env *EVM, from common.Address, feePayer common.Address, to common.Address, create bool, input []byte, value *big.Int) {
+	t.env = env
+	t.lookupAccount(from)
+	t.lookupAccount(feePayer)
+	t.lookupAccount(to)
+	if create {
+		t.created[to] = true
+	}
+}
+
+func (t *PrestateTracer) CaptureTxStart(gasLimit uint64) {}
+
+func (t *PrestateTracer) CaptureTxEnd(restGas uint64) {
+	if t.env == nil {
+		return
+	}
+	if !t.config.DiffMode {
+		for addr := range t.created {
+			if acc, ok := t.pre[addr]; ok && acc.empty() {
+				delete(t.pre, addr)
+			}
+		}
+		return
+	}
+
+	t.processDiffState()
+
+	for addr := range t.created {
+		if acc, ok := t.pre[addr]; ok && acc.empty() {
+			delete(t.pre, addr)
+		}
+	}
+}
+
+func (t *PrestateTracer) CaptureStart(env *EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) {
+	if t.env == nil {
+		t.env = env
+	}
+}
+
+func (t *PrestateTracer) CaptureEnd(output []byte, gasUsed uint64, err error) {}
+
+func (t *PrestateTracer) CaptureEnter(typ OpCode, from common.Address, to common.Address, input []byte, gas uint64, value *big.Int) {
+}
+
+func (t *PrestateTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
+
+func (t *PrestateTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost, ccLeft, ccOpcode uint64, scope *ScopeContext, depth int, err error) {
+	if err != nil || t.interrupt.Load() {
+		return
+	}
+	if t.env == nil {
+		t.env = env
+	}
+	stack := scope.Stack
+	stackData := stack.Data()
+	stackLen := len(stackData)
+	caller := scope.Contract.Address()
+	switch {
+	case stackLen >= 1 && (op == SLOAD || op == SSTORE):
+		t.lookupAccount(caller)
+		if !t.config.DisableStorage {
+			slot := common.Hash(stackData[stackLen-1].Bytes32())
+			t.lookupStorage(caller, slot)
+		}
+	case stackLen >= 1 && (op == EXTCODECOPY || op == EXTCODEHASH || op == EXTCODESIZE || op == BALANCE || op == SELFDESTRUCT):
+		addr := common.Address(stackData[stackLen-1].Bytes20())
+		t.lookupAccount(addr)
+		if op == SELFDESTRUCT {
+			t.lookupAccount(caller)
+		}
+	case stackLen >= 5 && (op == DELEGATECALL || op == CALL || op == STATICCALL || op == CALLCODE):
+		addr := common.Address(stackData[stackLen-2].Bytes20())
+		t.lookupAccount(addr)
+	case op == CREATE:
+		t.lookupAccount(caller)
+		nonce := t.env.StateDB.GetNonce(caller)
+		addr := crypto.CreateAddress(caller, nonce)
+		t.lookupAccount(addr)
+		t.created[addr] = true
+	case stackLen >= 4 && op == CREATE2:
+		t.lookupAccount(caller)
+		offset := stackData[stackLen-2]
+		size := stackData[stackLen-3]
+		init := scope.Memory.GetCopy(int64(offset.Uint64()), int64(size.Uint64()))
+		inithash := crypto.Keccak256(init)
+		salt := stackData[stackLen-4]
+		addr := crypto.CreateAddress2(caller, salt.Bytes32(), inithash)
+		t.lookupAccount(addr)
+		t.created[addr] = true
+	}
+}
+
+func (t *PrestateTracer) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost, ccLeft, ccOpcode uint64, scope *ScopeContext, depth int, err error) {
+}
+
+func (t *PrestateTracer) GetResult() (json.RawMessage, error) {
+	var (
+		res []byte
+		err error
+	)
+	if t.config.DiffMode {
+		res, err = json.Marshal(struct {
+			Pre  prestateState `json:"pre"`
+			Post prestateState `json:"post"`
+		}{t.pre, t.post})
+	} else {
+		res, err = json.Marshal(t.pre)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return res, t.reason
+}
+
+func (t *PrestateTracer) Stop(err error) {
+	t.reason = err
+	t.interrupt.Store(true)
+}
+
+func (t *PrestateTracer) processDiffState() {
+	for addr, preAcc := range t.pre {
+		if t.env.StateDB.HasSelfDestructed(addr) {
+			continue
+		}
+
+		modified := false
+		postAcc := &PrestateAccount{}
+		newBalance := t.env.StateDB.GetBalance(addr)
+		newNonce := t.env.StateDB.GetNonce(addr)
+		newCode := t.env.StateDB.GetCode(addr)
+
+		if newBalance.Cmp(preAcc.Balance) != 0 {
+			modified = true
+			postAcc.Balance = new(big.Int).Set(newBalance)
+		}
+		if newNonce != preAcc.Nonce {
+			modified = true
+			postAcc.Nonce = newNonce
+		}
+		if !t.config.DisableCode && !bytes.Equal(newCode, preAcc.Code) {
+			modified = true
+			postAcc.Code = common.CopyBytes(newCode)
+			if postAcc.Code == nil {
+				postAcc.Code = []byte{}
+			}
+		}
+
+		if t.config.DisableStorage {
+			if modified {
+				t.post[addr] = postAcc
+			} else {
+				delete(t.pre, addr)
+			}
+			continue
+		}
+
+		for key, val := range preAcc.Storage {
+			if val == (common.Hash{}) {
+				delete(preAcc.Storage, key)
+			}
+			newVal := t.env.StateDB.GetState(addr, key)
+			if val != newVal {
+				modified = true
+				if newVal != (common.Hash{}) {
+					if postAcc.Storage == nil {
+						postAcc.Storage = make(map[common.Hash]common.Hash)
+					}
+					postAcc.Storage[key] = newVal
+				}
+			} else {
+				delete(preAcc.Storage, key)
+			}
+		}
+		if len(preAcc.Storage) == 0 {
+			preAcc.Storage = nil
+		}
+
+		if modified {
+			t.post[addr] = postAcc
+		} else {
+			delete(t.pre, addr)
+		}
+	}
+}
+
+func (t *PrestateTracer) lookupAccount(addr common.Address) {
+	if _, ok := t.pre[addr]; ok {
+		return
+	}
+	balance := new(big.Int).Set(t.env.StateDB.GetBalance(addr))
+	if t.synthAmount != nil && addr == t.synthAddr {
+		balance.Sub(balance, t.synthAmount)
+	}
+	acc := &PrestateAccount{
+		Balance: balance,
+		Nonce:   t.env.StateDB.GetNonce(addr),
+	}
+	if !t.config.DisableStorage {
+		acc.Storage = make(map[common.Hash]common.Hash)
+	}
+	if !t.config.DisableCode {
+		acc.Code = common.CopyBytes(t.env.StateDB.GetCode(addr))
+		if acc.Code == nil {
+			acc.Code = []byte{}
+		}
+	}
+	t.pre[addr] = acc
+}
+
+func (t *PrestateTracer) lookupStorage(addr common.Address, key common.Hash) {
+	acc, ok := t.pre[addr]
+	if !ok {
+		t.lookupAccount(addr)
+		acc = t.pre[addr]
+	}
+	if acc.Storage == nil {
+		acc.Storage = make(map[common.Hash]common.Hash)
+	}
+	if _, ok := acc.Storage[key]; ok {
+		return
+	}
+	acc.Storage[key] = t.env.StateDB.GetState(addr, key)
+}

--- a/blockchain/vm/prestate_tracer.go
+++ b/blockchain/vm/prestate_tracer.go
@@ -81,7 +81,7 @@ type PrestateTracer struct {
 	synthFee    *big.Int
 
 	interrupt atomic.Bool
-	reason    error
+	reason    atomic.Pointer[error]
 }
 
 // NewPrestateTracer constructs a PrestateTracer. cfg may be nil.
@@ -233,11 +233,14 @@ func (t *PrestateTracer) GetResult() (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res, t.reason
+	if reason := t.reason.Load(); reason != nil {
+		return res, *reason
+	}
+	return res, nil
 }
 
 func (t *PrestateTracer) Stop(err error) {
-	t.reason = err
+	t.reason.Store(&err)
 	t.interrupt.Store(true)
 }
 

--- a/blockchain/vm/prestate_tracer.go
+++ b/blockchain/vm/prestate_tracer.go
@@ -346,7 +346,13 @@ func (t *PrestateTracer) adjustPostBalance(addr common.Address, stateBalance *bi
 	}
 	if t.synthFee != nil {
 		if recipient, ok := t.syntheticFeeRecipient(); ok && addr == recipient {
-			balance.Sub(balance, t.synthFee)
+			credit := new(big.Int).Set(t.synthFee)
+			// Since Magma + Non-deferred, half the fee is burned and only the remainder is
+			// credited to the rewardbase (see StateTransition.TransitionDb).
+			if t.env.ChainConfig().Rules(t.env.Context.BlockNumber).IsMagma {
+				credit.Sub(credit, new(big.Int).Div(credit, big.NewInt(2)))
+			}
+			balance.Sub(balance, credit)
 		}
 	}
 	return balance

--- a/blockchain/vm/prestate_tracer.go
+++ b/blockchain/vm/prestate_tracer.go
@@ -73,6 +73,9 @@ type PrestateTracer struct {
 
 	synthAddr   common.Address
 	synthAmount *big.Int
+	synthPrice  *big.Int
+	synthRefund *big.Int
+	synthFee    *big.Int
 
 	interrupt atomic.Bool
 	reason    error
@@ -97,10 +100,13 @@ func NewPrestateTracer(cfg json.RawMessage) (*PrestateTracer, error) {
 // SetSyntheticBalance records balance that debug_traceCall added only to make
 // simulation executable. The tracer subtracts it from prestate snapshots so the
 // output reflects the state selected by the caller plus stateOverrides.
-func (t *PrestateTracer) SetSyntheticBalance(addr common.Address, amount *big.Int) {
+func (t *PrestateTracer) SetSyntheticBalance(addr common.Address, amount *big.Int, gasPrice *big.Int) {
 	t.synthAddr = addr
 	if amount != nil {
 		t.synthAmount = new(big.Int).Set(amount)
+	}
+	if gasPrice != nil {
+		t.synthPrice = new(big.Int).Set(gasPrice)
 	}
 }
 
@@ -120,6 +126,7 @@ func (t *PrestateTracer) CaptureTxEnd(restGas uint64) {
 	if t.env == nil {
 		return
 	}
+	t.setSyntheticGasUsage(restGas)
 	if !t.config.DiffMode {
 		for addr := range t.created {
 			if acc, ok := t.pre[addr]; ok && acc.empty() {
@@ -232,7 +239,7 @@ func (t *PrestateTracer) processDiffState() {
 
 		modified := false
 		postAcc := &PrestateAccount{}
-		newBalance := t.env.StateDB.GetBalance(addr)
+		newBalance := t.adjustPostBalance(addr, t.env.StateDB.GetBalance(addr))
 		newNonce := t.env.StateDB.GetNonce(addr)
 		newCode := t.env.StateDB.GetCode(addr)
 
@@ -294,10 +301,7 @@ func (t *PrestateTracer) lookupAccount(addr common.Address) {
 	if _, ok := t.pre[addr]; ok {
 		return
 	}
-	balance := new(big.Int).Set(t.env.StateDB.GetBalance(addr))
-	if t.synthAmount != nil && addr == t.synthAddr {
-		balance.Sub(balance, t.synthAmount)
-	}
+	balance := t.adjustPreBalance(addr, t.env.StateDB.GetBalance(addr))
 	acc := &PrestateAccount{
 		Balance: balance,
 		Nonce:   t.env.StateDB.GetNonce(addr),
@@ -312,6 +316,48 @@ func (t *PrestateTracer) lookupAccount(addr common.Address) {
 		}
 	}
 	t.pre[addr] = acc
+}
+
+func (t *PrestateTracer) setSyntheticGasUsage(restGas uint64) {
+	if t.synthAmount == nil || t.synthPrice == nil {
+		return
+	}
+	t.synthRefund = new(big.Int).Mul(new(big.Int).SetUint64(restGas), t.synthPrice)
+	t.synthFee = new(big.Int).Sub(new(big.Int).Set(t.synthAmount), t.synthRefund)
+	if t.synthFee.Sign() < 0 {
+		t.synthFee.SetInt64(0)
+	}
+}
+
+func (t *PrestateTracer) adjustPreBalance(addr common.Address, stateBalance *big.Int) *big.Int {
+	balance := new(big.Int).Set(stateBalance)
+	if t.synthAmount != nil && addr == t.synthAddr {
+		balance.Sub(balance, t.synthAmount)
+	}
+	return balance
+}
+
+func (t *PrestateTracer) adjustPostBalance(addr common.Address, stateBalance *big.Int) *big.Int {
+	balance := new(big.Int).Set(stateBalance)
+	if t.synthRefund != nil && addr == t.synthAddr {
+		balance.Sub(balance, t.synthRefund)
+	}
+	if t.synthFee != nil {
+		if recipient, ok := t.syntheticFeeRecipient(); ok && addr == recipient {
+			balance.Sub(balance, t.synthFee)
+		}
+	}
+	return balance
+}
+
+func (t *PrestateTracer) syntheticFeeRecipient() (common.Address, bool) {
+	if t.env.ChainConfig().Governance != nil && t.env.ChainConfig().Governance.DeferredTxFee() {
+		return common.Address{}, false
+	}
+	if t.env.ChainConfig().Rules(t.env.Context.BlockNumber).IsMagma {
+		return t.env.Context.Rewardbase, true
+	}
+	return t.env.Context.Coinbase, true
 }
 
 func (t *PrestateTracer) lookupStorage(addr common.Address, key common.Hash) {

--- a/blockchain/vm/prestate_tracer.go
+++ b/blockchain/vm/prestate_tracer.go
@@ -15,8 +15,10 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 )
 
-var _ Tracer = (*PrestateTracer)(nil)
-var _ TxPrestateTracer = (*PrestateTracer)(nil)
+var (
+	_ Tracer           = (*PrestateTracer)(nil)
+	_ TxPrestateTracer = (*PrestateTracer)(nil)
+)
 
 // PrestateAccount captures account state for the prestate tracer.
 type PrestateAccount struct {

--- a/blockchain/vm/prestate_tracer.go
+++ b/blockchain/vm/prestate_tracer.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"sync/atomic"
 
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/crypto"
@@ -112,13 +113,20 @@ func (t *PrestateTracer) SetSyntheticBalance(addr common.Address, amount *big.In
 	}
 }
 
-func (t *PrestateTracer) CaptureTxStartPreCheck(env *EVM, from common.Address, feePayer common.Address, to common.Address, create bool, input []byte, value *big.Int) {
+func (t *PrestateTracer) CaptureTxStartPreCheck(env *EVM, from common.Address, feePayer common.Address, to common.Address, create bool, input []byte, value *big.Int, authList []types.SetCodeAuthorization) {
 	t.env = env
 	t.lookupAccount(from)
 	t.lookupAccount(feePayer)
 	t.lookupAccount(to)
 	if create {
 		t.created[to] = true
+	}
+	// Capture EIP-7702 authority accounts before applyAuthorization mutates
+	// their nonce and code, so the prestate reflects their pre-tx state.
+	for _, auth := range authList {
+		if authority, err := auth.Authority(); err == nil {
+			t.lookupAccount(authority)
+		}
 	}
 }
 

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -24,6 +24,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -257,10 +258,16 @@ func (api *CommonAPI) blockByNumberAndHash(ctx context.Context, number rpc.Block
 type TraceConfig struct {
 	*vm.LogConfig
 	Tracer         *string                   `json:"tracer,omitempty"`
+	TracerConfig   json.RawMessage           `json:"tracerConfig,omitempty"`
 	Timeout        *string                   `json:"timeout,omitempty"`
 	LoggerTimeout  *string                   `json:"loggerTimeout,omitempty"`
 	Reexec         *uint64                   `json:"reexec,omitempty"`
 	StateOverrides *kaiaapi.EthStateOverride `json:"stateOverrides,omitempty"`
+}
+
+type traceSyntheticBalance struct {
+	addr   common.Address
+	amount *big.Int
 }
 
 // StdTraceConfig holds extra parameters to standard-json trace functions.
@@ -973,18 +980,19 @@ func (api *CommonAPI) TraceCall(ctx context.Context, args kaiaapi.CallArgs, bloc
 	}
 
 	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
-	statedb.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.EffectiveGasPrice(block.Header(), api.backend.ChainConfig())))
+	traceCallTopUp := new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.EffectiveGasPrice(block.Header(), api.backend.ChainConfig()))
+	statedb.AddBalance(msg.ValidatedSender(), traceCallTopUp)
 
 	txCtx := blockchain.NewEVMTxContext(msg, block.Header(), api.backend.ChainConfig())
 	blockCtx := blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)
 
-	return api.traceTx(ctx, msg, blockCtx, txCtx, statedb, config)
+	return api.traceTx(ctx, msg, blockCtx, txCtx, statedb, config, traceSyntheticBalance{addr: msg.ValidatedSender(), amount: traceCallTopUp})
 }
 
 // traceTx configures a new tracer according to the provided configuration, and
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
-func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, blockCtx vm.BlockContext, txCtx vm.TxContext, statedb *state.StateDB, config *TraceConfig) (interface{}, error) {
+func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, blockCtx vm.BlockContext, txCtx vm.TxContext, statedb *state.StateDB, config *TraceConfig, syntheticBalance ...traceSyntheticBalance) (interface{}, error) {
 	// Assemble the structured logger or the JavaScript tracer
 	var (
 		tracer vm.Tracer
@@ -1002,10 +1010,20 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 
 		if *config.Tracer == "fastCallTracer" || *config.Tracer == "callTracer" {
 			tracer = vm.NewCallTracer()
+		} else if *config.Tracer == "prestateTracer" {
+			if tracer, err = vm.NewPrestateTracer(config.TracerConfig); err != nil {
+				return nil, err
+			}
 		} else {
 			// Construct the JavaScript tracer to execute with
 			if tracer, err = New(*config.Tracer, new(Context), api.unsafeTrace); err != nil {
 				return nil, err
+			}
+		}
+		if len(syntheticBalance) > 0 {
+			if prestateTracer, ok := tracer.(*vm.PrestateTracer); ok {
+				synthetic := syntheticBalance[0]
+				prestateTracer.SetSyntheticBalance(synthetic.addr, synthetic.amount)
 			}
 		}
 		// Handle timeouts and RPC cancellations
@@ -1019,6 +1037,8 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 				case *vm.InternalTxTracer:
 					t.Stop(errors.New("execution timeout"))
 				case *vm.CallTracer:
+					t.Stop(errors.New("execution timeout"))
+				case *vm.PrestateTracer:
 					t.Stop(errors.New("execution timeout"))
 				default:
 					logger.Warn("unknown tracer type", "type", reflect.TypeOf(t).String())
@@ -1065,6 +1085,8 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 	case *vm.InternalTxTracer:
 		return tracer.GetResult()
 	case *vm.CallTracer:
+		return tracer.GetResult()
+	case *vm.PrestateTracer:
 		return tracer.GetResult()
 
 	default:

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -1011,7 +1011,9 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 		}
 
 		if *config.Tracer == "fastCallTracer" || *config.Tracer == "callTracer" {
-			tracer = vm.NewCallTracer()
+			if tracer, err = vm.NewCallTracerWithConfig(config.TracerConfig); err != nil {
+				return nil, err
+			}
 		} else if *config.Tracer == "prestateTracer" {
 			if tracer, err = vm.NewPrestateTracer(config.TracerConfig); err != nil {
 				return nil, err

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -266,8 +266,9 @@ type TraceConfig struct {
 }
 
 type traceSyntheticBalance struct {
-	addr   common.Address
-	amount *big.Int
+	addr     common.Address
+	amount   *big.Int
+	gasPrice *big.Int
 }
 
 // StdTraceConfig holds extra parameters to standard-json trace functions.
@@ -980,13 +981,14 @@ func (api *CommonAPI) TraceCall(ctx context.Context, args kaiaapi.CallArgs, bloc
 	}
 
 	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
-	traceCallTopUp := new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.EffectiveGasPrice(block.Header(), api.backend.ChainConfig()))
+	traceCallGasPrice := msg.EffectiveGasPrice(block.Header(), api.backend.ChainConfig())
+	traceCallTopUp := new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), traceCallGasPrice)
 	statedb.AddBalance(msg.ValidatedSender(), traceCallTopUp)
 
 	txCtx := blockchain.NewEVMTxContext(msg, block.Header(), api.backend.ChainConfig())
 	blockCtx := blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)
 
-	return api.traceTx(ctx, msg, blockCtx, txCtx, statedb, config, traceSyntheticBalance{addr: msg.ValidatedSender(), amount: traceCallTopUp})
+	return api.traceTx(ctx, msg, blockCtx, txCtx, statedb, config, traceSyntheticBalance{addr: msg.ValidatedSender(), amount: traceCallTopUp, gasPrice: traceCallGasPrice})
 }
 
 // traceTx configures a new tracer according to the provided configuration, and
@@ -1023,7 +1025,7 @@ func (api *CommonAPI) traceTx(ctx context.Context, message blockchain.Message, b
 		if len(syntheticBalance) > 0 {
 			if prestateTracer, ok := tracer.(*vm.PrestateTracer); ok {
 				synthetic := syntheticBalance[0]
-				prestateTracer.SetSyntheticBalance(synthetic.addr, synthetic.amount)
+				prestateTracer.SetSyntheticBalance(synthetic.addr, synthetic.amount, synthetic.gasPrice)
 			}
 		}
 		// Handle timeouts and RPC cancellations

--- a/node/cn/tracers/api.go
+++ b/node/cn/tracers/api.go
@@ -256,10 +256,11 @@ func (api *CommonAPI) blockByNumberAndHash(ctx context.Context, number rpc.Block
 // TraceConfig holds extra parameters to trace functions.
 type TraceConfig struct {
 	*vm.LogConfig
-	Tracer        *string
-	Timeout       *string
-	LoggerTimeout *string
-	Reexec        *uint64
+	Tracer         *string                   `json:"tracer,omitempty"`
+	Timeout        *string                   `json:"timeout,omitempty"`
+	LoggerTimeout  *string                   `json:"loggerTimeout,omitempty"`
+	Reexec         *uint64                   `json:"reexec,omitempty"`
+	StateOverrides *kaiaapi.EthStateOverride `json:"stateOverrides,omitempty"`
 }
 
 // StdTraceConfig holds extra parameters to standard-json trace functions.
@@ -947,6 +948,12 @@ func (api *CommonAPI) TraceCall(ctx context.Context, args kaiaapi.CallArgs, bloc
 	}
 	defer release()
 
+	if config != nil && config.StateOverrides != nil {
+		if err := config.StateOverrides.Apply(statedb); err != nil {
+			return nil, err
+		}
+	}
+
 	// Execute the trace
 	intrinsicGas, err := types.IntrinsicGas(args.InputData(), args.GetAccessList(), nil, args.To == nil, api.backend.ChainConfig().Rules(block.Number()))
 	if err != nil {
@@ -966,7 +973,7 @@ func (api *CommonAPI) TraceCall(ctx context.Context, args kaiaapi.CallArgs, bloc
 	}
 
 	// Add gas fee to sender for estimating gasLimit/computing cost or calling a function by insufficient balance sender.
-	statedb.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), basefee))
+	statedb.AddBalance(msg.ValidatedSender(), new(big.Int).Mul(new(big.Int).SetUint64(msg.Gas()), msg.EffectiveGasPrice(block.Header(), api.backend.ChainConfig())))
 
 	txCtx := blockchain.NewEVMTxContext(msg, block.Header(), api.backend.ChainConfig())
 	blockCtx := blockchain.NewEVMBlockContext(block.Header(), newChainContext(ctx, api.backend), nil)

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -422,6 +422,59 @@ func TestTraceCallPrestateTracerKeepsLogicalPrestate(t *testing.T) {
 	assertTraceBalance(t, prestate[from], big.NewInt(0x42))
 }
 
+func TestTraceCallPrestateTracerDiffModeKeepsLogicalPostBalance(t *testing.T) {
+	t.Parallel()
+
+	from := common.HexToAddress("0x000000000000000000000000000000000000a111")
+	to := common.HexToAddress("0x000000000000000000000000000000000000b111")
+	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+		from: {Balance: big.NewInt(0)},
+	}}
+	api := NewAPI(newTestBackend(t, 1, genesis, nil))
+
+	tracerName := "prestateTracer"
+	gas := hexutil.Uint64(100000)
+	gasPrice := hexutil.Big(*big.NewInt(1))
+	value := hexutil.Big(*big.NewInt(0x1234))
+	overrideBalance := hexutil.Big(*big.NewInt(100000))
+	overrideBalancePtr := &overrideBalance
+	overrides := kaiaapi.EthStateOverride{
+		from: {Balance: &overrideBalancePtr},
+	}
+	config := &TraceConfig{
+		Tracer:         &tracerName,
+		TracerConfig:   json.RawMessage(`{"diffMode":true}`),
+		StateOverrides: &overrides,
+	}
+
+	blockNumber := rpc.LatestBlockNumber
+	result, err := api.TraceCall(context.Background(), kaiaapi.CallArgs{
+		From:     from,
+		To:       &to,
+		Gas:      &gas,
+		GasPrice: &gasPrice,
+		Value:    value,
+	}, rpc.BlockNumberOrHash{BlockNumber: &blockNumber}, config)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	raw, ok := result.(json.RawMessage)
+	if !assert.True(t, ok, "expected json.RawMessage result, got %T", result) {
+		return
+	}
+
+	var diff struct {
+		Pre  map[common.Address]tracedPrestateAccount `json:"pre"`
+		Post map[common.Address]tracedPrestateAccount `json:"post"`
+	}
+	assert.NoError(t, json.Unmarshal(raw, &diff))
+
+	assertTraceBalance(t, diff.Pre[from], (*big.Int)(&overrideBalance))
+	wantPost := new(big.Int).Sub((*big.Int)(&overrideBalance), (*big.Int)(&value))
+	assertTraceBalance(t, diff.Post[from], wantPost)
+}
+
 func TestTraceCallPrestateTracerDiffModeCreate(t *testing.T) {
 	t.Parallel()
 

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -287,7 +287,7 @@ func TestTraceCall(t *testing.T) {
 			call: kaiaapi.CallArgs{
 				From:  accounts[0].addr,
 				To:    &accounts[1].addr,
-				Value: (hexutil.Big)(*big.NewInt(1000)),
+				Value: hexutil.Big(*big.NewInt(1000)),
 			},
 			config:    nil,
 			expectErr: errors.New("tracing failed: insufficient balance for transfer"),
@@ -299,7 +299,7 @@ func TestTraceCall(t *testing.T) {
 			call: kaiaapi.CallArgs{
 				From:  accounts[0].addr,
 				To:    &accounts[1].addr,
-				Value: (hexutil.Big)(*big.NewInt(1000)),
+				Value: hexutil.Big(*big.NewInt(1000)),
 			},
 			config:    nil,
 			expectErr: nil,
@@ -316,7 +316,7 @@ func TestTraceCall(t *testing.T) {
 			call: kaiaapi.CallArgs{
 				From:  accounts[0].addr,
 				To:    &accounts[1].addr,
-				Value: (hexutil.Big)(*big.NewInt(1000)),
+				Value: hexutil.Big(*big.NewInt(1000)),
 			},
 			config:    nil,
 			expectErr: fmt.Errorf("the block does not exist (block number: %d)", genBlocks+1),
@@ -328,7 +328,7 @@ func TestTraceCall(t *testing.T) {
 			call: kaiaapi.CallArgs{
 				From:  accounts[0].addr,
 				To:    &accounts[1].addr,
-				Value: (hexutil.Big)(*big.NewInt(1000)),
+				Value: hexutil.Big(*big.NewInt(1000)),
 			},
 			config:    nil,
 			expectErr: nil,
@@ -345,7 +345,7 @@ func TestTraceCall(t *testing.T) {
 			call: kaiaapi.CallArgs{
 				From:  accounts[0].addr,
 				To:    &accounts[1].addr,
-				Value: (hexutil.Big)(*big.NewInt(1000)),
+				Value: hexutil.Big(*big.NewInt(1000)),
 			},
 			config:    nil,
 			expectErr: nil,
@@ -546,7 +546,7 @@ func TestTraceCallPrestateTracerDiffModePrunesUnchangedStorage(t *testing.T) {
 	gasPrice := hexutil.Big(*big.NewInt(0))
 	code := hexutil.Bytes(common.FromHex("0x600054600160015500"))
 	state := map[common.Hash]common.Hash{
-		common.Hash{}: common.BigToHash(big.NewInt(1)),
+		{}: common.BigToHash(big.NewInt(1)),
 	}
 	overrides := kaiaapi.EthStateOverride{
 		contract: {Code: &code, State: &state},

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -475,6 +475,62 @@ func TestTraceCallPrestateTracerDiffModeKeepsLogicalPostBalance(t *testing.T) {
 	assertTraceBalance(t, diff.Post[from], wantPost)
 }
 
+func TestTraceCallPrestateTracerDiffModeHidesMagmaFee(t *testing.T) {
+	t.Parallel()
+
+	from := common.HexToAddress("0x000000000000000000000000000000000000a121")
+	rewardbase := common.HexToAddress("0x000000000000000000000000000000000000b121")
+	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+		from: {Balance: big.NewInt(0)},
+	}}
+	api := NewAPI(newTestBackend(t, 1, genesis, func(i int, b *blockchain.BlockGen) {
+		b.SetRewardbase(rewardbase)
+	}))
+
+	tracerName := "prestateTracer"
+	gas := hexutil.Uint64(100000)
+	gasPrice := hexutil.Big(*big.NewInt(1))
+	value := hexutil.Big(*big.NewInt(0x10000))
+	overrideBalance := hexutil.Big(*big.NewInt(0x100000))
+	overrideBalancePtr := &overrideBalance
+	overrides := kaiaapi.EthStateOverride{
+		from: {Balance: &overrideBalancePtr},
+	}
+	config := &TraceConfig{
+		Tracer:         &tracerName,
+		TracerConfig:   json.RawMessage(`{"diffMode":true}`),
+		StateOverrides: &overrides,
+	}
+
+	// The call target is also the Magma rewardbase, so it receives both the
+	// transferred value and the (half-burned) synthetic gas fee. The fee must be
+	// hidden, leaving only the value in its post balance.
+	blockNumber := rpc.LatestBlockNumber
+	result, err := api.TraceCall(context.Background(), kaiaapi.CallArgs{
+		From:     from,
+		To:       &rewardbase,
+		Gas:      &gas,
+		GasPrice: &gasPrice,
+		Value:    value,
+	}, rpc.BlockNumberOrHash{BlockNumber: &blockNumber}, config)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	raw, ok := result.(json.RawMessage)
+	if !assert.True(t, ok, "expected json.RawMessage result, got %T", result) {
+		return
+	}
+
+	var diff struct {
+		Pre  map[common.Address]tracedPrestateAccount `json:"pre"`
+		Post map[common.Address]tracedPrestateAccount `json:"post"`
+	}
+	assert.NoError(t, json.Unmarshal(raw, &diff))
+
+	assertTraceBalance(t, diff.Post[rewardbase], (*big.Int)(&value))
+}
+
 func TestTraceCallPrestateTracerDiffModeCreate(t *testing.T) {
 	t.Parallel()
 

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -364,6 +364,169 @@ func TestTraceCall(t *testing.T) {
 	}
 }
 
+type tracedPrestateAccount struct {
+	Balance *hexutil.Big                `json:"balance"`
+	Nonce   uint64                      `json:"nonce"`
+	Code    hexutil.Bytes               `json:"code"`
+	Storage map[common.Hash]common.Hash `json:"storage"`
+}
+
+func assertTraceBalance(t *testing.T, account tracedPrestateAccount, want *big.Int) {
+	t.Helper()
+	if assert.NotNil(t, account.Balance) {
+		assert.Equal(t, 0, (*big.Int)(account.Balance).Cmp(want))
+	}
+}
+
+func traceCallPrestate(t *testing.T, api *API, call kaiaapi.CallArgs, config *TraceConfig) map[common.Address]tracedPrestateAccount {
+	t.Helper()
+	blockNumber := rpc.LatestBlockNumber
+	result, err := api.TraceCall(context.Background(), call, rpc.BlockNumberOrHash{BlockNumber: &blockNumber}, config)
+	assert.NoError(t, err)
+	if err != nil {
+		return nil
+	}
+	raw, ok := result.(json.RawMessage)
+	if !assert.True(t, ok, "expected json.RawMessage result, got %T", result) {
+		return nil
+	}
+	var prestate map[common.Address]tracedPrestateAccount
+	assert.NoError(t, json.Unmarshal(raw, &prestate))
+	return prestate
+}
+
+func TestTraceCallPrestateTracerKeepsLogicalPrestate(t *testing.T) {
+	t.Parallel()
+
+	from := common.HexToAddress("0x000000000000000000000000000000000000aaaa")
+	to := common.HexToAddress("0x000000000000000000000000000000000000bbbb")
+	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+		from: {Balance: big.NewInt(0)},
+	}}
+	api := NewAPI(newTestBackend(t, 1, genesis, nil))
+
+	tracerName := "prestateTracer"
+	gas := hexutil.Uint64(params.TxGas)
+	gasPrice := hexutil.Big(*big.NewInt(1))
+	call := kaiaapi.CallArgs{From: from, To: &to, Gas: &gas, GasPrice: &gasPrice}
+
+	prestate := traceCallPrestate(t, api, call, &TraceConfig{Tracer: &tracerName})
+	assertTraceBalance(t, prestate[from], big.NewInt(0))
+
+	overrideBalance := hexutil.Big(*big.NewInt(0x42))
+	overrideBalancePtr := &overrideBalance
+	overrides := kaiaapi.EthStateOverride{
+		from: {Balance: &overrideBalancePtr},
+	}
+	prestate = traceCallPrestate(t, api, call, &TraceConfig{Tracer: &tracerName, StateOverrides: &overrides})
+	assertTraceBalance(t, prestate[from], big.NewInt(0x42))
+}
+
+func TestTraceCallPrestateTracerDiffModeCreate(t *testing.T) {
+	t.Parallel()
+
+	from := common.HexToAddress("0x000000000000000000000000000000000000cafe")
+	created := crypto.CreateAddress(from, 0)
+	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+		from:    {Balance: big.NewInt(5)},
+		created: {Balance: big.NewInt(0x10)},
+	}}
+	api := NewAPI(newTestBackend(t, 1, genesis, nil))
+
+	tracerName := "prestateTracer"
+	gas := hexutil.Uint64(200000)
+	gasPrice := hexutil.Big(*big.NewInt(0))
+	value := hexutil.Big(*big.NewInt(5))
+	initCode := hexutil.Bytes(common.FromHex("0x303150600160005560006000526001601ff3"))
+	config := &TraceConfig{Tracer: &tracerName, TracerConfig: json.RawMessage(`{"diffMode":true}`)}
+
+	blockNumber := rpc.LatestBlockNumber
+	result, err := api.TraceCall(context.Background(), kaiaapi.CallArgs{
+		From:     from,
+		Gas:      &gas,
+		GasPrice: &gasPrice,
+		Value:    value,
+		Data:     initCode,
+	}, rpc.BlockNumberOrHash{BlockNumber: &blockNumber}, config)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	raw, ok := result.(json.RawMessage)
+	if !assert.True(t, ok, "expected json.RawMessage result, got %T", result) {
+		return
+	}
+
+	var diff struct {
+		Pre  map[common.Address]tracedPrestateAccount `json:"pre"`
+		Post map[common.Address]tracedPrestateAccount `json:"post"`
+	}
+	assert.NoError(t, json.Unmarshal(raw, &diff))
+
+	preCreated, ok := diff.Pre[created]
+	if assert.True(t, ok, "created account missing from pre diff") {
+		assertTraceBalance(t, preCreated, big.NewInt(0x10))
+		assert.Equal(t, uint64(0), preCreated.Nonce)
+		assert.NotContains(t, preCreated.Storage, common.Hash{})
+	}
+	postCreated, ok := diff.Post[created]
+	if assert.True(t, ok, "created account missing from post diff") {
+		assertTraceBalance(t, postCreated, big.NewInt(0x15))
+		assert.Equal(t, uint64(1), postCreated.Nonce)
+		assert.Equal(t, hexutil.Bytes{0}, postCreated.Code)
+		assert.Equal(t, common.BigToHash(big.NewInt(1)), postCreated.Storage[common.Hash{}])
+	}
+}
+
+func TestTraceCallPrestateTracerDiffModePrunesUnchangedStorage(t *testing.T) {
+	t.Parallel()
+
+	from := common.HexToAddress("0x000000000000000000000000000000000000d001")
+	contract := common.HexToAddress("0x000000000000000000000000000000000000d002")
+	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+		from: {Balance: big.NewInt(0)},
+	}}
+	api := NewAPI(newTestBackend(t, 1, genesis, nil))
+
+	tracerName := "prestateTracer"
+	gas := hexutil.Uint64(100000)
+	gasPrice := hexutil.Big(*big.NewInt(0))
+	code := hexutil.Bytes(common.FromHex("0x600054600160015500"))
+	state := map[common.Hash]common.Hash{
+		common.Hash{}: common.BigToHash(big.NewInt(1)),
+	}
+	overrides := kaiaapi.EthStateOverride{
+		contract: {Code: &code, State: &state},
+	}
+	config := &TraceConfig{Tracer: &tracerName, TracerConfig: json.RawMessage(`{"diffMode":true}`), StateOverrides: &overrides}
+
+	blockNumber := rpc.LatestBlockNumber
+	result, err := api.TraceCall(context.Background(), kaiaapi.CallArgs{
+		From:     from,
+		To:       &contract,
+		Gas:      &gas,
+		GasPrice: &gasPrice,
+	}, rpc.BlockNumberOrHash{BlockNumber: &blockNumber}, config)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	raw, ok := result.(json.RawMessage)
+	if !assert.True(t, ok, "expected json.RawMessage result, got %T", result) {
+		return
+	}
+
+	var diff struct {
+		Pre  map[common.Address]tracedPrestateAccount `json:"pre"`
+		Post map[common.Address]tracedPrestateAccount `json:"post"`
+	}
+	assert.NoError(t, json.Unmarshal(raw, &diff))
+
+	preContract := diff.Pre[contract]
+	assert.NotContains(t, preContract.Storage, common.Hash{})
+	assert.Equal(t, common.BigToHash(big.NewInt(1)), diff.Post[contract].Storage[common.BigToHash(big.NewInt(1))])
+}
+
 func TestTraceTransaction(t *testing.T) {
 	t.Parallel()
 

--- a/node/cn/tracers/api_test.go
+++ b/node/cn/tracers/api_test.go
@@ -580,6 +580,57 @@ func TestTraceCallPrestateTracerDiffModePrunesUnchangedStorage(t *testing.T) {
 	assert.Equal(t, common.BigToHash(big.NewInt(1)), diff.Post[contract].Storage[common.BigToHash(big.NewInt(1))])
 }
 
+func TestTraceCallCallTracerWithLog(t *testing.T) {
+	t.Parallel()
+
+	from := common.HexToAddress("0x000000000000000000000000000000000000a222")
+	contract := common.HexToAddress("0x000000000000000000000000000000000000b222")
+	genesis := &blockchain.Genesis{Alloc: blockchain.GenesisAlloc{
+		from: {Balance: big.NewInt(0)},
+	}}
+	api := NewAPI(newTestBackend(t, 1, genesis, nil))
+
+	tracerName := "callTracer"
+	gas := hexutil.Uint64(100000)
+	gasPrice := hexutil.Big(*big.NewInt(0))
+	topic := common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	code := hexutil.Bytes(common.FromHex("0x7f111111111111111111111111111111111111111111111111111111111111111160006000a100"))
+	overrides := kaiaapi.EthStateOverride{
+		contract: {Code: &code},
+	}
+	config := &TraceConfig{
+		Tracer:         &tracerName,
+		TracerConfig:   json.RawMessage(`{"withLog":true}`),
+		StateOverrides: &overrides,
+	}
+
+	blockNumber := rpc.LatestBlockNumber
+	result, err := api.TraceCall(context.Background(), kaiaapi.CallArgs{
+		From:     from,
+		To:       &contract,
+		Gas:      &gas,
+		GasPrice: &gasPrice,
+	}, rpc.BlockNumberOrHash{BlockNumber: &blockNumber}, config)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	frame, ok := result.(vm.CallFrame)
+	if !assert.True(t, ok, "expected vm.CallFrame result, got %T", result) {
+		return
+	}
+	if assert.Len(t, frame.Logs, 1) {
+		assert.Equal(t, contract, frame.Logs[0].Address)
+		assert.Equal(t, []common.Hash{topic}, frame.Logs[0].Topics)
+		assert.Empty(t, frame.Logs[0].Data)
+		assert.Equal(t, hexutil.Uint(0), frame.Logs[0].Index)
+		assert.Equal(t, hexutil.Uint(0), frame.Logs[0].Position)
+	}
+	encoded, err := json.Marshal(frame)
+	assert.NoError(t, err)
+	assert.Contains(t, string(encoded), `"logs"`)
+}
+
 func TestTraceTransaction(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Proposed changes

This PR adds native tracer support needed for richer `debug_traceCall` inspection.


- **Native `prestateTracer`** (`blockchain/vm/prestate_tracer.go`)
  - Default mode: the pre-state of every account/slot touched by the tx.
  - `diffMode`: `{pre, post}` showing only what changed.
  - Config: `diffMode`, `disableCode`, `disableStorage`.
- **`callTracer` config** (`blockchain/vm/call_tracer.go`)
  - `withLog`: capture `LOG0`–`LOG4` events per call frame (logs from reverted
    frames are pruned, matching geth).
  - `onlyTopCall`: skip nested frames.
- **`debug_traceCall` fixes** (`node/cn/tracers/api.go`)
  - Accepts `stateOverrides` (balance/nonce/code/state), applied before the trace.
  - Tops up the caller's balance using the effective gas price instead of base fee,
    so calls with a non-base-fee gas price don't fail with insufficient balance.
  - Wires `tracerConfig` through to the native tracers.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

#### The "synthetic balance" concept

`debug_traceCall` simulates a call against historical state plus optional `stateOverrides`.
The caller is frequently an account that can't actually afford gas (`gas * gasPrice`) — you might trace a call from a zero-balance address.
To keep the EVM from aborting with "insufficient balance for gas," `TraceCall` injects a **synthetic balance** into the caller before execution:

```
synthAmount = gas * effectiveGasPrice
statedb.AddBalance(sender, synthAmount)
```

This money is scaffolding, not real state.

The problem: `prestateTracer` reports account balances, so the synthetic top-up would leak into the output — the caller's reported pre-balance would be inflated, and in `diffMode` the post-balance would show phantom gas movement. So the tracer subtracts the scaffolding back out.

During execution the synthetic money splits between two accounts:
```
sender:   + synthAmount        (injected)
          - gasprice           (buyGas, charged up front for the whole limit)
          + restGasprice       (unused gas refunded -> stays with the SENDER)
fee:      - gasUsed*price      (paid out to the block PROPOSER: coinbase/rewardbase)
```

So after the tx the synthetic money sits in two places:
- `restGas*price` left in the **sender** — `synthRefund`.
- `gasUsed*price` went to the **proposer** — `synthFee`.

The tracer removes each piece from where it landed:
- `pre`: subtract `synthAmount` from the sender (`adjustPreBalance`) → pre shows the balance the caller actually selected (genesis/historical + `stateOverrides`).
- `post`: subtract `synthRefund` from the sender and `synthFee` from the proposer (`adjustPostBalance`).

Net result: the diff reflects logical state changes (value transfers, storage, created contracts) with the simulation's gas accounting fully hidden.
The sender and proposer are distinct accounts, which is why there are two legs.
