### PR TITLE
p2p: rate-limit bootstrap-node pings and bind endpoint proofs to IP

### DIFF
--- a/cmd/kbn/main.go
+++ b/cmd/kbn/main.go
@@ -147,6 +147,8 @@ func bootnode(ctx *cli.Context) error {
 		Id:            discover.PubkeyID(&bcfg.nodeKey.PublicKey),
 		NodeType:      p2p.ConvertNodeType(common.BOOTNODE),
 		DiscoverTypes: discover.DiscoverTypesConfig{CN: true, PN: true, EN: true},
+		PingRateLimit: float64(ctx.Int(utils.BNPingRateLimitFlag.Name)),
+		PingBurst:     ctx.Int(utils.BNPingBurstFlag.Name),
 	}
 
 	disc, err := discover.NewDiscovery2(&cfg)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1308,7 +1308,7 @@ var (
 	}
 	BNPingBurstFlag = &cli.IntFlag{
 		Name:     "bn.ping-burst",
-		Usage:    "Burst size for the bootstrap-node discovery ping rate limit (used only when bn.ping-ratelimit > 0)",
+		Usage:    "Burst size for the discovery PING rate limiter: the token-bucket capacity, i.e. the maximum number of pings allowed immediately from a full bucket before throttling. (used only when bn.ping-ratelimit > 0)",
 		Value:    10,
 		EnvVars:  []string{"KLAYTN_BN_PING_BURST", "KAIA_BN_PING_BURST"},
 		Category: "MISC",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1299,6 +1299,20 @@ var (
 		Aliases: []string{"p2p.bn-addr"},
 		EnvVars: []string{"KLAYTN_BNADDR", "KAIA_BNADDR"},
 	}
+	BNPingRateLimitFlag = &cli.IntFlag{
+		Name:     "bn.ping-ratelimit",
+		Usage:    "Per-source-IP discovery ping rate limit in pings/sec on a bootstrap node. 0 disables it; LAN/loopback sources are always exempt",
+		Value:    0,
+		EnvVars:  []string{"KLAYTN_BN_PING_RATELIMIT", "KAIA_BN_PING_RATELIMIT"},
+		Category: "MISC",
+	}
+	BNPingBurstFlag = &cli.IntFlag{
+		Name:     "bn.ping-burst",
+		Usage:    "Burst size for the bootstrap-node discovery ping rate limit (used only when bn.ping-ratelimit > 0)",
+		Value:    10,
+		EnvVars:  []string{"KLAYTN_BN_PING_BURST", "KAIA_BN_PING_BURST"},
+		Category: "MISC",
+	}
 	GenKeyFlag = &cli.StringFlag{
 		Name:     "genkey",
 		Usage:    "generate a node private key and write to given filename",

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -338,6 +338,8 @@ var BNFlags = []cli.Flag{
 	altsrc.NewStringFlag(NodeKeyHexFlag),
 	altsrc.NewBoolFlag(WriteAddressFlag),
 	altsrc.NewStringFlag(BNAddrFlag),
+	altsrc.NewIntFlag(BNPingRateLimitFlag),
+	altsrc.NewIntFlag(BNPingBurstFlag),
 	altsrc.NewStringFlag(NATFlag),
 	altsrc.NewStringFlag(NetrestrictFlag),
 	altsrc.NewBoolFlag(MetricsEnabledFlag),

--- a/networks/p2p/discover/database.go
+++ b/networks/p2p/discover/database.go
@@ -29,6 +29,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/binary"
+	"net"
 	"os"
 	"sync"
 	"time"
@@ -69,6 +70,11 @@ var (
 	nodeDBDiscoverPong      = nodeDBDiscoverRoot + ":lastpong"
 	nodeDBDiscoverFindFails = nodeDBDiscoverRoot + ":findfail"
 )
+
+// nodeDBVersion is the on-disk schema version; bumping it flushes stale
+// databases on upgrade. Starts at 5 because legacy builds stored the wire
+// Version (4) here. v5: lastping/lastpong/findfail are keyed per-IP.
+const nodeDBVersion = 5
 
 // newNodeDB creates a new node database for storing and retrieving infos about
 // known peers in the network. If no path is given, an in-memory, temporary
@@ -143,6 +149,17 @@ func makeKey(id NodeID, field string) []byte {
 		return []byte(field)
 	}
 	return append(nodeDBItemPrefix, append(id[:], field...)...)
+}
+
+// makeItemKey generates the leveldb key for a per-IP item (lastping, lastpong,
+// findfail), binding the entry to both the node id and the IP it concerns. The
+// node record itself (nodeDBDiscoverRoot) is keyed by id only, via makeKey.
+func makeItemKey(id NodeID, ip net.IP, field string) []byte {
+	key := append([]byte(nil), nodeDBItemPrefix...)
+	key = append(key, id[:]...)
+	key = append(key, field...)
+	key = append(key, ip.To16()...)
+	return key
 }
 
 // splitKey tries to split a database key into a node id and a field part.
@@ -263,10 +280,14 @@ func (db *nodeDB) expireNodes() error {
 		if field != nodeDBDiscoverRoot {
 			continue
 		}
-		// Skip the node if not expired yet (and not self)
+		// Skip the node if not expired yet (and not self). The bond time is
+		// keyed per-IP, so decode the record to learn the node's IP.
 		if !bytes.Equal(id[:], db.self[:]) {
-			if seen := db.bondTime(id); seen.After(threshold) {
-				continue
+			var n Node
+			if err := rlp.DecodeBytes(it.Value(), &n); err == nil {
+				if seen := db.bondTime(id, n.IP); seen.After(threshold) {
+					continue
+				}
 			}
 		}
 		// Otherwise delete all associated information
@@ -275,40 +296,48 @@ func (db *nodeDB) expireNodes() error {
 	return nil
 }
 
-// lastPing retrieves the time of the last ping packet send to a remote node,
-// requesting binding.
-func (db *nodeDB) lastPing(id NodeID) time.Time {
-	return time.Unix(db.fetchInt64(makeKey(id, nodeDBDiscoverPing)), 0)
+// lastPing retrieves the time of the last ping packet sent to a remote node at
+// the given IP, requesting binding.
+func (db *nodeDB) lastPing(id NodeID, ip net.IP) time.Time {
+	return time.Unix(db.fetchInt64(makeItemKey(id, ip, nodeDBDiscoverPing)), 0)
 }
 
-// updateLastPing updates the last time we tried contacting a remote node.
-func (db *nodeDB) updateLastPing(id NodeID, instance time.Time) error {
-	return db.storeInt64(makeKey(id, nodeDBDiscoverPing), instance.Unix())
+// updateLastPing updates the last time we tried contacting a remote node at ip.
+func (db *nodeDB) updateLastPing(id NodeID, ip net.IP, instance time.Time) error {
+	return db.storeInt64(makeItemKey(id, ip, nodeDBDiscoverPing), instance.Unix())
 }
 
-// bondTime retrieves the time of the last successful pong from remote node.
-func (db *nodeDB) bondTime(id NodeID) time.Time {
-	return time.Unix(db.fetchInt64(makeKey(id, nodeDBDiscoverPong)), 0)
+// bondTime retrieves the time of the last successful pong from a remote node at
+// the given IP. The endpoint proof is bound to (id, ip): a pong received at one
+// IP does not bond the node at a different (e.g. spoofed) IP.
+func (db *nodeDB) bondTime(id NodeID, ip net.IP) time.Time {
+	if ip == nil {
+		return time.Time{}
+	}
+	return time.Unix(db.fetchInt64(makeItemKey(id, ip, nodeDBDiscoverPong)), 0)
 }
 
-// hasBond reports whether the given node is considered bonded.
-func (db *nodeDB) hasBond(id NodeID) bool {
-	return time.Since(db.bondTime(id)) < nodeDBNodeExpiration
+// hasBond reports whether the given node is considered bonded at the given IP.
+func (db *nodeDB) hasBond(id NodeID, ip net.IP) bool {
+	return time.Since(db.bondTime(id, ip)) < nodeDBNodeExpiration
 }
 
-// updateBondTime updates the last pong time of a node.
-func (db *nodeDB) updateBondTime(id NodeID, instance time.Time) error {
-	return db.storeInt64(makeKey(id, nodeDBDiscoverPong), instance.Unix())
+// updateBondTime updates the last pong time of a node at the given IP.
+func (db *nodeDB) updateBondTime(id NodeID, ip net.IP, instance time.Time) error {
+	if ip == nil {
+		return nil
+	}
+	return db.storeInt64(makeItemKey(id, ip, nodeDBDiscoverPong), instance.Unix())
 }
 
-// findFails retrieves the number of findnode failures since bonding.
-func (db *nodeDB) findFails(id NodeID) int {
-	return int(db.fetchInt64(makeKey(id, nodeDBDiscoverFindFails)))
+// findFails retrieves the number of findnode failures since bonding for (id, ip).
+func (db *nodeDB) findFails(id NodeID, ip net.IP) int {
+	return int(db.fetchInt64(makeItemKey(id, ip, nodeDBDiscoverFindFails)))
 }
 
-// updateFindFails updates the number of findnode failures since bonding.
-func (db *nodeDB) updateFindFails(id NodeID, fails int) error {
-	return db.storeInt64(makeKey(id, nodeDBDiscoverFindFails), int64(fails))
+// updateFindFails updates the number of findnode failures since bonding for (id, ip).
+func (db *nodeDB) updateFindFails(id NodeID, ip net.IP, fails int) error {
+	return db.storeInt64(makeItemKey(id, ip, nodeDBDiscoverFindFails), int64(fails))
 }
 
 // querySeeds retrieves random nodes to be used as potential seed nodes
@@ -340,7 +369,7 @@ seek:
 		if n.ID == db.self {
 			continue seek
 		}
-		if now.Sub(db.bondTime(n.ID)) > maxAge {
+		if now.Sub(db.bondTime(n.ID, n.IP)) > maxAge {
 			continue seek
 		}
 		for i := range nodes {

--- a/networks/p2p/discover/database_test.go
+++ b/networks/p2p/discover/database_test.go
@@ -123,33 +123,33 @@ func TestNodeDBFetchStore(t *testing.T) {
 	defer db.close()
 
 	// Check fetch/store operations on a node ping object
-	if stored := db.lastPing(node.ID); stored.Unix() != 0 {
+	if stored := db.lastPing(node.ID, node.IP); stored.Unix() != 0 {
 		t.Errorf("ping: non-existing object: %v", stored)
 	}
-	if err := db.updateLastPing(node.ID, inst); err != nil {
+	if err := db.updateLastPing(node.ID, node.IP, inst); err != nil {
 		t.Errorf("ping: failed to update: %v", err)
 	}
-	if stored := db.lastPing(node.ID); stored.Unix() != inst.Unix() {
+	if stored := db.lastPing(node.ID, node.IP); stored.Unix() != inst.Unix() {
 		t.Errorf("ping: value mismatch: have %v, want %v", stored, inst)
 	}
 	// Check fetch/store operations on a node pong object
-	if stored := db.bondTime(node.ID); stored.Unix() != 0 {
+	if stored := db.bondTime(node.ID, node.IP); stored.Unix() != 0 {
 		t.Errorf("pong: non-existing object: %v", stored)
 	}
-	if err := db.updateBondTime(node.ID, inst); err != nil {
+	if err := db.updateBondTime(node.ID, node.IP, inst); err != nil {
 		t.Errorf("pong: failed to update: %v", err)
 	}
-	if stored := db.bondTime(node.ID); stored.Unix() != inst.Unix() {
+	if stored := db.bondTime(node.ID, node.IP); stored.Unix() != inst.Unix() {
 		t.Errorf("pong: value mismatch: have %v, want %v", stored, inst)
 	}
 	// Check fetch/store operations on a node findnode-failure object
-	if stored := db.findFails(node.ID); stored != 0 {
+	if stored := db.findFails(node.ID, node.IP); stored != 0 {
 		t.Errorf("find-node fails: non-existing object: %v", stored)
 	}
-	if err := db.updateFindFails(node.ID, num); err != nil {
+	if err := db.updateFindFails(node.ID, node.IP, num); err != nil {
 		t.Errorf("find-node fails: failed to update: %v", err)
 	}
-	if stored := db.findFails(node.ID); stored != num {
+	if stored := db.findFails(node.ID, node.IP); stored != num {
 		t.Errorf("find-node fails: value mismatch: have %v, want %v", stored, num)
 	}
 	// Check fetch/store operations on an actual node object
@@ -163,6 +163,32 @@ func TestNodeDBFetchStore(t *testing.T) {
 		t.Errorf("node: not found")
 	} else if !reflect.DeepEqual(stored, node) {
 		t.Errorf("node: data mismatch: have %v, want %v", stored, node)
+	}
+}
+
+// TestNodeDBBondIPBinding verifies a bond is keyed by (NodeID, IP): a pong at
+// one IP must not count as a bond at another, and lookup is stable across the
+// 4-byte and 16-byte forms of the same IPv4 address.
+func TestNodeDBBondIPBinding(t *testing.T) {
+	id := MustHexID("0x1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439")
+	ip1 := net.IP{192, 168, 0, 1}
+	ip2 := net.IP{203, 0, 113, 9}
+
+	db, _ := newNodeDB("", Version, NodeID{})
+	defer db.close()
+
+	if err := db.updateBondTime(id, ip1, time.Now()); err != nil {
+		t.Fatalf("failed to record bond at ip1: %v", err)
+	}
+	if !db.hasBond(id, ip1) {
+		t.Fatal("node should be bonded at the IP that produced the pong")
+	}
+	if db.hasBond(id, ip2) {
+		t.Fatal("node must NOT be bonded at a different IP (IP-binding broken)")
+	}
+	// 4-byte and 16-byte forms of the same IPv4 must resolve to the same bond.
+	if !db.hasBond(id, ip1.To16()) {
+		t.Fatal("bond lookup must be stable across 4-byte and 16-byte IPv4 forms")
 	}
 }
 
@@ -242,7 +268,7 @@ func TestNodeDBSeedQuery(t *testing.T) {
 		if err := db.updateNode(seed.node); err != nil {
 			t.Fatalf("node %d: failed to insert: %v", i, err)
 		}
-		if err := db.updateBondTime(seed.node.ID, seed.pong); err != nil {
+		if err := db.updateBondTime(seed.node.ID, seed.node.IP, seed.pong); err != nil {
 			t.Fatalf("node %d: failed to insert bondTime: %v", i, err)
 		}
 	}
@@ -354,7 +380,7 @@ func TestNodeDBExpiration(t *testing.T) {
 		if err := db.updateNode(seed.node); err != nil {
 			t.Fatalf("node %d: failed to insert: %v", i, err)
 		}
-		if err := db.updateBondTime(seed.node.ID, seed.pong); err != nil {
+		if err := db.updateBondTime(seed.node.ID, seed.node.IP, seed.pong); err != nil {
 			t.Fatalf("node %d: failed to update bondTime: %v", i, err)
 		}
 	}
@@ -387,7 +413,7 @@ func TestNodeDBSelfExpiration(t *testing.T) {
 		if err := db.updateNode(seed.node); err != nil {
 			t.Fatalf("node %d: failed to insert: %v", i, err)
 		}
-		if err := db.updateBondTime(seed.node.ID, seed.pong); err != nil {
+		if err := db.updateBondTime(seed.node.ID, seed.node.IP, seed.pong); err != nil {
 			t.Fatalf("node %d: failed to update bondTime: %v", i, err)
 		}
 	}

--- a/networks/p2p/discover/discovery.go
+++ b/networks/p2p/discover/discovery.go
@@ -61,6 +61,12 @@ type Config struct {
 
 	// DiscoverNodetype is list of node type to enable discovery.
 	DiscoverTypes DiscoverTypesConfig
+
+	// PingRateLimit, when > 0, enables a per-source-IP discovery-ping rate limit
+	// (in pings/sec) on bootstrap nodes; 0 disables it. PingBurst is the
+	// token-bucket burst size (default applied when <= 0).
+	PingRateLimit float64
+	PingBurst     int
 }
 
 // discovery2 combines a UDP transport and a Table2 into a Discovery2 implementation.

--- a/networks/p2p/discover/metrics.go
+++ b/networks/p2p/discover/metrics.go
@@ -31,5 +31,5 @@ var (
 	pendingNeighborsCounter = metrics.NewRegisteredCounter("discover/pendingNeighbors", nil) // pending neighbors counter at the moment
 	neighborsMeter          = metrics.NewRegisteredMeter("discover/neighbors", nil)          // received neighbors packet meter
 	mismatchNetworkCounter  = metrics.NewRegisteredMeter("discover/mismatchNetwork", nil)    // mismatch network ping packet counter
-	pingRateLimitedCounter  = metrics.NewRegisteredMeter("discover/pingRateLimited", nil)    // rate-limited ping packet meter (KIP-311 R2)
+	pingRateLimitedCounter  = metrics.NewRegisteredMeter("discover/pingRateLimited", nil)    // rate-limited ping packet meter
 )

--- a/networks/p2p/discover/metrics.go
+++ b/networks/p2p/discover/metrics.go
@@ -31,4 +31,5 @@ var (
 	pendingNeighborsCounter = metrics.NewRegisteredCounter("discover/pendingNeighbors", nil) // pending neighbors counter at the moment
 	neighborsMeter          = metrics.NewRegisteredMeter("discover/neighbors", nil)          // received neighbors packet meter
 	mismatchNetworkCounter  = metrics.NewRegisteredMeter("discover/mismatchNetwork", nil)    // mismatch network ping packet counter
+	pingRateLimitedCounter  = metrics.NewRegisteredMeter("discover/pingRateLimited", nil)    // rate-limited ping packet meter (KIP-311 R2)
 )

--- a/networks/p2p/discover/ratelimit.go
+++ b/networks/p2p/discover/ratelimit.go
@@ -25,11 +25,13 @@ import (
 )
 
 const (
-	// pingRatePerIP is the sustained discovery-ping rate allowed per source IP
-	// on a bootstrap node (KIP-311 R2).
-	pingRatePerIP = rate.Limit(1) // 1 ping/sec sustained
+	// pingRatePerIP is the sustained discovery-ping rate allowed per source IP.
+	// A node pings a bootnode at up to ~1/s while its dialer drives repeated
+	// discovery refreshes, so this leaves headroom for a few nodes sharing one
+	// (non-LAN) public IP.
+	pingRatePerIP = rate.Limit(3) // 3 pings/sec sustained
 	// pingBurstPerIP is the burst of pings tolerated per source IP.
-	pingBurstPerIP = 5
+	pingBurstPerIP = 10
 	// maxLimitedIPs bounds the number of tracked source IPs so the limiter map
 	// cannot grow without limit under source-IP rotation.
 	maxLimitedIPs = 16384
@@ -39,12 +41,11 @@ const (
 )
 
 // ipRateLimiter applies a per-source-IP token-bucket rate limit. It is used by
-// bootstrap nodes to throttle discovery pings from unknown (unbonded) nodes,
-// bounding amplification/DoS against the UDP endpoint (KIP-311 R2).
+// bootstrap nodes to throttle discovery pings, bounding amplification/DoS
+// against the UDP endpoint.
 //
 // Source IPs in UDP are spoofable, so this is a partial, application-level
-// defense intended to be complemented by network-layer (L3/L4) protections, as
-// required by KIP-311's Security Considerations.
+// defense intended to be complemented by network-layer (L3/L4) protections.
 type ipRateLimiter struct {
 	mu      sync.Mutex
 	limit   rate.Limit

--- a/networks/p2p/discover/ratelimit.go
+++ b/networks/p2p/discover/ratelimit.go
@@ -106,6 +106,7 @@ func (l *ipRateLimiter) allow(ip net.IP, now time.Time) bool {
 
 // evictIdle removes entries idle for longer than idleTTL. An idle entry's token
 // bucket is necessarily full, so dropping it loses no rate-limit state.
+// The caller must hold l.mu.
 func (l *ipRateLimiter) evictIdle(now time.Time) {
 	for k, e := range l.ips {
 		if now.Sub(e.lastSeen) > l.idleTTL {
@@ -115,7 +116,7 @@ func (l *ipRateLimiter) evictIdle(now time.Time) {
 }
 
 // evictOldest removes the single least-recently-seen entry to make room for a
-// new IP when the map is at capacity.
+// new IP when the map is at capacity. The caller must hold l.mu.
 func (l *ipRateLimiter) evictOldest() {
 	var (
 		oldestKey  string

--- a/networks/p2p/discover/ratelimit.go
+++ b/networks/p2p/discover/ratelimit.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	// pingRatePerIP is the sustained discovery-ping rate allowed per source IP
+	// on a bootstrap node (KIP-311 R2).
+	pingRatePerIP = rate.Limit(1) // 1 ping/sec sustained
+	// pingBurstPerIP is the burst of pings tolerated per source IP.
+	pingBurstPerIP = 5
+	// maxLimitedIPs bounds the number of tracked source IPs so the limiter map
+	// cannot grow without limit under source-IP rotation.
+	maxLimitedIPs = 16384
+	// limiterIdleTTL is how long an idle per-IP limiter is retained before it
+	// becomes eligible for eviction.
+	limiterIdleTTL = 10 * time.Minute
+)
+
+// ipRateLimiter applies a per-source-IP token-bucket rate limit. It is used by
+// bootstrap nodes to throttle discovery pings from unknown (unbonded) nodes,
+// bounding amplification/DoS against the UDP endpoint (KIP-311 R2).
+//
+// Source IPs in UDP are spoofable, so this is a partial, application-level
+// defense intended to be complemented by network-layer (L3/L4) protections, as
+// required by KIP-311's Security Considerations.
+type ipRateLimiter struct {
+	mu      sync.Mutex
+	limit   rate.Limit
+	burst   int
+	maxIPs  int
+	idleTTL time.Duration
+	ips     map[string]*ipLimiterEntry
+}
+
+type ipLimiterEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+func newIPRateLimiter(limit rate.Limit, burst, maxIPs int, idleTTL time.Duration) *ipRateLimiter {
+	return &ipRateLimiter{
+		limit:   limit,
+		burst:   burst,
+		maxIPs:  maxIPs,
+		idleTTL: idleTTL,
+		ips:     make(map[string]*ipLimiterEntry),
+	}
+}
+
+// allow reports whether an event from ip is permitted at time now. now is passed
+// in so the limiter is deterministic and testable.
+func (l *ipRateLimiter) allow(ip net.IP, now time.Time) bool {
+	key := ip.String()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	e, ok := l.ips[key]
+	if !ok {
+		// Keep the map bounded: drop idle entries first, then evict the
+		// least-recently-seen one if still at capacity.
+		if len(l.ips) >= l.maxIPs {
+			l.evictIdle(now)
+		}
+		if len(l.ips) >= l.maxIPs {
+			l.evictOldest()
+		}
+		e = &ipLimiterEntry{limiter: rate.NewLimiter(l.limit, l.burst)}
+		l.ips[key] = e
+	}
+	e.lastSeen = now
+	return e.limiter.AllowN(now, 1)
+}
+
+// evictIdle removes entries idle for longer than idleTTL. An idle entry's token
+// bucket is necessarily full, so dropping it loses no rate-limit state.
+func (l *ipRateLimiter) evictIdle(now time.Time) {
+	for k, e := range l.ips {
+		if now.Sub(e.lastSeen) > l.idleTTL {
+			delete(l.ips, k)
+		}
+	}
+}
+
+// evictOldest removes the single least-recently-seen entry to make room for a
+// new IP when the map is at capacity.
+func (l *ipRateLimiter) evictOldest() {
+	var (
+		oldestKey  string
+		oldestTime time.Time
+		found      bool
+	)
+	for k, e := range l.ips {
+		if !found || e.lastSeen.Before(oldestTime) {
+			oldestKey, oldestTime, found = k, e.lastSeen, true
+		}
+	}
+	if found {
+		delete(l.ips, oldestKey)
+	}
+}
+
+// len returns the number of tracked IPs.
+func (l *ipRateLimiter) len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.ips)
+}

--- a/networks/p2p/discover/ratelimit.go
+++ b/networks/p2p/discover/ratelimit.go
@@ -25,13 +25,13 @@ import (
 )
 
 const (
-	// pingRatePerIP is the sustained discovery-ping rate allowed per source IP.
-	// A node pings a bootnode at up to ~1/s while its dialer drives repeated
-	// discovery refreshes, so this leaves headroom for a few nodes sharing one
-	// (non-LAN) public IP.
-	pingRatePerIP = rate.Limit(3) // 3 pings/sec sustained
-	// pingBurstPerIP is the burst of pings tolerated per source IP.
-	pingBurstPerIP = 10
+	// defaultPingBurst is the token-bucket burst used when ping rate limiting is
+	// enabled without an explicit burst. LAN/loopback sources are exempt, so the
+	// limiter only sees public IPs — where several nodes can sit behind one IP
+	// via NAT and share its bucket. Each node pings a bootnode at ~1/s (its
+	// dialer drives repeated discovery refreshes), so a burst of 10 absorbs
+	// short spikes from a handful of such nodes without throttling them.
+	defaultPingBurst = 10
 	// maxLimitedIPs bounds the number of tracked source IPs so the limiter map
 	// cannot grow without limit under source-IP rotation.
 	maxLimitedIPs = 16384
@@ -68,6 +68,15 @@ func newIPRateLimiter(limit rate.Limit, burst, maxIPs int, idleTTL time.Duration
 		idleTTL: idleTTL,
 		ips:     make(map[string]*ipLimiterEntry),
 	}
+}
+
+// newPingLimiter builds the per-IP discovery-ping limiter for a bootstrap node
+// from operator-provided values, applying defaultPingBurst when burst <= 0.
+func newPingLimiter(ratePerSec float64, burst int) *ipRateLimiter {
+	if burst <= 0 {
+		burst = defaultPingBurst
+	}
+	return newIPRateLimiter(rate.Limit(ratePerSec), burst, maxLimitedIPs, limiterIdleTTL)
 }
 
 // allow reports whether an event from ip is permitted at time now. now is passed

--- a/networks/p2p/discover/ratelimit_test.go
+++ b/networks/p2p/discover/ratelimit_test.go
@@ -79,3 +79,59 @@ func TestIPRateLimiterBounded(t *testing.T) {
 		t.Fatalf("limiter map exceeded cap: got %d, want <= %d", got, max)
 	}
 }
+
+// newPingTestUDP builds a minimal udp instance for exercising ping.preverify.
+// It carries only the fields the rate-limit gate reads: the local network id,
+// this node's type (BN gating), and the per-IP ping limiter.
+func newPingTestUDP(nodeType NodeType, networkID uint64) *udp {
+	return &udp{
+		networkID:   networkID,
+		ourEndpoint: rpcEndpoint{NType: nodeType},
+		pingLimiter: newIPRateLimiter(pingRatePerIP, pingBurstPerIP, maxLimitedIPs, limiterIdleTTL),
+	}
+}
+
+// TestPingPreverifyRateLimit exercises the full ping rate-limit gate in
+// ping.preverify end to end: a bootstrap node throttles pings from a non-LAN
+// source IP once the burst is spent, exempts LAN/loopback sources, and does not
+// rate-limit at all when the node is not a bootstrap node.
+func TestPingPreverifyRateLimit(t *testing.T) {
+	const networkID = 12345
+	req := &ping{NetworkID: networkID, Expiration: futureExp}
+	fromID := NodeID{}
+
+	t.Run("BN throttles non-LAN flood after burst", func(t *testing.T) {
+		u := newPingTestUDP(NodeTypeBN, networkID)
+		from := &net.UDPAddr{IP: net.ParseIP("203.0.113.5"), Port: 30303}
+		// The burst (token bucket capacity) is allowed in one flood.
+		for i := 0; i < pingBurstPerIP; i++ {
+			if err := req.preverify(u, from, fromID); err != nil {
+				t.Fatalf("ping %d within burst should pass, got %v", i, err)
+			}
+		}
+		// The very next ping (no time for tokens to refill) is throttled.
+		if err := req.preverify(u, from, fromID); err != errPingRateLimited {
+			t.Fatalf("ping beyond burst should be rate limited, got %v", err)
+		}
+	})
+
+	t.Run("LAN source is exempt", func(t *testing.T) {
+		u := newPingTestUDP(NodeTypeBN, networkID)
+		from := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 30303}
+		for i := 0; i < pingBurstPerIP*3; i++ {
+			if err := req.preverify(u, from, fromID); err != nil {
+				t.Fatalf("LAN ping %d must never be rate limited, got %v", i, err)
+			}
+		}
+	})
+
+	t.Run("non-BN node never rate-limits", func(t *testing.T) {
+		u := newPingTestUDP(NodeTypeCN, networkID)
+		from := &net.UDPAddr{IP: net.ParseIP("203.0.113.5"), Port: 30303}
+		for i := 0; i < pingBurstPerIP*3; i++ {
+			if err := req.preverify(u, from, fromID); err != nil {
+				t.Fatalf("non-BN ping %d must never be rate limited, got %v", i, err)
+			}
+		}
+	})
+}

--- a/networks/p2p/discover/ratelimit_test.go
+++ b/networks/p2p/discover/ratelimit_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// TestIPRateLimiterBurstThenThrottle verifies a single IP gets its burst, is
+// then throttled, and recovers as tokens replenish.
+func TestIPRateLimiterBurstThenThrottle(t *testing.T) {
+	burst := 5
+	l := newIPRateLimiter(rate.Limit(1), burst, 1024, time.Minute)
+	ip := net.ParseIP("203.0.113.7")
+	now := time.Unix(0, 0)
+
+	for i := 0; i < burst; i++ {
+		if !l.allow(ip, now) {
+			t.Fatalf("burst ping %d should be allowed", i)
+		}
+	}
+	if l.allow(ip, now) {
+		t.Fatal("ping beyond burst should be throttled")
+	}
+	// rate = 1/s, so one token is back after a second.
+	if !l.allow(ip, now.Add(time.Second)) {
+		t.Fatal("ping after 1s should be allowed again")
+	}
+}
+
+// TestIPRateLimiterPerIP verifies budgets are independent per source IP.
+func TestIPRateLimiterPerIP(t *testing.T) {
+	l := newIPRateLimiter(rate.Limit(1), 1, 1024, time.Minute)
+	now := time.Unix(0, 0)
+	a := net.ParseIP("203.0.113.1")
+	b := net.ParseIP("203.0.113.2")
+
+	if !l.allow(a, now) || !l.allow(b, now) {
+		t.Fatal("first ping from each IP should be allowed")
+	}
+	if l.allow(a, now) {
+		t.Fatal("second ping from A within the same instant should be throttled")
+	}
+	if !l.allow(b, now.Add(time.Second)) {
+		t.Fatal("B's budget should be independent of A")
+	}
+}
+
+// TestIPRateLimiterBounded verifies the map stays within its cap under
+// source-IP rotation (eviction works).
+func TestIPRateLimiterBounded(t *testing.T) {
+	const max = 64
+	l := newIPRateLimiter(rate.Limit(1), 1, max, time.Hour)
+	now := time.Unix(0, 0)
+	for i := 0; i < max*4; i++ {
+		ip := net.IPv4(10, 0, byte(i>>8), byte(i))
+		l.allow(ip, now)
+		now = now.Add(time.Millisecond)
+	}
+	if got := l.len(); got > max {
+		t.Fatalf("limiter map exceeded cap: got %d, want <= %d", got, max)
+	}
+}

--- a/networks/p2p/discover/ratelimit_test.go
+++ b/networks/p2p/discover/ratelimit_test.go
@@ -80,6 +80,11 @@ func TestIPRateLimiterBounded(t *testing.T) {
 	}
 }
 
+const (
+	testPingRate  = 3  // pings/sec for ping.preverify tests
+	testPingBurst = 10 // token-bucket burst for ping.preverify tests
+)
+
 // newPingTestUDP builds a minimal udp instance for exercising ping.preverify.
 // It carries only the fields the rate-limit gate reads: the local network id,
 // this node's type (BN gating), and the per-IP ping limiter.
@@ -87,7 +92,7 @@ func newPingTestUDP(nodeType NodeType, networkID uint64) *udp {
 	return &udp{
 		networkID:   networkID,
 		ourEndpoint: rpcEndpoint{NType: nodeType},
-		pingLimiter: newIPRateLimiter(pingRatePerIP, pingBurstPerIP, maxLimitedIPs, limiterIdleTTL),
+		pingLimiter: newPingLimiter(testPingRate, testPingBurst),
 	}
 }
 
@@ -104,7 +109,7 @@ func TestPingPreverifyRateLimit(t *testing.T) {
 		u := newPingTestUDP(NodeTypeBN, networkID)
 		from := &net.UDPAddr{IP: net.ParseIP("203.0.113.5"), Port: 30303}
 		// The burst (token bucket capacity) is allowed in one flood.
-		for i := 0; i < pingBurstPerIP; i++ {
+		for i := 0; i < testPingBurst; i++ {
 			if err := req.preverify(u, from, fromID); err != nil {
 				t.Fatalf("ping %d within burst should pass, got %v", i, err)
 			}
@@ -118,7 +123,7 @@ func TestPingPreverifyRateLimit(t *testing.T) {
 	t.Run("LAN source is exempt", func(t *testing.T) {
 		u := newPingTestUDP(NodeTypeBN, networkID)
 		from := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 30303}
-		for i := 0; i < pingBurstPerIP*3; i++ {
+		for i := 0; i < testPingBurst*3; i++ {
 			if err := req.preverify(u, from, fromID); err != nil {
 				t.Fatalf("LAN ping %d must never be rate limited, got %v", i, err)
 			}
@@ -128,7 +133,7 @@ func TestPingPreverifyRateLimit(t *testing.T) {
 	t.Run("non-BN node never rate-limits", func(t *testing.T) {
 		u := newPingTestUDP(NodeTypeCN, networkID)
 		from := &net.UDPAddr{IP: net.ParseIP("203.0.113.5"), Port: 30303}
-		for i := 0; i < pingBurstPerIP*3; i++ {
+		for i := 0; i < testPingBurst*3; i++ {
 			if err := req.preverify(u, from, fromID); err != nil {
 				t.Fatalf("non-BN ping %d must never be rate limited, got %v", i, err)
 			}

--- a/networks/p2p/discover/table_bond.go
+++ b/networks/p2p/discover/table_bond.go
@@ -18,6 +18,7 @@ package discover
 
 import (
 	"errors"
+	"net"
 	"sync"
 	"time"
 )
@@ -59,7 +60,7 @@ func (tab *Table2) revalidateOnce(s tableStorage) {
 		return
 	}
 
-	if tab.bondAge(n.ID) < revalidateBackoff {
+	if tab.bondAge(n.ID, n.IP) < revalidateBackoff {
 		logger.Trace("skip revalidate", "node", n.addr())
 		return
 	}
@@ -67,7 +68,7 @@ func (tab *Table2) revalidateOnce(s tableStorage) {
 	err := tab.udp.ping(n.ID, n.addr())
 	if err == nil {
 		s.add(n) // bump the node
-		tab.db.updateBondTime(n.ID, time.Now())
+		tab.db.updateBondTime(n.ID, n.IP, time.Now())
 		logger.Debug("Discovery revalidation passed", "node", n.addr())
 	} else {
 		s.delete(n)
@@ -78,8 +79,8 @@ func (tab *Table2) revalidateOnce(s tableStorage) {
 
 // Returns the time since the last bond with the given node.
 // If the node is not bonded, return a very large duration.
-func (tab *Table2) bondAge(id NodeID) time.Duration {
-	return time.Since(tab.db.bondTime(id))
+func (tab *Table2) bondAge(id NodeID, ip net.IP) time.Duration {
+	return time.Since(tab.db.bondTime(id, ip))
 }
 
 //// Bonding primitives
@@ -141,7 +142,7 @@ func (tab *Table2) Bond(pinged bool, n *Node) error {
 	}
 
 	// Skip if we're really sure that this node is reachable and completed the bonding process.
-	if tab.canAssumeBonded(n.ID) {
+	if tab.canAssumeBonded(n.ID, n.IP) {
 		return nil
 	}
 
@@ -180,16 +181,16 @@ func (tab *Table2) pingpong(pinged bool, n *Node) error {
 }
 
 // A node is assumed to be bonded if all values are recently written by recordBonded().
-func (tab *Table2) canAssumeBonded(id NodeID) bool {
-	recentlyBonded := tab.db.hasBond(id)
-	neverFailed := tab.db.findFails(id) == 0
+func (tab *Table2) canAssumeBonded(id NodeID, ip net.IP) bool {
+	recentlyBonded := tab.db.hasBond(id, ip)
+	neverFailed := tab.db.findFails(id, ip) == 0
 	storedInDB := tab.db.node(id) != nil
 	return recentlyBonded && neverFailed && storedInDB
 }
 
 func (tab *Table2) recordBonded(n *Node) {
-	tab.db.updateBondTime(n.ID, time.Now())
-	tab.db.updateFindFails(n.ID, 0)
+	tab.db.updateBondTime(n.ID, n.IP, time.Now())
+	tab.db.updateFindFails(n.ID, n.IP, 0)
 	tab.db.updateNode(n)
 
 	bucketEntriesGauge.Update(int64(tab.len()))

--- a/networks/p2p/discover/table_bond_test.go
+++ b/networks/p2p/discover/table_bond_test.go
@@ -40,7 +40,7 @@ func Test_Table_revalidateOnce_success(t *testing.T) {
 	// Node is still in storage (bumped to front on success).
 	assert.Equal(t, 1, s.len())
 	// Bond time is updated in the database.
-	assert.True(t, tab.db.hasBond(n.ID), "bondTime should be recent after successful revalidation")
+	assert.True(t, tab.db.hasBond(n.ID, n.IP), "bondTime should be recent after successful revalidation")
 	assert.Equal(t, int32(1), udp.pingCnt.Load())
 }
 
@@ -151,9 +151,9 @@ func Test_Table_Bond_happy(t *testing.T) {
 	// Node should be added to the EN storage.
 	assert.Equal(t, 1, tab.storages[NodeTypeEN].len(), "node should appear in EN storage")
 	// DB should reflect successful bonding.
-	assert.True(t, tab.db.hasBond(n.ID), "DB bond time should be set")
+	assert.True(t, tab.db.hasBond(n.ID, n.IP), "DB bond time should be set")
 	assert.NotNil(t, tab.db.node(n.ID), "DB should store the node")
-	assert.Equal(t, 0, tab.db.findFails(n.ID), "DB find failures should be 0")
+	assert.Equal(t, 0, tab.db.findFails(n.ID, n.IP), "DB find failures should be 0")
 	assert.Equal(t, int32(1), udp.pingCnt.Load())
 }
 
@@ -222,8 +222,8 @@ func Test_Table_Bond_recentlyBonded(t *testing.T) {
 
 	// canAssumeBonded requires node to be stored in DB too.
 	require.NotNil(t, tab.db.node(n.ID))
-	require.True(t, tab.db.hasBond(n.ID))
-	require.Equal(t, 0, tab.db.findFails(n.ID))
+	require.True(t, tab.db.hasBond(n.ID, n.IP))
+	require.Equal(t, 0, tab.db.findFails(n.ID, n.IP))
 
 	err := tab.Bond(false, n)
 

--- a/networks/p2p/discover/table_data.go
+++ b/networks/p2p/discover/table_data.go
@@ -17,6 +17,8 @@
 package discover
 
 import (
+	"net"
+
 	"github.com/kaiachain/kaia/crypto"
 )
 
@@ -36,8 +38,8 @@ func (tab *Table2) ClosestNodes(targetID NodeID, targetType NodeType, max int) [
 	}
 }
 
-func (tab *Table2) IsBonded(id NodeID) bool {
-	return tab.bondAge(id) < nodeDBNodeExpiration
+func (tab *Table2) IsBonded(id NodeID, ip net.IP) bool {
+	return tab.bondAge(id, ip) < nodeDBNodeExpiration
 }
 
 //// Wrappers for underlying storages.

--- a/networks/p2p/discover/table_data_test.go
+++ b/networks/p2p/discover/table_data_test.go
@@ -117,12 +117,12 @@ func Test_Table_ClosestNodes_happy(t *testing.T) {
 func Test_Table_IsBonded_false(t *testing.T) {
 	tab := newTestTable2(t, nil)
 	n := newTestNode(t, NodeTypeEN)
-	assert.False(t, tab.IsBonded(n.ID), "brand-new node should not be bonded")
+	assert.False(t, tab.IsBonded(n.ID, n.IP), "brand-new node should not be bonded")
 }
 
 func Test_Table_IsBonded_true(t *testing.T) {
 	tab := newTestTable2(t, nil)
 	n := newTestNode(t, NodeTypeEN)
 	tab.recordBonded(n)
-	assert.True(t, tab.IsBonded(n.ID), "node with recent bond time should be bonded")
+	assert.True(t, tab.IsBonded(n.ID, n.IP), "node with recent bond time should be bonded")
 }

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -84,7 +84,7 @@ func newTable2(cfg *Config, udp transport) (*Table2, error) {
 		return nil, err
 	}
 
-	db, err := newNodeDB(cfg.NodeDBPath, Version, cfg.Id)
+	db, err := newNodeDB(cfg.NodeDBPath, nodeDBVersion, cfg.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/networks/p2p/discover/table_lookup.go
+++ b/networks/p2p/discover/table_lookup.go
@@ -180,8 +180,8 @@ func (tab *Table2) findNodesOnce(seed *Node, targetID NodeID, targetType NodeTyp
 
 // Records a findnode failure.
 func (tab *Table2) recordFindFailure(seed *Node) {
-	fails := tab.db.findFails(seed.ID) + 1
-	tab.db.updateFindFails(seed.ID, fails)
+	fails := tab.db.findFails(seed.ID, seed.IP) + 1
+	tab.db.updateFindFails(seed.ID, seed.IP, fails)
 	logger.Trace("Findnode failure", "id", seed.ID, "failcount", fails)
 
 	if fails >= maxFindnodeFailures {

--- a/networks/p2p/discover/table_lookup_test.go
+++ b/networks/p2p/discover/table_lookup_test.go
@@ -74,9 +74,9 @@ func Test_Table_recordFindFailure_increments(t *testing.T) {
 	n := newTestNode(t, NodeTypeEN)
 	tab.addNode(n)
 
-	require.Equal(t, 0, tab.db.findFails(n.ID))
+	require.Equal(t, 0, tab.db.findFails(n.ID, n.IP))
 	tab.recordFindFailure(n)
-	assert.Equal(t, 1, tab.db.findFails(n.ID))
+	assert.Equal(t, 1, tab.db.findFails(n.ID, n.IP))
 	// Node still in the table (1 < maxFindnodeFailures).
 	assert.Equal(t, 1, tab.storages[NodeTypeEN].len())
 }
@@ -107,7 +107,7 @@ func Test_Table_findNodesOnce_error(t *testing.T) {
 
 	result := tab.findNodesOnce(seed, NodeID{}, NodeTypeEN, 10)
 	assert.Empty(t, result)
-	assert.Equal(t, 1, tab.db.findFails(seed.ID), "failure should be recorded in DB")
+	assert.Equal(t, 1, tab.db.findFails(seed.ID, seed.IP), "failure should be recorded in DB")
 }
 
 func Test_Table_findNodesOnce_success(t *testing.T) {
@@ -143,7 +143,7 @@ func Test_Table_findNodesOnce_timeout_noFailure(t *testing.T) {
 	result := tab.findNodesOnce(seed, NodeID{}, NodeTypeCN, 100)
 	require.Len(t, result, 1)
 	assert.Equal(t, peer.ID, result[0].ID)
-	assert.Equal(t, 0, tab.db.findFails(seed.ID), "timeout with response must not record a find failure")
+	assert.Equal(t, 0, tab.db.findFails(seed.ID, seed.IP), "timeout with response must not record a find failure")
 }
 
 func Test_Table_lookup_emptyTable(t *testing.T) {

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -52,6 +52,7 @@ var (
 	errClockWarp        = errors.New("reply deadline too far in the future")
 	errClosed           = errors.New("socket closed")
 	errMismatchNetwork  = errors.New("mismatch network id")
+	errPingRateLimited  = errors.New("ping rate limited")
 )
 
 // Timeouts
@@ -312,6 +313,10 @@ type udp struct {
 	wg      sync.WaitGroup
 
 	tab *Table2
+
+	// pingLimiter throttles discovery pings from unknown source IPs. It is only
+	// enforced when this node is a bootstrap node (KIP-311 R2).
+	pingLimiter *ipRateLimiter
 }
 
 // #region UDP Init
@@ -325,6 +330,7 @@ func newUDPv4(cfg *Config) *udp {
 		closing:     make(chan struct{}),
 		gotreply:    make(chan reply),
 		addpending:  make(chan *pending),
+		pingLimiter: newIPRateLimiter(pingRatePerIP, pingBurstPerIP, maxLimitedIPs, limiterIdleTTL),
 	}
 	realaddr := cfg.Addr
 	if cfg.AnnounceAddr != nil {
@@ -727,6 +733,21 @@ func (req *ping) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 		logger.Debug("udp: ping: mismatch networkid", "local", t.networkID, "remote", req.NetworkID)
 		mismatchNetworkCounter.Mark(1)
 		return errMismatchNetwork
+	}
+	// KIP-311 R2: bootstrap nodes rate-limit pings per source IP to bound
+	// amplification/DoS against the UDP endpoint. Rejecting here prevents both
+	// the pong reply and the bonding goroutine in handle().
+	//
+	// The limit is applied to every source IP, not just unbonded ones: a UDP
+	// source IP is unauthenticated/spoofable, and kaia's bond is keyed by NodeID
+	// only (not IP), so a "bonded NodeID + spoofed source IP" packet could
+	// otherwise bypass the limit and reflect a pong to the spoofed victim.
+	if t.ourEndpoint.NType == NodeTypeBN && t.pingLimiter != nil {
+		if !t.pingLimiter.allow(from.IP, time.Now()) {
+			logger.Trace("udp: ping: rate limited", "addr", from)
+			pingRateLimitedCounter.Mark(1)
+			return errPingRateLimited
+		}
 	}
 	return nil
 }

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -314,8 +314,8 @@ type udp struct {
 
 	tab *Table2
 
-	// pingLimiter throttles discovery pings from unknown source IPs. It is only
-	// enforced when this node is a bootstrap node (KIP-311 R2).
+	// pingLimiter throttles discovery pings per source IP. It is only enforced
+	// when this node is a bootstrap node.
 	pingLimiter *ipRateLimiter
 }
 
@@ -353,8 +353,8 @@ func (t *udp) close() {
 	t.wg.Wait()
 }
 
-func (t *udp) hasBond(fromID NodeID) bool {
-	return t.tab.IsBonded(fromID)
+func (t *udp) hasBond(fromID NodeID, fromIP net.IP) bool {
+	return t.tab.IsBonded(fromID, fromIP)
 }
 
 func (t *udp) bond(pinged bool, id NodeID, addr *net.UDPAddr, tcpPort uint16, nType NodeType) {
@@ -734,15 +734,21 @@ func (req *ping) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 		mismatchNetworkCounter.Mark(1)
 		return errMismatchNetwork
 	}
-	// KIP-311 R2: bootstrap nodes rate-limit pings per source IP to bound
+	// Bootstrap nodes rate-limit discovery pings per source IP to bound
 	// amplification/DoS against the UDP endpoint. Rejecting here prevents both
 	// the pong reply and the bonding goroutine in handle().
 	//
-	// The limit is applied to every source IP, not just unbonded ones: a UDP
-	// source IP is unauthenticated/spoofable, and kaia's bond is keyed by NodeID
-	// only (not IP), so a "bonded NodeID + spoofed source IP" packet could
-	// otherwise bypass the limit and reflect a pong to the spoofed victim.
-	if t.ourEndpoint.NType == NodeTypeBN && t.pingLimiter != nil {
+	// LAN/loopback sources are exempt: the limit protects an internet-reachable
+	// BN from public ping floods, while co-located/local nodes legitimately share
+	// a single private IP (e.g. many nodes behind one NAT, or localhost in tests)
+	// and must not throttle one another. This mirrors the LAN exemption on the
+	// inbound TCP connection throttle.
+	//
+	// The limit is otherwise applied to every (non-LAN) source IP, not just
+	// unbonded ones: a UDP source IP is unauthenticated/spoofable and kaia's bond
+	// is keyed by NodeID only, so a "bonded NodeID + spoofed source IP" packet
+	// could otherwise bypass the limit and reflect a pong to the spoofed victim.
+	if t.ourEndpoint.NType == NodeTypeBN && t.pingLimiter != nil && !netutil.IsLAN(from.IP) {
 		if !t.pingLimiter.allow(from.IP, time.Now()) {
 			logger.Trace("udp: ping: rate limited", "addr", from)
 			pingRateLimitedCounter.Mark(1)
@@ -791,14 +797,15 @@ func (req *findnode) preverify(t *udp, from *net.UDPAddr, fromID NodeID) error {
 	if expired(req.Expiration) {
 		return errExpired
 	}
-	if !t.hasBond(fromID) {
-		// No bond exists, we don't process the packet. This prevents
-		// an attack vector where the discovery protocol could be used
-		// to amplify traffic in a DDOS attack. A malicious actor
-		// would send a findnode request with the IP address and UDP
-		// port of the target as the source address. The recipient of
-		// the findnode packet would then send a neighbors packet
-		// (which is a much bigger packet than findnode) to the victim.
+	if !t.hasBond(fromID, from.IP) {
+		// No bond exists for this (NodeID, source IP), so we don't process the
+		// packet. This prevents an attack vector where the discovery protocol
+		// could be used to amplify traffic in a DDOS attack. A malicious actor
+		// would send a findnode request with the IP address and UDP port of the
+		// target as the source address. The recipient of the findnode packet
+		// would then send a neighbors packet (which is a much bigger packet than
+		// findnode) to the victim. Binding the bond to the source IP ensures a
+		// spoofed source cannot reuse another node's endpoint proof.
 		return errUnknownNode
 	}
 	return nil

--- a/networks/p2p/discover/udp.go
+++ b/networks/p2p/discover/udp.go
@@ -330,7 +330,12 @@ func newUDPv4(cfg *Config) *udp {
 		closing:     make(chan struct{}),
 		gotreply:    make(chan reply),
 		addpending:  make(chan *pending),
-		pingLimiter: newIPRateLimiter(pingRatePerIP, pingBurstPerIP, maxLimitedIPs, limiterIdleTTL),
+	}
+	// Opt-in: the per-IP discovery-ping limiter is enabled only when a positive
+	// rate is configured (bootstrap nodes via --bn.ping-ratelimit). preverify
+	// additionally restricts it to bootstrap nodes and exempts LAN sources.
+	if cfg.PingRateLimit > 0 {
+		u.pingLimiter = newPingLimiter(cfg.PingRateLimit, cfg.PingBurst)
 	}
 	realaddr := cfg.Addr
 	if cfg.AnnounceAddr != nil {

--- a/networks/p2p/discover/udp_test.go
+++ b/networks/p2p/discover/udp_test.go
@@ -270,7 +270,7 @@ func TestUDP_findnode_EN(t *testing.T) {
 
 	// ensure there's a bond with the test node,
 	// findnode won't be accepted otherwise.
-	test.table.db.updateBondTime(PubkeyID(&test.remotekey.PublicKey), time.Now())
+	test.table.db.updateBondTime(PubkeyID(&test.remotekey.PublicKey), test.remoteaddr.IP, time.Now())
 
 	// check that closest neighbors are returned.
 	test.packetIn(nil, findnodePacket, &findnode{Target: testTarget, TargetType: NodeTypeEN, Expiration: futureExp})
@@ -312,7 +312,7 @@ func TestUDP_findnode_CN_overfill(t *testing.T) {
 
 	// ensure there's a bond with the test node,
 	// findnode won't be accepted otherwise.
-	test.table.db.updateBondTime(PubkeyID(&test.remotekey.PublicKey), time.Now())
+	test.table.db.updateBondTime(PubkeyID(&test.remotekey.PublicKey), test.remoteaddr.IP, time.Now())
 
 	// Trigger the findnode. retrieveSize for NodeTypeCN is 100.
 	test.packetIn(nil, findnodePacket, &findnode{Target: testTarget, TargetType: NodeTypeCN, Expiration: futureExp})


### PR DESCRIPTION
## Proposed changes

Hardens the discovery (Kademlia v4) layer against UDP abuse on bootstrap nodes:

1. **Opt-in per-source-IP rate limit on discovery `PING`s** — bounds amplification/DoS against the public UDP endpoint. Per-IP token bucket with a bounded map (idle + LRU eviction), enforced in `ping.preverify` on bootstrap nodes only, LAN/loopback exempt. **Disabled by default**, enabled via `kbn` flags:
   - `--bn.ping-ratelimit <N>` — pings/sec; `0` (default) = off
   - `--bn.ping-burst <B>` — burst (default `10`)
2. **IP-bound endpoint proofs** — `lastping`/`lastpong`/`findfail` are keyed by `(NodeID, IP)` instead of `NodeID` alone, so a spoofed source IP can't reuse another node's bond (strengthens the `FINDNODE` amplification gate; mirrors go-ethereum's per-IP endpoint proof, ethereum/go-ethereum#18963). Node-DB schema version bumped → stale DBs are flushed on upgrade (re-bootstraps in minutes; no chain/state impact).

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

KIP-311 (permissionless networking) — bootstrap-node discovery DoS hardening.

## Further comments

- The rate limit is bootstrap-node-only and LAN-exempt by design.
- A UDP source IP is spoofable, so this application-layer limit is partial and is meant to complement network-layer (L3/L4) protection.
