### PR TITLE
kaiabft/opt: speculative execution state warming and prefetch

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -115,7 +115,6 @@ const (
 	DefaultTriesInMemory        = 128
 	DefaultBlockInterval        = 128
 	DefaultLivePruningRetention = 172800 // 2*params.DefaultStakeUpdateInterval
-	MaxPrefetchTxs              = 20000
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	// Changelog:
@@ -220,19 +219,10 @@ type BlockChain struct {
 	lastCommittedBlock uint64
 	quitWarmUp         chan struct{}
 
-	prefetchTxCh chan prefetchTx
-
 	// kaiax modules
 	headerModules     []kaiax.HeaderModule
 	executionModules  []kaiax.ExecutionModule
 	rewindableModules []kaiax.RewindableModule
-}
-
-// prefetchTx is used to prefetch transactions, when fetcher works.
-type prefetchTx struct {
-	ti                int
-	block             *types.Block
-	followupInterrupt *uint32
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -279,7 +269,6 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		specCache:          NewSpeculativeResultCache(),
 		parallelDBWrite:    db.IsParallelDBWrite(),
 		stopStateMigration: make(chan struct{}),
-		prefetchTxCh:       make(chan prefetchTx, MaxPrefetchTxs),
 	}
 
 	// set hardForkBlockNumberConfig which will be used as a global variable
@@ -368,12 +357,6 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotCacheSize, head.Root(), bc.cacheConfig.SnapshotAsyncGen, true, recover)
 	}
 
-	for i := 1; i <= bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker; i++ {
-		bc.wg.Add(1)
-		go bc.prefetchTxWorker(i)
-	}
-	logger.Info("prefetchTxWorkers are started", "num", bc.cacheConfig.TrieNodeCacheConfig.NumFetcherPrefetchWorker)
-
 	// Take ownership of this particular state
 	go bc.update()
 	bc.gcCachedNodeLoop()
@@ -391,30 +374,6 @@ func NewBlockChain(db database.DBManager, cacheConfig *CacheConfig, chainConfig 
 	}
 
 	return bc, nil
-}
-
-// prefetchTxWorker receives a block and a transaction index, which it pre-executes
-// to retrieve and cache the data for the actual block processing.
-func (bc *BlockChain) prefetchTxWorker(index int) {
-	defer bc.wg.Done()
-
-	logger.Debug("prefetchTxWorker is started", "index", index)
-	var snaps *snapshot.Tree
-	if bc.cacheConfig.TrieNodeCacheConfig.UseSnapshotForPrefetch {
-		snaps = bc.snaps
-	}
-	for followup := range bc.prefetchTxCh {
-		stateDB, err := state.New(bc.CurrentBlock().Root(), bc.stateCache, snaps,
-			&statedb.TrieOpts{Prefetching: true})
-		if err != nil {
-			logger.Debug("failed to retrieve stateDB for prefetchTxWorker", "err", err)
-			continue
-		}
-		vmCfg := bc.vmConfig
-		vmCfg.Prefetching = true
-		bc.prefetcher.PrefetchTx(followup.block, followup.ti, stateDB, vmCfg, followup.followupInterrupt)
-	}
-	logger.Debug("prefetchTxWorker is terminated", "index", index)
 }
 
 // SetCanonicalBlock resets the canonical as the block with the given block number.
@@ -1157,7 +1116,6 @@ func (bc *BlockChain) Stop() {
 		bc.CloseBlockSubscriptionLoop()
 	}
 
-	close(bc.prefetchTxCh)
 	close(bc.quit)
 	atomic.StoreInt32(&bc.procInterrupt, 1)
 
@@ -2003,13 +1961,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 				snaps = bc.snaps
 			}
 
-			// Tx prefetcher is enabled for all cases (both single and multiple block insertion).
-			for ti := range block.Transactions() {
-				select {
-				case bc.prefetchTxCh <- prefetchTx{ti, block, &followupInterrupt}:
-				default:
-				}
-			}
 			if i < len(chain)-1 {
 				// current block is not the last one, so prefetch the right next block
 				followup := chain[i+1]

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -23,6 +23,7 @@
 package blockchain
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -2107,7 +2108,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 			}
 
 			// Process block using the parent state as reference point.
-			receipts, logs, usedGas, internalTxTraces, procStats, err = bc.processor.Process(block, stateDB, bc.vmConfig)
+			receipts, logs, usedGas, internalTxTraces, procStats, err = bc.processor.Process(context.Background(), block, stateDB, bc.vmConfig)
 			if err != nil {
 				bc.reportBlock(block, receipts, err)
 				atomic.StoreUint32(&followupInterrupt, 1)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -202,6 +202,7 @@ type BlockChain struct {
 	validator  Validator  // block and state validator interface
 	vmConfig   vm.Config
 	specCache  *SpeculativeResultCache // single-entry cache for speculative execution results
+	txLookup   atomic.Pointer[chainTxLookup]
 
 	parallelDBWrite bool // TODO-Kaia-Storage parallelDBWrite will be replaced by number of goroutines when worker pool pattern is introduced.
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -24,6 +24,7 @@ package blockchain
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"encoding/binary"
 	"encoding/json"
@@ -176,7 +177,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 		if err != nil {
 			return err
 		}
-		receipts, _, usedGas, _, _, err := blockchain.Processor().Process(block, statedb, vm.Config{})
+		receipts, _, usedGas, _, _, err := blockchain.Processor().Process(context.Background(), block, statedb, vm.Config{})
 		if err != nil {
 			blockchain.reportBlock(block, receipts, err)
 			return err

--- a/blockchain/chain_makers.go
+++ b/blockchain/chain_makers.go
@@ -349,3 +349,4 @@ func (cr *fakeChainReader) GetHeaderByNumber(number uint64) *types.Header       
 func (cr *fakeChainReader) GetHeaderByHash(hash common.Hash) *types.Header          { return nil }
 func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *types.Header { return nil }
 func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
+func (cr *fakeChainReader) TxLookup() func(common.Hash) *types.Transaction          { return nil }

--- a/blockchain/headerchain.go
+++ b/blockchain/headerchain.go
@@ -445,3 +445,7 @@ func (hc *HeaderChain) State() (*state.StateDB, error) {
 func (hc *HeaderChain) StateAt(root common.Hash) (*state.StateDB, error) {
 	return nil, errors.New("HeaderChain does not support StateAt() method")
 }
+
+func (hc *HeaderChain) TxLookup() func(common.Hash) *types.Transaction {
+	return nil
+}

--- a/blockchain/prefetch.go
+++ b/blockchain/prefetch.go
@@ -1,4 +1,18 @@
-// Modifications Copyright 2024 The Kaia Authors
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
 package blockchain
 

--- a/blockchain/prefetch.go
+++ b/blockchain/prefetch.go
@@ -34,28 +34,35 @@ func PrefetchBlockState(ctx context.Context, stateReader stateAtReader, parentRo
 			return
 		default:
 		}
-		if _, err := tx.ValidateSender(signer, statedb, blockNumber); err != nil {
-			continue
+		prefetchTxState(statedb, signer, tx, blockNumber)
+	}
+}
+
+// prefetchTxState warms the trie nodes execution will need for one tx
+// without running the EVM: sender + (fee-payer) account keys via
+// ValidateSender, and recipient bytecode/storage-trie root.
+func prefetchTxState(statedb *state.StateDB, signer types.Signer, tx *types.Transaction, blockNumber uint64) {
+	if _, err := tx.ValidateSender(signer, statedb, blockNumber); err != nil {
+		return
+	}
+	from := tx.ValidatedSender()
+	statedb.Exist(from)
+	if tx.IsFeeDelegatedTransaction() {
+		if _, err := tx.ValidateFeePayer(signer, statedb, blockNumber); err == nil {
+			statedb.Exist(tx.ValidatedFeePayer())
 		}
-		from := tx.ValidatedSender()
-		statedb.Exist(from)
-		if tx.IsFeeDelegatedTransaction() {
-			if _, err := tx.ValidateFeePayer(signer, statedb, blockNumber); err == nil {
-				statedb.Exist(tx.ValidatedFeePayer())
-			}
-		}
-		// EIP-7702: sender may carry delegated code; warm its code + storage too.
-		if statedb.GetCodeHash(from) != types.EmptyCodeHash {
-			statedb.GetCode(from)
-			statedb.GetState(from, common.Hash{})
-		}
-		to := tx.To()
-		if to == nil {
-			continue
-		}
-		if statedb.GetCodeHash(*to) != types.EmptyCodeHash {
-			statedb.GetCode(*to)
-			statedb.GetState(*to, common.Hash{})
-		}
+	}
+	// EIP-7702: sender may carry delegated code; warm its code + storage too.
+	if statedb.GetCodeHash(from) != types.EmptyCodeHash {
+		statedb.GetCode(from)
+		statedb.GetState(from, common.Hash{})
+	}
+	to := tx.To()
+	if to == nil {
+		return
+	}
+	if statedb.GetCodeHash(*to) != types.EmptyCodeHash {
+		statedb.GetCode(*to)
+		statedb.GetState(*to, common.Hash{})
 	}
 }

--- a/blockchain/prefetch.go
+++ b/blockchain/prefetch.go
@@ -1,0 +1,61 @@
+// Modifications Copyright 2024 The Kaia Authors
+
+package blockchain
+
+import (
+	"context"
+
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+)
+
+type stateAtReader interface {
+	StateAt(root common.Hash) (*state.StateDB, error)
+}
+
+// PrefetchBlockState warms the trieDB node cache via a disposable StateDB.
+func PrefetchBlockState(ctx context.Context, stateReader stateAtReader, parentRoot common.Hash, blockNumber uint64, txs []*types.Transaction, signer types.Signer) {
+	if stateReader == nil || len(txs) == 0 {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Warn("PrefetchBlockState recovered from panic", "err", r)
+		}
+	}()
+	statedb, err := stateReader.StateAt(parentRoot)
+	if err != nil {
+		return
+	}
+	for _, tx := range txs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if _, err := tx.ValidateSender(signer, statedb, blockNumber); err != nil {
+			continue
+		}
+		from := tx.ValidatedSender()
+		statedb.Exist(from)
+		if tx.IsFeeDelegatedTransaction() {
+			if _, err := tx.ValidateFeePayer(signer, statedb, blockNumber); err == nil {
+				statedb.Exist(tx.ValidatedFeePayer())
+			}
+		}
+		// EIP-7702: sender may carry delegated code; warm its code + storage too.
+		if statedb.GetCodeHash(from) != types.EmptyCodeHash {
+			statedb.GetCode(from)
+			statedb.GetState(from, common.Hash{})
+		}
+		to := tx.To()
+		if to == nil {
+			continue
+		}
+		if statedb.GetCodeHash(*to) != types.EmptyCodeHash {
+			statedb.GetCode(*to)
+			statedb.GetState(*to, common.Hash{})
+		}
+	}
+}

--- a/blockchain/sender_cacher.go
+++ b/blockchain/sender_cacher.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 )
 
 // senderCacher is a concurrent transaction sender recoverer and cacher.
@@ -131,4 +132,34 @@ func (cacher *txSenderCacher) recoverFromBlocks(signer types.Signer, blocks []*t
 		txs = append(txs, block.Transactions()...)
 	}
 	cacher.recover(signer, txs)
+}
+
+// WarmSenders copies sender cache from pool-resident twins (when lookup is set)
+// and kicks async ecrecover for the rest. Pass nil lookup to skip the transplant.
+func WarmSenders(signer types.Signer, block *types.Block, lookup func(common.Hash) *types.Transaction) {
+	if block == nil {
+		return
+	}
+	txs := block.Transactions()
+	toRecover := make([]*types.Transaction, 0, len(txs))
+	if lookup != nil {
+		for _, tx := range txs {
+			if tx == nil {
+				continue
+			}
+			known := lookup(tx.Hash())
+			if known == nil || known == tx {
+				toRecover = append(toRecover, tx)
+				continue
+			}
+			tx.CopySenderFrom(known)
+			// recover is idempotent on cached txs; queue all to avoid a second pass.
+			toRecover = append(toRecover, tx)
+		}
+	} else {
+		toRecover = append(toRecover, txs...)
+	}
+	if len(toRecover) > 0 {
+		senderCacher.recover(signer, toRecover)
+	}
 }

--- a/blockchain/sender_cacher.go
+++ b/blockchain/sender_cacher.go
@@ -23,7 +23,6 @@
 package blockchain
 
 import (
-	"math"
 	"runtime"
 
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -34,8 +33,7 @@ import (
 var senderCacher = newTxSenderCacher(calcNumSenderCachers())
 
 func calcNumSenderCachers() int {
-	numWorkers := math.Ceil(float64(runtime.NumCPU()) * 2.0 / 3.0)
-	return int(numWorkers)
+	return runtime.NumCPU()
 }
 
 // txSenderCacherRequest is a request for recovering transaction senders with a

--- a/blockchain/speculative_cache.go
+++ b/blockchain/speculative_cache.go
@@ -165,6 +165,23 @@ func (c *SpeculativeResultCache) TryGet(hash common.Hash, timeout time.Duration)
 	return e.result
 }
 
+// HasUsable reports whether an entry for hash is in flight or completed
+// successfully, i.e. re-Reserving it would discard useful work.
+func (c *SpeculativeResultCache) HasUsable(hash common.Hash) bool {
+	c.mu.Lock()
+	e := c.entry
+	c.mu.Unlock()
+	if e == nil || e.blockHash != hash {
+		return false
+	}
+	select {
+	case <-e.done:
+		return e.err == nil
+	default:
+		return true // in flight
+	}
+}
+
 // Clear removes the current entry. Safe to call when no entry exists.
 func (c *SpeculativeResultCache) Clear() {
 	c.mu.Lock()

--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
-	"github.com/kaiachain/kaia/common"
 )
 
 // statePrefetcher is a basic Prefetcher, which blindly executes a block on top
@@ -45,61 +44,14 @@ func newStatePrefetcher(chain ChainContext) *statePrefetcher {
 	}
 }
 
-// Prefetch processes the state changes according to the Kaia rules by running
-// the transaction messages using the statedb, but any changes are discarded. The
-// only goal is to pre-cache transaction signatures and state trie nodes.
-func (p *statePrefetcher) Prefetch(block *types.Block, stateDB *state.StateDB, cfg vm.Config, interrupt *uint32) {
-	header := block.Header()
-	// Iterate over and process the individual transactions
-	for i, tx := range block.Transactions() {
-		// If block precaching was interrupted, abort
+// Prefetch warms state caches via prefetchTxState (no EVM).
+func (p *statePrefetcher) Prefetch(block *types.Block, stateDB *state.StateDB, _ vm.Config, interrupt *uint32) {
+	signer := types.MakeSigner(p.chain.Config(), block.Header().Number)
+	blockNumber := block.NumberU64()
+	for _, tx := range block.Transactions() {
 		if interrupt != nil && atomic.LoadUint32(interrupt) == 1 {
 			return
 		}
-		// Block precaching permitted to continue, execute the transaction
-		stateDB.SetTxContext(tx.Hash(), block.Hash(), i)
-		if err := precacheTransaction(p.chain, nil, stateDB, header, tx, cfg); err != nil {
-			return // Ugh, something went horribly wrong, bail out
-		}
+		prefetchTxState(stateDB, signer, tx, blockNumber)
 	}
-}
-
-// PrefetchTx processes the state changes according to the Kaia rules by running
-// a single transaction message using the statedb, but any changes are discarded. The
-// only goal is to pre-cache transaction signatures and state trie nodes. It is used
-// when fetcher works, so it fetches only a block.
-func (p *statePrefetcher) PrefetchTx(block *types.Block, ti int, stateDB *state.StateDB, cfg vm.Config, interrupt *uint32) {
-	var (
-		header = block.Header()
-		tx     = block.Transactions()[ti]
-	)
-
-	// If block precaching was interrupted, abort
-	if interrupt != nil && atomic.LoadUint32(interrupt) == 1 {
-		return
-	}
-
-	// Block precaching permitted to continue, execute the transaction
-	stateDB.SetTxContext(tx.Hash(), block.Hash(), ti)
-	if err := precacheTransaction(p.chain, nil, stateDB, header, tx, cfg); err != nil {
-		return // Ugh, something went horribly wrong, bail out
-	}
-}
-
-// precacheTransaction attempts to apply a transaction to the given state database
-// and uses the input parameters for its environment. The goal is not to execute
-// the transaction successfully, rather to warm up touched data slots.
-func precacheTransaction(chain ChainContext, author *common.Address, statedb *state.StateDB, header *types.Header, tx *types.Transaction, cfg vm.Config) error {
-	// Convert the transaction into an executable message and pre-cache its sender
-	msg, err := tx.AsMessageWithAccountKeyPicker(types.MakeSigner(chain.Config(), header.Number), statedb, header.Number.Uint64())
-	if err != nil {
-		return err
-	}
-	// Create the EVM and execute the transaction
-	blockContext := NewEVMBlockContext(header, chain, author)
-	txContext := NewEVMTxContext(msg, header, chain.Config())
-	vm := vm.NewEVM(blockContext, txContext, statedb, chain.Config(), &cfg)
-
-	_, err = ApplyMessage(vm, msg)
-	return err
 }

--- a/blockchain/state_processor.go
+++ b/blockchain/state_processor.go
@@ -23,6 +23,7 @@
 package blockchain
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -65,7 +66,7 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain) *StateProcess
 // Process returns the receipts and logs accumulated during the process and
 // returns the amount of gas that was used in the process. If any of the
 // transactions failed to execute due to insufficient gas it will return an error.
-func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, []*vm.InternalTxTrace, ProcessStats, error) {
+func (p *StateProcessor) Process(ctx context.Context, block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, []*vm.InternalTxTrace, ProcessStats, error) {
 	var (
 		receipts         types.Receipts
 		usedGas          = new(uint64)
@@ -83,6 +84,11 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	processStats.BeforeApplyTxs = time.Now()
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
+		// Abort between txs when the speculative result is no longer needed.
+		// InsertChain passes context.Background(), so this never fires on commit.
+		if err := ctx.Err(); err != nil {
+			return nil, nil, 0, nil, processStats, err
+		}
 		statedb.SetTxContext(tx.Hash(), block.Hash(), i)
 		receipt, internalTxTrace, err := p.bc.ApplyTransaction(p.config, &author, statedb, header, tx, usedGas, &cfg)
 		if err != nil {

--- a/blockchain/tx_lookup.go
+++ b/blockchain/tx_lookup.go
@@ -1,4 +1,18 @@
-// Modifications Copyright 2024 The Kaia Authors
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
 
 package blockchain
 

--- a/blockchain/tx_lookup.go
+++ b/blockchain/tx_lookup.go
@@ -1,0 +1,31 @@
+// Modifications Copyright 2024 The Kaia Authors
+
+package blockchain
+
+import (
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+)
+
+type chainTxLookup struct {
+	fn func(common.Hash) *types.Transaction
+}
+
+// SetTxLookup registers the hash→tx resolver used by sender warming. Nil is ignored.
+func (bc *BlockChain) SetTxLookup(fn func(common.Hash) *types.Transaction) {
+	if bc == nil || fn == nil {
+		return
+	}
+	bc.txLookup.Store(&chainTxLookup{fn: fn})
+}
+
+// TxLookup returns the registered hash→tx resolver, or nil if not set.
+func (bc *BlockChain) TxLookup() func(common.Hash) *types.Transaction {
+	if bc == nil {
+		return nil
+	}
+	if lookup := bc.txLookup.Load(); lookup != nil {
+		return lookup.fn
+	}
+	return nil
+}

--- a/blockchain/tx_lookup_test.go
+++ b/blockchain/tx_lookup_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
 package blockchain
 
 import (

--- a/blockchain/tx_lookup_test.go
+++ b/blockchain/tx_lookup_test.go
@@ -1,0 +1,35 @@
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
+)
+
+func TestBlockChainTxLookup(t *testing.T) {
+	var bc BlockChain
+	if bc.TxLookup() != nil {
+		t.Fatal("unexpected tx lookup on zero BlockChain")
+	}
+
+	called := false
+	bc.SetTxLookup(func(common.Hash) *types.Transaction {
+		called = true
+		return nil
+	})
+
+	lookup := bc.TxLookup()
+	if lookup == nil {
+		t.Fatal("expected tx lookup to be registered")
+	}
+	lookup(common.Hash{})
+	if !called {
+		t.Fatal("registered tx lookup was not invoked")
+	}
+
+	bc.SetTxLookup(nil)
+	if bc.TxLookup() == nil {
+		t.Fatal("nil tx lookup registration should be ignored")
+	}
+}

--- a/blockchain/types.go
+++ b/blockchain/types.go
@@ -66,7 +66,6 @@ type Prefetcher interface {
 	// the transaction messages using the statedb, but any changes are discarded. The
 	// only goal is to pre-cache transaction signatures and state trie nodes.
 	Prefetch(block *types.Block, stateDB *state.StateDB, cfg vm.Config, interrupt *uint32)
-	PrefetchTx(block *types.Block, ti int, stateDB *state.StateDB, cfg vm.Config, interrupt *uint32)
 }
 
 // Processor is an interface for processing blocks using a given initial state.

--- a/blockchain/types.go
+++ b/blockchain/types.go
@@ -23,6 +23,8 @@
 package blockchain
 
 import (
+	"context"
+
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
@@ -81,6 +83,9 @@ type Processor interface {
 
 	// Process processes the state changes according to the Kaia rules by running
 	// the transaction messages using the statedb and applying any rewards to
-	// the processor (coinbase).
-	Process(block *types.Block, stateDB *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, []*vm.InternalTxTrace, ProcessStats, error)
+	// the processor (coinbase). ctx aborts execution between transactions; pass
+	// context.Background() on the InsertChain path, which must never abort
+	// mid-block. Only speculative execution (validator path) passes a
+	// cancellable context.
+	Process(ctx context.Context, block *types.Block, stateDB *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, []*vm.InternalTxTrace, ProcessStats, error)
 }

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -414,6 +414,21 @@ func (tx *Transaction) WithoutBlobTxSidecar() *Transaction {
 	return cpy
 }
 
+// CopySenderFrom transplants the cached sender (and fee-payer) from a same-hash twin.
+func (tx *Transaction) CopySenderFrom(src *Transaction) {
+	if src == nil || src == tx {
+		return
+	}
+	if v := src.from.Load(); v != nil {
+		tx.from.Store(v)
+	}
+	if tx.IsFeeDelegatedTransaction() {
+		if v := src.feePayer.Load(); v != nil {
+			tx.feePayer.Store(v)
+		}
+	}
+}
+
 // WithBlobTxSidecar returns a copy of tx with the blob sidecar added.
 func (tx *Transaction) WithBlobTxSidecar(sideCar *BlobTxSidecar) *Transaction {
 	blobtx, ok := tx.GetTxInternalData().(*TxInternalDataEthereumBlob)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -73,6 +73,9 @@ type ChainReader interface {
 
 	// PrunableStateAt retrieves statedb on a particular point in time with live pruning
 	PrunableStateAt(root common.Hash, num uint64) (*state.StateDB, error)
+
+	// TxLookup returns the optional hash→tx resolver used by sender warming.
+	TxLookup() func(common.Hash) *types.Transaction
 }
 
 // ChainContext extends ChainReader with transaction execution capability.

--- a/consensus/executor.go
+++ b/consensus/executor.go
@@ -17,6 +17,7 @@
 package consensus
 
 import (
+	"context"
 	"time"
 
 	"github.com/kaiachain/kaia/blockchain/state"
@@ -76,8 +77,9 @@ type Executor interface {
 	// ProcessBlock executes the given transaction list in the provided
 	// order without re-sorting. This is the path validators use during
 	// speculative execution of a received pre-prepare: they must replay the
-	// exact order encoded in the proposer's block body.
-	ProcessBlock(txs []*types.Transaction) (*ExecutionResult, error)
+	// exact order encoded in the proposer's block body. ctx aborts execution
+	// between transactions when the speculative result is no longer needed.
+	ProcessBlock(ctx context.Context, txs []*types.Transaction) (*ExecutionResult, error)
 
 	// FinalizeState runs post-transaction state modifications and assembles final block.
 	FinalizeState(result *ExecutionResult) (*types.Block, error)

--- a/consensus/kaiabft/backend.go
+++ b/consensus/kaiabft/backend.go
@@ -699,6 +699,10 @@ func (b *backend) startSpeculativeExecution(proposal bft.Proposal) {
 	blockHash := block.Hash()
 	entry := b.specCache.Reserve(blockHash)
 
+	// Adopt pool-known senders; kick async ecrecover for the rest.
+	signer := types.MakeSigner(b.chain.Config(), block.Number())
+	blockchain.WarmSenders(signer, block, b.chain.TxLookup())
+
 	executor := b.executor.Clone()
 
 	parentHeader := b.chain.GetHeader(block.ParentHash(), block.NumberU64()-1)

--- a/consensus/kaiabft/backend.go
+++ b/consensus/kaiabft/backend.go
@@ -712,6 +712,13 @@ func (b *backend) startSpeculativeExecution(proposal bft.Proposal) {
 		return
 	}
 
+	// Warm trie-node cache for spec-exec; ctx ties prefetch to this round.
+	b.specWg.Add(1)
+	go func() {
+		defer b.specWg.Done()
+		blockchain.PrefetchBlockState(ctx, b.chain, parentHeader.Root, block.NumberU64(), block.Transactions(), signer)
+	}()
+
 	b.specWg.Add(1)
 	go func() {
 		defer b.specWg.Done()

--- a/consensus/kaiabft/backend.go
+++ b/consensus/kaiabft/backend.go
@@ -688,6 +688,13 @@ func (b *backend) startSpeculativeExecution(proposal bft.Proposal) {
 		return
 	}
 
+	blockHash := block.Hash()
+	// Re-entry for the same proposal (e.g. future-block retry) keeps the
+	// in-flight or completed execution instead of restarting it.
+	if b.specCache.HasUsable(blockHash) {
+		return
+	}
+
 	b.specMu.Lock()
 	if b.specCancel != nil {
 		b.specCancel()
@@ -696,13 +703,9 @@ func (b *backend) startSpeculativeExecution(proposal bft.Proposal) {
 	b.specCancel = cancel
 	b.specMu.Unlock()
 
-	blockHash := block.Hash()
 	entry := b.specCache.Reserve(blockHash)
 
-	// Adopt pool-known senders; kick async ecrecover for the rest.
 	signer := types.MakeSigner(b.chain.Config(), block.Number())
-	blockchain.WarmSenders(signer, block, b.chain.TxLookup())
-
 	executor := b.executor.Clone()
 
 	parentHeader := b.chain.GetHeader(block.ParentHash(), block.NumberU64()-1)
@@ -711,6 +714,10 @@ func (b *backend) startSpeculativeExecution(proposal bft.Proposal) {
 		cancel()
 		return
 	}
+
+	// Adopt pool-known senders; kick async ecrecover for the rest. Runs
+	// synchronously so execution and prefetch always see warmed senders.
+	blockchain.WarmSenders(signer, block, b.chain.TxLookup())
 
 	// Warm trie-node cache for spec-exec; ctx ties prefetch to this round.
 	b.specWg.Add(1)

--- a/consensus/kaiabft/backend.go
+++ b/consensus/kaiabft/backend.go
@@ -755,7 +755,7 @@ func (b *backend) startSpeculativeExecution(proposal bft.Proposal) {
 		// ProcessBlock delegates to StateProcessor.Process() which already
 		// applies rewards and computes the state root — do NOT call
 		// FinalizeState again.
-		result, err := executor.ProcessBlock(block.Transactions())
+		result, err := executor.ProcessBlock(ctx, block.Transactions())
 		if err != nil {
 			entry.Complete(nil, err)
 			return

--- a/consensus/kaiabft/machine.go
+++ b/consensus/kaiabft/machine.go
@@ -297,13 +297,22 @@ func (m *machine) handlePreprepare(msg *bft.Message, src common.Address) error {
 		return errNotFromProposer
 	}
 
+	// Start speculative execution before verify so the tx-root derivation
+	// below overlaps execution; the result is consumed only after the full
+	// InsertChain validation.
+	if m.state == stateAcceptRequest && !m.isHashLocked() && !m.isProposer() {
+		m.b.startSpeculativeExecution(pp.Proposal)
+	}
+
 	if duration, err := m.b.verify(pp.Proposal); err != nil {
 		if err == consensus.ErrFutureBlock {
+			// Keep the in-flight execution; the retry reuses it.
 			m.stopFuturePreprepareTimer()
 			m.futurePreprepareTimer = time.AfterFunc(duration, func() {
 				m.b.eventMux.Post(backlogEvent{src: src, msg: msg, Hash: msg.Hash})
 			})
 		} else {
+			m.b.cancelSpeculativeExecution()
 			m.sendNextRoundChange("handlePreprepare: verification failure")
 		}
 		return err
@@ -330,10 +339,6 @@ func (m *machine) handlePreprepare(msg *bft.Message, src common.Address) error {
 		} else {
 			logger.Debug("Accepted preprepare, moving to Preprepared",
 				"seq", m.sequence, "round", m.round, "from", src, "hash", pp.Proposal.Hash())
-			// Speculative execution (kaiabft-specific).
-			if !m.isProposer() {
-				m.b.startSpeculativeExecution(pp.Proposal)
-			}
 
 			// Accept preprepare and move to Preprepared state
 			m.acceptPreprepare(pp)

--- a/consensus/mocks/executor_mock.go
+++ b/consensus/mocks/executor_mock.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -82,18 +83,18 @@ func (mr *MockExecutorMockRecorder) FinalizeState(arg0 interface{}) *gomock.Call
 }
 
 // ProcessBlock mocks base method.
-func (m *MockExecutor) ProcessBlock(arg0 []*types.Transaction) (*consensus.ExecutionResult, error) {
+func (m *MockExecutor) ProcessBlock(arg0 context.Context, arg1 []*types.Transaction) (*consensus.ExecutionResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessBlock", arg0)
+	ret := m.ctrl.Call(m, "ProcessBlock", arg0, arg1)
 	ret0, _ := ret[0].(*consensus.ExecutionResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ProcessBlock indicates an expected call of ProcessBlock.
-func (mr *MockExecutorMockRecorder) ProcessBlock(arg0 interface{}) *gomock.Call {
+func (mr *MockExecutorMockRecorder) ProcessBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlock", reflect.TypeOf((*MockExecutor)(nil).ProcessBlock), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlock", reflect.TypeOf((*MockExecutor)(nil).ProcessBlock), arg0, arg1)
 }
 
 // ResetWithState mocks base method.

--- a/kaiax/gov/impl/mock/blockchain_mock.go
+++ b/kaiax/gov/impl/mock/blockchain_mock.go
@@ -209,6 +209,20 @@ func (mr *MockBlockChainMockRecorder) StateAt(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateAt", reflect.TypeOf((*MockBlockChain)(nil).StateAt), arg0)
 }
 
+// TxLookup mocks base method.
+func (m *MockBlockChain) TxLookup() func(common.Hash) *types.Transaction {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxLookup")
+	ret0, _ := ret[0].(func(common.Hash) *types.Transaction)
+	return ret0
+}
+
+// TxLookup indicates an expected call of TxLookup.
+func (mr *MockBlockChainMockRecorder) TxLookup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxLookup", reflect.TypeOf((*MockBlockChain)(nil).TxLookup))
+}
+
 // ValidateHeader mocks base method.
 func (m *MockBlockChain) ValidateHeader(arg0 *types.Header) error {
 	m.ctrl.T.Helper()

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -354,6 +354,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	config.TxPool.BlobStorageConfig = &blobStorageConfig
 
 	cn.txPool = blockchain.NewTxPool(config.TxPool, cn.chainConfig, bc, mGov)
+	bc.SetTxLookup(cn.txPool.Get)
 
 	// Permit the downloader to use the trie cache allowance during fast sync
 	cacheLimit := cacheConfig.TrieNodeCacheConfig.LocalCacheSizeMiB

--- a/node/cn/state_accessor.go
+++ b/node/cn/state_accessor.go
@@ -21,6 +21,7 @@
 package cn
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -164,7 +165,7 @@ func (cn *CN) stateAtBlock(block *types.Block, reexec uint64, base *state.StateD
 		if current = cn.blockchain.GetBlockByNumber(next); current == nil {
 			return nil, nil, fmt.Errorf("block #%d not found", next)
 		}
-		_, _, _, _, _, err := cn.blockchain.Processor().Process(current, statedb, vm.Config{})
+		_, _, _, _, _, err := cn.blockchain.Processor().Process(context.Background(), current, statedb, vm.Config{})
 		if err != nil {
 			return nil, nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}

--- a/tests/executor_test.go
+++ b/tests/executor_test.go
@@ -17,6 +17,7 @@
 package tests
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
@@ -66,7 +67,7 @@ func TestDefaultExecutor_Clone(t *testing.T) {
 	require.NoError(t, executor.ResetWithState(parentState, header))
 
 	// Clone should fail ProcessBlock because it was never initialized.
-	_, err = clone.ProcessBlock(nil)
+	_, err = clone.ProcessBlock(context.Background(), nil)
 	assert.ErrorIs(t, err, work.ErrExecutorNotInitialized)
 
 	// Initialize clone separately — should succeed independently.
@@ -74,7 +75,7 @@ func TestDefaultExecutor_Clone(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, clone.ResetWithState(cloneState, header))
 
-	result, err := clone.ProcessBlock(nil)
+	result, err := clone.ProcessBlock(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), result.UsedGas)
 }
@@ -134,7 +135,7 @@ func TestProcessBlock_MatchesInsertChain(t *testing.T) {
 	executor := work.NewDefaultExecutor(bcdata.bc.Config(), bcdata.bc, common.Address{}, vm.Config{})
 	require.NoError(t, executor.ResetWithState(parentState, block.Header()))
 
-	specResult, err := executor.ProcessBlock(block.Transactions())
+	specResult, err := executor.ProcessBlock(context.Background(), block.Transactions())
 	require.NoError(t, err)
 
 	// --- 4. Compare speculative results with block header ---
@@ -172,6 +173,54 @@ func TestProcessBlock_MatchesInsertChain(t *testing.T) {
 	n, err := bcdata.bc.InsertChain(types.Blocks{block})
 	assert.NoError(t, err, "InsertChain should accept the block")
 	assert.Equal(t, 0, n, "InsertChain should process the block at index 0")
+}
+
+// TestProcessBlock_ContextCancellation verifies that a cancelled context aborts
+// speculative execution between transactions rather than running the whole block.
+// A pre-cancelled context must bail on the first loop iteration, before any tx
+// is applied, so no result is produced.
+func TestProcessBlock_ContextCancellation(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlTrace)
+
+	bcdata, err := NewBCDataWithConfigs(6, 4, Forks["Magma"], nil)
+	require.NoError(t, err)
+	defer bcdata.Shutdown()
+
+	signer := types.LatestSignerForChainID(bcdata.bc.Config().ChainID)
+	gasPrice := new(big.Int).Add(bcdata.bc.CurrentBlock().Header().BaseFee, big.NewInt(1))
+
+	var txs types.Transactions
+	sender := bcdata.privKeys[0]
+	senderAddr := *bcdata.addrs[0]
+	stateDb, err := bcdata.bc.State()
+	require.NoError(t, err)
+	nonce := stateDb.GetNonce(senderAddr)
+	for i := range 5 {
+		tx := types.NewTransaction(nonce, *bcdata.addrs[1+i%4], new(big.Int).SetUint64(1000), params.TxGas, gasPrice, nil)
+		signedTx, err := types.SignTx(tx, signer, sender)
+		require.NoError(t, err)
+		txs = append(txs, signedTx)
+		nonce++
+	}
+
+	prof := profile.NewProfiler()
+	_, block, _, err := bcdata.MineABlock(txs, signer, prof, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, block.Transactions(), "block must contain txs for the test to be meaningful")
+
+	parent := bcdata.bc.CurrentBlock()
+	parentState, err := bcdata.bc.PrunableStateAt(parent.Root(), parent.NumberU64())
+	require.NoError(t, err)
+
+	executor := work.NewDefaultExecutor(bcdata.bc.Config(), bcdata.bc, common.Address{}, vm.Config{})
+	require.NoError(t, executor.ResetWithState(parentState, block.Header()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel: Process must bail on the first loop iteration
+
+	specResult, err := executor.ProcessBlock(ctx, block.Transactions())
+	require.ErrorIs(t, err, context.Canceled, "cancelled context must abort ProcessBlock")
+	require.Nil(t, specResult, "no result expected on cancellation")
 }
 
 // TestInsertChain_SpeculativeCacheHit verifies that InsertChain uses a
@@ -216,7 +265,7 @@ func TestInsertChain_SpeculativeCacheHit(t *testing.T) {
 	executor := work.NewDefaultExecutor(bcdata.bc.Config(), bcdata.bc, common.Address{}, vm.Config{})
 	require.NoError(t, executor.ResetWithState(parentState, block.Header()))
 
-	specResult, err := executor.ProcessBlock(block.Transactions())
+	specResult, err := executor.ProcessBlock(context.Background(), block.Transactions())
 	require.NoError(t, err)
 
 	// --- 3. Populate the speculative cache ---
@@ -348,7 +397,7 @@ func TestInsertChain_SpeculativeCacheWait(t *testing.T) {
 	executor := work.NewDefaultExecutor(bcdata.bc.Config(), bcdata.bc, common.Address{}, vm.Config{})
 	require.NoError(t, executor.ResetWithState(parentState, block.Header()))
 
-	specResult, err := executor.ProcessBlock(block.Transactions())
+	specResult, err := executor.ProcessBlock(context.Background(), block.Transactions())
 	require.NoError(t, err)
 
 	hitsBefore := bcdata.bc.SpeculativeCache().Hits()
@@ -461,7 +510,7 @@ func TestKaiaBFT_SpeculativeExecution_ClonePath(t *testing.T) {
 
 	require.NoError(t, clonedExecutor.ResetWithState(parentState, block.Header()))
 
-	specResult, err := clonedExecutor.ProcessBlock(block.Transactions())
+	specResult, err := clonedExecutor.ProcessBlock(context.Background(), block.Transactions())
 	require.NoError(t, err)
 
 	assert.Equal(t, block.Root(), specResult.State.IntermediateRoot(true), "state root mismatch")

--- a/work/execution.go
+++ b/work/execution.go
@@ -17,6 +17,7 @@
 package work
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -152,7 +153,7 @@ func (e *DefaultExecutor) Execute(txs *types.TransactionsByPriceAndNonce, mux *e
 // InitializeState + ApplyTransaction×N + FinalizeState in one call,
 // producing results identical to the normal block insertion path.
 // The caller must NOT call FinalizeState separately.
-func (e *DefaultExecutor) ProcessBlock(txs []*types.Transaction) (*consensus.ExecutionResult, error) {
+func (e *DefaultExecutor) ProcessBlock(ctx context.Context, txs []*types.Transaction) (*consensus.ExecutionResult, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -167,7 +168,7 @@ func (e *DefaultExecutor) ProcessBlock(txs []*types.Transaction) (*consensus.Exe
 	block := types.NewBlockWithHeader(e.header).WithBody(txs)
 
 	// Delegate to Process() — the same function InsertChain uses.
-	receipts, logs, usedGas, internalTxTraces, procStats, err := e.chain.Processor().Process(block, e.state, e.vmConfig)
+	receipts, logs, usedGas, internalTxTraces, procStats, err := e.chain.Processor().Process(ctx, block, e.state, e.vmConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -1077,6 +1077,20 @@ func (mr *MockBlockChainMockRecorder) TrieNode(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieNode", reflect.TypeOf((*MockBlockChain)(nil).TrieNode), arg0)
 }
 
+// TxLookup mocks base method.
+func (m *MockBlockChain) TxLookup() func(common.Hash) *types.Transaction {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxLookup")
+	ret0, _ := ret[0].(func(common.Hash) *types.Transaction)
+	return ret0
+}
+
+// TxLookup indicates an expected call of TxLookup.
+func (mr *MockBlockChainMockRecorder) TxLookup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxLookup", reflect.TypeOf((*MockBlockChain)(nil).TxLookup))
+}
+
 // VMConfig mocks base method.
 func (m *MockBlockChain) VMConfig() vm.Config {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -166,7 +166,7 @@ func (self *Miner) Start() {
 		logger.Info("Starting mining operation")
 	}
 	self.worker.start()
-	// commitNewWork() is triggered by NewSequenceEvent from startNewRound()
+	// New work is triggered by NewSequenceEvent from startNewRound().
 }
 
 func (self *Miner) Stop() {
@@ -289,6 +289,7 @@ type BlockChain interface {
 	ResetWithGenesisBlock(gb *types.Block) error
 	Validator() blockchain.Validator
 	HasBadBlock(hash common.Hash) bool
+	TxLookup() func(common.Hash) *types.Transaction
 	WriteBlockWithState(block *types.Block, receipts []*types.Receipt, stateDB *state.StateDB) (blockchain.WriteResult, error)
 	PostChainEvents(events []interface{}, logs []*types.Log)
 	ApplyTransaction(config *params.ChainConfig, author *common.Address, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg *vm.Config) (*types.Receipt, *vm.InternalTxTrace, error)


### PR DESCRIPTION
## Proposed changes

Blockchain-layer state-warming and prefetch optimizations for the kaiabft speculative-execution path. Reduces per-block execution latency on validators by warming sender recovery and account state ahead of speculative execution.

- **tx-lookup hook + `WarmSenders`** — adds a tx-lookup hook on the chain and a `WarmSenders` helper that adopts pool-known senders and kicks off async ecrecover for the rest before speculative execution (renames `tx_cacher.go` → `sender_cacher.go`). Includes `TestBlockChainTxLookup`.
- **`PrefetchBlockState`** — prefetches the block's account state into the trie cache for spec exec.
- **Cheap state warming** — replaces the EVM-based block prefetcher with lightweight account/state warming, removing the redundant speculative EVM run.
- **Sender-cacher parallelism = NumCPU** — raises ecrecover worker parallelism to the core count.
- **Start speculative execution before verify** — launch spec exec ahead of `verify()` so tx-root derivation overlaps execution; guarded to non-proposer/non-hash-locked, cancelled on verify failure, retry-safe via a cache `HasUsable` check.

**Pure diff (this PR's commits only):**
https://github.com/hyeonLewis/kaia/compare/kbft-opt-1-consensus...kbft-opt-2-specexec-warming

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- kaiabft speculative-execution optimization series -->

## Further comments

**Stacked PR (2/3).** Depends on `kaiabft/opt: consensus related optimization` (#1 of the stack) — `WarmSenders` is wired into the kaiabft `startSpeculativeExecution` path that the consensus PR touches. Merge after PR (1/3).

The GitHub "Files changed" view will show PR (1/3)'s commits until that one merges; the pure-diff link above isolates the four commits this PR introduces.