### PR TITLE
p2p, node/cn: exempt trusted and static peers from CN peer-type validation

### DIFF
--- a/networks/p2p/peer.go
+++ b/networks/p2p/peer.go
@@ -194,6 +194,12 @@ func (p *Peer) Inbound() bool {
 	return p.rws[ConnDefault].flags&inboundConn != 0
 }
 
+// IsTrustedOrStatic reports whether the peer's default connection is a trusted peer
+// or a static outbound dial. See (*conn).isTrustedOrStatic.
+func (p *Peer) IsTrustedOrStatic() bool {
+	return p.rws[ConnDefault].isTrustedOrStatic()
+}
+
 // GetNumberInboundAndOutbound returns the number of
 // inbound and outbound connections connected to the peer.
 func (p *Peer) GetNumberInboundAndOutbound() (int, int) {

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -276,7 +276,7 @@ func (srv *BaseServer) protoHandshakeChecks(peers map[discover.NodeID]*Peer, inb
 
 func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCount int, c *conn) error {
 	switch {
-	case !c.is(trustedConn|staticDialedConn) && len(peers) >= srv.Config.MaxPhysicalConnections:
+	case !c.isTrustedOrStatic() && len(peers) >= srv.Config.MaxPhysicalConnections:
 		return DiscTooManyPeers
 	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
 		return DiscTooManyPeers
@@ -292,7 +292,7 @@ func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inbou
 }
 
 func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *conn) bool {
-	if c.is(trustedConn | staticDialedConn) {
+	if c.isTrustedOrStatic() {
 		return false
 	}
 
@@ -313,7 +313,7 @@ func (srv *BaseServer) admitByCNPeers(c *conn) error {
 	if EffectiveConnType(c.conntype) != common.CONSENSUSNODE {
 		return nil
 	}
-	if c.is(trustedConn | staticDialedConn) {
+	if c.isTrustedOrStatic() {
 		return nil
 	}
 	if srv.cnPeerAddrs == nil {
@@ -639,7 +639,7 @@ func (srv *BaseServer) peersOutsideCNPeerAddrs() []*Peer {
 		if p == nil || EffectiveConnType(p.ConnType()) != common.CONSENSUSNODE {
 			continue
 		}
-		if p.rws[ConnDefault].is(trustedConn | staticDialedConn) {
+		if p.rws[ConnDefault].isTrustedOrStatic() {
 			continue
 		}
 		addr, err := addressFromNodeID(id)

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -118,6 +118,15 @@ func (c *conn) is(f connFlag) bool {
 	return c.flags&f != 0
 }
 
+// isTrustedOrStatic reports whether this connection is a trusted peer or a static
+// outbound dial (staticDialedConn is set only on dial). Such connections bypass
+// (1) CNPeers authorization, and
+// (2) peer-count limits (physical cap, per-type targets).
+// Split into purpose-specific predicates if those policies diverge.
+func (c *conn) isTrustedOrStatic() bool {
+	return c.is(trustedConn | staticDialedConn)
+}
+
 // sharedUDPConn implements a shared connection. Write sends messages to the underlying connection while read returns
 // messages that were found unprocessable and sent to the unhandled channel by the primary listener.
 type sharedUDPConn struct {

--- a/node/cn/peer_set.go
+++ b/node/cn/peer_set.go
@@ -151,8 +151,12 @@ func (ps *peerSet) Register(p Peer, ext *snap.Peer) error {
 		return errAlreadyRegistered
 	}
 
-	if err := peerTypeValidator.ValidatePeerType(p.GetAddr()); err != nil {
-		return fmt.Errorf("fail to validate peer type: %s", err)
+	// Trusted/static-outbound peers bypass CNPeers authorization, matching the
+	// p2p server admission check.
+	if pp := p.GetP2PPeer(); pp == nil || !pp.IsTrustedOrStatic() {
+		if err := peerTypeValidator.ValidatePeerType(p.GetAddr()); err != nil {
+			return fmt.Errorf("fail to validate peer type: %s", err)
+		}
 	}
 
 	if ext != nil {

--- a/node/cn/peer_set_test.go
+++ b/node/cn/peer_set_test.go
@@ -35,6 +35,8 @@ func setMockPeers(mockPeers []*MockPeer) {
 		mp.EXPECT().GetAddr().Return(addrs[i]).AnyTimes()
 		mp.EXPECT().GetID().Return(nodeids[i].String()).AnyTimes()
 		mp.EXPECT().Broadcast().AnyTimes()
+		// Register calls GetP2PPeer() for the exemption check; nil keeps validation.
+		mp.EXPECT().GetP2PPeer().Return(nil).AnyTimes()
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

`ValidatePeerType` (consensus peer registration) rejected CN peers outside the
CNPeers set even when trusted or static-dialed, though the p2p admission check
already exempts them — so such a node (e.g. a trusted/static `ValInactive` CN) was
admitted at the p2p layer but dropped at registration, isolating it after a restart.

Fix: apply the same exemption in `ValidatePeerType`, unifying the check into one
`isTrustedOrStatic` predicate.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues
