### PR TITLE
system: fix KIP113 mock address collision

### DIFF
--- a/blockchain/system/constant.go
+++ b/blockchain/system/constant.go
@@ -65,9 +65,9 @@ var (
 	RegistryAddr    = common.HexToAddress("0x0000000000000000000000000000000000000401")
 	MultiCallAddr   = common.HexToAddress("0x0000000000000000000000000000000000000402")
 	// The following addresses are only used for testing.
-	Kip113ProxyAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000402")
-	Kip113LogicAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000403")
-	AuctionEntryPointAddrMock = common.HexToAddress("0x0000000000000000000000000000000000000404")
+	Kip113ProxyAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000403")
+	Kip113LogicAddrMock       = common.HexToAddress("0x0000000000000000000000000000000000000404")
+	AuctionEntryPointAddrMock = common.HexToAddress("0x0000000000000000000000000000000000000405")
 
 	// Registry will return zero address for non-existent system contract.
 	NonExistentAddress = common.HexToAddress("0x0000000000000000000000000000000000000000")

--- a/params/config.go
+++ b/params/config.go
@@ -251,9 +251,10 @@ const (
 
 var (
 	// DefaultRegistryConfig is the default registry config for the Randao fork.
+	// NOTE: KIP113 address must match system.Kip113LogicAddrMock in blockchain/system/constant.go.
 	DefaultRegistryConfig = &RegistryConfig{
 		Records: map[string]common.Address{
-			"KIP113": common.HexToAddress("0x0000000000000000000000000000000000000403"),
+			"KIP113": common.HexToAddress("0x0000000000000000000000000000000000000404"),
 		},
 		Owner: common.HexToAddress("0x0000000000000000000000000000000000000000"),
 	}


### PR DESCRIPTION
## Proposed changes

`Kip113ProxyAddrMock` collides with `MultiCallAddr` at `0x402`. Shift the testing-only mock addresses by +1 and update `DefaultRegistryConfig` to match:

- `Kip113ProxyAddrMock`: 0x402 → 0x403
- `Kip113LogicAddrMock`: 0x403 → 0x404
- `AuctionEntryPointAddrMock`: 0x404 → 0x405
- `DefaultRegistryConfig["KIP113"]`: 0x403 → 0x404

This re-applies the fix from the permissionless branch (#803, #812) that was lost while re-landing the work on dev. Without it, homi-generated test networks place the KIP113 proxy at 0x402, where the runtime-injected MultiCall shadows it.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

- #803, #812 (original fix on the permissionless branch)