### PR TITLE
p2p: throttle repeated inbound connections and back off on temporary accept errors

### DIFF
--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -43,6 +43,11 @@ const (
 	defaultMaxPendingPeers = 50
 	defaultDialRatio       = 3
 
+	// inboundThrottleTime is the minimum time between inbound connection
+	// attempts allowed from a single (non-LAN) remote IP. It bounds
+	// connection-flood attempts from a single peer.
+	inboundThrottleTime = 30 * time.Second
+
 	// Maximum time allowed for reading a complete message.
 	// This is effectively the amount of time a connection can be idle.
 	frameReadTimeout = 30 * time.Second

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -30,6 +30,7 @@ import (
 	"net"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/mclock"
@@ -37,6 +38,12 @@ import (
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/networks/p2p/nat"
+	"github.com/kaiachain/kaia/networks/p2p/netutil"
+)
+
+var (
+	errNotWhitelisted         = errors.New("not whitelisted in NetRestrict")
+	errTooManyInboundAttempts = errors.New("too many inbound connection attempts")
 )
 
 // BaseServer is a common data structure used by implementations of Server.
@@ -71,6 +78,12 @@ type BaseServer struct {
 	trusted       map[discover.NodeID]bool
 	dialSched     *DialSched
 	cnPeerAddrs   map[common.Address]struct{} // KIP-311 peerNodes allowlist for CN-CN connections.
+
+	// Inbound connection throttling. inboundHistory tracks the last seen time
+	// per remote IP; its mutex guards concurrent access from multiple
+	// listenLoop goroutines (one per listener in MultiChannelServer).
+	inboundHistory   expHeap
+	inboundHistoryMu sync.Mutex
 }
 
 // SingleChannelServer is a server that uses a single channel.
@@ -355,6 +368,77 @@ func (srv *BaseServer) maxDialedConns() int {
 	}
 }
 
+// checkInboundConn decides whether an inbound connection from remoteIP should
+// be accepted. It rejects connections that do not match NetRestrict, and
+// throttles repeated attempts from the same non-LAN IP within
+// inboundThrottleTime to bound connection-flood attempts. now is passed in so
+// the throttle window is deterministic and testable.
+func (srv *BaseServer) checkInboundConn(remoteIP net.IP, now mclock.AbsTime) error {
+	if remoteIP == nil {
+		// No usable remote IP (e.g. in-process test pipes); nothing to throttle.
+		return nil
+	}
+	// Reject connections that do not match NetRestrict.
+	if srv.NetRestrict != nil && !srv.NetRestrict.Contains(remoteIP) {
+		return errNotWhitelisted
+	}
+	// Reject peers that try to connect too frequently. LAN addresses are
+	// exempt so co-located/internal nodes are never throttled.
+	srv.inboundHistoryMu.Lock()
+	defer srv.inboundHistoryMu.Unlock()
+	srv.inboundHistory.expire(now, nil)
+	if !netutil.IsLAN(remoteIP) && srv.inboundHistory.contains(remoteIP.String()) {
+		return errTooManyInboundAttempts
+	}
+	srv.inboundHistory.add(remoteIP.String(), now+mclock.AbsTime(inboundThrottleTime))
+	return nil
+}
+
+// acceptWithBackoff accepts the next connection from listener. On temporary
+// errors (e.g. fd exhaustion) it backs off to avoid busy-looping and log
+// flooding while resources recover. It returns nil when the listener is
+// permanently closed and the caller should stop the loop.
+func (srv *BaseServer) acceptWithBackoff(listener net.Listener, lastLog *time.Time) net.Conn {
+	for {
+		fd, err := listener.Accept()
+		if tempErr, ok := err.(tempError); ok && tempErr.Temporary() {
+			if time.Since(*lastLog) > 1*time.Second {
+				srv.logger.Debug("Temporary read error", "err", err)
+				*lastLog = time.Now()
+			}
+			time.Sleep(200 * time.Millisecond)
+			continue
+		} else if err != nil {
+			srv.logger.Debug("Read error", "err", err)
+			return nil
+		}
+		return fd
+	}
+}
+
+// acceptInbound returns the next inbound connection worth handshaking. It wraps
+// acceptWithBackoff and applies the inbound checks (NetRestrict + per-IP
+// throttle), silently dropping rejected connections. It returns nil when the
+// listener is permanently closed and the caller should stop the loop.
+//
+// The handshake slot is held across rejects: listenLoop is the sole receiver of
+// its slots channel (SetupConn goroutines only send), so releasing and
+// re-acquiring a token on each reject would be a no-op.
+func (srv *BaseServer) acceptInbound(listener net.Listener, lastLog *time.Time) net.Conn {
+	for {
+		fd := srv.acceptWithBackoff(listener, lastLog)
+		if fd == nil {
+			return nil
+		}
+		if err := srv.checkInboundConn(tcpAddrIP(fd.RemoteAddr()), mclock.Now()); err != nil {
+			srv.logger.Debug("Rejected inbound connection", "addr", fd.RemoteAddr(), "err", err)
+			fd.Close()
+			continue
+		}
+		return fd
+	}
+}
+
 // listenLoop runs in its own goroutine and accepts
 // inbound connections.
 func (srv *BaseServer) listenLoop() {
@@ -370,34 +454,14 @@ func (srv *BaseServer) listenLoop() {
 		slots <- struct{}{}
 	}
 
+	var lastLog time.Time
 	for {
 		// Wait for a handshake slot before accepting.
 		<-slots
 
-		var (
-			fd  net.Conn
-			err error
-		)
-		for {
-			fd, err = srv.listener.Accept()
-			if tempErr, ok := err.(tempError); ok && tempErr.Temporary() {
-				srv.logger.Debug("Temporary read error", "err", err)
-				continue
-			} else if err != nil {
-				srv.logger.Debug("Read error", "err", err)
-				return
-			}
-			break
-		}
-
-		// Reject connections that do not match NetRestrict.
-		if srv.NetRestrict != nil {
-			if tcp, ok := fd.RemoteAddr().(*net.TCPAddr); ok && !srv.NetRestrict.Contains(tcp.IP) {
-				srv.logger.Debug("Rejected conn (not whitelisted in NetRestrict)", "addr", fd.RemoteAddr())
-				fd.Close()
-				slots <- struct{}{}
-				continue
-			}
+		fd := srv.acceptInbound(srv.listener, &lastLog)
+		if fd == nil {
+			return
 		}
 
 		fd = newMeteredConn(fd, true)

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/mclock"
@@ -205,34 +206,14 @@ func (srv *MultiChannelServer) listenLoop(listener net.Listener) {
 		slots <- struct{}{}
 	}
 
+	var lastLog time.Time
 	for {
 		// Wait for a handshake slot before accepting.
 		<-slots
 
-		var (
-			fd  net.Conn
-			err error
-		)
-		for {
-			fd, err = listener.Accept()
-			if tempErr, ok := err.(tempError); ok && tempErr.Temporary() {
-				srv.logger.Debug("Temporary read error", "err", err)
-				continue
-			} else if err != nil {
-				srv.logger.Debug("Read error", "err", err)
-				return
-			}
-			break
-		}
-
-		// Reject connections that do not match NetRestrict.
-		if srv.NetRestrict != nil {
-			if tcp, ok := fd.RemoteAddr().(*net.TCPAddr); ok && !srv.NetRestrict.Contains(tcp.IP) {
-				srv.logger.Debug("Rejected conn (not whitelisted in NetRestrict)", "addr", fd.RemoteAddr())
-				fd.Close()
-				slots <- struct{}{}
-				continue
-			}
+		fd := srv.acceptInbound(listener, &lastLog)
+		if fd == nil {
+			return
 		}
 
 		fd = newMeteredConn(fd, true)

--- a/networks/p2p/util.go
+++ b/networks/p2p/util.go
@@ -1,5 +1,4 @@
-// Modifications Copyright 2024 The Kaia Authors
-// Modifications Copyright 2019 The klaytn Authors
+// Modifications Copyright 2026 The Kaia Authors
 // Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
@@ -17,7 +16,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 //
 // This file is derived from p2p/util.go (2019/04/02).
-// Modified and improved for the klaytn development.
 // Modified and improved for the Kaia development.
 
 package p2p

--- a/networks/p2p/util.go
+++ b/networks/p2p/util.go
@@ -1,0 +1,92 @@
+// Modifications Copyright 2024 The Kaia Authors
+// Modifications Copyright 2019 The klaytn Authors
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from p2p/util.go (2019/04/02).
+// Modified and improved for the klaytn development.
+// Modified and improved for the Kaia development.
+
+package p2p
+
+import (
+	"container/heap"
+	"net"
+
+	"github.com/kaiachain/kaia/common/mclock"
+)
+
+// expHeap tracks strings and their expiry time.
+type expHeap []expItem
+
+// expItem is an entry in addrHistory.
+type expItem struct {
+	item string
+	exp  mclock.AbsTime
+}
+
+// nextExpiry returns the next expiry time.
+func (h *expHeap) nextExpiry() mclock.AbsTime {
+	return (*h)[0].exp
+}
+
+// add adds an item and sets its expiry time.
+func (h *expHeap) add(item string, exp mclock.AbsTime) {
+	heap.Push(h, expItem{item, exp})
+}
+
+// contains checks whether an item is present.
+func (h expHeap) contains(item string) bool {
+	for _, v := range h {
+		if v.item == item {
+			return true
+		}
+	}
+	return false
+}
+
+// expire removes items with expiry time before 'now'.
+func (h *expHeap) expire(now mclock.AbsTime, onExp func(string)) {
+	for h.Len() > 0 && h.nextExpiry() < now {
+		item := heap.Pop(h)
+		if onExp != nil {
+			onExp(item.(expItem).item)
+		}
+	}
+}
+
+// heap.Interface boilerplate
+func (h expHeap) Len() int            { return len(h) }
+func (h expHeap) Less(i, j int) bool  { return h[i].exp < h[j].exp }
+func (h expHeap) Swap(i, j int)       { h[i], h[j] = h[j], h[i] }
+func (h *expHeap) Push(x interface{}) { *h = append(*h, x.(expItem)) }
+func (h *expHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	old[n-1] = expItem{}
+	*h = old[0 : n-1]
+	return x
+}
+
+// tcpAddrIP returns the IP of a *net.TCPAddr, or nil for any other address
+// type (e.g. in-process test pipes that have no usable remote IP).
+func tcpAddrIP(addr net.Addr) net.IP {
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		return tcp.IP
+	}
+	return nil
+}

--- a/networks/p2p/util_test.go
+++ b/networks/p2p/util_test.go
@@ -1,0 +1,113 @@
+// Modifications Copyright 2024 The Kaia Authors
+// Modifications Copyright 2019 The klaytn Authors
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+//
+// This file is derived from p2p/util_test.go (2019/04/02).
+// Modified and improved for the klaytn development.
+// Modified and improved for the Kaia development.
+
+package p2p
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/kaiachain/kaia/common/mclock"
+	"github.com/kaiachain/kaia/networks/p2p/netutil"
+)
+
+func TestExpHeap(t *testing.T) {
+	var h expHeap
+
+	var (
+		basetime = mclock.AbsTime(10)
+		exptimeA = basetime + mclock.AbsTime(2*time.Second)
+		exptimeB = basetime + mclock.AbsTime(3*time.Second)
+		exptimeC = basetime + mclock.AbsTime(4*time.Second)
+	)
+	h.add("b", exptimeB)
+	h.add("a", exptimeA)
+	h.add("c", exptimeC)
+
+	if h.nextExpiry() != exptimeA {
+		t.Fatal("wrong nextExpiry")
+	}
+	if !h.contains("a") || !h.contains("b") || !h.contains("c") {
+		t.Fatal("heap doesn't contain all live items")
+	}
+
+	h.expire(exptimeA+1, nil)
+	if h.nextExpiry() != exptimeB {
+		t.Fatal("wrong nextExpiry")
+	}
+	if h.contains("a") {
+		t.Fatal("heap contains a even though it has already expired")
+	}
+	if !h.contains("b") || !h.contains("c") {
+		t.Fatal("heap doesn't contain all live items")
+	}
+}
+
+// TestCheckInboundConnThrottle verifies that repeated attempts from the same
+// non-LAN IP within inboundThrottleTime are rejected, and allowed again once
+// the throttle window has elapsed.
+func TestCheckInboundConnThrottle(t *testing.T) {
+	srv := &BaseServer{}
+	ip := net.ParseIP("203.0.113.7") // TEST-NET-3, treated as a public (non-LAN) IP
+	now := mclock.AbsTime(0)
+
+	if err := srv.checkInboundConn(ip, now); err != nil {
+		t.Fatalf("first attempt should be accepted, got %v", err)
+	}
+	if err := srv.checkInboundConn(ip, now+mclock.AbsTime(inboundThrottleTime/2)); err != errTooManyInboundAttempts {
+		t.Fatalf("attempt within throttle window should be rejected, got %v", err)
+	}
+	if err := srv.checkInboundConn(ip, now+mclock.AbsTime(inboundThrottleTime)+1); err != nil {
+		t.Fatalf("attempt after throttle window should be accepted, got %v", err)
+	}
+}
+
+// TestCheckInboundConnLANExempt verifies that LAN/loopback IPs are never
+// throttled, so co-located/internal nodes can reconnect freely.
+func TestCheckInboundConnLANExempt(t *testing.T) {
+	srv := &BaseServer{}
+	ip := net.ParseIP("127.0.0.1")
+	for i := 0; i < 5; i++ {
+		if err := srv.checkInboundConn(ip, mclock.AbsTime(0)); err != nil {
+			t.Fatalf("LAN IP should never be throttled, got %v on attempt %d", err, i)
+		}
+	}
+}
+
+// TestCheckInboundConnNetRestrict verifies that NetRestrict is enforced before
+// throttling.
+func TestCheckInboundConnNetRestrict(t *testing.T) {
+	list, err := netutil.ParseNetlist("192.0.2.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &BaseServer{}
+	srv.NetRestrict = list
+
+	if err := srv.checkInboundConn(net.ParseIP("203.0.113.7"), 0); err != errNotWhitelisted {
+		t.Fatalf("IP outside NetRestrict should be rejected, got %v", err)
+	}
+	if err := srv.checkInboundConn(net.ParseIP("192.0.2.5"), 0); err != nil {
+		t.Fatalf("IP within NetRestrict should be accepted, got %v", err)
+	}
+}

--- a/networks/p2p/util_test.go
+++ b/networks/p2p/util_test.go
@@ -1,5 +1,4 @@
-// Modifications Copyright 2024 The Kaia Authors
-// Modifications Copyright 2019 The klaytn Authors
+// Modifications Copyright 2026 The Kaia Authors
 // Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
@@ -17,7 +16,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 //
 // This file is derived from p2p/util_test.go (2019/04/02).
-// Modified and improved for the klaytn development.
 // Modified and improved for the Kaia development.
 
 package p2p


### PR DESCRIPTION
## Proposed changes

Ports two RLPx-listener protections that exist in go-ethereum but were missing in
Kaia, to bound connection-flood attempts on the inbound path:

1. **Per-IP inbound throttle** — a non-LAN remote IP that reconnects within `inboundThrottleTime` (30s) is rejected. LAN/loopback IPs are exempt so co-located/internal nodes (e.g. CN↔CN over localhost) are never throttled. Ported from [go-ethereum#19684](https://github.com/ethereum/go-ethereum/pull/19684).
2. **Accept-error backoff** — temporary `Accept()` errors (e.g. fd exhaustion) now sleep 200ms and throttle the log to 1/s instead of busy-looping. Ported from [go-ethereum#21878](https://github.com/ethereum/go-ethereum/pull/21878).

Without these, a single remote IP can repeatedly connect/disconnect with no per-IP cooldown, and a sustained temporary `Accept()` error spins the listen loop (100% CPU+ log flood). This matters more as the network moves toward permissionless participation.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
