### PR TITLE
consensus, node/cn: wire VRank CFS consensus message flow

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
@@ -120,6 +121,10 @@ type Sealer interface {
 type Engine interface {
 	// RegisterKaiaxModules wires kaiax modules to the consensus engine.
 	RegisterKaiaxModules(mGov gov.GovModule, mValset valset.ValsetModule)
+
+	// RegisterVRankModule wires the VRank module so the engine relays accepted
+	// PRE-PREPAREs into it. Engines without VRank support implement this as a no-op.
+	RegisterVRankModule(mVRank vrank.VRankModule)
 
 	// Start starts any consensus-specific background lifecycle.
 	// Engines without a background runtime should implement this as a no-op.

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
@@ -129,6 +130,9 @@ func (f *Faker) Sealer() consensus.Sealer { return f }
 
 // RegisterKaiaxModules is a no-op for faker.
 func (f *Faker) RegisterKaiaxModules(mGov gov.GovModule, mValset valset.ValsetModule) {}
+
+// RegisterVRankModule is a no-op for faker.
+func (f *Faker) RegisterVRankModule(mVRank vrank.VRankModule) {}
 
 func (f *Faker) SigHash(_ *types.Header) common.Hash {
 	return common.Hash{}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/log"
 )
 
@@ -116,6 +117,13 @@ type backend struct {
 	// Reference to the kaiax modules
 	valsetModule valset.ValsetModule
 	sealer       *istanbul.IstanbulSealer
+
+	// VRank consensus-participation collection: accepted PRE-PREPAREs are relayed
+	// to the VRank module off the consensus hot path. nil until RegisterVRankModule.
+	vrankModule       vrank.VRankModule
+	prepreparedSub    *event.TypeMuxSubscription
+	prepreparedStopCh chan struct{}
+	prepreparedWg     sync.WaitGroup
 
 	// Node type
 	nodetype common.ConnType

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -200,7 +200,9 @@ func (sb *backend) Start(chain consensus.ChainReader, executor consensus.Executo
 	sb.SetChain(chain)
 	sb.executor = executor
 
+	sb.startPrepreparedRelay()
 	if err := sb.core.Start(); err != nil {
+		sb.stopPrepreparedRelay()
 		return err
 	}
 
@@ -224,6 +226,7 @@ func (sb *backend) Stop() error {
 		sb.commitCh = nil
 	}
 	sb.sealMu.Unlock()
+	sb.stopPrepreparedRelay()
 	if err := sb.core.Stop(); err != nil {
 		return err
 	}

--- a/consensus/istanbul/backend/vrank.go
+++ b/consensus/istanbul/backend/vrank.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package backend
+
+import (
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/kaiax/vrank"
+)
+
+// RegisterVRankModule sets the VRank module of the Istanbul backend so that
+// accepted PRE-PREPAREs are relayed to it for consensus-participation scoring.
+func (sb *backend) RegisterVRankModule(module vrank.VRankModule) {
+	sb.vrankModule = module
+}
+
+// startPrepreparedRelay subscribes to PrepreparedEvent and forwards each accepted
+// (block, view) to the VRank module on dedicated goroutines, so the consensus hot
+// path is never blocked. No-op if no VRank module is registered.
+func (sb *backend) startPrepreparedRelay() {
+	if sb.vrankModule == nil || sb.prepreparedSub != nil {
+		return
+	}
+	const relayQueueSize = 32
+
+	sub := sb.istanbulEventMux.Subscribe(istanbul.PrepreparedEvent{})
+	stopCh := make(chan struct{})
+	queue := make(chan istanbul.PrepreparedEvent, relayQueueSize)
+
+	sb.prepreparedSub = sub
+	sb.prepreparedStopCh = stopCh
+
+	sb.prepreparedWg.Add(1)
+	go func() {
+		defer close(queue)
+		defer sb.prepreparedWg.Done()
+		for {
+			select {
+			case ev, ok := <-sub.Chan():
+				if !ok {
+					return
+				}
+				preprepared, ok := ev.Data.(istanbul.PrepreparedEvent)
+				if !ok || preprepared.Block == nil || preprepared.View == nil {
+					continue
+				}
+				// Non-blocking enqueue keeps the TypeMux Post path free of backpressure.
+				select {
+				case queue <- preprepared:
+				default:
+					logger.Warn("Dropping PrepreparedEvent due to full relay queue",
+						"blockNum", preprepared.Block.NumberU64(), "round", preprepared.View.Round.Uint64())
+				}
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+
+	sb.prepreparedWg.Add(1)
+	go func() {
+		defer sb.prepreparedWg.Done()
+		for preprepared := range queue {
+			sb.vrankModule.HandleIstanbulPreprepare(preprepared.Block, preprepared.View)
+		}
+	}()
+}
+
+// stopPrepreparedRelay unsubscribes and waits for the relay goroutines to exit.
+func (sb *backend) stopPrepreparedRelay() {
+	if sb.prepreparedSub != nil {
+		sb.prepreparedSub.Unsubscribe()
+		sb.prepreparedSub = nil
+	}
+	if sb.prepreparedStopCh != nil {
+		close(sb.prepreparedStopCh)
+		sb.prepreparedStopCh = nil
+	}
+	sb.prepreparedWg.Wait()
+}

--- a/consensus/istanbul/backend/vrank_test.go
+++ b/consensus/istanbul/backend/vrank_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package backend
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	vrank_mock "github.com/kaiachain/kaia/kaiax/vrank/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackend_startPrepreparedRelay asserts that, with a VRank module registered, a
+// PrepreparedEvent posted on the Istanbul mux is forwarded once to the module's
+// HandleIstanbulPreprepare with the same (block, view).
+func TestBackend_startPrepreparedRelay(t *testing.T) {
+	sb := newTestBackend()
+	defer sb.Stop()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockVRank := vrank_mock.NewMockVRankModule(mockCtrl)
+
+	// Capture the forwarded (block, view); the channel send/receive synchronizes the
+	// relay goroutine's writes with the assertions below.
+	var (
+		gotBlock *types.Block
+		gotView  *bft.View
+		got      = make(chan struct{}, 1)
+	)
+	mockVRank.EXPECT().HandleIstanbulPreprepare(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(b *types.Block, v *bft.View) {
+			gotBlock, gotView = b, v
+			got <- struct{}{}
+		}).Times(1)
+
+	sb.RegisterVRankModule(mockVRank)
+	sb.startPrepreparedRelay()
+	defer sb.stopPrepreparedRelay()
+
+	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(7)})
+	view := &bft.View{Sequence: big.NewInt(7), Round: big.NewInt(0)}
+	sb.istanbulEventMux.Post(istanbul.PrepreparedEvent{Block: block, View: view})
+
+	select {
+	case <-got:
+		require.NotNil(t, gotBlock)
+		assert.Equal(t, block.Hash(), gotBlock.Hash())
+		require.NotNil(t, gotView)
+		assert.Equal(t, view.Sequence.Uint64(), gotView.Sequence.Uint64())
+		assert.Equal(t, view.Round.Uint64(), gotView.Round.Uint64())
+	case <-time.After(3 * time.Second):
+		t.Fatal("relay did not forward PrepreparedEvent to the VRank module")
+	}
+}
+
+// TestBackend_startPrepreparedRelay_NoModule ensures the relay is a no-op when no
+// VRank module is registered (e.g. on non-CN nodes), rather than panicking.
+func TestBackend_startPrepreparedRelay_NoModule(t *testing.T) {
+	sb := newTestBackend()
+	defer sb.Stop()
+
+	sb.startPrepreparedRelay()
+	defer sb.stopPrepreparedRelay()
+
+	// Posting an event must not panic or block even though nothing consumes it.
+	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
+	sb.istanbulEventMux.Post(istanbul.PrepreparedEvent{Block: block, View: &bft.View{Sequence: big.NewInt(1), Round: big.NewInt(0)}})
+
+	assert.Nil(t, sb.prepreparedSub, "relay must not subscribe without a VRank module")
+}

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -556,6 +556,109 @@ func TestCore_handlerMsg(t *testing.T) {
 	}
 }
 
+// TestCore_postPrepreparedEvent asserts the core posts a PrepreparedEvent on both
+// emission sites: sendPreprepare (proposer) and handlePreprepare (receiver).
+func TestCore_postPrepreparedEvent(t *testing.T) {
+	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
+	defer fork.ClearHardForkBlockNumberConfig()
+
+	validatorAddrs, validatorKeyMap := genValidators(10)
+
+	// startCore builds and starts a core whose owner (validatorAddrs[0]) is also the
+	// round-0 proposer (see newMockBackend), so both emission paths are reachable.
+	startCore := func(t *testing.T) (*core, *mock_istanbul.MockBackend, func()) {
+		mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+		istConfig := istanbul.DefaultConfig.Copy()
+		istConfig.ProposerPolicy = istanbul.WeightedRandom
+		istCore := New(mockBackend, istConfig).(*core)
+		istCore.RegisterKaiaxModules(mockValset, mockGov)
+		if err := istCore.Start(); err != nil {
+			t.Fatal(err)
+		}
+		return istCore, mockBackend, func() {
+			istCore.Stop()
+			mockCtrl.Finish()
+		}
+	}
+
+	// awaitEvent reads the next PrepreparedEvent concurrently. event.TypeMux uses an
+	// unbuffered channel, so the synchronous Post blocks until a reader is present;
+	// the reader must be started before the triggering call.
+	awaitEvent := func(sub *event.TypeMuxSubscription) <-chan istanbul.PrepreparedEvent {
+		out := make(chan istanbul.PrepreparedEvent, 1)
+		go func() {
+			if ev := <-sub.Chan(); ev != nil {
+				if pe, ok := ev.Data.(istanbul.PrepreparedEvent); ok {
+					out <- pe
+				}
+			}
+		}()
+		return out
+	}
+
+	t.Run("proposer path (sendPreprepare)", func(t *testing.T) {
+		istCore, mockBackend, cleanup := startCore(t)
+		defer cleanup()
+
+		lastProposal, _ := mockBackend.LastProposal()
+		lastBlock := lastProposal.(*types.Block)
+		wantSeq := lastBlock.NumberU64() + 1
+
+		sub := mockBackend.EventMux().Subscribe(istanbul.PrepreparedEvent{})
+		defer sub.Unsubscribe()
+		out := awaitEvent(sub)
+
+		proposal, err := genBlock(lastBlock, validatorKeyMap[validatorAddrs[0]])
+		require.NoError(t, err)
+
+		// sendPreprepare re-seals the proposal, so assert on number/view, not hash.
+		istCore.sendPreprepare(&bft.Request{Proposal: proposal})
+
+		select {
+		case pe := <-out:
+			require.NotNil(t, pe.Block)
+			assert.Equal(t, wantSeq, pe.Block.NumberU64())
+			assert.Equal(t, wantSeq, pe.View.Sequence.Uint64())
+			assert.Equal(t, uint64(0), pe.View.Round.Uint64())
+		case <-time.After(3 * time.Second):
+			t.Fatal("expected PrepreparedEvent from sendPreprepare was not posted")
+		}
+	})
+
+	t.Run("receiver path (handlePreprepare)", func(t *testing.T) {
+		istCore, mockBackend, cleanup := startCore(t)
+		defer cleanup()
+
+		lastProposal, _ := mockBackend.LastProposal()
+		lastBlock := lastProposal.(*types.Block)
+		wantSeq := lastBlock.NumberU64() + 1
+		committeeSize := uint64(len(validatorAddrs) / 3)
+		_, _, proposer, _ := getTestCommitteeState(validatorAddrs, committeeSize, wantSeq, 0)
+		proposerKey := validatorKeyMap[proposer]
+
+		sub := mockBackend.EventMux().Subscribe(istanbul.PrepreparedEvent{})
+		defer sub.Unsubscribe()
+		out := awaitEvent(sub)
+
+		proposal, err := genBlock(lastBlock, proposerKey)
+		require.NoError(t, err)
+		istanbulMsg, err := genIstanbulMsg(bft.MsgPreprepare, lastBlock.Hash(), proposal, proposer, proposerKey)
+		require.NoError(t, err)
+
+		require.NoError(t, istCore.handleMsg(istanbulMsg.Payload))
+
+		select {
+		case pe := <-out:
+			require.NotNil(t, pe.Block)
+			assert.Equal(t, proposal.Hash(), pe.Block.Hash())
+			assert.Equal(t, wantSeq, pe.View.Sequence.Uint64())
+			assert.Equal(t, uint64(0), pe.View.Round.Uint64())
+		case <-time.After(3 * time.Second):
+			t.Fatal("expected PrepreparedEvent from handlePreprepare was not posted")
+		}
+	})
+}
+
 // TODO-Kaia: To enable logging in the test code, we can use the following function.
 // This function will be moved to somewhere utility functions are located.
 func enableLog() {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -556,107 +556,62 @@ func TestCore_handlerMsg(t *testing.T) {
 	}
 }
 
-// TestCore_postPrepreparedEvent asserts the core posts a PrepreparedEvent on both
-// emission sites: sendPreprepare (proposer) and handlePreprepare (receiver).
+// TestCore_postPrepreparedEvent asserts the core posts a PrepreparedEvent when it
+// accepts a PRE-PREPARE in handlePreprepare. This is the sole emission site; the
+// proposer reaches it via the backend's self-broadcast loopback, like any receiver.
 func TestCore_postPrepreparedEvent(t *testing.T) {
 	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
 	defer fork.ClearHardForkBlockNumberConfig()
 
 	validatorAddrs, validatorKeyMap := genValidators(10)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	defer mockCtrl.Finish()
 
-	// startCore builds and starts a core whose owner (validatorAddrs[0]) is also the
-	// round-0 proposer (see newMockBackend), so both emission paths are reachable.
-	startCore := func(t *testing.T) (*core, *mock_istanbul.MockBackend, func()) {
-		mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
-		istConfig := istanbul.DefaultConfig.Copy()
-		istConfig.ProposerPolicy = istanbul.WeightedRandom
-		istCore := New(mockBackend, istConfig).(*core)
-		istCore.RegisterKaiaxModules(mockValset, mockGov)
-		if err := istCore.Start(); err != nil {
-			t.Fatal(err)
-		}
-		return istCore, mockBackend, func() {
-			istCore.Stop()
-			mockCtrl.Finish()
-		}
+	istConfig := istanbul.DefaultConfig.Copy()
+	istConfig.ProposerPolicy = istanbul.WeightedRandom
+	istCore := New(mockBackend, istConfig).(*core)
+	istCore.RegisterKaiaxModules(mockValset, mockGov)
+	if err := istCore.Start(); err != nil {
+		t.Fatal(err)
 	}
+	defer istCore.Stop()
 
-	// awaitEvent reads the next PrepreparedEvent concurrently. event.TypeMux uses an
-	// unbuffered channel, so the synchronous Post blocks until a reader is present;
-	// the reader must be started before the triggering call.
-	awaitEvent := func(sub *event.TypeMuxSubscription) <-chan istanbul.PrepreparedEvent {
-		out := make(chan istanbul.PrepreparedEvent, 1)
-		go func() {
-			if ev := <-sub.Chan(); ev != nil {
-				if pe, ok := ev.Data.(istanbul.PrepreparedEvent); ok {
-					out <- pe
-				}
+	lastProposal, _ := mockBackend.LastProposal()
+	lastBlock := lastProposal.(*types.Block)
+	wantSeq := lastBlock.NumberU64() + 1
+	committeeSize := uint64(len(validatorAddrs) / 3)
+	_, _, proposer, _ := getTestCommitteeState(validatorAddrs, committeeSize, wantSeq, 0)
+	proposerKey := validatorKeyMap[proposer]
+
+	sub := mockBackend.EventMux().Subscribe(istanbul.PrepreparedEvent{})
+	defer sub.Unsubscribe()
+
+	// event.TypeMux uses an unbuffered channel, so handleMsg's synchronous Post blocks
+	// until a reader is present; start the reader before triggering.
+	out := make(chan istanbul.PrepreparedEvent, 1)
+	go func() {
+		if ev := <-sub.Chan(); ev != nil {
+			if pe, ok := ev.Data.(istanbul.PrepreparedEvent); ok {
+				out <- pe
 			}
-		}()
-		return out
+		}
+	}()
+
+	proposal, err := genBlock(lastBlock, proposerKey)
+	require.NoError(t, err)
+	istanbulMsg, err := genIstanbulMsg(bft.MsgPreprepare, lastBlock.Hash(), proposal, proposer, proposerKey)
+	require.NoError(t, err)
+	require.NoError(t, istCore.handleMsg(istanbulMsg.Payload))
+
+	select {
+	case pe := <-out:
+		require.NotNil(t, pe.Block)
+		assert.Equal(t, proposal.Hash(), pe.Block.Hash())
+		assert.Equal(t, wantSeq, pe.View.Sequence.Uint64())
+		assert.Equal(t, uint64(0), pe.View.Round.Uint64())
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected PrepreparedEvent from handlePreprepare was not posted")
 	}
-
-	t.Run("proposer path (sendPreprepare)", func(t *testing.T) {
-		istCore, mockBackend, cleanup := startCore(t)
-		defer cleanup()
-
-		lastProposal, _ := mockBackend.LastProposal()
-		lastBlock := lastProposal.(*types.Block)
-		wantSeq := lastBlock.NumberU64() + 1
-
-		sub := mockBackend.EventMux().Subscribe(istanbul.PrepreparedEvent{})
-		defer sub.Unsubscribe()
-		out := awaitEvent(sub)
-
-		proposal, err := genBlock(lastBlock, validatorKeyMap[validatorAddrs[0]])
-		require.NoError(t, err)
-
-		// sendPreprepare re-seals the proposal, so assert on number/view, not hash.
-		istCore.sendPreprepare(&bft.Request{Proposal: proposal})
-
-		select {
-		case pe := <-out:
-			require.NotNil(t, pe.Block)
-			assert.Equal(t, wantSeq, pe.Block.NumberU64())
-			assert.Equal(t, wantSeq, pe.View.Sequence.Uint64())
-			assert.Equal(t, uint64(0), pe.View.Round.Uint64())
-		case <-time.After(3 * time.Second):
-			t.Fatal("expected PrepreparedEvent from sendPreprepare was not posted")
-		}
-	})
-
-	t.Run("receiver path (handlePreprepare)", func(t *testing.T) {
-		istCore, mockBackend, cleanup := startCore(t)
-		defer cleanup()
-
-		lastProposal, _ := mockBackend.LastProposal()
-		lastBlock := lastProposal.(*types.Block)
-		wantSeq := lastBlock.NumberU64() + 1
-		committeeSize := uint64(len(validatorAddrs) / 3)
-		_, _, proposer, _ := getTestCommitteeState(validatorAddrs, committeeSize, wantSeq, 0)
-		proposerKey := validatorKeyMap[proposer]
-
-		sub := mockBackend.EventMux().Subscribe(istanbul.PrepreparedEvent{})
-		defer sub.Unsubscribe()
-		out := awaitEvent(sub)
-
-		proposal, err := genBlock(lastBlock, proposerKey)
-		require.NoError(t, err)
-		istanbulMsg, err := genIstanbulMsg(bft.MsgPreprepare, lastBlock.Hash(), proposal, proposer, proposerKey)
-		require.NoError(t, err)
-
-		require.NoError(t, istCore.handleMsg(istanbulMsg.Payload))
-
-		select {
-		case pe := <-out:
-			require.NotNil(t, pe.Block)
-			assert.Equal(t, proposal.Hash(), pe.Block.Hash())
-			assert.Equal(t, wantSeq, pe.View.Sequence.Uint64())
-			assert.Equal(t, uint64(0), pe.View.Round.Uint64())
-		case <-time.After(3 * time.Second):
-			t.Fatal("expected PrepreparedEvent from handlePreprepare was not posted")
-		}
-	})
 }
 
 // TODO-Kaia: To enable logging in the test code, we can use the following function.

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -57,8 +57,6 @@ func (c *core) sendPreprepare(request *bft.Request) {
 			Code: bft.MsgPreprepare,
 			Msg:  preprepare,
 		})
-		// Notify VRank: proposer accepted its own preprepare.
-		c.postPrepreparedEvent(&bft.Preprepare{View: curView, Proposal: request.Proposal})
 	}
 }
 

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -23,11 +23,14 @@
 package core
 
 import (
+	"math/big"
 	"time"
 
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/consensus/istanbul"
 )
 
 func (c *core) sendPreprepare(request *bft.Request) {
@@ -54,6 +57,8 @@ func (c *core) sendPreprepare(request *bft.Request) {
 			Code: bft.MsgPreprepare,
 			Msg:  preprepare,
 		})
+		// Notify VRank: proposer accepted its own preprepare.
+		c.postPrepreparedEvent(&bft.Preprepare{View: curView, Proposal: request.Proposal})
 	}
 }
 
@@ -124,6 +129,7 @@ func (c *core) handlePreprepare(msg *bft.Message, src common.Address) error {
 				logger.Warn("Received preprepare message of the hash locked proposal and change state to prepared")
 				// Broadcast COMMIT and enters Prepared state directly
 				c.acceptPreprepare(preprepare)
+				c.postPrepreparedEvent(preprepare)
 				c.setState(StatePrepared)
 				c.sendCommit()
 			} else {
@@ -135,6 +141,7 @@ func (c *core) handlePreprepare(msg *bft.Message, src common.Address) error {
 			//   1. the locked proposal and the received proposal match
 			//   2. we have no locked proposal
 			c.acceptPreprepare(preprepare)
+			c.postPrepreparedEvent(preprepare)
 			c.setState(StatePreprepared)
 			c.sendPrepare()
 		}
@@ -146,4 +153,20 @@ func (c *core) handlePreprepare(msg *bft.Message, src common.Address) error {
 func (c *core) acceptPreprepare(preprepare *bft.Preprepare) {
 	c.consensusTimestamp = time.Now()
 	c.current.SetPreprepare(preprepare)
+}
+
+// postPrepreparedEvent notifies subscribers (VRank) that this node accepted the
+// PRE-PREPARE for the given (block, view). The view is deep-copied so later
+// round mutations don't alias the event payload.
+func (c *core) postPrepreparedEvent(preprepare *bft.Preprepare) {
+	block, ok := preprepare.Proposal.(*types.Block)
+	if !ok {
+		c.logger.Warn("Failed to post preprepared event due to unexpected proposal type")
+		return
+	}
+	view := &bft.View{
+		Round:    new(big.Int).Set(preprepare.View.Round),
+		Sequence: new(big.Int).Set(preprepare.View.Sequence),
+	}
+	c.sendEvent(istanbul.PrepreparedEvent{Block: block, View: view})
 }

--- a/consensus/istanbul/events.go
+++ b/consensus/istanbul/events.go
@@ -23,6 +23,7 @@
 package istanbul
 
 import (
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/bft"
 )
@@ -48,3 +49,10 @@ type ChainHeadEvent struct{}
 // NewSequenceEvent is posted when a new sequence (block number) starts.
 // This signals the worker to start preparing the next block.
 type NewSequenceEvent struct{}
+
+// PrepreparedEvent is posted when this node accepts a PRE-PREPARE for a (block, view).
+// VRank subscribes to it to record consensus participation timing for the view.
+type PrepreparedEvent struct {
+	Block *types.Block
+	View  *bft.View
+}

--- a/consensus/mocks/engine_mock.go
+++ b/consensus/mocks/engine_mock.go
@@ -14,6 +14,7 @@ import (
 	event "github.com/kaiachain/kaia/event"
 	gov "github.com/kaiachain/kaia/kaiax/gov"
 	valset "github.com/kaiachain/kaia/kaiax/valset"
+	vrank "github.com/kaiachain/kaia/kaiax/vrank"
 	rpc "github.com/kaiachain/kaia/networks/rpc"
 )
 
@@ -76,6 +77,18 @@ func (m *MockEngine) RegisterKaiaxModules(arg0 gov.GovModule, arg1 valset.Valset
 func (mr *MockEngineMockRecorder) RegisterKaiaxModules(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterKaiaxModules", reflect.TypeOf((*MockEngine)(nil).RegisterKaiaxModules), arg0, arg1)
+}
+
+// RegisterVRankModule mocks base method.
+func (m *MockEngine) RegisterVRankModule(arg0 vrank.VRankModule) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterVRankModule", arg0)
+}
+
+// RegisterVRankModule indicates an expected call of RegisterVRankModule.
+func (mr *MockEngineMockRecorder) RegisterVRankModule(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterVRankModule", reflect.TypeOf((*MockEngine)(nil).RegisterVRankModule), arg0)
 }
 
 // Start mocks base method.

--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -206,6 +206,7 @@ func (ctx *TransitionContext) applyEpochTransition(m valset.NodeMap) valset.Node
 			if ctx.isPassVrankTest(addr) {
 				competeOrDemote(addr, val)
 			} else {
+				logger.Trace("VRank test failed: CandTesting → Registered", "addr", addr, "cfs", ctx.CFS[addr], "cfsThreshold", ctx.CfsThreshold)
 				val.State = valset.Registered // T2
 			}
 		case valset.ValReady, valset.ValActive, valset.ValPaused:

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -282,7 +282,7 @@ func (v *VRankModule) BroadcastVRankPreprepare(vrankPreprepare *vrank.VRankPrepr
 		return
 	}
 	vrankPreprepare.Sig = sig
-	v.broadcast(candidates, vrank.VRankPreprepareMsg, vrankPreprepare)
+	v.broadcast(candidates, vrankPreprepare)
 }
 
 // BroadcastVRankCandidate is called by candidates.
@@ -294,13 +294,12 @@ func (v *VRankModule) BroadcastVRankCandidate(vrankCandidate *vrank.VRankCandida
 		return
 	}
 
-	v.broadcast(validators, vrank.VRankCandidateMsg, vrankCandidate)
+	v.broadcast(validators, vrankCandidate)
 }
 
-func (v *VRankModule) broadcast(targets []common.Address, code int, msg any) {
+func (v *VRankModule) broadcast(targets []common.Address, msg any) {
 	req := &vrank.VRankBroadcastEvent{
 		Targets: targets,
-		Code:    code,
 		Msg:     msg,
 	}
 	v.broadcastCh <- req

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -344,7 +344,6 @@ func TestHandleVRankPreprepare(t *testing.T) {
 
 		req := mustPop(t, candidate.sub)
 		assert.Equal(t, []common.Address{round1Val1.Addr, round1Val2.Addr}, req.Targets)
-		assert.Equal(t, vrank.VRankCandidateMsg, req.Code)
 		assert.Len(t, req.Msg.(*vrank.VRankCandidate).BlsSig, 96)
 	})
 

--- a/kaiax/vrank/impl/init_test.go
+++ b/kaiax/vrank/impl/init_test.go
@@ -374,12 +374,11 @@ func TestVRankModule_RestartAfterStop(t *testing.T) {
 	module.Stop() // Stop must be idempotent
 
 	require.NoError(t, module.Start())
-	module.broadcast([]common.Address{numToAddr(0)}, vrank.VRankCandidateMsg, "test")
+	module.broadcast([]common.Address{numToAddr(0)}, "test")
 
 	select {
 	case req := <-sink:
 		assert.Equal(t, []common.Address{numToAddr(0)}, req.Targets)
-		assert.Equal(t, vrank.VRankCandidateMsg, req.Code)
 		assert.Equal(t, "test", req.Msg)
 	case <-time.After(time.Second):
 		t.Fatal("broadcast did not resume after restart")

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -64,3 +64,9 @@ type VRankModule interface {
 
 	SubscribeVRank(sink chan<- *VRankBroadcastEvent) event.Subscription
 }
+
+// VRankModuleHost is implemented by the protocol manager to accept the VRank
+// module for p2p send/receive of VRank messages.
+type VRankModuleHost interface {
+	RegisterVRankModule(module VRankModule)
+}

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -69,19 +69,13 @@ func (m CPMatrix) ProposerCount() int {
 }
 
 const (
-	VRankPreprepareMsg = 0x17
-	VRankCandidateMsg  = 0x18
-)
-
-const (
 	// MaxRound is the maximum allowed consensus round per block (range [0, MaxRound]).
 	MaxRound = 10
 )
 
 type VRankBroadcastEvent struct {
 	Targets []common.Address
-	Code    int // VRankPreprepareMsg or VRankCandidateMsg
-	Msg     any // VRankPreprepare or VRankCandidate
+	Msg     any // *VRankPreprepare or *VRankCandidate; node/cn routes on the type
 }
 
 type VRankPreprepare struct {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -58,6 +58,7 @@ import (
 	system_impl "github.com/kaiachain/kaia/kaiax/system/impl"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	valset_impl "github.com/kaiachain/kaia/kaiax/valset/impl"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	vrank_impl "github.com/kaiachain/kaia/kaiax/vrank/impl"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/rpc"
@@ -111,6 +112,7 @@ type BackendProtocolManager interface {
 	SetSyncStop(flag bool)
 	staking.StakingModuleHost
 	auction.AuctionModuleHost
+	vrank.VRankModuleHost
 }
 
 type chainAwareConsensusEngine interface {
@@ -591,7 +593,7 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 		return err
 	}
 
-	mBase := []kaiax.BaseModule{s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao, mSystem}
+	mBase := []kaiax.BaseModule{s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao, mSystem, mVRank}
 	mExecution := []kaiax.ExecutionModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao}
 	mTxBundling := []kaiax.TxBundlingModule{}
 	mTxPool := []kaiax.TxPoolModule{}
@@ -629,7 +631,12 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	s.blockchain.RegisterKaiaxModules(s.govModule, mValset, mExecution, mRewindable, mHeader, mBlockState)
 	s.txPool.RegisterTxPoolModule(mTxPool...)
 	s.engine.RegisterKaiaxModules(s.govModule, mValset)
+	s.engine.RegisterVRankModule(mVRank)
 	s.protocolManager.RegisterStakingModule(s.stakingModule)
+	// VRank p2p send/receive runs on consensus nodes only (candidates are CN-typed).
+	if ctx.NodeType() == common.CONSENSUSNODE {
+		s.protocolManager.RegisterVRankModule(mVRank)
+	}
 
 	return nil
 }

--- a/node/cn/channel_manager.go
+++ b/node/cn/channel_manager.go
@@ -76,6 +76,9 @@ func NewChannelManager(channelSize int) *ChannelManager {
 	channelMgr.RegisterMsgCode(MiscChannel, BlobSidecarsRequestMsg)
 	channelMgr.RegisterMsgCode(MiscChannel, BlobSidecarsMsg)
 
+	channelMgr.RegisterMsgCode(MiscChannel, VRankPreprepareMsg)
+	channelMgr.RegisterMsgCode(MiscChannel, VRankCandidateMsg)
+
 	return channelMgr
 }
 

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/auction"
 	"github.com/kaiachain/kaia/kaiax/staking"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/node/cn/snap"
@@ -68,6 +69,9 @@ const (
 	// bidChanSize is the size of channel listening to NewBidEvent.
 	// The number is referenced from the size of bid pool.
 	bidChanSize = 2048
+
+	// vrankChanSize is the size of channel listening to VRankBroadcastEvent.
+	vrankChanSize = 2048
 
 	concurrentPerPeer  = 3
 	channelSizePerPeer = 20
@@ -122,6 +126,8 @@ type ProtocolManager struct {
 	minedBlockSub *event.TypeMuxSubscription
 	bidCh         chan *auction.Bid
 	bidSub        event.Subscription
+	vrankCh       chan *vrank.VRankBroadcastEvent
+	vrankSub      event.Subscription
 
 	// channels for fetcher, syncer, txsyncLoop
 	newPeerCh   chan Peer
@@ -147,6 +153,7 @@ type ProtocolManager struct {
 
 	stakingModule staking.StakingModule
 	auctionModule auction.AuctionModule
+	vrankModule   vrank.VRankModule
 
 	missingBlobSidecarCh  <-chan *kaia_blockchain.MissingBlobSidecar
 	blobSidecarReqManager *sidecarReqManager
@@ -374,6 +381,14 @@ func (pm *ProtocolManager) IsAuctionModuleDisabled() bool {
 	return pm.auctionModule == nil
 }
 
+func (pm *ProtocolManager) RegisterVRankModule(m vrank.VRankModule) {
+	pm.vrankModule = m
+}
+
+func (pm *ProtocolManager) IsVRankModuleDisabled() bool {
+	return pm.vrankModule == nil
+}
+
 func (pm *ProtocolManager) getWSEndPoint() string {
 	return pm.wsendpoint
 }
@@ -424,6 +439,13 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 		go pm.bidBroadcastLoop()
 	}
 
+	if !pm.IsVRankModuleDisabled() {
+		// broadcast VRank preprepare/candidate messages
+		pm.vrankCh = make(chan *vrank.VRankBroadcastEvent, vrankChanSize)
+		pm.vrankSub = pm.vrankModule.SubscribeVRank(pm.vrankCh)
+		go pm.vrankBroadcastLoop()
+	}
+
 	// sync missing blob sidecars
 	pm.missingBlobSidecarCh = pm.txpool.SubscribeMissingBlobSidecars()
 	go pm.blobSidecarSyncLoop()
@@ -440,6 +462,9 @@ func (pm *ProtocolManager) Stop() {
 	pm.minedBlockSub.Unsubscribe() // quits blockBroadcastLoop
 	if !pm.IsAuctionModuleDisabled() {
 		pm.bidSub.Unsubscribe() // quits bidBroadcastLoop
+	}
+	if !pm.IsVRankModuleDisabled() {
+		pm.vrankSub.Unsubscribe() // quits vrankBroadcastLoop
 	}
 
 	// Quit the sync loop.
@@ -773,6 +798,16 @@ func (pm *ProtocolManager) handleMsg(p Peer, addr common.Address, msg p2p.Msg) e
 
 	case p.GetVersion() >= kaia67 && msg.Code == BlobSidecarsMsg:
 		if err := handleBlobSidecarsMsg(pm, p, msg); err != nil {
+			return err
+		}
+
+	case p.GetVersion() >= kaia68 && msg.Code == VRankPreprepareMsg:
+		if err := handleVRankPreprepareMsg(pm, p, msg); err != nil {
+			return err
+		}
+
+	case p.GetVersion() >= kaia68 && msg.Code == VRankCandidateMsg:
+		if err := handleVRankCandidateMsg(pm, p, msg); err != nil {
 			return err
 		}
 
@@ -1190,6 +1225,51 @@ func handleBidMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	}
 
 	pm.auctionModule.HandleBid(p.GetID(), data)
+
+	return nil
+}
+
+// handleVRankPreprepareMsg handles a VRankPreprepare message.
+func handleVRankPreprepareMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
+	if pm.IsVRankModuleDisabled() {
+		return nil
+	}
+
+	var data *vrank.VRankPreprepare
+	if err := msg.Decode(&data); err != nil {
+		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	}
+	if data == nil || data.Block == nil || data.View == nil || data.View.Sequence == nil || data.View.Round == nil {
+		return errResp(ErrDecode, "msg %v: malformed VRankPreprepare", msg)
+	}
+
+	if err := pm.vrankModule.HandleVRankPreprepare(data); err != nil {
+		logger.Debug("Failed to handle VRankPreprepare", "err", err)
+	}
+
+	return nil
+}
+
+// handleVRankCandidateMsg handles a VRankCandidate message.
+func handleVRankCandidateMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
+	if pm.IsVRankModuleDisabled() {
+		return nil
+	}
+
+	var data *vrank.VRankCandidate
+	if err := msg.Decode(&data); err != nil {
+		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	}
+	if data == nil || len(data.Sig) == 0 || len(data.BlsSig) == 0 {
+		return errResp(ErrDecode, "msg %v: malformed VRankCandidate", msg)
+	}
+
+	if err := pm.vrankModule.HandleVRankCandidate(data); err != nil {
+		if errors.Is(err, vrank.ErrRoundOutOfRange) || errors.Is(err, vrank.ErrInvalidCandidateSig) || errors.Is(err, vrank.ErrInvalidCandidateBlsSig) {
+			return err
+		}
+		logger.Debug("Failed to handle VRankCandidate", "err", err)
+	}
 
 	return nil
 }
@@ -1721,6 +1801,55 @@ func (pm *ProtocolManager) bidBroadcastLoop() {
 		case <-pm.bidSub.Err():
 			return
 		}
+	}
+}
+
+func (pm *ProtocolManager) vrankBroadcastLoop() {
+	for {
+		select {
+		case ev := <-pm.vrankCh:
+			pm.BroadcastVRank(ev)
+		case <-pm.vrankSub.Err():
+			return
+		}
+	}
+}
+
+// BroadcastVRank propagates a VRank message to the target CN peers carried in the
+// event. The VRank module decides the recipients (ev.Targets); this only routes.
+func (pm *ProtocolManager) BroadcastVRank(ev *vrank.VRankBroadcastEvent) {
+	if pm.nodetype != common.CONSENSUSNODE || ev == nil {
+		return
+	}
+
+	targets := make(map[common.Address]bool, len(ev.Targets))
+	for _, target := range ev.Targets {
+		targets[target] = true
+	}
+
+	var asyncSend func(peer Peer)
+	switch ev.Code {
+	case VRankPreprepareMsg:
+		preprepare, ok := ev.Msg.(*vrank.VRankPreprepare)
+		if !ok {
+			return
+		}
+		asyncSend = func(peer Peer) { peer.AsyncSendVRankPreprepare(preprepare) }
+	case VRankCandidateMsg:
+		candidate, ok := ev.Msg.(*vrank.VRankCandidate)
+		if !ok {
+			return
+		}
+		asyncSend = func(peer Peer) { peer.AsyncSendVRankCandidate(candidate) }
+	default:
+		return
+	}
+
+	for addr, peer := range pm.peers.CNPeers() {
+		if !targets[addr] || peer.GetVersion() < kaia68 {
+			continue
+		}
+		asyncSend(peer)
 	}
 }
 

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1828,19 +1828,11 @@ func (pm *ProtocolManager) BroadcastVRank(ev *vrank.VRankBroadcastEvent) {
 	}
 
 	var asyncSend func(peer Peer)
-	switch ev.Code {
-	case VRankPreprepareMsg:
-		preprepare, ok := ev.Msg.(*vrank.VRankPreprepare)
-		if !ok {
-			return
-		}
-		asyncSend = func(peer Peer) { peer.AsyncSendVRankPreprepare(preprepare) }
-	case VRankCandidateMsg:
-		candidate, ok := ev.Msg.(*vrank.VRankCandidate)
-		if !ok {
-			return
-		}
-		asyncSend = func(peer Peer) { peer.AsyncSendVRankCandidate(candidate) }
+	switch msg := ev.Msg.(type) {
+	case *vrank.VRankPreprepare:
+		asyncSend = func(peer Peer) { peer.AsyncSendVRankPreprepare(msg) }
+	case *vrank.VRankCandidate:
+		asyncSend = func(peer Peer) { peer.AsyncSendVRankCandidate(msg) }
 	default:
 		return
 	}

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -742,7 +742,7 @@ func TestHandleBidMsg(t *testing.T) {
 
 	msg := generateMsg(t, BidMsg, testBid)
 
-	mockPeer.EXPECT().GetVersion().Return(kaia63).Times(9)
+	mockPeer.EXPECT().GetVersion().Return(kaia63).Times(11)
 	assert.Error(t, pm.handleMsg(mockPeer, addrs[0], msg), "should return error when protocol version is not kaia66")
 
 	mockPeer.EXPECT().GetVersion().Return(kaia66).AnyTimes()

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/kaiax/auction"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/node/cn/snap"
@@ -75,6 +76,14 @@ const (
 	// maxQueuedBids is the maximum number of bid lists to queue up before
 	// dropping broadcasts.
 	maxQueuedBids = 128
+
+	// maxQueuedVRankPreprepare is the maximum number of VRankPreprepare messages to queue up before
+	// dropping broadcasts.
+	maxQueuedVRankPreprepare = 128
+
+	// maxQueuedVRankCandidate is the maximum number of VRankCandidate messages to queue up before
+	// dropping broadcasts.
+	maxQueuedVRankCandidate = 128
 
 	handshakeTimeout = 5 * time.Second
 )
@@ -146,6 +155,20 @@ type Peer interface {
 	// AsyncSendBid queues the availability of a bid for propagation to a remote peer.
 	// If the peer's broadcast queue is full, the event is silently dropped.
 	AsyncSendBid(bid *auction.Bid)
+
+	// SendVRankPreprepare sends a VRankPreprepare message to a remote peer.
+	SendVRankPreprepare(msg *vrank.VRankPreprepare) error
+
+	// AsyncSendVRankPreprepare queues a VRankPreprepare message for propagation to a remote peer.
+	// If the peer's broadcast queue is full, the event is silently dropped.
+	AsyncSendVRankPreprepare(msg *vrank.VRankPreprepare)
+
+	// SendVRankCandidate sends a VRankCandidate message to a remote peer.
+	SendVRankCandidate(msg *vrank.VRankCandidate) error
+
+	// AsyncSendVRankCandidate queues a VRankCandidate message for propagation to a remote peer.
+	// If the peer's broadcast queue is full, the event is silently dropped.
+	AsyncSendVRankCandidate(msg *vrank.VRankCandidate)
 
 	// SendNewBlock propagates an entire block to a remote peer.
 	SendNewBlock(block *types.Block, td *big.Int) error
@@ -286,11 +309,13 @@ type basePeer struct {
 	knownTxsCache    *knownHashSet             // bounded FIFO set of tx hashes known to be known by this peer
 	knownBlocksCache *knownHashSet             // bounded FIFO set of block hashes known to be known by this peer
 	knownBidsCache   *knownHashSet             // bounded FIFO set of bid hashes known to be known by this peer
-	queuedTxs        chan []*types.Transaction // Queue of transactions to broadcast to the peer
-	queuedProps      chan *propEvent           // Queue of blocks to broadcast to the peer
-	queuedAnns       chan *types.Block         // Queue of blocks to announce to the peer
-	queuedBids       chan *auction.Bid         // Queue of bids to broadcast to the peer
-	term             chan struct{}             // Termination channel to stop the broadcaster
+	queuedTxs              chan []*types.Transaction    // Queue of transactions to broadcast to the peer
+	queuedProps            chan *propEvent              // Queue of blocks to broadcast to the peer
+	queuedAnns             chan *types.Block            // Queue of blocks to announce to the peer
+	queuedBids             chan *auction.Bid            // Queue of bids to broadcast to the peer
+	queuedVRankPreprepare  chan *vrank.VRankPreprepare  // Queue of VRankPreprepare messages to broadcast to the peer
+	queuedVRankCandidate   chan *vrank.VRankCandidate   // Queue of VRankCandidate messages to broadcast to the peer
+	term                   chan struct{}                // Termination channel to stop the broadcaster
 
 	chainID *big.Int // ChainID to sign a transaction
 
@@ -318,18 +343,20 @@ func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) Peer {
 
 	return &singleChannelPeer{
 		basePeer: &basePeer{
-			Peer:             p,
-			rw:               rw,
-			version:          version,
-			id:               fmt.Sprintf("%x", id[:8]),
-			knownTxsCache:    newKnownTxCache(),
-			knownBlocksCache: newKnownBlockCache(),
-			knownBidsCache:   newKnownBidCache(),
-			queuedTxs:        make(chan []*types.Transaction, maxQueuedTxs),
-			queuedProps:      make(chan *propEvent, maxQueuedProps),
-			queuedAnns:       make(chan *types.Block, maxQueuedAnns),
-			queuedBids:       make(chan *auction.Bid, maxQueuedBids),
-			term:             make(chan struct{}),
+			Peer:                  p,
+			rw:                    rw,
+			version:               version,
+			id:                    fmt.Sprintf("%x", id[:8]),
+			knownTxsCache:         newKnownTxCache(),
+			knownBlocksCache:      newKnownBlockCache(),
+			knownBidsCache:        newKnownBidCache(),
+			queuedTxs:             make(chan []*types.Transaction, maxQueuedTxs),
+			queuedProps:           make(chan *propEvent, maxQueuedProps),
+			queuedAnns:            make(chan *types.Block, maxQueuedAnns),
+			queuedBids:            make(chan *auction.Bid, maxQueuedBids),
+			queuedVRankPreprepare: make(chan *vrank.VRankPreprepare, maxQueuedVRankPreprepare),
+			queuedVRankCandidate:  make(chan *vrank.VRankCandidate, maxQueuedVRankCandidate),
+			term:                  make(chan struct{}),
 		},
 	}
 }
@@ -365,6 +392,10 @@ var ChannelOfMessage = map[uint64]int{
 	// Protocol messages belonging to kaia/67
 	BlobSidecarsRequestMsg: p2p.ConnDefault,
 	BlobSidecarsMsg:        p2p.ConnDefault,
+
+	// Protocol messages belonging to kaia/68
+	VRankPreprepareMsg: p2p.ConnDefault,
+	VRankCandidateMsg:  p2p.ConnDefault,
 }
 
 var ConcurrentOfChannel = []int{
@@ -381,18 +412,20 @@ func newPeerWithRWs(version int, p *p2p.Peer, rws []p2p.MsgReadWriter) (Peer, er
 		return newPeer(version, p, rws[p2p.ConnDefault]), nil
 	} else if lenRWs > 1 {
 		bPeer := &basePeer{
-			Peer:             p,
-			rw:               rws[p2p.ConnDefault],
-			version:          version,
-			id:               fmt.Sprintf("%x", id[:8]),
-			knownTxsCache:    newKnownTxCache(),
-			knownBlocksCache: newKnownBlockCache(),
-			knownBidsCache:   newKnownBidCache(),
-			queuedTxs:        make(chan []*types.Transaction, maxQueuedTxs),
-			queuedProps:      make(chan *propEvent, maxQueuedProps),
-			queuedAnns:       make(chan *types.Block, maxQueuedAnns),
-			queuedBids:       make(chan *auction.Bid, maxQueuedBids),
-			term:             make(chan struct{}),
+			Peer:                  p,
+			rw:                    rws[p2p.ConnDefault],
+			version:               version,
+			id:                    fmt.Sprintf("%x", id[:8]),
+			knownTxsCache:         newKnownTxCache(),
+			knownBlocksCache:      newKnownBlockCache(),
+			knownBidsCache:        newKnownBidCache(),
+			queuedTxs:             make(chan []*types.Transaction, maxQueuedTxs),
+			queuedProps:           make(chan *propEvent, maxQueuedProps),
+			queuedAnns:            make(chan *types.Block, maxQueuedAnns),
+			queuedBids:            make(chan *auction.Bid, maxQueuedBids),
+			queuedVRankPreprepare: make(chan *vrank.VRankPreprepare, maxQueuedVRankPreprepare),
+			queuedVRankCandidate:  make(chan *vrank.VRankCandidate, maxQueuedVRankCandidate),
+			term:                  make(chan struct{}),
 		}
 		return &multiChannelPeer{
 			basePeer: bPeer,
@@ -441,6 +474,20 @@ func (p *basePeer) Broadcast() {
 				// return
 			}
 			p.Log().Trace("Broadcast bid", "peer", p.id, "hash", bid.Hash())
+
+		case msg := <-p.queuedVRankPreprepare:
+			if err := p.SendVRankPreprepare(msg); err != nil {
+				logger.Error("fail to SendVRankPreprepare", "peer", p.id, "err", err)
+				continue
+			}
+			p.Log().Trace("Broadcast VRankPreprepare", "peer", p.id)
+
+		case msg := <-p.queuedVRankCandidate:
+			if err := p.SendVRankCandidate(msg); err != nil {
+				logger.Error("fail to SendVRankCandidate", "peer", p.id, "err", err)
+				continue
+			}
+			p.Log().Trace("Broadcast VRankCandidate", "peer", p.id)
 
 		case <-p.term:
 			p.Log().Debug("Peer broadcast loop end", "peer", p.id)
@@ -589,6 +636,22 @@ func (p *basePeer) AsyncSendBid(bid *auction.Bid) {
 	}
 }
 
+func (p *basePeer) AsyncSendVRankPreprepare(msg *vrank.VRankPreprepare) {
+	select {
+	case p.queuedVRankPreprepare <- msg:
+	default:
+		p.Log().Debug("Dropping VRankPreprepare propagation")
+	}
+}
+
+func (p *basePeer) AsyncSendVRankCandidate(msg *vrank.VRankCandidate) {
+	select {
+	case p.queuedVRankCandidate <- msg:
+	default:
+		p.Log().Debug("Dropping VRankCandidate propagation")
+	}
+}
+
 // SendBlockHeaders sends a batch of block headers to the remote peer.
 func (p *basePeer) SendBlockHeaders(headers []*types.Header) error {
 	return p2p.Send(p.rw, BlockHeadersMsg, headers)
@@ -637,6 +700,16 @@ func (p *basePeer) SendStakingInfoRLP(stakingInfos []rlp.RawValue) error {
 // SendBid sends a bid to the remote peer.
 func (p *basePeer) SendBid(bid *auction.Bid) error {
 	return p2p.Send(p.rw, BidMsg, bid)
+}
+
+// SendVRankPreprepare sends a VRankPreprepare message to the remote peer.
+func (p *basePeer) SendVRankPreprepare(msg *vrank.VRankPreprepare) error {
+	return p2p.Send(p.rw, VRankPreprepareMsg, msg)
+}
+
+// SendVRankCandidate sends a VRankCandidate message to the remote peer.
+func (p *basePeer) SendVRankCandidate(msg *vrank.VRankCandidate) error {
+	return p2p.Send(p.rw, VRankCandidateMsg, msg)
 }
 
 // SendBlobSidecarsRLP sends a batch of blob sidecars to the remote peer from
@@ -933,6 +1006,20 @@ func (p *multiChannelPeer) Broadcast() {
 			}
 			p.Log().Trace("Broadcast bid", "peer", p.id, "hash", bid.Hash())
 
+		case msg := <-p.queuedVRankPreprepare:
+			if err := p.SendVRankPreprepare(msg); err != nil {
+				logger.Error("fail to SendVRankPreprepare", "peer", p.id, "err", err)
+				continue
+			}
+			p.Log().Trace("Broadcast VRankPreprepare", "peer", p.id)
+
+		case msg := <-p.queuedVRankCandidate:
+			if err := p.SendVRankCandidate(msg); err != nil {
+				logger.Error("fail to SendVRankCandidate", "peer", p.id, "err", err)
+				continue
+			}
+			p.Log().Trace("Broadcast VRankCandidate", "peer", p.id)
+
 		case <-p.term:
 			p.Log().Debug("Peer broadcast loop end", "peer", p.id)
 			return
@@ -1027,6 +1114,16 @@ func (p *multiChannelPeer) SendStakingInfoRLP(stakingInfos []rlp.RawValue) error
 func (p *multiChannelPeer) SendBid(bid *auction.Bid) error {
 	p.AddToKnownBids(bid.Hash())
 	return p.msgSender(BidMsg, bid)
+}
+
+// SendVRankPreprepare sends a VRankPreprepare message to the remote peer.
+func (p *multiChannelPeer) SendVRankPreprepare(msg *vrank.VRankPreprepare) error {
+	return p.msgSender(VRankPreprepareMsg, msg)
+}
+
+// SendVRankCandidate sends a VRankCandidate message to the remote peer.
+func (p *multiChannelPeer) SendVRankCandidate(msg *vrank.VRankCandidate) error {
+	return p.msgSender(VRankCandidateMsg, msg)
 }
 
 // SendBlobSidecarsRLP sends a batch of blob sidecars to the remote peer from

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -306,16 +306,16 @@ type basePeer struct {
 	td   *big.Int
 	lock sync.RWMutex
 
-	knownTxsCache    *knownHashSet             // bounded FIFO set of tx hashes known to be known by this peer
-	knownBlocksCache *knownHashSet             // bounded FIFO set of block hashes known to be known by this peer
-	knownBidsCache   *knownHashSet             // bounded FIFO set of bid hashes known to be known by this peer
-	queuedTxs              chan []*types.Transaction    // Queue of transactions to broadcast to the peer
-	queuedProps            chan *propEvent              // Queue of blocks to broadcast to the peer
-	queuedAnns             chan *types.Block            // Queue of blocks to announce to the peer
-	queuedBids             chan *auction.Bid            // Queue of bids to broadcast to the peer
-	queuedVRankPreprepare  chan *vrank.VRankPreprepare  // Queue of VRankPreprepare messages to broadcast to the peer
-	queuedVRankCandidate   chan *vrank.VRankCandidate   // Queue of VRankCandidate messages to broadcast to the peer
-	term                   chan struct{}                // Termination channel to stop the broadcaster
+	knownTxsCache         *knownHashSet               // bounded FIFO set of tx hashes known to be known by this peer
+	knownBlocksCache      *knownHashSet               // bounded FIFO set of block hashes known to be known by this peer
+	knownBidsCache        *knownHashSet               // bounded FIFO set of bid hashes known to be known by this peer
+	queuedTxs             chan []*types.Transaction   // Queue of transactions to broadcast to the peer
+	queuedProps           chan *propEvent             // Queue of blocks to broadcast to the peer
+	queuedAnns            chan *types.Block           // Queue of blocks to announce to the peer
+	queuedBids            chan *auction.Bid           // Queue of bids to broadcast to the peer
+	queuedVRankPreprepare chan *vrank.VRankPreprepare // Queue of VRankPreprepare messages to broadcast to the peer
+	queuedVRankCandidate  chan *vrank.VRankCandidate  // Queue of VRankCandidate messages to broadcast to the peer
+	term                  chan struct{}               // Termination channel to stop the broadcaster
 
 	chainID *big.Int // ChainID to sign a transaction
 

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -23,6 +23,7 @@
 package cn
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -346,7 +347,7 @@ func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter) Peer {
 			Peer:                  p,
 			rw:                    rw,
 			version:               version,
-			id:                    fmt.Sprintf("%x", id[:8]),
+			id:                    hex.EncodeToString(id[:8]),
 			knownTxsCache:         newKnownTxCache(),
 			knownBlocksCache:      newKnownBlockCache(),
 			knownBidsCache:        newKnownBidCache(),
@@ -415,7 +416,7 @@ func newPeerWithRWs(version int, p *p2p.Peer, rws []p2p.MsgReadWriter) (Peer, er
 			Peer:                  p,
 			rw:                    rws[p2p.ConnDefault],
 			version:               version,
-			id:                    fmt.Sprintf("%x", id[:8]),
+			id:                    hex.EncodeToString(id[:8]),
 			knownTxsCache:         newKnownTxCache(),
 			knownBlocksCache:      newKnownBlockCache(),
 			knownBidsCache:        newKnownBidCache(),

--- a/node/cn/peer_mock_test.go
+++ b/node/cn/peer_mock_test.go
@@ -12,6 +12,7 @@ import (
 	types "github.com/kaiachain/kaia/blockchain/types"
 	common "github.com/kaiachain/kaia/common"
 	auction "github.com/kaiachain/kaia/kaiax/auction"
+	vrank "github.com/kaiachain/kaia/kaiax/vrank"
 	p2p "github.com/kaiachain/kaia/networks/p2p"
 	discover "github.com/kaiachain/kaia/networks/p2p/discover"
 	snap "github.com/kaiachain/kaia/node/cn/snap"
@@ -123,6 +124,30 @@ func (m *MockPeer) AsyncSendTransactions(arg0 types.Transactions) {
 func (mr *MockPeerMockRecorder) AsyncSendTransactions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendTransactions", reflect.TypeOf((*MockPeer)(nil).AsyncSendTransactions), arg0)
+}
+
+// AsyncSendVRankCandidate mocks base method.
+func (m *MockPeer) AsyncSendVRankCandidate(arg0 *vrank.VRankCandidate) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AsyncSendVRankCandidate", arg0)
+}
+
+// AsyncSendVRankCandidate indicates an expected call of AsyncSendVRankCandidate.
+func (mr *MockPeerMockRecorder) AsyncSendVRankCandidate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendVRankCandidate", reflect.TypeOf((*MockPeer)(nil).AsyncSendVRankCandidate), arg0)
+}
+
+// AsyncSendVRankPreprepare mocks base method.
+func (m *MockPeer) AsyncSendVRankPreprepare(arg0 *vrank.VRankPreprepare) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AsyncSendVRankPreprepare", arg0)
+}
+
+// AsyncSendVRankPreprepare indicates an expected call of AsyncSendVRankPreprepare.
+func (mr *MockPeerMockRecorder) AsyncSendVRankPreprepare(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncSendVRankPreprepare", reflect.TypeOf((*MockPeer)(nil).AsyncSendVRankPreprepare), arg0)
 }
 
 // Broadcast mocks base method.
@@ -748,6 +773,34 @@ func (m *MockPeer) SendTransactions(arg0 types.Transactions) error {
 func (mr *MockPeerMockRecorder) SendTransactions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTransactions", reflect.TypeOf((*MockPeer)(nil).SendTransactions), arg0)
+}
+
+// SendVRankCandidate mocks base method.
+func (m *MockPeer) SendVRankCandidate(arg0 *vrank.VRankCandidate) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendVRankCandidate", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendVRankCandidate indicates an expected call of SendVRankCandidate.
+func (mr *MockPeerMockRecorder) SendVRankCandidate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendVRankCandidate", reflect.TypeOf((*MockPeer)(nil).SendVRankCandidate), arg0)
+}
+
+// SendVRankPreprepare mocks base method.
+func (m *MockPeer) SendVRankPreprepare(arg0 *vrank.VRankPreprepare) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendVRankPreprepare", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendVRankPreprepare indicates an expected call of SendVRankPreprepare.
+func (mr *MockPeerMockRecorder) SendVRankPreprepare(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendVRankPreprepare", reflect.TypeOf((*MockPeer)(nil).SendVRankPreprepare), arg0)
 }
 
 // SetAddr mocks base method.

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -45,6 +45,7 @@ const (
 	kaia65 = 65
 	kaia66 = 66
 	kaia67 = 67
+	kaia68 = 68
 )
 
 // Protocol defines the P2P protocol metadata used during capability negotiation.
@@ -60,8 +61,8 @@ type Protocol struct {
 // ConsensusProtocol is the P2P protocol used by BFT consensus nodes.
 var ConsensusProtocol = Protocol{
 	Name:     "istanbul",
-	Versions: []uint{kaia67, kaia66, kaia65, kaia64},
-	Lengths:  []uint64{26, 24, 23, 21},
+	Versions: []uint{kaia68, kaia67, kaia66, kaia65, kaia64},
+	Lengths:  []uint64{28, 26, 24, 23, 21},
 }
 
 const ProtocolMaxMsgSize = 12 * 1024 * 1024 // Maximum cap on the size of a protocol message
@@ -104,7 +105,11 @@ const (
 	BlobSidecarsRequestMsg = 0x15
 	BlobSidecarsMsg        = 0x16
 
-	MsgCodeEnd = 0x17
+	// Protocol messages belonging to kaia/68
+	VRankPreprepareMsg = 0x17
+	VRankCandidateMsg  = 0x18
+
+	MsgCodeEnd = 0x19
 )
 
 type errCode int

--- a/node/cn/protocolmanager_mock_test.go
+++ b/node/cn/protocolmanager_mock_test.go
@@ -12,6 +12,7 @@ import (
 	common "github.com/kaiachain/kaia/common"
 	auction "github.com/kaiachain/kaia/kaiax/auction"
 	staking "github.com/kaiachain/kaia/kaiax/staking"
+	vrank "github.com/kaiachain/kaia/kaiax/vrank"
 	p2p "github.com/kaiachain/kaia/networks/p2p"
 )
 
@@ -128,6 +129,18 @@ func (m *MockBackendProtocolManager) RegisterStakingModule(arg0 staking.StakingM
 func (mr *MockBackendProtocolManagerMockRecorder) RegisterStakingModule(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterStakingModule", reflect.TypeOf((*MockBackendProtocolManager)(nil).RegisterStakingModule), arg0)
+}
+
+// RegisterVRankModule mocks base method.
+func (m *MockBackendProtocolManager) RegisterVRankModule(arg0 vrank.VRankModule) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterVRankModule", arg0)
+}
+
+// RegisterVRankModule indicates an expected call of RegisterVRankModule.
+func (mr *MockBackendProtocolManagerMockRecorder) RegisterVRankModule(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterVRankModule", reflect.TypeOf((*MockBackendProtocolManager)(nil).RegisterVRankModule), arg0)
 }
 
 // SetAcceptTxs mocks base method.


### PR DESCRIPTION
## Proposed changes

VRank's CFS scoring (KIP-227) existed but nothing fed it at runtime, so every `CandTesting` node was scored as failed. This wires the flow end to end:

- istanbul `core` posts a `PrepreparedEvent` on accepting a PRE-PREPARE; the backend relays it to `VRankModule.HandleIstanbulPreprepare` off the hot path (new `consensus/istanbul/backend/vrank.go`).
- `node/cn` adds protocol `kaia68` with `VRankPreprepare`/`VRankCandidate` messages, version-gated dispatch, and a broadcast loop.
- `VRankModule` is registered with the engine and protocol manager, and added to the `BaseModule` set so its broadcast loop starts.

## Types of changes

- [x] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements

## Checklist

- [x] 📖 CONTRIBUTING read
- [x] 📝 CLA signed
- [x] 🟢 Lint and unit tests pass locally

## Related issues

<!-- KIP-227 -->

## Further comments
