### PR TITLE
kaiax/valset: serve committee/qualified validators from the header

### DIFF
--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -47,16 +47,30 @@ func (v *ValsetModule) GetDemotedValidators(num uint64) ([]common.Address, error
 	return demoted.List(), nil
 }
 
-func (v *ValsetModule) GetQualifiedValidators(num uint64) ([]common.Address, error) {
-	var (
-		qualified *valset.AddressSet
-		err       error
-	)
-	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		qualified, err = v.getQualifiedValidators(num)
-	} else {
-		qualified, err = v.getQualifiedPermissioned(num)
+// qualifiedFromHeaderOrState returns the qualified validator set for block `num`.
+//
+// Post-fork, a canonical header already carries the verified validator set (== the
+// committee in permissionless), so we read it from the header to avoid a state trie
+// lookup that fails with "missing trie node" on pruned blocks. We compute from state
+// instead when pre-fork, or when the header isn't available yet (block being
+// produced) or unparsable.
+//
+// Safe: VerifyHeader independently rechecks the header against state-computed
+// qualified validators, so the header we trust here is already validated.
+func (v *ValsetModule) qualifiedFromHeaderOrState(num uint64) (*valset.AddressSet, error) {
+	if !v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
+		return v.getQualifiedPermissioned(num)
 	}
+	if header := v.Chain.GetHeaderByNumber(num); header != nil {
+		if vals, err := v.Chain.Sealer().Validators(header); err == nil {
+			return valset.NewAddressSet(vals), nil
+		}
+	}
+	return v.getQualifiedValidators(num)
+}
+
+func (v *ValsetModule) GetQualifiedValidators(num uint64) ([]common.Address, error) {
+	qualified, err := v.qualifiedFromHeaderOrState(num)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +83,13 @@ func (v *ValsetModule) GetCommittee(num uint64, round uint64) ([]common.Address,
 		return v.GetCouncil(0)
 	}
 	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		return v.getCommittee(num)
+		// Permissionless committee == qualified validators (no round-based
+		// subselection), so serve it from the header when available.
+		qualified, err := v.qualifiedFromHeaderOrState(num)
+		if err != nil {
+			return nil, err
+		}
+		return qualified.List(), nil
 	}
 
 	// TODO-kaiax: Sync blockContext

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -42,31 +42,12 @@ type blockContext struct {
 }
 
 func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
-	var (
-		qualified *valset.AddressSet
-		err       error
-	)
-
-	// After the fork, canonical headers already carry the verified validator set.
-	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		if header := v.Chain.GetHeaderByNumber(num); header != nil {
-			vals, err := v.Chain.Sealer().Validators(header)
-			if err != nil {
-				return nil, err
-			}
-			qualified = valset.NewAddressSet(vals)
-		}
-	}
-
-	if qualified == nil {
-		if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-			qualified, err = v.getQualifiedValidators(num)
-		} else {
-			qualified, err = v.getQualifiedPermissioned(num)
-		}
-		if err != nil {
-			return nil, err
-		}
+	// Canonical headers already carry the verified validator set;
+	// qualifiedFromHeaderOrState reads it from the header when available and
+	// falls back to state otherwise.
+	qualified, err := v.qualifiedFromHeaderOrState(num)
+	if err != nil {
+		return nil, err
 	}
 
 	prevHeader := v.Chain.GetHeaderByNumber(num - 1)

--- a/kaiax/valset/impl/getter_permissionless.go
+++ b/kaiax/valset/impl/getter_permissionless.go
@@ -58,15 +58,6 @@ func (v *ValsetModule) getQualifiedValidators(num uint64) (*valset.AddressSet, e
 	return valset.NewAddressSet(committee.Addresses()), nil
 }
 
-// getCommittee: committee: qualified = {VA} − suspended
-func (v *ValsetModule) getCommittee(num uint64) ([]common.Address, error) {
-	qualified, err := v.getQualifiedValidators(num)
-	if err != nil {
-		return nil, err
-	}
-	return qualified.List(), nil
-}
-
 // getDemoted: demoted = council − qualified = {VP} ∪ {Suspended}.
 func (v *ValsetModule) getDemoted(num uint64) ([]common.Address, error) {
 	nodes, err := v.getNodes(num)

--- a/kaiax/valset/impl/getter_permissionless_test.go
+++ b/kaiax/valset/impl/getter_permissionless_test.go
@@ -17,10 +17,13 @@
 package impl
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/engine"
 	"github.com/kaiachain/kaia/storage/database"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
@@ -133,7 +136,7 @@ func TestSuspendedFallback(t *testing.T) {
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []common.Address{addr1, addr2}, qualified.List())
 
-		committee, err := v.getCommittee(testGetterBlock)
+		committee, err := v.GetCommittee(testGetterBlock, 0)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []common.Address{addr1, addr2}, committee)
 	})
@@ -247,9 +250,39 @@ func newCachedPermissionlessValset(t *testing.T, nodes NodeMap) *ValsetModule {
 
 	mockChain := chain_mock.NewMockBlockChain(ctrl)
 	mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+	// The committee/qualified getters prefer the canonical header; return nil so
+	// they fall back to the pre-cached transition result (the state path under test).
+	mockChain.EXPECT().GetHeaderByNumber(gomock.Any()).Return(nil).AnyTimes()
 
 	v := NewValsetModule()
 	v.Chain = mockChain
 	v.transitionResultCache.Add(testGetterBlock, &TransitionResult{Nodes: nodes})
 	return v
+}
+
+// TestPermissionlessCommitteeFromHeader checks that GetCommittee and
+// GetQualifiedValidators serve the set from the canonical header: no
+// transitionResultCache is set up, so any state read would fail the test.
+func TestPermissionlessCommitteeFromHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	sealer := engine.NewSealer(nil, nil)
+
+	mockChain := chain_mock.NewMockBlockChain(ctrl)
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+	mockChain.EXPECT().Sealer().Return(sealer).AnyTimes()
+
+	header := &types.Header{Number: new(big.Int).SetUint64(testGetterBlock)}
+	require.NoError(t, sealer.WriteValidators(header, numsToAddrs(1, 2)))
+	mockChain.EXPECT().GetHeaderByNumber(testGetterBlock).Return(header).AnyTimes()
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+
+	committee, err := v.GetCommittee(testGetterBlock, 0)
+	require.NoError(t, err)
+	assert.Equal(t, numsToAddrs(1, 2), committee)
+
+	qualified, err := v.GetQualifiedValidators(testGetterBlock)
+	require.NoError(t, err)
+	assert.Equal(t, numsToAddrs(1, 2), qualified)
 }


### PR DESCRIPTION
## Proposed changes

`GetCommittee` and `GetQualifiedValidators` recomputed the validator set from state (`getNodes → StateAt(parent.Root)`), which throws `missing trie node` on pruned blocks (RPC, historical re-validation, reward recompute).

Post-fork the canonical header already carries this set (written by `WriteValidators`, checked by `VerifyHeader`), so this serves it straight from the header and only falls back to state when the header isn't available yet (block being produced) or pre-fork — the same pattern `getBlockContext` already uses for `GetProposer`. Also removes the now-unused internal `getCommittee`.

Not changed: `VerifyHeader` still recomputes from state (malicious-proposer guard intact); consensus core stays state-based (in-flight block isn't canonical); `GetCouncil`/`GetDemotedValidators`/etc. still need state (header doesn't carry their data).

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

N/A
