### PR TITLE
vrank: register kaia_getCFS / kaia_getPFS RPC APIs

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -1178,6 +1178,18 @@ var klayMethods = [
 		name: 'isConsoleLogEnabled',
 		call: 'klay_isConsoleLogEnabled',
 	}),
+	new web3._extend.Method({
+		name: 'getPFS',
+		call: 'kaia_getPFS',
+		params: 1,
+		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
+	}),
+	new web3._extend.Method({
+		name: 'getCFS',
+		call: 'kaia_getCFS',
+		params: 1,
+		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
+	}),
 ];
 `
 

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -620,6 +620,9 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 		}
 	}
 
+	// VRank exposes the kaia_getCFS / kaia_getPFS JSON-RPC APIs on all node types.
+	mJsonRpc = append(mJsonRpc, mVRank)
+
 	// Register modules to respective components
 	// TODO-kaiax: Organize below lines.
 	s.RegisterBaseModules(mBase...)


### PR DESCRIPTION
## Proposed changes

Register the VRank module in `mJsonRpc` so its `kaia_getCFS` / `kaia_getPFS` APIs are actually served. Previously `mVRank` was missing from the list, so `kaia_getCFS` returned "method does not exist". Also add the console web3 extension wrappers.


## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues
