### PR TITLE
consensus: harden IBFT header and message verification

### DIFF
--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -255,9 +255,34 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		if err != nil {
 			return err
 		}
+		// author == proposer implies the author is the committee-selected proposer,
+		// so a separate qualified-membership check is redundant here.
 		if author != proposer {
 			return consensus.ErrUnauthorized
 		}
+
+		// Count committed seals only from the round's committee, matching the set the
+		// live consensus commits against (handleCommit rejects non-committee senders),
+		// rather than the broader qualified/council set.
+		committee, err := v.mValset.GetCommittee(blockNum, uint64(round))
+		if err != nil {
+			return err
+		}
+		committeeSet := valset.NewAddressSet(committee)
+		validSeal := 0
+		for _, addr := range committers {
+			if committeeSet.Remove(addr) {
+				validSeal++
+			} else {
+				return istanbul.ErrInvalidCommittedSeals
+			}
+		}
+		// Require the quorum over the committee. Post-permissionless the committee
+		// equals the qualified set, so pass its size for both arguments.
+		if validSeal < v.sealer.Quorum(blockNum, len(committee), len(committee)) {
+			return istanbul.ErrInvalidCommittedSeals
+		}
+		return nil
 	}
 
 	qualified, err := v.mValset.GetQualifiedValidators(blockNum)
@@ -291,7 +316,9 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	if !gov.DeprecatedAt(gov.IstanbulCommitteeSize, rules) {
 		committeeSize = int(v.mGov.GetParamSet(blockNum).CommitteeSize)
 	}
-	if validSeal < v.sealer.Quorum(blockNum, qualifiedLen, committeeSize) {
+	// Pre-permissionless uses the legacy 2f+1 quorum. sealer.Quorum now returns
+	// ceil(2N/3), so compute 2f+1 explicitly to preserve historical header validity.
+	if validSeal < 2*v.sealer.F(blockNum, qualifiedLen, committeeSize)+1 {
 		return istanbul.ErrInvalidCommittedSeals
 	}
 	return nil

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/kaiax"
@@ -269,13 +270,9 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 			return err
 		}
 		committeeSet := valset.NewAddressSet(committee)
-		validSeal := 0
-		for _, addr := range committers {
-			if committeeSet.Remove(addr) {
-				validSeal++
-			} else {
-				return istanbul.ErrInvalidCommittedSeals
-			}
+		validSeal, err := countValidCommittedSeals(committers, committeeSet)
+		if err != nil {
+			return err
 		}
 		// Require the quorum over the committee. Post-permissionless the committee
 		// equals the qualified set, so pass its size for both arguments.
@@ -302,13 +299,9 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		}
 		signerSet = valset.NewAddressSet(council).Copy()
 	}
-	validSeal := 0
-	for _, addr := range committers {
-		if signerSet.Remove(addr) {
-			validSeal++
-		} else {
-			return istanbul.ErrInvalidCommittedSeals
-		}
+	validSeal, err := countValidCommittedSeals(committers, signerSet)
+	if err != nil {
+		return err
 	}
 
 	qualifiedLen := len(qualified)
@@ -322,6 +315,17 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		return istanbul.ErrInvalidCommittedSeals
 	}
 	return nil
+}
+
+func countValidCommittedSeals(committers []common.Address, signerSet *valset.AddressSet) (int, error) {
+	validSeal := 0
+	for _, addr := range committers {
+		if !signerSet.Remove(addr) {
+			return 0, istanbul.ErrInvalidCommittedSeals
+		}
+		validSeal++
+	}
+	return validSeal, nil
 }
 
 // ValidateBody verifies the block

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -251,7 +251,7 @@ func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
 	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
-	mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author}, nil)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{author}, nil)
 
 	validator := &BlockValidator{
 		config:  params.TestKaiaConfig("permissionless"),
@@ -263,7 +263,10 @@ func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
 	assert.NoError(t, validator.verifySeals(header))
 }
 
-func TestVerifySealsPermissionlessUsesQualifiedAsCommitteeSize(t *testing.T) {
+// TestVerifySealsPermissionlessUsesSealerQuorum checks that post-permissionless, the
+// quorum is taken from sealer.Quorum with the committee size passed for both
+// arguments (committee == qualified), and validSeal must meet it.
+func TestVerifySealsPermissionlessUsesSealerQuorum(t *testing.T) {
 	var (
 		author    = common.HexToAddress("0x0001")
 		b         = common.HexToAddress("0x0002")
@@ -272,7 +275,7 @@ func TestVerifySealsPermissionlessUsesQualifiedAsCommitteeSize(t *testing.T) {
 		e         = common.HexToAddress("0x0005")
 		blockNum  = uint64(7)
 		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
-		qualified = []common.Address{author, b, c, d, e}
+		committee = []common.Address{author, b, c, d, e}
 		sealer    = &verifySealsTestSealer{
 			Sealer:     faker.NewFaker(),
 			author:     author,
@@ -287,7 +290,7 @@ func TestVerifySealsPermissionlessUsesQualifiedAsCommitteeSize(t *testing.T) {
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
 	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
-	mValset.EXPECT().GetQualifiedValidators(blockNum).Return(qualified, nil)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
 		config:  params.TestKaiaConfig("permissionless"),
@@ -297,25 +300,27 @@ func TestVerifySealsPermissionlessUsesQualifiedAsCommitteeSize(t *testing.T) {
 	}
 
 	assert.NoError(t, validator.verifySeals(header))
-	assert.Equal(t, len(qualified), sealer.qualifiedLen)
-	assert.Equal(t, len(qualified), sealer.committeeSize)
+	// Quorum is computed over the committee size, passed as both arguments.
+	assert.Equal(t, len(committee), sealer.qualifiedLen)
+	assert.Equal(t, len(committee), sealer.committeeSize)
 }
 
-func TestVerifySealsPermissionlessRejectsNonQualifiedCommitter(t *testing.T) {
+// TestVerifySealsPermissionlessRejectsBelowQuorum checks that fewer committed seals
+// than sealer.Quorum reports are rejected.
+func TestVerifySealsPermissionlessRejectsBelowQuorum(t *testing.T) {
 	var (
 		author    = common.HexToAddress("0x0001")
 		b         = common.HexToAddress("0x0002")
 		c         = common.HexToAddress("0x0003")
 		d         = common.HexToAddress("0x0004")
-		paused    = common.HexToAddress("0x0005")
 		blockNum  = uint64(7)
 		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
-		qualified = []common.Address{author, b, c, d}
+		committee = []common.Address{author, b, c, d}
 		sealer    = &verifySealsTestSealer{
 			Sealer:     faker.NewFaker(),
 			author:     author,
-			committers: []common.Address{author, b, paused},
-			quorum:     3,
+			committers: []common.Address{author, b, c},
+			quorum:     4,
 		}
 	)
 
@@ -325,7 +330,45 @@ func TestVerifySealsPermissionlessRejectsNonQualifiedCommitter(t *testing.T) {
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
 	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
-	mValset.EXPECT().GetQualifiedValidators(blockNum).Return(qualified, nil)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
+
+	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+}
+
+// TestVerifySealsPermissionlessRejectsNonCommitteeCommitter checks that a committed
+// seal from a validator outside the round's committee is rejected, even if it
+// belongs to the broader qualified/council set.
+func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
+	var (
+		author       = common.HexToAddress("0x0001")
+		b            = common.HexToAddress("0x0002")
+		c            = common.HexToAddress("0x0003")
+		d            = common.HexToAddress("0x0004")
+		nonCommittee = common.HexToAddress("0x0005")
+		blockNum     = uint64(7)
+		header       = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		committee    = []common.Address{author, b, c, d}
+		sealer       = &verifySealsTestSealer{
+			Sealer:     faker.NewFaker(),
+			author:     author,
+			committers: []common.Address{author, b, nonCommittee},
+		}
+	)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
 		config:  params.TestKaiaConfig("permissionless"),

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	mock_gov "github.com/kaiachain/kaia/kaiax/gov/mock"
+	"github.com/kaiachain/kaia/kaiax/valset"
 	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
@@ -70,6 +71,55 @@ func (s *verifySealsTestSealer) Quorum(_ uint64, qualifiedLen, committeeSize int
 	s.qualifiedLen = qualifiedLen
 	s.committeeSize = committeeSize
 	return s.quorum
+}
+
+func TestCountValidCommittedSeals(t *testing.T) {
+	var (
+		a = common.HexToAddress("0x0001")
+		b = common.HexToAddress("0x0002")
+		c = common.HexToAddress("0x0003")
+		d = common.HexToAddress("0x0004")
+	)
+
+	testcases := []struct {
+		name          string
+		signers       []common.Address
+		committers    []common.Address
+		expectedCount int
+		expectedErr   error
+	}{
+		{
+			name:          "counts unique committed seals",
+			signers:       []common.Address{a, b, c},
+			committers:    []common.Address{a, b},
+			expectedCount: 2,
+		},
+		{
+			name:        "rejects duplicate committer",
+			signers:     []common.Address{a, b, c},
+			committers:  []common.Address{a, a, b},
+			expectedErr: istanbul.ErrInvalidCommittedSeals,
+		},
+		{
+			name:        "rejects non-signer committer",
+			signers:     []common.Address{a, b, c},
+			committers:  []common.Address{a, d},
+			expectedErr: istanbul.ErrInvalidCommittedSeals,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			count, err := countValidCommittedSeals(tc.committers, valset.NewAddressSet(tc.signers))
+
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.expectedErr)
+			}
+			assert.Equal(t, tc.expectedCount, count)
+		})
+	}
 }
 
 func TestValidateHeader(t *testing.T) {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -23,9 +23,6 @@
 package backend
 
 import (
-	"encoding/hex"
-
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
@@ -39,26 +36,6 @@ const (
 	inmemoryPeers    = 200
 	inmemoryMessages = 4096
 )
-
-var (
-	inmemoryBlocks             = 2048 // Number of blocks to precompute validators' addresses
-	inmemoryValidatorsPerBlock = 30   // Approximate number of validators' addresses from ecrecover
-	signatureAddresses, _      = lru.NewARC(inmemoryBlocks * inmemoryValidatorsPerBlock)
-)
-
-// cacheSignatureAddresses extracts the address from the given data and signature and cache them for later usage.
-func cacheSignatureAddresses(data []byte, sig []byte) (common.Address, error) {
-	sigStr := hex.EncodeToString(sig)
-	if addr, ok := signatureAddresses.Get(sigStr); ok {
-		return addr.(common.Address), nil
-	}
-	addr, err := istanbul.GetSignatureAddress(data, sig)
-	if err != nil {
-		return common.Address{}, err
-	}
-	signatureAddresses.Add(sigStr, addr)
-	return addr, err
-}
 
 // Seal generates a new block for the given input block with the local miner's
 // seal place on top.

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -25,6 +25,7 @@ package core
 import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/consensus/istanbul"
 )
 
 func (c *core) sendCommit() {
@@ -92,6 +93,15 @@ func (c *core) handleCommit(msg *bft.Message, src common.Address) error {
 		logger.Warn("received an istanbul commit message from non-committee",
 			"currentSequence", c.current.sequence.Uint64(), "sender", src.String(), "msgView", commit.View.String())
 		return errNotFromCommittee
+	}
+
+	// Verify msg.CommittedSeal is the sender's signature over the proposal's
+	// committed-seal preimage. Without this, an arbitrary seal would be copied verbatim into the sealed block.
+	// commit.Digest is the proposal hash, already validated by verifyCommit above.
+	committer, err := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSeal(commit.Digest), msg.CommittedSeal)
+	if err != nil || committer != src {
+		logger.Warn("invalid committed seal in commit message", "sender", src.String(), "recovered", committer.String(), "err", err)
+		return errInvalidCommittedSeal
 	}
 
 	c.acceptCommit(msg, src)

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -27,6 +27,9 @@ var (
 	errNotFromProposer = errors.New("message does not come from proposer")
 	// errNotFromCommittee is returned when received message is supposed to be from a committee.
 	errNotFromCommittee = errors.New("message does not come from a committee")
+	// errInvalidCommittedSeal is returned when a COMMIT's CommittedSeal is not the
+	// sender's signature over the proposal's committed-seal preimage.
+	errInvalidCommittedSeal = errors.New("invalid committed seal")
 	// errIgnored is returned when a message was ignored.
 	errIgnored = errors.New("message is ignored")
 	// errFutureMessage is returned when current view is earlier than the

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -87,7 +87,8 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 				return validatorAddrs[2 : committeeSize+2], nil
 			}
 			return validatorAddrs[0:committeeSize], nil
-		}).AnyTimes()
+		},
+	).AnyTimes()
 	mockValsetModule.EXPECT().GetProposer(gomock.Any(), gomock.Any()).Return(validatorAddrs[0], nil).AnyTimes()
 
 	// Gov module: required by core registration checks.
@@ -242,6 +243,13 @@ func genBlockParams(prevBlock *types.Block, signerKey *ecdsa.PrivateKey, gasUsed
 
 // genIstanbulMsg generates an istanbul message with given values
 func genIstanbulMsg(msgType uint64, prevHash common.Hash, proposal *types.Block, signerAddr common.Address, signerKey *ecdsa.PrivateKey) (istanbul.MessageEvent, error) {
+	return genIstanbulMsgWithSealKey(msgType, prevHash, proposal, signerAddr, signerKey, signerKey)
+}
+
+// genIstanbulMsgWithSealKey builds an istanbul message signed (outer signature) by
+// signerKey, but whose COMMIT CommittedSeal is signed by sealKey. A sealKey different
+// from signerKey forges the committed seal.
+func genIstanbulMsgWithSealKey(msgType uint64, prevHash common.Hash, proposal *types.Block, signerAddr common.Address, signerKey, sealKey *ecdsa.PrivateKey) (istanbul.MessageEvent, error) {
 	var subject interface{}
 
 	if msgType == bft.MsgPreprepare {
@@ -273,6 +281,15 @@ func genIstanbulMsg(msgType uint64, prevHash common.Hash, proposal *types.Block,
 		Code:    msgType,
 		Msg:     encodedSubject,
 		Address: signerAddr,
+	}
+
+	// A COMMIT carries a CommittedSeal: the sender's signature over the proposal's
+	// committed-seal preimage, which handleCommit verifies.
+	if msgType == bft.MsgCommit {
+		msg.CommittedSeal, err = crypto.Sign(crypto.Keccak256(istanbul.PrepareCommittedSeal(proposal.Hash())), sealKey)
+		if err != nil {
+			return istanbul.MessageEvent{}, err
+		}
 	}
 
 	data, err := msg.PayloadNoSig()
@@ -484,6 +501,85 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 		time.Sleep(time.Second)
 		assert.Equal(t, 1, len(istCore.roundChangeSet.roundChanges[0].messages)) // round is set to 0 in this test
 	}
+}
+
+// TestCore_handleCommit_RejectsForgedCommittedSeal checks that a COMMIT from a
+// committee member whose CommittedSeal is signed by a different key (a forged seal)
+// is rejected, while a correctly-signed COMMIT is accepted.
+func TestCore_handleCommit_RejectsForgedCommittedSeal(t *testing.T) {
+	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
+	defer fork.ClearHardForkBlockNumberConfig()
+
+	validatorAddrs, validatorKeyMap := genValidators(30)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	defer mockCtrl.Finish()
+
+	istConfig := istanbul.DefaultConfig
+	istConfig.ProposerPolicy = istanbul.WeightedRandom
+
+	istCore := New(mockBackend, istConfig).(*core)
+	istCore.RegisterKaiaxModules(mockValset, mockGov)
+	if err := istCore.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer istCore.Stop()
+
+	eventMux := mockBackend.EventMux()
+	lastProposal, _ := mockBackend.LastProposal()
+	lastBlock := lastProposal.(*types.Block)
+	committeeSize := uint64(len(validatorAddrs) / 3)
+
+	// Establish a proposal via a valid preprepare from the proposer.
+	_, committee, proposer, _ := getTestCommitteeState(validatorAddrs, committeeSize, istCore.currentView().Sequence.Uint64(), istCore.currentView().Round.Uint64())
+	proposerKey := validatorKeyMap[proposer]
+	newProposal, err := genBlock(lastBlock, proposerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preprepareMsg, err := genIstanbulMsg(bft.MsgPreprepare, lastBlock.Hash(), newProposal, proposer, proposerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eventMux.Post(preprepareMsg); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Second)
+	require.NotNil(t, istCore.current.Preprepare)
+	proposalBlock := istCore.current.Preprepare.Proposal.(*types.Block)
+
+	// Pick a committee member distinct from the proposer to send the commits.
+	var sender common.Address
+	for i := 0; i < committee.Len(); i++ {
+		if committee.At(i) != proposer {
+			sender = committee.At(i)
+			break
+		}
+	}
+	senderKey := validatorKeyMap[sender]
+
+	// A committed seal signed by the proposer's key (not the sender's) is forged:
+	// the recovered signer != sender, so handleCommit must reject it.
+	forged, err := genIstanbulMsgWithSealKey(bft.MsgCommit, lastBlock.Hash(), proposalBlock, sender, senderKey, proposerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eventMux.Post(forged); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Second)
+	assert.Equal(t, 0, len(istCore.current.Commits.messages), "forged committed seal must be rejected")
+
+	// A correctly-signed committed seal from the same sender is accepted, proving
+	// it was specifically the forged seal (not the sender) that caused rejection.
+	valid, err := genIstanbulMsg(bft.MsgCommit, lastBlock.Hash(), proposalBlock, sender, senderKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eventMux.Post(valid); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Second)
+	assert.Equal(t, 1, len(istCore.current.Commits.messages), "valid committed seal must be accepted")
 }
 
 func TestCore_handlerMsg(t *testing.T) {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -465,28 +465,30 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 		assert.Equal(t, 1, len(istCore.current.Commits.messages))
 	}
 
-	//// RoundChange message originated from invalid sender
-	//{
-	//	msgSender := getRandomValidator(false, validators, lastBlock.Hash(), istCore.currentView())
-	//	msgSenderKey := validatorKeyMap[msgSender.Address()]
-	//
-	//	istanbulMsg, err := genIstanbulMsg(bft.MsgRoundChange, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender.Address(), msgSenderKey)
-	//	if err != nil {
-	//		t.Fatal(err)
-	//	}
-	//
-	//	if err := eventMux.Post(istanbulMsg); err != nil {
-	//		t.Fatal(err)
-	//	}
-	//
-	//	time.Sleep(time.Second)
-	//	assert.Nil(t, istCore.roundChangeSet.roundChanges[0]) // round is set to 0 in this test
-	//}
-
-	// RoundChange message originated from valid sender even though using non-committee sender because there is no checking for committee in round change
-	// See: TODO-Kaia-Istanbul: establish round change messaging policy and then apply it
+	// RoundChange message originated from invalid (non-committee) sender is rejected.
+	// Round-change admission is now gated on committee membership so that the
+	// (qualified - committee) validators cannot force a round change.
 	{
 		msgSender := nonCommittee.At(rand.Int() % (nonCommittee.Len() - 1))
+		msgSenderKey := validatorKeyMap[msgSender]
+
+		istanbulMsg, err := genIstanbulMsg(bft.MsgRoundChange, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender, msgSenderKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := eventMux.Post(istanbulMsg); err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(time.Second)
+		assert.Nil(t, istCore.roundChangeSet.roundChanges[0]) // round is set to 0 in this test
+	}
+
+	// RoundChange message originated from valid (committee) sender is accepted.
+	{
+		_, committee, _, _ := getTestCommitteeState(validatorAddrs, committeeSize, istCore.currentView().Sequence.Uint64(), istCore.currentView().Round.Uint64())
+		msgSender := committee.At(rand.Int() % (committee.Len() - 1))
 		msgSenderKey := validatorKeyMap[msgSender]
 
 		istanbulMsg, err := genIstanbulMsg(bft.MsgRoundChange, lastBlock.Hash(), istCore.current.Preprepare.Proposal.(*types.Block), msgSender, msgSenderKey)

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -95,13 +95,19 @@ func (c *core) handleRoundChange(msg *bft.Message, src common.Address) error {
 		return bft.ErrInvalidMessage
 	}
 
-	// TODO-Kaia-Istanbul: establish round change messaging policy and then apply it
-	//if !c.valSet.CheckInSubList(msg.Hash, rc.View, src.Address()) {
-	//	return errNotFromCommittee
-	//}
-
 	if err := c.checkMessage(bft.MsgRoundChange, rc.View); err != nil {
 		return err
+	}
+
+	// Restrict round-change admission to committee members, mirroring handleCommit.
+	// The thresholds (requiredMessageCount, f) are committee-sized, but messageSet
+	// admits any qualified validator; gating on the committee keeps admission
+	// consistent with the thresholds. The committee equals the qualified set (now and
+	// post-permissionless), so this is round-agnostic.
+	if !c.current.committee.Contains(src) {
+		logger.Warn("received an istanbul round change message from non-committee",
+			"currentSequence", c.current.sequence.Uint64(), "sender", src.Hex(), "msgView", rc.View.String())
+		return errNotFromCommittee
 	}
 
 	cv := c.currentView()

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -3,7 +3,6 @@ package istanbul
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"encoding/hex"
 	"errors"
 	"io"
 	"math"
@@ -329,14 +328,16 @@ func (m *IstanbulSealer) MakeAuthorSeal(header *types.Header) ([]byte, error) {
 }
 
 func cacheSignatureAddress(data []byte, sig []byte) (common.Address, error) {
-	sigHex := hex.EncodeToString(sig)
-	if addr, ok := signatureAddresses.Get(sigHex); ok {
+	// Key on both data and sig: ecrecover depends on data, so keying on sig alone
+	// would return a cached address even when queried with different data.
+	key := string(crypto.Keccak256(data, sig))
+	if addr, ok := signatureAddresses.Get(key); ok {
 		return addr.(common.Address), nil
 	}
 	addr, err := GetSignatureAddress(data, sig)
 	if err != nil {
 		return common.Address{}, err
 	}
-	signatureAddresses.Add(sigHex, addr)
+	signatureAddresses.Add(key, addr)
 	return addr, nil
 }

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -308,8 +308,16 @@ func (m *IstanbulSealer) F(_ uint64, qualifiedLen, committeeSize int) int {
 	return int(math.Ceil(float64(qualifiedLen)/3)) - 1
 }
 
-func (m *IstanbulSealer) Quorum(blockNum uint64, qualifiedlen, committeeSize int) int {
-	return 2*m.F(blockNum, qualifiedlen, committeeSize) + 1
+// Quorum returns the quorum: ceil(2N/3) over the effective size
+// N = min(qualifiedlen, committeeSize), or N for tiny committees. This matches
+// calcQuorumSize used by the consensus core.
+// Pre-permissionless sealer quorum: 2f+1
+func (m *IstanbulSealer) Quorum(_ uint64, qualifiedlen, committeeSize int) int {
+	n := min(qualifiedlen, committeeSize)
+	if n < 4 {
+		return n
+	}
+	return int(math.Ceil(float64(2*n) / 3))
 }
 
 func (m *IstanbulSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) {

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -143,7 +143,7 @@ func istanbulFilteredHeader(h *types.Header, keepSeal bool) *types.Header {
 	return newHeader
 }
 
-func prepareCommittedSeal(hash common.Hash) []byte {
+func PrepareCommittedSeal(hash common.Hash) []byte {
 	var buf bytes.Buffer
 	buf.Write(hash.Bytes())
 	buf.Write([]byte{byte(2)}) // keep in sync with bft.MsgCommit
@@ -174,7 +174,7 @@ func (m *IstanbulSealer) Committers(header *types.Header) ([]common.Address, err
 		return []common.Address{}, nil
 	}
 
-	proposalSeal := prepareCommittedSeal(m.HeaderHash(header)) // bft.MsgCommit
+	proposalSeal := PrepareCommittedSeal(m.HeaderHash(header)) // bft.MsgCommit
 	committers := make([]common.Address, 0, len(extra.CommittedSeal))
 	for _, seal := range extra.CommittedSeal {
 		addr, err := cacheSignatureAddress(proposalSeal, seal)
@@ -321,7 +321,7 @@ func (m *IstanbulSealer) Quorum(_ uint64, qualifiedlen, committeeSize int) int {
 }
 
 func (m *IstanbulSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) {
-	return crypto.Sign(crypto.Keccak256(prepareCommittedSeal(m.HeaderHash(header))), m.privateKey)
+	return crypto.Sign(crypto.Keccak256(PrepareCommittedSeal(m.HeaderHash(header))), m.privateKey)
 }
 
 func (m *IstanbulSealer) MakeAuthorSeal(header *types.Header) ([]byte, error) {

--- a/consensus/istanbul/sealer_test.go
+++ b/consensus/istanbul/sealer_test.go
@@ -43,6 +43,36 @@ func TestCommitters(t *testing.T) {
 	assert.NotEmpty(t, committedSeals)
 }
 
+// TestCacheSignatureAddress_BindsData checks that the cache binds data: a signature
+// cached for one data must not be returned as the signer when queried with different
+// data (which would let a forged header reuse a cached recovery).
+func TestCacheSignatureAddress_BindsData(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	signer := crypto.PubkeyToAddress(key.PublicKey)
+
+	// A legitimate (data, sig) pair, e.g. recovered while processing block N-1.
+	legitData := []byte("legitimate block sighash preimage")
+	sig, err := crypto.Sign(crypto.Keccak256(legitData), key)
+	require.NoError(t, err)
+
+	got, err := cacheSignatureAddress(legitData, sig)
+	require.NoError(t, err)
+	require.Equal(t, signer, got) // populates the cache for sig
+
+	// Reuse the same sig over different data (the forged block N). The recovered
+	// address must reflect ecrecover(forgedData, sig), NOT the cached legit signer.
+	forgedData := []byte("forged block sighash preimage")
+	want, err := GetSignatureAddress(forgedData, sig)
+	require.NoError(t, err)
+	require.NotEqual(t, signer, want) // sanity: different data recovers a different address
+
+	cached, err := cacheSignatureAddress(forgedData, sig)
+	require.NoError(t, err)
+	assert.Equal(t, want, cached, "cache must bind data; a reused sig with different data must not return the cached signer")
+	assert.NotEqual(t, signer, cached)
+}
+
 func TestWriteValidators(t *testing.T) {
 	var (
 		validators = []common.Address{

--- a/consensus/istanbul/sealer_test.go
+++ b/consensus/istanbul/sealer_test.go
@@ -214,7 +214,7 @@ func TestMakeSeals_GenesisHandled(t *testing.T) {
 	committedSeal, err := s.MakeCommittedSeal(h)
 	require.NoError(t, err)
 	assert.Len(t, committedSeal, IstanbulExtraSeal)
-	addr, err := GetSignatureAddress(prepareCommittedSeal(s.HeaderHash(h)), committedSeal)
+	addr, err := GetSignatureAddress(PrepareCommittedSeal(s.HeaderHash(h)), committedSeal)
 	require.NoError(t, err)
 	assert.Equal(t, crypto.PubkeyToAddress(key.PublicKey), addr)
 }

--- a/consensus/istanbul/sealer_test.go
+++ b/consensus/istanbul/sealer_test.go
@@ -73,6 +73,18 @@ func TestCacheSignatureAddress_BindsData(t *testing.T) {
 	assert.NotEqual(t, signer, cached)
 }
 
+// TestQuorum checks that Quorum is ceil(2N/3) over min(qualified, committee),
+// and N for tiny committees.
+func TestQuorum(t *testing.T) {
+	s := NewSealerImpl(nil)
+	for _, tc := range []struct{ n, want int }{
+		{1, 1}, {2, 2}, {3, 3}, // < 4: everyone
+		{4, 3}, {5, 4}, {6, 4}, {7, 5}, {21, 14}, {22, 15}, {50, 34}, {100, 67},
+	} {
+		assert.Equalf(t, tc.want, s.Quorum(0, tc.n, tc.n), "Quorum(%d, %d)", tc.n, tc.n)
+	}
+}
+
 func TestWriteValidators(t *testing.T) {
 	var (
 		validators = []common.Address{


### PR DESCRIPTION
## Proposed changes

For permissionless phase, make IBFT verification accept only headers/messages the live consensus could actually have produced. Four independent fixes.

**1. Bind data into the signature-recovery cache key.**
`cacheSignatureAddress` keyed its LRU on the signature alone, but
`ecrecover(data, sig)` depends on `data` — so a header reusing a cached
signature over different data recovered the original signer, letting
`VerifyHeader` accept a forged header. Now keyed on `keccak256(data, sig)`.

**2. Verify committed seals against the committee with the consensus quorum.**
`verifySeals` counted seals against the council/qualified set (a superset of
the round's committee) and required only `2f+1`, while consensus commits
against the committee with `ceil(2N/3)`. `IstanbulSealer.Quorum` now returns
`ceil(2N/3)`; post-permissionless, `verifySeals` counts against the committee
and requires that quorum. Gated behind the Permissionless fork; the
pre-permissionless path is preserved exactly (`2f+1`).

**3. Verify a COMMIT's `CommittedSeal`.** `handleCommit` never checked the inner
`CommittedSeal` was the sender's signature before copying it into the sealed
block. Now recovers the signer and requires it equals the sender.

**4. Restrict round-change admission to the committee.** ROUND CHANGE was
admitted from any qualified validator while the thresholds are committee-sized.
Now gated on committee membership, mirroring `handleCommit`.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)
