### PR TITLE
p2p: add PN compatibility for EN discovery and dial targets

### DIFF
--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -242,8 +242,9 @@ func setDefaultDiscoverTypes(cfg *p2p.Config) {
 	if cfg.ConnectionType == common.CONSENSUSNODE {
 		cfg.DiscoverTypes.CN = true
 		cfg.DiscoverTypes.EN = true
-	} else { // PN is EN-equivalent under KIP-311.
+	} else {
 		cfg.DiscoverTypes.CN = true
+		cfg.DiscoverTypes.PN = true // required until all PNs are deprecated. TODO: remove PN
 		cfg.DiscoverTypes.EN = true
 	}
 }

--- a/cmd/utils/config_test.go
+++ b/cmd/utils/config_test.go
@@ -314,3 +314,26 @@ func TestSetDefaultMaxPhysicalConnections(t *testing.T) {
 		})
 	}
 }
+
+func TestSetDefaultDiscoverTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		connType common.ConnType
+		wantCN   bool
+		wantPN   bool
+		wantEN   bool
+	}{
+		{name: "CN", connType: common.CONSENSUSNODE, wantCN: true, wantEN: true},
+		{name: "EN", connType: common.ENDPOINTNODE, wantCN: true, wantPN: true, wantEN: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &p2p.Config{ConnectionType: tt.connType}
+			setDefaultDiscoverTypes(cfg)
+			assert.Equal(t, tt.wantCN, cfg.DiscoverTypes.CN)
+			assert.Equal(t, tt.wantPN, cfg.DiscoverTypes.PN)
+			assert.Equal(t, tt.wantEN, cfg.DiscoverTypes.EN)
+		})
+	}
+}

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -66,8 +66,8 @@ type DialConfig struct {
 	// See also: discover.table.discoverTargets.
 	connTarget map[discover.NodeType]int
 
-	// maxENToENDialTarget is the EN-to-EN target derived from MaxPhysicalConnections / DialRatio.
-	// Pass the result of Server.maxDialedConns() here.
+	// maxENToENDialTarget is the dynamic-dial EN cap derived from
+	// MaxPhysicalConnections / DialRatio. Pass Server.maxDialedConns() here.
 	maxENToENDialTarget *int
 
 	// maxPeers is the total peer capacity (inbound + outbound).
@@ -316,8 +316,8 @@ func (ds *DialSched) dialLoop() {
 //
 // If there are too many dynamic CN candidates, EN dialing can be delayed. But it is unlikely under the connTarget settings.
 // - CN's connTarget = {CN: 100}. No starvation possible.
-// - EN's connTarget = {CN: 2, EN: maxENToENDialTarget}.
-// EN dialing is delayed only if static nodes and CN candidates fill maxConcurrentDials first.
+// - EN's connTarget = {CN: 2, PN: 2, EN: maxENToENDialTarget}.
+// PN/EN dialing is delayed only if static nodes and CN candidates fill maxConcurrentDials first.
 // But in reality, there are much less static nodes, and even so they will be filtered out by shouldDial() in later iterations quite soon.
 func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh bool) {
 	ds.mu.RLock()
@@ -471,7 +471,7 @@ func (ds *DialSched) refillCandidates() {
 	for targetType := range ds.connTarget {
 		if len(ds.candidateQueue[targetType]) == 0 {
 			buf := make([]*discover.Node, candidateQueueSize)
-			n := ds.tab.RandomNodes(buf, discover.EffectiveNodeType(targetType))
+			n := ds.tab.RandomNodes(buf, targetType)
 			ds.candidateQueue[targetType] = buf[:n]
 		}
 	}

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -478,7 +478,7 @@ func (ds *DialSched) refillCandidates() {
 }
 
 func (ds *DialSched) dynamicCandidateAllowed(targetType discover.NodeType, n *discover.Node) bool {
-	if ds.selfType != discover.NodeTypeCN || discover.EffectiveNodeType(targetType) != discover.NodeTypeCN {
+	if ds.selfType != discover.NodeTypeCN || targetType != discover.NodeTypeCN {
 		return true
 	}
 

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -169,7 +169,8 @@ func TestDialSched_OnPeerConnected(t *testing.T) {
 	assert.True(t, ds.connectedOutbound.contains(outbound.ID), "outbound peer should be counted as connected outbound")
 	assert.True(t, ds.connectedAll.contains(outbound.ID), "outbound peer should be counted as connected")
 	cands, _ = ds.getCandidates()
-	assert.Len(t, cands, 0, "expected no outbound candidate when outbound legacy PN fulfills EN target")
+	require.Len(t, cands, 1, "expected outbound PN not to fulfill exact EN target")
+	assert.Equal(t, candidate.ID, cands[0].ID)
 }
 
 // Correctly enforces discovery table refresh throttling.
@@ -360,7 +361,7 @@ func TestDialSched_GetCandidates_CNPeerAllowlistOnlyAppliesToCN(t *testing.T) {
 	assert.False(t, needRefresh)
 }
 
-func TestDialSched_GetCandidates_LegacyPNTargetUsesEffectiveEN(t *testing.T) {
+func TestDialSched_GetCandidates_PNTargetQueriesPN(t *testing.T) {
 	var (
 		pn  = testNode(201, "10.0.0.201", discover.NodeTypePN)
 		en  = testNode(202, "10.0.0.202", discover.NodeTypeEN)
@@ -379,8 +380,8 @@ func TestDialSched_GetCandidates_LegacyPNTargetUsesEffectiveEN(t *testing.T) {
 
 	cands, needRefresh := ds.getCandidates()
 
-	assert.True(t, hasNodeID(cands, en.ID), "legacy PN target should include EN candidates")
-	assert.False(t, hasNodeID(cands, pn.ID), "legacy PN target should not query PN candidates")
+	assert.True(t, hasNodeID(cands, pn.ID), "PN target should include PN candidates")
+	assert.False(t, hasNodeID(cands, en.ID), "PN target should not query EN candidates")
 	assert.False(t, needRefresh)
 }
 

--- a/networks/p2p/dialsched_util.go
+++ b/networks/p2p/dialsched_util.go
@@ -25,11 +25,14 @@ import (
 // dialTargets from KIP-311.
 var dialTargets = map[discover.NodeType]map[discover.NodeType]int{
 	discover.NodeTypeCN: {discover.NodeTypeCN: 100, discover.NodeTypeEN: 1},
-	discover.NodeTypeEN: {discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
+	discover.NodeTypeEN: {
+		discover.NodeTypeCN: 2,
+		discover.NodeTypePN: 2,
+		discover.NodeTypeEN: 3,
+	},
 }
 
-// defaultConnTarget applies KIP-311 dialTargets. EN-to-EN preserves the legacy
-// DialRatio semantics by using maxENToENDialTarget when provided.
+// defaultConnTarget applies KIP-311 dialTargets plus PN compatibility.
 func defaultConnTarget(cfg DialConfig) map[discover.NodeType]int {
 	targets := dialTargets[discover.EffectiveNodeType(cfg.selfType)]
 	targets = cloneTargets(targets)
@@ -102,11 +105,5 @@ func (t *typedNodeSet) contains(id discover.NodeID) bool {
 }
 
 func (t *typedNodeSet) count(nType discover.NodeType) int {
-	// PN is a legacy wire value. For target accounting, PN and EN share
-	// the same effective role bucket.
-	nType = discover.EffectiveNodeType(nType)
-	if nType == discover.NodeTypeEN {
-		return t.counts[discover.NodeTypeEN] + t.counts[discover.NodeTypePN]
-	}
 	return t.counts[nType]
 }

--- a/networks/p2p/dialsched_util_test.go
+++ b/networks/p2p/dialsched_util_test.go
@@ -53,8 +53,8 @@ func TestTypedNodeSet_BasicOps(t *testing.T) {
 	set.add(n2)
 
 	assert.Equal(t, 2, set.len())
-	assert.Equal(t, 2, set.count(discover.NodeTypePN))
-	assert.Equal(t, 2, set.count(discover.NodeTypeEN))
+	assert.Equal(t, 1, set.count(discover.NodeTypePN))
+	assert.Equal(t, 1, set.count(discover.NodeTypeEN))
 	assert.Equal(t, 0, set.count(discover.NodeTypeCN))
 	assert.True(t, set.contains(n1.ID))
 	assert.True(t, set.contains(n2.ID))
@@ -67,7 +67,7 @@ func TestTypedNodeSet_BasicOps(t *testing.T) {
 	assert.True(t, hasNode(all, n2.ID))
 }
 
-func TestTypedNodeSet_CountTreatsPNAsEN(t *testing.T) {
+func TestTypedNodeSet_CountsPNAndENExactly(t *testing.T) {
 	set := newTypedNodeSet()
 	pn := typedSetNode(1, "10.0.0.1", discover.NodeTypePN)
 	en := typedSetNode(2, "10.0.0.2", discover.NodeTypeEN)
@@ -77,8 +77,8 @@ func TestTypedNodeSet_CountTreatsPNAsEN(t *testing.T) {
 	set.add(en)
 	set.add(cn)
 
-	assert.Equal(t, 2, set.count(discover.NodeTypePN))
-	assert.Equal(t, 2, set.count(discover.NodeTypeEN))
+	assert.Equal(t, 1, set.count(discover.NodeTypePN))
+	assert.Equal(t, 1, set.count(discover.NodeTypeEN))
 	assert.Equal(t, 1, set.count(discover.NodeTypeCN))
 }
 
@@ -119,16 +119,14 @@ func TestTypedNodeSet_RemoveNoopAndNilAdd(t *testing.T) {
 func TestDefaultConnTarget(t *testing.T) {
 	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 100, discover.NodeTypeEN: 1},
 		defaultConnTarget(DialConfig{selfType: discover.NodeTypeCN}))
-	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypePN: 2, discover.NodeTypeEN: 3},
 		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN}))
-	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 3},
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypePN: 2, discover.NodeTypeEN: 3},
 		defaultConnTarget(DialConfig{selfType: discover.NodeTypePN}))
-
-	maxENToENDialTarget := 5
-	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 5},
+	maxENToENDialTarget := 1
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypePN: 2, discover.NodeTypeEN: 1},
 		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDialTarget: &maxENToENDialTarget}))
-
-	maxENToENDialTarget = 0
-	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypeEN: 0},
+	maxENToENDialTarget = 3
+	assert.Equal(t, map[discover.NodeType]int{discover.NodeTypeCN: 2, discover.NodeTypePN: 2, discover.NodeTypeEN: 3},
 		defaultConnTarget(DialConfig{selfType: discover.NodeTypeEN, maxENToENDialTarget: &maxENToENDialTarget}))
 }

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -145,7 +145,23 @@ func getDiscoverTargets(cfg *Config) map[NodeType]int {
 	if len(targets) == 0 {
 		logger.Error("Unsupported node type", "NodeType", cfg.NodeType)
 	}
-	return cloneNodeTypeTargets(targets)
+	targets = cloneNodeTypeTargets(targets)
+
+	// An all-false DiscoverTypesConfig means "not configured" for callers that
+	// construct discovery.Config directly. CLI auto/default paths populate it.
+	if !cfg.DiscoverTypes.CN && !cfg.DiscoverTypes.PN && !cfg.DiscoverTypes.EN {
+		return targets
+	}
+	if !cfg.DiscoverTypes.CN {
+		delete(targets, NodeTypeCN)
+	}
+	if !cfg.DiscoverTypes.PN {
+		delete(targets, NodeTypePN)
+	}
+	if !cfg.DiscoverTypes.EN {
+		delete(targets, NodeTypeEN)
+	}
+	return targets
 }
 
 // Filter bootnodes to be used as initial seeds.

--- a/networks/p2p/discover/table_init_test.go
+++ b/networks/p2p/discover/table_init_test.go
@@ -69,12 +69,23 @@ func Test_Table_getBootnodes_netRestrict(t *testing.T) {
 func Test_Table_getDiscoverTargets(t *testing.T) {
 	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypeEN: 1, NodeTypeBN: 3},
 		getDiscoverTargets(&Config{NodeType: NodeTypeCN}))
-	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypeEN: math.MaxInt32, NodeTypeBN: 3},
+	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypePN: 2, NodeTypeEN: math.MaxInt32, NodeTypeBN: 3},
 		getDiscoverTargets(&Config{NodeType: NodeTypeEN}))
-	assert.Equal(t, getDiscoverTargets(&Config{NodeType: NodeTypeEN}),
-		getDiscoverTargets(&Config{NodeType: NodeTypePN}))
 	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypeBN: 3},
 		getDiscoverTargets(&Config{NodeType: NodeTypeBN}))
+}
+
+func Test_Table_getDiscoverTargets_FiltersDiscoverTypes(t *testing.T) {
+	cfg := &Config{
+		NodeType: NodeTypeEN,
+		DiscoverTypes: DiscoverTypesConfig{
+			PN: true,
+		},
+	}
+	assert.Equal(t, map[NodeType]int{NodeTypePN: 2, NodeTypeBN: 3}, getDiscoverTargets(cfg))
+
+	cfg.DiscoverTypes = DiscoverTypesConfig{CN: true, EN: true}
+	assert.Equal(t, map[NodeType]int{NodeTypeCN: 100, NodeTypeEN: math.MaxInt32, NodeTypeBN: 3}, getDiscoverTargets(cfg))
 }
 
 func Test_Table_StartClose(t *testing.T) {

--- a/networks/p2p/discover/utils.go
+++ b/networks/p2p/discover/utils.go
@@ -254,7 +254,7 @@ func EffectiveNodeType(nt NodeType) NodeType {
 // KIP-311 discoverTargets
 var discoverTargets = map[NodeType]map[NodeType]int{
 	NodeTypeCN: {NodeTypeCN: 100, NodeTypeEN: 1, NodeTypeBN: 3},
-	NodeTypeEN: {NodeTypeCN: 100, NodeTypeEN: math.MaxInt32, NodeTypeBN: 3},
+	NodeTypeEN: {NodeTypeCN: 100, NodeTypePN: 2, NodeTypeEN: math.MaxInt32, NodeTypeBN: 3},
 	NodeTypeBN: {NodeTypeCN: 100, NodeTypeBN: 3},
 }
 


### PR DESCRIPTION
## Proposed changes

This PR adds PN compatibility targets to discovery and dial scheduling while PNs are still present in the network. This is to guarantee EN-PN-CN connection in a mixed network of node versions.

- Adds `discoverTargets[EN][PN] = 2` so EN discovery includes PN candidates.
- Adds `dialTargets[EN][PN] = 2` so EN nodes keep a separate outbound PN dial target.
- Updates default EN discovery config to include PN discovery.
- Applies `DiscoverTypesConfig` filtering to discovery targets when it is explicitly configured.
- Counts PN and EN outbound peers separately for dial target accounting.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

https://github.com/kaiachain/kips/pull/121/changes

## Further comments

`peerTargets[EN][PN]` remains unset, so there is no extra PN peer cap beyond global peer limits.

There are some remaining EffectiveNodeType. Use EffectiveNodeType for self-role/default policy selection, and do not use it for remote target buckets where PN and EN have separate targets. In other words, PN node use EN discovery/dial defaults.
