### PR TITLE
consensus: remove unused onPrepared callback from SubmitTransactions

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -131,9 +131,7 @@ type Engine interface {
 
 	// SubmitTransactions submits transactions for execution and consensus.
 	// Returns finalizeCh which receives the execution result when block is finalized (for DB write and broadcast).
-	// onPrepared is called after transactions are executed and block is finalized but before consensus sealing.
-	// This allows the caller to update pending block state for APIs.
-	SubmitTransactions(txs *types.TransactionsByPriceAndNonce, state *state.StateDB, header *types.Header, mux *event.TypeMux, onPrepared func(*ExecutionResult)) (finalizeCh <-chan *ExecutionResult)
+	SubmitTransactions(txs *types.TransactionsByPriceAndNonce, state *state.StateDB, header *types.Header, mux *event.TypeMux) (finalizeCh <-chan *ExecutionResult)
 
 	// APIs returns the RPC APIs this consensus engine provides.
 	APIs(chain ChainReader) []rpc.API

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -270,7 +270,7 @@ func (f *Faker) PurgeCache() {
 }
 
 // SubmitTransactions is not implemented for faker - it uses push() flow instead.
-func (f *Faker) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, state *state.StateDB, header *types.Header, mux *event.TypeMux, onPrepared func(*consensus.ExecutionResult)) (finalizeCh <-chan *consensus.ExecutionResult) {
+func (f *Faker) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, state *state.StateDB, header *types.Header, mux *event.TypeMux) (finalizeCh <-chan *consensus.ExecutionResult) {
 	// Return nil channel - faker uses the legacy push() flow
 	return nil
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -432,7 +432,7 @@ func (sb *backend) HasBadProposal(hash common.Hash) bool {
 // Returns a channel that will receive the execution result when consensus is complete.
 // In Istanbul: execute first → then consensus → finalize → send result
 // In Kaia-BFT: consensus + execute in parallel → committed → send result
-func (sb *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, statedb *state.StateDB, header *types.Header, mux *event.TypeMux, onPrepared func(*consensus.ExecutionResult)) (finalizeCh <-chan *consensus.ExecutionResult) {
+func (sb *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, statedb *state.StateDB, header *types.Header, mux *event.TypeMux) (finalizeCh <-chan *consensus.ExecutionResult) {
 	resultCh := make(chan *consensus.ExecutionResult, 1)
 
 	go func() {
@@ -478,10 +478,14 @@ func (sb *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, st
 		result.FinalizeTime = time.Since(finalizeStart)
 		result.Block = block
 
-		// Notify caller that block is prepared (for pending block API)
-		if onPrepared != nil {
-			onPrepared(result)
-		}
+		// Log block preparation completion (all validators log this, before seal)
+		logger.Info("Prepared new block",
+			"number", result.Block.Number(),
+			"hash", result.Block.Hash(),
+			"txs", len(result.Txs),
+			"elapsed", common.PrettyDuration(result.ExecuteTime+result.FinalizeTime),
+			"executeTime", common.PrettyDuration(result.ExecuteTime),
+			"finalizeTime", common.PrettyDuration(result.FinalizeTime))
 
 		// Trigger consensus (Seal) - this will run BFT consensus
 		// Seal is blocking until consensus is complete

--- a/consensus/mocks/engine_mock.go
+++ b/consensus/mocks/engine_mock.go
@@ -107,17 +107,17 @@ func (mr *MockEngineMockRecorder) Stop() *gomock.Call {
 }
 
 // SubmitTransactions mocks base method.
-func (m *MockEngine) SubmitTransactions(arg0 *types.TransactionsByPriceAndNonce, arg1 *state.StateDB, arg2 *types.Header, arg3 *event.TypeMux, arg4 func(*consensus.ExecutionResult)) <-chan *consensus.ExecutionResult {
+func (m *MockEngine) SubmitTransactions(arg0 *types.TransactionsByPriceAndNonce, arg1 *state.StateDB, arg2 *types.Header, arg3 *event.TypeMux) <-chan *consensus.ExecutionResult {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SubmitTransactions", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "SubmitTransactions", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(<-chan *consensus.ExecutionResult)
 	return ret0
 }
 
 // SubmitTransactions indicates an expected call of SubmitTransactions.
-func (mr *MockEngineMockRecorder) SubmitTransactions(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) SubmitTransactions(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTransactions", reflect.TypeOf((*MockEngine)(nil).SubmitTransactions), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTransactions", reflect.TypeOf((*MockEngine)(nil).SubmitTransactions), arg0, arg1, arg2, arg3)
 }
 
 // SubscribeNewSequence mocks base method.

--- a/work/worker.go
+++ b/work/worker.go
@@ -439,18 +439,7 @@ func (self *worker) commitNewWork() {
 	self.pendingWork = self.current
 	self.pendingWorkStart = tstart
 
-	onPrepared := func(result *consensus.ExecutionResult) {
-		// Log block preparation completion (all validators log this, before seal)
-		logger.Info("Prepared new block",
-			"number", result.Block.Number(),
-			"hash", result.Block.Hash(),
-			"txs", len(result.Txs),
-			"elapsed", common.PrettyDuration(result.ExecuteTime+result.FinalizeTime),
-			"executeTime", common.PrettyDuration(result.ExecuteTime),
-			"finalizeTime", common.PrettyDuration(result.FinalizeTime))
-	}
-
-	self.finalizeCh = self.engine.SubmitTransactions(txs, self.current.state, self.current.header, self.mux, onPrepared)
+	self.finalizeCh = self.engine.SubmitTransactions(txs, self.current.state, self.current.header, self.mux)
 
 	// Results will be handled in update() loop:
 	// - finalizeCh -> handleFinalizedBlock() for DB write and broadcast


### PR DESCRIPTION
## Proposed changes

Follow-up to #925.

After #925, `pending()` returns `chain.CurrentBlock()` and no longer uses the block snapshot that the `onPrepared` callback fed. Its only consumer (worker) just logged `"Prepared new block"`, so the hook is now unused.

- Remove `onPrepared` from the `consensus.Engine.SubmitTransactions` interface
- Emit the log directly in `backend.SubmitTransactions` (before seal)
- Update faker, worker, and regenerated `engine_mock.go`

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

Follow-up to #925.

## Further comments

The `"Prepared new block"` log keeps the same fields and pre-seal timing but is now emitted under the `ConsensusIstanbulBackend` module instead of `Work`. `engine_mock.go` was regenerated via the existing `//go:generate` directive.
