### PR TITLE
kaiabft/opt: consensus related optimization

### DIFF
--- a/consensus/events.go
+++ b/consensus/events.go
@@ -1,0 +1,5 @@
+package consensus
+
+type NewSequenceEvent struct {
+	IsProposer bool
+}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -516,7 +516,7 @@ func (sb *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, st
 }
 
 // SubscribeNewSequence subscribes to new sequence events.
-// When a new block sequence starts (not round change), this subscription receives a signal.
+// Istanbul emits this only when a new block sequence starts.
 func (sb *backend) SubscribeNewSequence() *event.TypeMuxSubscription {
-	return sb.istanbulEventMux.Subscribe(istanbul.NewSequenceEvent{})
+	return sb.istanbulEventMux.Subscribe(consensus.NewSequenceEvent{})
 }

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/prque"
+	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/bft"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/event"
@@ -340,9 +341,8 @@ func (c *core) startNewRound(round *big.Int) {
 		}
 	}
 
-	// For new sequences, notify worker to start new block
 	if !roundChange {
-		c.backend.EventMux().Post(istanbul.NewSequenceEvent{})
+		c.backend.EventMux().Post(consensus.NewSequenceEvent{IsProposer: true})
 	}
 	c.newRoundChangeTimer()
 

--- a/consensus/istanbul/events.go
+++ b/consensus/istanbul/events.go
@@ -44,7 +44,3 @@ type CommitEvent struct {
 
 // ChainHeadEvent is posted when a new block is added to the chain
 type ChainHeadEvent struct{}
-
-// NewSequenceEvent is posted when a new sequence (block number) starts.
-// This signals the worker to start preparing the next block.
-type NewSequenceEvent struct{}

--- a/consensus/kaiabft/backend.go
+++ b/consensus/kaiabft/backend.go
@@ -217,6 +217,23 @@ func (b *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, sta
 			}
 		}()
 
+		if cv, ok := b.currentView.Load().(*bft.View); ok && cv != nil &&
+			cv.Sequence.Cmp(header.Number) == 0 {
+			proposer, err := b.valsetModule.GetProposer(cv.Sequence.Uint64(), cv.Round.Uint64())
+			if err != nil {
+				logger.Warn("Failed to resolve proposer for local block execution",
+					"number", header.Number.Uint64(), "viewSeq", cv.Sequence.Uint64(),
+					"viewRound", cv.Round.Uint64(), "self", b.address, "err", err)
+			} else if proposer != b.address {
+				logger.Debug("Skipping local block execution on non-proposer",
+					"number", header.Number.Uint64(), "proposer", proposer)
+				resultCh <- nil
+				return
+			}
+		}
+		// If currentView is stale or unavailable, fall through to the legacy
+		// full execution path as a defensive fallback.
+
 		validators, err := b.valsetModule.GetQualifiedValidators(header.Number.Uint64())
 		if err != nil {
 			resultCh <- nil
@@ -295,7 +312,7 @@ func (b *backend) APIs(chain consensus.ChainReader) []rpc.API {
 func (b *backend) PurgeCache() {}
 
 func (b *backend) SubscribeNewSequence() *event.TypeMuxSubscription {
-	return b.eventMux.Subscribe(newSequenceEvent{})
+	return b.eventMux.Subscribe(consensus.NewSequenceEvent{})
 }
 
 // ---------------------------------------------------------------------------
@@ -410,7 +427,7 @@ func (b *backend) seal(block *types.Block) (*types.Block, error) {
 	if commitCh == nil {
 		return nil, nil
 	}
-	defer b.cleanupSealState()
+	defer b.cleanupSealState(commitCh)
 
 	go b.eventMux.Post(requestEvent{Proposal: block})
 
@@ -463,14 +480,29 @@ func (b *backend) initSealState(number uint64, blockHash common.Hash) chan *type
 		b.sealSkippedNum = 0
 		return nil
 	}
+	// A prior in-flight seal() for this sequence (e.g. a round-change rebuild
+	// superseding an earlier build) is still blocked on the old channel. Release
+	// it with a nil result so its goroutine returns instead of leaking. The
+	// channel is buffered (cap 1) and the old sealer is its only reader, so this
+	// never blocks: it either hands nil to the waiting sealer or fills the buffer
+	// of a sealer that has already returned.
+	if b.commitCh != nil {
+		b.commitCh <- nil
+	}
 	b.proposedBlockHash = blockHash
 	b.commitCh = make(chan *types.Result, 1)
 	return b.commitCh
 }
 
-func (b *backend) cleanupSealState() {
+func (b *backend) cleanupSealState(ch chan *types.Result) {
 	b.sealMu.Lock()
 	defer b.sealMu.Unlock()
+	// Only clear if we still own the current channel: a superseding seal()
+	// (see initSealState) may have already replaced it, and clearing then would
+	// wipe the live seal's state.
+	if b.commitCh != ch {
+		return
+	}
 	b.proposedBlockHash = common.Hash{}
 	b.commitCh = nil
 }
@@ -762,8 +794,6 @@ type messageEvent struct {
 }
 
 type chainHeadEvent struct{}
-
-type newSequenceEvent struct{}
 
 type backlogEvent struct {
 	src  common.Address

--- a/consensus/kaiabft/machine.go
+++ b/consensus/kaiabft/machine.go
@@ -988,6 +988,12 @@ func (m *machine) checkMessage(msgCode uint64, view *bft.View) error {
 	cv := m.currentView()
 
 	if msgCode == bft.MsgRoundChange {
+		// Round-change buckets are keyed by uint64 round in roundChangeSets;
+		// reject out-of-range rounds early to avoid truncation collisions and to
+		// match istanbul's checkMessage (mixed-engine wire compatibility).
+		if !view.Round.IsUint64() {
+			return bft.ErrInvalidMessage
+		}
 		if view.Sequence.Cmp(cv.Sequence) > 0 {
 			return errFutureMessage
 		}

--- a/consensus/kaiabft/machine.go
+++ b/consensus/kaiabft/machine.go
@@ -656,6 +656,7 @@ func (m *machine) startNewRound(round *big.Int) {
 func (m *machine) catchUpRound(view *bft.View) {
 	oldRound := new(big.Int).Set(m.round)
 	oldSeq := new(big.Int).Set(m.sequence)
+	oldProposer := m.proposer // capture before the update below so the log is accurate
 
 	if diff := new(big.Int).Sub(view.Round, m.round); diff.Sign() > 0 {
 		m.metrics.Round.Mark(diff.Int64())
@@ -693,9 +694,17 @@ func (m *machine) catchUpRound(view *bft.View) {
 	newProposer, err := m.b.valsetModule.GetProposer(view.Sequence.Uint64(), view.Round.Uint64())
 	if err != nil {
 		logger.Warn("Failed to get proposer for catch-up round", "err", err)
+	} else {
+		m.proposer = newProposer
 	}
+	// Keep the shared view in sync with the round-change view so isProposer()
+	// and the SubmitTransactions proposer check don't act on the pre-RC round.
+	m.b.currentView.Store(&bft.View{
+		Sequence: new(big.Int).Set(view.Sequence),
+		Round:    new(big.Int).Set(view.Round),
+	})
 	logger.Warn("[RC] Catch up round",
-		"oldRound", oldRound, "oldSeq", oldSeq, "oldProposer", m.proposer,
+		"oldRound", oldRound, "oldSeq", oldSeq, "oldProposer", oldProposer,
 		"newRound", view.Round, "newSeq", view.Sequence, "newProposer", newProposer,
 		"hashLocked", !common.EmptyHash(oldLockedHash))
 }
@@ -713,15 +722,33 @@ func (m *machine) sendPreprepare(request *bft.Request) {
 		return
 	}
 	curView := m.currentView()
-	encoded, err := bft.Encode(&bft.Preprepare{View: curView, Proposal: request.Proposal})
+	pp := &bft.Preprepare{View: curView, Proposal: request.Proposal}
+	encoded, err := bft.Encode(pp)
 	if err != nil {
 		return
 	}
-	m.broadcastMsg(&bft.Message{
+	msg := &bft.Message{
 		Hash: request.Proposal.ParentHash(),
 		Code: bft.MsgPreprepare,
 		Msg:  encoded,
-	})
+	}
+	// Self-accept and gossip directly to peers; skip the self-loop (otherwise
+	// the proposer pays the decode + verify on its own block). Skipping the
+	// self-loop also skips checkMessage, so re-check waitingForRoundChange here:
+	// a late request during round change must not gossip a stale-round proposal.
+	if m.state == stateAcceptRequest && !m.isHashLocked() && !m.waitingForRoundChange {
+		payload := m.signPayload(msg)
+		if payload == nil {
+			return
+		}
+		m.b.gossipSubPeer(msg.Hash, payload)
+		m.acceptPreprepare(pp)
+		m.setState(statePreprepared)
+		m.sendPrepare()
+		return
+	}
+	// Hash-locked round-change path keeps the legacy self-loop.
+	m.broadcastMsg(msg)
 }
 
 func (m *machine) sendPrepare() {
@@ -814,32 +841,38 @@ func (m *machine) sendRoundChange(round *big.Int) {
 }
 
 func (m *machine) broadcastMsg(msg *bft.Message) {
-	msg.Address = m.b.address
-	msg.CommittedSeal = []byte{}
-	if msg.Code == bft.MsgCommit && m.preprepare != nil {
-		var err error
-		msg.CommittedSeal, err = m.b.sealer.MakeCommittedSeal(m.preprepare.Proposal.Header())
-		if err != nil {
-			return
-		}
-	}
-
-	data, err := msg.PayloadNoSig()
-	if err != nil {
-		return
-	}
-	msg.Signature, err = m.b.sign(data)
-	if err != nil {
-		return
-	}
-
-	payload, err := msg.Payload()
-	if err != nil {
+	payload := m.signPayload(msg)
+	if payload == nil {
 		return
 	}
 	if err := m.b.broadcast(msg.Hash, payload); err != nil {
 		logger.Error("Failed to broadcast message", "err", err)
 	}
+}
+
+func (m *machine) signPayload(msg *bft.Message) []byte {
+	msg.Address = m.b.address
+	msg.CommittedSeal = []byte{}
+	if msg.Code == bft.MsgCommit && m.preprepare != nil {
+		seal, err := m.b.sealer.MakeCommittedSeal(m.preprepare.Proposal.Header())
+		if err != nil {
+			return nil
+		}
+		msg.CommittedSeal = seal
+	}
+	data, err := msg.PayloadNoSig()
+	if err != nil {
+		return nil
+	}
+	msg.Signature, err = m.b.sign(data)
+	if err != nil {
+		return nil
+	}
+	payload, err := msg.Payload()
+	if err != nil {
+		return nil
+	}
+	return payload
 }
 
 func (m *machine) doCommit() {

--- a/consensus/kaiabft/machine.go
+++ b/consensus/kaiabft/machine.go
@@ -631,11 +631,17 @@ func (m *machine) startNewRound(round *big.Int) {
 			m.sendPreprepare(&bft.Request{Proposal: m.preprepare.Proposal})
 		} else if m.pendingRequest != nil {
 			m.sendPreprepare(m.pendingRequest)
+		} else {
+			// Round-change proposer with no local pendingRequest: ask worker to build lazily.
+			logger.Info("Requesting local proposal build for round-change proposer",
+				"seq", newView.Sequence.Uint64(), "round", newView.Round.Uint64(),
+				"proposer", m.proposer, "self", m.b.address)
+			m.b.eventMux.Post(consensus.NewSequenceEvent{IsProposer: true})
 		}
 	}
 
 	if !roundChange {
-		m.b.eventMux.Post(newSequenceEvent{})
+		m.b.eventMux.Post(consensus.NewSequenceEvent{IsProposer: m.isProposer()})
 	}
 
 	m.newRoundChangeTimer()

--- a/work/worker.go
+++ b/work/worker.go
@@ -164,10 +164,9 @@ type worker struct {
 	executionModules  []kaiax.ExecutionModule
 	txBundlingModules []builder.TxBundlingModule
 
-	// Channels for consensus-worker communication
-	// finalizeCh receives finalized block results for DB write and broadcast
+	// finalizeCh receives finalized block results for DB write and broadcast.
 	finalizeCh <-chan *consensus.ExecutionResult
-	// newSequenceSub receives signals when a new block sequence starts (not round change)
+	// newSequenceSub receives new-sequence signals and lazy round-change build requests.
 	newSequenceSub *event.TypeMuxSubscription
 	// Pending work context for async execution
 	pendingWork      *Task
@@ -299,7 +298,12 @@ func (self *worker) update() {
 			self.handleFinalizedBlock(result)
 
 		// Handle new sequence event from consensus - start mining next block
-		case <-self.newSequenceSub.Chan():
+		case ev := <-self.newSequenceSub.Chan():
+			// Only the proposer builds a block (non-proposers rely on speculative
+			// execution of the received proposal).
+			if req, ok := ev.Data.(consensus.NewSequenceEvent); ok && !req.IsProposer {
+				continue
+			}
 			self.commitNewWork()
 
 			// TODO-Klaytn-Issue264 If we are using istanbul BFT, then we always have a canonical chain.
@@ -361,7 +365,10 @@ func (self *worker) commitNewWork() {
 	parent := self.chain.CurrentBlock()
 	nextBlockNum := new(big.Int).Add(parent.Number(), common.Big1)
 
-	// Wait for ideal block time to ensure consistent block intervals
+	// Wait for the ideal block time to keep block intervals consistent and the
+	// header timestamp valid. After a round change this is a no-op in practice
+	// (the round-change timeout already exceeds the block interval), matching
+	// istanbul's behavior of always proposing a normally-timed block.
 	self.waitForIdealBlockTime(parent)
 	tstart := time.Now()
 
@@ -455,6 +462,8 @@ func (self *worker) handleFinalizedBlock(result *consensus.ExecutionResult) {
 
 	if result == nil || result.Block == nil {
 		// Not the proposer - block will be received via ChainHeadEvent
+		self.pendingWork = nil
+		self.finalizeCh = nil
 		logger.Debug("Not proposer, waiting for block via ChainHeadEvent")
 		return
 	}


### PR DESCRIPTION
## Proposed changes

Consensus-layer optimizations for the kaiabft engine (part of the kaiabft speculative-execution performance series). Engine-scoped; no effect on the istanbul path.

- **Skip non-proposer mining** — a non-proposer node no longer runs the full local block-execution path during `SubmitTransactions`; it resolves the proposer for the current view and returns early when it is not the proposer. Falls back to the legacy full-execution path if the current view is stale/unavailable.
- **Send preprepare before self-validation** — the proposer broadcasts the preprepare message before performing its own validation, shaving latency off the critical consensus path.

**Pure diff (this PR's commits only):**
https://github.com/hyeonLewis/kaia/compare/kaiabft-sync-dev...kbft-opt-1-consensus

Commits:
- `consensus: skip non-proposer mining for kaiabft`
- `consensus: send preprepare msg before self validation`

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- kaiabft speculative-execution optimization series -->

## Further comments

**Stacked PR (1/3).** This is the base of a 3-PR optimization stack that lands after the dev→kaiabft sync. Merge order: dev-sync → **this PR** → `kaiabft/opt: speculative execution state warming and prefetch` → `kaiabft/opt: block building and txpool optimization`.

The branch is based on the synced base (`kaiabft-sync-dev`); the pure-diff link above shows only the two commits this PR introduces.
