### PR TITLE
worker: make pending behavior consistent through node type

### DIFF
--- a/work/worker.go
+++ b/work/worker.go
@@ -439,7 +439,6 @@ func (self *worker) commitNewWork() {
 	self.pendingWork = self.current
 	self.pendingWorkStart = tstart
 
-	// Callback to update snapshot when block is prepared (before consensus sealing)
 	onPrepared := func(result *consensus.ExecutionResult) {
 		// Log block preparation completion (all validators log this, before seal)
 		logger.Info("Prepared new block",

--- a/work/worker.go
+++ b/work/worker.go
@@ -179,11 +179,6 @@ type worker struct {
 	current   *Task
 	nodeAddr  common.Address
 
-	snapshotMu       sync.RWMutex // The lock used to protect the block snapshot and state snapshot
-	snapshotBlock    *types.Block
-	snapshotReceipts types.Receipts
-	snapshotState    *state.StateDB
-
 	// atomic status counters
 	mining atomic.Int32
 
@@ -225,18 +220,20 @@ func (self *worker) setExtra(extra []byte) {
 }
 
 func (self *worker) pending() (*types.Block, types.Receipts, *state.StateDB) {
-	self.snapshotMu.RLock()
-	defer self.snapshotMu.RUnlock()
-	if self.snapshotState == nil {
+	block := self.chain.CurrentBlock()
+	if block == nil {
 		return nil, nil, nil
 	}
-	return self.snapshotBlock, self.snapshotReceipts, self.snapshotState.Copy()
+	receipts := self.chain.GetReceiptsByBlockHash(block.Hash())
+	state, err := self.chain.StateAt(block.Root())
+	if err != nil {
+		return nil, nil, nil
+	}
+	return block, receipts, state
 }
 
 func (self *worker) pendingBlock() *types.Block {
-	self.snapshotMu.RLock()
-	defer self.snapshotMu.RUnlock()
-	return self.snapshotBlock
+	return self.chain.CurrentBlock()
 }
 
 func (self *worker) start() {
@@ -452,12 +449,6 @@ func (self *worker) commitNewWork() {
 			"elapsed", common.PrettyDuration(result.ExecuteTime+result.FinalizeTime),
 			"executeTime", common.PrettyDuration(result.ExecuteTime),
 			"finalizeTime", common.PrettyDuration(result.FinalizeTime))
-
-		self.snapshotMu.Lock()
-		defer self.snapshotMu.Unlock()
-		self.snapshotBlock = result.Block
-		self.snapshotReceipts = result.Receipts
-		self.snapshotState = result.State.Copy()
 	}
 
 	self.finalizeCh = self.engine.SubmitTransactions(txs, self.current.state, self.current.header, self.mux, onPrepared)
@@ -581,21 +572,6 @@ func (self *worker) handleFinalizedBlock(result *consensus.ExecutionResult) {
 	logger.Info("Successfully wrote mined block", "num", block.NumberU64(),
 		"hash", block.Hash(), "txs", len(block.Transactions()), "elapsed", blockWriteTime)
 	self.chain.PostChainEvents(events, logs)
-
-	self.updateSnapshot()
-}
-
-func (self *worker) updateSnapshot() {
-	self.snapshotMu.Lock()
-	defer self.snapshotMu.Unlock()
-
-	self.snapshotBlock = types.NewBlock(
-		self.current.header,
-		self.current.txs,
-		self.current.receipts,
-	)
-	self.snapshotReceipts = self.current.receipts
-	self.snapshotState = self.current.state.Copy()
 }
 
 func (self *worker) RegisterExecutionModule(modules ...kaiax.ExecutionModule) {


### PR DESCRIPTION
## Proposed changes

After consensus refactoring, execution becomes async, making it complex to track a valid pending block for CN. Given the meaning of "pending" for Kaia and its usage (CN doesn't support RPC), it's better to unify the pending block call schematic across all node types. 

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
