### PR TITLE
kaiabft/opt: block building and txpool optimization

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -170,14 +170,15 @@ type BlockChain struct {
 	chBlock chan gcBlock       // chPushBlockGCPrque is a channel for delivering the gc item to gc loop.
 	chPrune chan uint64        // chPrune is a channel for delivering the current block number for pruning loop.
 
-	hc            *HeaderChain
-	rmLogsFeed    event.Feed
-	chainFeed     event.Feed
-	chainSideFeed event.Feed
-	chainHeadFeed event.Feed
-	logsFeed      event.Feed
-	scope         event.SubscriptionScope
-	genesisBlock  *types.Block
+	hc                 *HeaderChain
+	rmLogsFeed         event.Feed
+	chainFeed          event.Feed
+	chainSideFeed      event.Feed
+	chainHeadFeed      event.Feed
+	chainPreCommitFeed event.Feed
+	logsFeed           event.Feed
+	scope              event.SubscriptionScope
+	genesisBlock       *types.Block
 
 	mu sync.RWMutex // global mutex for locking chain operations
 
@@ -1593,13 +1594,19 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
-	return bc.writeBlockWithState(block, receipts, stateDB)
+	return bc.writeBlockWithState(block, receipts, stateDB, true)
 }
 
 // writeBlockWithState writes the block and all associated state to the database.
 // If BlockChain.parallelDBWrite is true, it calls writeBlockWithStateParallel.
 // If not, it calls writeBlockWithStateSerial.
-func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, stateDB *state.StateDB) (WriteResult, error) {
+// When announce is set, a ChainPreCommitEvent is published so subscribers can
+// prepare for the new head in parallel; bulk (sync) inserts skip it.
+func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, stateDB *state.StateDB, announce bool) (WriteResult, error) {
+	if announce {
+		bc.announceChainPreCommit(block, stateDB)
+	}
+
 	var status WriteResult
 	var err error
 	if bc.parallelDBWrite {
@@ -2126,7 +2133,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		afterValidate := time.Now()
 
 		// Write the block to the chain and get the writeResult.
-		writeResult, err := bc.writeBlockWithState(block, receipts, stateDB)
+		// Pre-commit announcement is only worth its state copy for live
+		// single-block inserts; sync batches skip it.
+		writeResult, err := bc.writeBlockWithState(block, receipts, stateDB, len(chain) == 1)
 		if err != nil {
 			atomic.StoreUint32(&followupInterrupt, 1)
 			if err == ErrKnownBlock {
@@ -2758,6 +2767,22 @@ func (bc *BlockChain) SubscribeChainEvent(ch chan<- ChainEvent) event.Subscripti
 // SubscribeChainHeadEvent registers a subscription of ChainHeadEvent.
 func (bc *BlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscription {
 	return bc.scope.Track(bc.chainHeadFeed.Subscribe(ch))
+}
+
+// SubscribeChainPreCommitEvent registers a subscription of ChainPreCommitEvent.
+func (bc *BlockChain) SubscribeChainPreCommitEvent(ch chan<- ChainPreCommitEvent) event.Subscription {
+	return bc.scope.Track(bc.chainPreCommitFeed.Subscribe(ch))
+}
+
+// announceChainPreCommit publishes the upcoming head with a private copy of its
+// post-execution state. Blocks not extending the current head are skipped.
+func (bc *BlockChain) announceChainPreCommit(block *types.Block, stateDB *state.StateDB) {
+	if block.ParentHash() != bc.CurrentBlock().Hash() {
+		return
+	}
+	ev := ChainPreCommitEvent{Block: block, State: stateDB.Copy()}
+	// Feed.Send blocks until delivery; keep it off the bc.mu critical section.
+	go bc.chainPreCommitFeed.Send(ev)
 }
 
 // SubscribeChainSideEvent registers a subscription of ChainSideEvent.

--- a/blockchain/events.go
+++ b/blockchain/events.go
@@ -25,6 +25,7 @@ package blockchain
 import (
 	"encoding/json"
 
+	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
@@ -68,3 +69,11 @@ type ChainSideEvent struct {
 }
 
 type ChainHeadEvent struct{ Block *types.Block }
+
+// ChainPreCommitEvent is posted when a block starts being written, before it
+// becomes the canonical head. State is a private copy of its post-execution
+// state, letting subscribers prepare for the new head during the write.
+type ChainPreCommitEvent struct {
+	Block *types.Block
+	State *state.StateDB
+}

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -141,6 +141,7 @@ type blockChain interface {
 	GetTxAndLookupInfo(txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64)
 
 	SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscription
+	SubscribeChainPreCommitEvent(ch chan<- ChainPreCommitEvent) event.Subscription
 }
 
 // TxPoolConfig are the configuration parameters of the transaction pool.
@@ -223,17 +224,19 @@ type MissingBlobSidecar struct {
 // current state) and future transactions. Transactions move between those
 // two states over time as they are received and processed.
 type TxPool struct {
-	config       TxPoolConfig
-	chainconfig  *params.ChainConfig
-	chain        blockChain
-	gasPrice     *big.Int // minimum required gasPrice = unitPrice (before Magma) or baseFee (since Magma)
-	blobBaseFee  *big.Int // minimum required blobFee =  0 (before Osaka for nil safety) or blobBaseFee (since Osaka)
-	txFeed       event.Feed
-	scope        event.SubscriptionScope
-	chainHeadCh  chan ChainHeadEvent
-	chainHeadSub event.Subscription
-	signer       types.Signer
-	mu           sync.RWMutex
+	config            TxPoolConfig
+	chainconfig       *params.ChainConfig
+	chain             blockChain
+	gasPrice          *big.Int // minimum required gasPrice = unitPrice (before Magma) or baseFee (since Magma)
+	blobBaseFee       *big.Int // minimum required blobFee =  0 (before Osaka for nil safety) or blobBaseFee (since Osaka)
+	txFeed            event.Feed
+	scope             event.SubscriptionScope
+	chainHeadCh       chan ChainHeadEvent
+	chainHeadSub      event.Subscription
+	chainPreCommitCh  chan ChainPreCommitEvent
+	chainPreCommitSub event.Subscription
+	signer            types.Signer
+	mu                sync.RWMutex
 
 	currentBlockNumber uint64                    // Current block number
 	currentState       *state.StateDB            // Current state in the blockchain head
@@ -292,6 +295,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		all:                   newTxLookup(),
 		pendingNonce:          make(map[common.Address]uint64),
 		chainHeadCh:           make(chan ChainHeadEvent, chainHeadChanSize),
+		chainPreCommitCh:      make(chan ChainPreCommitEvent, chainHeadChanSize),
 		gasPrice:              new(big.Int).SetUint64(pset.UnitPrice),
 		blobBaseFee:           new(big.Int).SetUint64(params.ZeroBaseFee),
 		txMsgCh:               make(chan types.Transactions, txMsgChSize),
@@ -301,7 +305,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 	}
 	pool.locals = newAccountSet(pool.signer)
 	pool.priced = newTxPricedList(pool.all)
-	pool.reset(nil, chain.CurrentBlock().Header())
+	pool.reset(nil, chain.CurrentBlock().Header(), nil)
 
 	// If local transactions and journaling is enabled, load from disk
 	if !config.NoLocals && config.Journal != "" {
@@ -316,6 +320,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 	}
 	// Subscribe events from blockchain
 	pool.chainHeadSub = pool.chain.SubscribeChainHeadEvent(pool.chainHeadCh)
+	pool.chainPreCommitSub = pool.chain.SubscribeChainPreCommitEvent(pool.chainPreCommitCh)
 
 	// Initialize blob storage
 	if config.BlobStorageConfig != nil {
@@ -361,10 +366,29 @@ func (pool *TxPool) loop() {
 	// Keep waiting for and reacting to the various events
 	for {
 		select {
+		// Handle ChainPreCommitEvent: reset early to the upcoming head. Only
+		// direct children of the pool head qualify; anything else (reorg,
+		// sync backlog) is left to the ChainHeadEvent path below.
+		case ev := <-pool.chainPreCommitCh:
+			if ev.Block == nil || ev.State == nil || ev.Block.ParentHash() != head.Hash() {
+				continue
+			}
+			pool.mu.Lock()
+			pool.reset(head.Header(), ev.Block.Header(), ev.State)
+			// Advance head only if the reset took effect, so a failed reset
+			// is retried via the ChainHeadEvent path instead of deduped away.
+			if pool.currentBlockNumber == ev.Block.NumberU64() {
+				head = ev.Block
+			}
+			pool.mu.Unlock()
+
 		// Handle ChainHeadEvent
 		case ev := <-pool.chainHeadCh:
 			if ev.Block != nil {
 				pool.saveAndPruneBlobStorage(ev.Block)
+				if ev.Block.Hash() == head.Hash() {
+					continue // already reset via ChainPreCommitEvent
+				}
 				pool.mu.Lock()
 				currBlock := pool.chain.CurrentBlock()
 				if ev.Block.Root() != currBlock.Root() {
@@ -374,12 +398,14 @@ func (pool *TxPool) loop() {
 						"currNum", currBlock.NumberU64(), "currHash", currBlock.Hash().String())
 					continue
 				}
-				pool.reset(head.Header(), ev.Block.Header())
+				pool.reset(head.Header(), ev.Block.Header(), nil)
 				head = ev.Block
 				pool.mu.Unlock()
 			}
 		// Be unsubscribed due to system stopped
 		case <-pool.chainHeadSub.Err():
+			return
+		case <-pool.chainPreCommitSub.Err():
 			return
 
 		// Handle stats reporting ticks
@@ -437,12 +463,13 @@ func (pool *TxPool) lockedReset(oldHead, newHead *types.Header) {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
-	pool.reset(oldHead, newHead)
+	pool.reset(oldHead, newHead, nil)
 }
 
 // reset retrieves the current state of the blockchain and ensures the content
-// of the transaction pool is valid with regard to the chain state.
-func (pool *TxPool) reset(oldHead, newHead *types.Header) {
+// of the transaction pool is valid with regard to the chain state. A non-nil
+// newState is used as the head state instead of StateAt (pre-commit path).
+func (pool *TxPool) reset(oldHead, newHead *types.Header, newState *state.StateDB) {
 	pool.txMu.Lock()
 	var drops []common.Hash
 	for _, module := range pool.modules {
@@ -524,10 +551,14 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	if newHead == nil {
 		newHead = pool.chain.CurrentBlock().Header() // Special case during testing
 	}
-	stateDB, err := pool.chain.StateAt(newHead.Root)
-	if err != nil {
-		logger.Error("Failed to reset txpool state", "err", err)
-		return
+	stateDB := newState
+	if stateDB == nil {
+		var err error
+		stateDB, err = pool.chain.StateAt(newHead.Root)
+		if err != nil {
+			logger.Error("Failed to reset txpool state", "err", err)
+			return
+		}
 	}
 	pool.currentState = stateDB
 	pool.pendingNonce = make(map[common.Address]uint64)
@@ -607,6 +638,7 @@ func (pool *TxPool) Stop() {
 
 	// Unsubscribe subscriptions registered from blockchain
 	pool.chainHeadSub.Unsubscribe()
+	pool.chainPreCommitSub.Unsubscribe()
 	pool.wg.Wait()
 
 	if pool.journal != nil {
@@ -655,6 +687,14 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 
 		pool.mu.Unlock()
 	}
+}
+
+// CurrentBlockNumber returns the head block number the pool last reset to.
+func (pool *TxPool) CurrentBlockNumber() uint64 {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	return pool.currentBlockNumber
 }
 
 // Stats retrieves the current pool stats, namely the number of pending and the

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1356,8 +1356,6 @@ func (pool *TxPool) HandleTxMsg(txs types.Transactions) {
 		}
 	}
 
-	// TODO-Kaia: Consider removing the next line and move the above logic to `addTx` or `AddRemotes`
-	senderCacher.recover(pool.signer, txs)
 	pool.txMsgCh <- txs
 }
 
@@ -1531,7 +1529,10 @@ func (pool *TxPool) checkAndAddTxs(txs []*types.Transaction, local bool) []error
 
 // addTx enqueues a single transaction into the pool if it is valid.
 func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
-	senderCacher.recover(pool.signer, []*types.Transaction{tx})
+	// RPC latency path: recover sender synchronously, skipping the async queue.
+	if !pool.warmFromKnownTx(tx) {
+		cacheSender(pool.signer, tx)
+	}
 
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
@@ -1551,12 +1552,27 @@ func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
 
 // addTxs attempts to queue a batch of transactions if they are valid.
 func (pool *TxPool) addTxs(txs []*types.Transaction, local bool) []error {
-	senderCacher.recover(pool.signer, txs)
+	toRecover := make([]*types.Transaction, 0, len(txs))
+	for _, tx := range txs {
+		if !pool.warmFromKnownTx(tx) {
+			toRecover = append(toRecover, tx)
+		}
+	}
+	senderCacher.recover(pool.signer, toRecover)
 
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
 	return pool.addTxsLocked(txs, local)
+}
+
+func (pool *TxPool) warmFromKnownTx(tx *types.Transaction) bool {
+	known := pool.Get(tx.Hash())
+	if known == nil {
+		return false
+	}
+	tx.CopySenderFrom(known)
+	return true
 }
 
 // addTxsLocked attempts to queue a batch of transactions if they are valid,

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -81,10 +81,11 @@ func init() {
 }
 
 type testBlockChain struct {
-	statedb       *state.StateDB
-	gasLimit      uint64
-	chainHeadFeed *event.Feed
-	txMap         map[common.Hash]*types.Transaction
+	statedb            *state.StateDB
+	gasLimit           uint64
+	chainHeadFeed      *event.Feed
+	chainPreCommitFeed event.Feed
+	txMap              map[common.Hash]*types.Transaction
 }
 
 func (pool *TxPool) SetBaseFee(baseFee *big.Int) {
@@ -123,6 +124,10 @@ func (bc *testBlockChain) addTransaction(tx *types.Transaction) {
 
 func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscription {
 	return bc.chainHeadFeed.Subscribe(ch)
+}
+
+func (bc *testBlockChain) SubscribeChainPreCommitEvent(ch chan<- ChainPreCommitEvent) event.Subscription {
+	return bc.chainPreCommitFeed.Subscribe(ch)
 }
 
 func transaction(nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) *types.Transaction {
@@ -4598,5 +4603,52 @@ func benchmarkAddTxManySenders(b *testing.B, numSenders int) {
 	if gotP != wantP || gotQ != wantQ {
 		b.Fatalf("counter drift after bench: pending counter=%d actual=%d, queued counter=%d actual=%d",
 			gotP, wantP, gotQ, wantQ)
+	}
+}
+
+// TestChainPreCommitReset verifies the pool resets to a new head on
+// ChainPreCommitEvent alone, using the event-supplied state — before any
+// ChainHeadEvent for the block arrives and before StateAt could serve it.
+func TestChainPreCommitReset(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupTxPool()
+	defer pool.Stop()
+
+	from, _ := deriveSender(transaction(0, 100000, key))
+	if err := pool.AddRemote(transaction(0, 100000, key)); err != nil {
+		t.Fatalf("add tx: %v", err)
+	}
+	if pending, _ := pool.Stats(); pending != 1 {
+		t.Fatalf("pending = %d, want 1", pending)
+	}
+
+	// Mine the tx in a private state copy only; the chain's StateAt still
+	// returns nonce 0, so a successful demotion proves the event state is used.
+	bc := pool.chain.(*testBlockChain)
+	minedState := bc.statedb.Copy()
+	minedState.SetNonce(from, 1)
+	parent := bc.CurrentBlock()
+
+	// Events that must be skipped: a block not extending the pool head, and a
+	// child block without state. If either advanced the pool head, the valid
+	// event below would fail its parent-linkage check and never apply.
+	orphan := types.NewBlock(&types.Header{Number: big.NewInt(5), ParentHash: common.HexToHash("0xdead")}, nil, nil)
+	bc.chainPreCommitFeed.Send(ChainPreCommitEvent{Block: orphan, State: minedState})
+	stateless := types.NewBlock(&types.Header{Number: big.NewInt(3), ParentHash: parent.Hash()}, nil, nil)
+	bc.chainPreCommitFeed.Send(ChainPreCommitEvent{Block: stateless})
+
+	block := types.NewBlock(&types.Header{Number: big.NewInt(1), ParentHash: parent.Hash()}, nil, nil)
+	bc.chainPreCommitFeed.Send(ChainPreCommitEvent{Block: block, State: minedState})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for pool.CurrentBlockNumber() != 1 {
+		if time.Now().After(deadline) {
+			t.Fatalf("pool did not reset on ChainPreCommitEvent (head=%d)", pool.CurrentBlockNumber())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if pending, queued := pool.Stats(); pending != 0 || queued != 0 {
+		t.Fatalf("pool not drained after pre-commit reset: pending=%d queued=%d", pending, queued)
 	}
 }

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -1215,6 +1215,15 @@ func (t *TransactionsByPriceAndNonce) Empty() bool {
 	return len(t.heads) == 0
 }
 
+// Len returns the total number of transactions remaining in the set.
+func (t *TransactionsByPriceAndNonce) Len() int {
+	n := len(t.heads)
+	for _, txs := range t.txs {
+		n += len(txs)
+	}
+	return n
+}
+
 // Clear removes the entire content of the heap.
 func (t *TransactionsByPriceAndNonce) Clear() {
 	t.heads, t.txs = nil, nil

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -754,7 +754,7 @@ func (kCfg *KaiaConfig) SetKaiaConfig(ctx *cli.Context, stack *node.Node) {
 		cfg.RPCTxFeeCap = ctx.Float64(RPCGlobalEthTxFeeCapFlag.Name)
 	}
 
-	// Only CNs could set BlockGenerationIntervalFlag and BlockGenerationTimeLimitFlag
+	// Only CNs could set block-generation tuning flags.
 	if ctx.IsSet(BlockGenerationIntervalFlag.Name) {
 		params.BlockGenerationInterval = ctx.Int64(BlockGenerationIntervalFlag.Name)
 		if params.BlockGenerationInterval < 1 {
@@ -765,6 +765,12 @@ func (kCfg *KaiaConfig) SetKaiaConfig(ctx *cli.Context, stack *node.Node) {
 		params.BlockGenerationTimeLimit = ctx.Duration(BlockGenerationTimeLimitFlag.Name)
 	} else if cfg.ConsensusEngine == "kaiabft" {
 		params.BlockGenerationTimeLimit = params.KaiaBFTBlockGenerationTimeLimit
+	}
+	if ctx.IsSet(BlockGenerationTxLimitFlag.Name) {
+		params.BlockGenerationTxLimit = ctx.Int(BlockGenerationTxLimitFlag.Name)
+		if params.BlockGenerationTxLimit < 0 {
+			logger.Crit("Block generation tx limit should be zero or larger", "limit", params.BlockGenerationTxLimit)
+		}
 	}
 	if ctx.IsSet(OpcodeComputationCostLimitFlag.Name) {
 		params.OpcodeComputationCostLimitOverride = ctx.Uint64(OpcodeComputationCostLimitFlag.Name)

--- a/cmd/utils/flaggroup.go
+++ b/cmd/utils/flaggroup.go
@@ -55,6 +55,7 @@ var FlagGroups = []FlagGroup{
 			StartBlockNumberFlag,
 			BlockGenerationIntervalFlag,
 			BlockGenerationTimeLimitFlag,
+			BlockGenerationTxLimitFlag,
 			OpcodeComputationCostLimitFlag,
 			UseConsoleLogFlag,
 		},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2030,6 +2030,15 @@ var (
 		EnvVars:  []string{"KLAYTN_BLOCK_GENERATION_TIME_LIMIT", "KAIA_BLOCK_GENERATION_TIME_LIMIT"},
 		Category: "KAIA",
 	}
+	BlockGenerationTxLimitFlag = &cli.IntFlag{
+		Name: "block-generation-tx-limit",
+		Usage: "(experimental option) Cap the number of top-priced transactions inspected during block generation. " +
+			"Preserves price priority within the bounded set. Zero disables the cap. Only applicable to CN.",
+		Value:    params.DefaultBlockGenerationTxLimit,
+		Aliases:  []string{"experimental.block-generation-tx-limit"},
+		EnvVars:  []string{"KLAYTN_BLOCK_GENERATION_TX_LIMIT", "KAIA_BLOCK_GENERATION_TX_LIMIT"},
+		Category: "KAIA",
+	}
 	OpcodeComputationCostLimitFlag = &cli.Uint64Flag{
 		Name: "opcode-computation-cost-limit",
 		Usage: "(experimental option) Set the computation cost limit for a tx. " +

--- a/cmd/utils/nodeflags.go
+++ b/cmd/utils/nodeflags.go
@@ -352,6 +352,7 @@ var KCNFlags = []cli.Flag{
 	altsrc.NewBoolFlag(KairosFlag),
 	altsrc.NewInt64Flag(BlockGenerationIntervalFlag),
 	altsrc.NewDurationFlag(BlockGenerationTimeLimitFlag),
+	altsrc.NewIntFlag(BlockGenerationTxLimitFlag),
 	altsrc.NewBoolFlag(gasless.DisableFlag),
 	altsrc.NewStringFlag(ConsensusEngineFlag),
 }
@@ -400,6 +401,7 @@ var KSCNFlags = []cli.Flag{
 	altsrc.NewStringFlag(RewardbaseFlag),
 	altsrc.NewInt64Flag(BlockGenerationIntervalFlag),
 	altsrc.NewDurationFlag(BlockGenerationTimeLimitFlag),
+	altsrc.NewIntFlag(BlockGenerationTxLimitFlag),
 	altsrc.NewStringFlag(ServiceChainSignerFlag),
 	altsrc.NewUint64Flag(AnchoringPeriodFlag),
 	altsrc.NewUint64Flag(SentChainTxsLimit),

--- a/kaiax/gasless/impl/getter_test.go
+++ b/kaiax/gasless/impl/getter_test.go
@@ -235,7 +235,7 @@ func TestGetLendTxGenerator(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			g := NewGaslessModule()
-			bc := &testBlockChain{sdb.Copy(), 10000000, new(event.Feed)}
+			bc := &testBlockChain{statedb: sdb.Copy(), gasLimit: 10000000, chainHeadFeed: new(event.Feed)}
 			pool := blockchain.NewTxPool(testTxPoolConfig, testChainConfig, bc, &dummyGovModule{chainConfig: testChainConfig})
 			err := g.Init(&InitOpts{
 				ChainConfig:   testChainConfig,

--- a/kaiax/gasless/impl/helper_test.go
+++ b/kaiax/gasless/impl/helper_test.go
@@ -77,9 +77,10 @@ var (
 )
 
 type testBlockChain struct {
-	statedb       *state.StateDB
-	gasLimit      uint64
-	chainHeadFeed *event.Feed
+	statedb            *state.StateDB
+	gasLimit           uint64
+	chainHeadFeed      *event.Feed
+	chainPreCommitFeed event.Feed
 }
 
 func (bc *testBlockChain) CurrentBlock() *types.Block {
@@ -104,6 +105,10 @@ func (bc *testBlockChain) GetTxAndLookupInfo(txHash common.Hash) (*types.Transac
 
 func (bc *testBlockChain) SubscribeChainHeadEvent(ch chan<- blockchain.ChainHeadEvent) event.Subscription {
 	return bc.chainHeadFeed.Subscribe(ch)
+}
+
+func (bc *testBlockChain) SubscribeChainPreCommitEvent(ch chan<- blockchain.ChainPreCommitEvent) event.Subscription {
+	return bc.chainPreCommitFeed.Subscribe(ch)
 }
 
 type dummyGovModule struct {

--- a/kaiax/gasless/impl/tx_pool_test.go
+++ b/kaiax/gasless/impl/tx_pool_test.go
@@ -342,7 +342,7 @@ func TestPromoteGaslessTxsWithSingleSender(t *testing.T) {
 		if tc.balance {
 			cdb.SetBalance(crypto.PubkeyToAddress(userKey.PublicKey), new(big.Int).SetUint64(params.KAIA))
 		}
-		bc := &testBlockChain{cdb, 10000000, new(event.Feed)}
+		bc := &testBlockChain{statedb: cdb, gasLimit: 10000000, chainHeadFeed: new(event.Feed)}
 		pool := blockchain.NewTxPool(testTxPoolConfig, testChainConfig, bc, &dummyGovModule{chainConfig: testChainConfig})
 		g := NewGaslessModule()
 		err := g.Init(&InitOpts{
@@ -438,7 +438,7 @@ func TestPromoteGaslessTxsWithMultiSenders(t *testing.T) {
 	// send A1, S1, A2, S2, S3, T4, and T5 in random order and then check if pending has expected txs.
 	for range make([]int, 1000) {
 		cdb := sdb.Copy()
-		bc := &testBlockChain{cdb, 10000000, new(event.Feed)}
+		bc := &testBlockChain{statedb: cdb, gasLimit: 10000000, chainHeadFeed: new(event.Feed)}
 		pool := blockchain.NewTxPool(testTxPoolConfig, testChainConfig, bc, &dummyGovModule{chainConfig: testChainConfig})
 		g := NewGaslessModule()
 		err := g.Init(&InitOpts{

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -226,6 +226,10 @@ const (
 	DefaultBlockGenerationInterval  = int64(1) // unit: seconds
 	DefaultBlockGenerationTimeLimit = 250 * time.Millisecond
 
+	// DefaultBlockGenerationTxLimit caps how many top-priced transactions a proposer
+	// will inspect during one block-building round.
+	DefaultBlockGenerationTxLimit = 12_000
+
 	// KaiaBFTBlockGenerationTimeLimit is the default tx execution time limit
 	// for kaiabft. Speculative execution lets non-proposers overlap execution
 	// with consensus, so the proposer can use a larger execution window.
@@ -271,6 +275,9 @@ var (
 	// TODO-Kaia-Governance Change the following variables to governance items which requires consensus of CCN
 	// Block generation interval in seconds. It should be equal or larger than 1
 	BlockGenerationInterval = DefaultBlockGenerationInterval
+
+	// Tx limit for one block-building round. Zero disables the cap.
+	BlockGenerationTxLimit = DefaultBlockGenerationTxLimit
 )
 
 // istanbul BFT

--- a/work/builder/builder.go
+++ b/work/builder/builder.go
@@ -115,13 +115,13 @@ func incorporate(txs []*TxOrGen, bundle *Bundle) ([]*TxOrGen, error) {
 	return ret, nil
 }
 
-// Arrayify flattens transaction heaps into a single array
-func Arrayify(heap *types.TransactionsByPriceAndNonce) []*types.Transaction {
-	ret := make([]*types.Transaction, 0)
-	copied := heap.Copy()
-	for !copied.Empty() {
-		ret = append(ret, copied.Peek())
-		copied.Shift()
+// Arrayify drains the heap in price-sorted order into a flat slice.
+// The heap is consumed and will be empty after this call.
+func Arrayify(txs *types.TransactionsByPriceAndNonce) []*types.Transaction {
+	ret := make([]*types.Transaction, 0, txs.Len())
+	for !txs.Empty() {
+		ret = append(ret, txs.Peek())
+		txs.Shift()
 	}
 	return ret
 }

--- a/work/builder/builder.go
+++ b/work/builder/builder.go
@@ -118,8 +118,17 @@ func incorporate(txs []*TxOrGen, bundle *Bundle) ([]*TxOrGen, error) {
 // Arrayify drains the heap in price-sorted order into a flat slice.
 // The heap is consumed and will be empty after this call.
 func Arrayify(txs *types.TransactionsByPriceAndNonce) []*types.Transaction {
-	ret := make([]*types.Transaction, 0, txs.Len())
-	for !txs.Empty() {
+	return ArrayifyByCount(txs, txs.Len())
+}
+
+// ArrayifyByCount drains at most count transactions from the heap in price-sorted order.
+// When count is non-positive, the heap is fully drained.
+func ArrayifyByCount(txs *types.TransactionsByPriceAndNonce, count int) []*types.Transaction {
+	if count <= 0 || count > txs.Len() {
+		count = txs.Len()
+	}
+	ret := make([]*types.Transaction, 0, count)
+	for !txs.Empty() && len(ret) < count {
 		ret = append(ret, txs.Peek())
 		txs.Shift()
 	}

--- a/work/builder/builder_test.go
+++ b/work/builder/builder_test.go
@@ -235,6 +235,48 @@ func TestArrayify(t *testing.T) {
 	assert.True(t, heap.Empty()) // Arrayify drains the heap
 }
 
+func TestArrayifyByCount(t *testing.T) {
+	keyLen := 4
+	txLen := 6
+	limit := 5
+
+	keys := make([]*ecdsa.PrivateKey, keyLen)
+	for i := range keys {
+		keys[i], _ = crypto.GenerateKey()
+	}
+
+	signer := types.LatestSignerForChainID(common.Big1)
+	mkGroups := func() map[common.Address]types.Transactions {
+		groups := map[common.Address]types.Transactions{}
+		for start, key := range keys {
+			addr := crypto.PubkeyToAddress(key.PublicKey)
+			for i := range txLen {
+				tx, _ := types.SignTx(types.NewTransaction(uint64(start+i), common.Address{}, big.NewInt(100), 100, big.NewInt(int64(start+i)), nil), signer, key)
+				groups[addr] = append(groups[addr], tx)
+			}
+		}
+		return groups
+	}
+
+	fullOrder := Arrayify(types.NewTransactionsByPriceAndNonce(signer, mkGroups(), nil))
+	heap := types.NewTransactionsByPriceAndNonce(signer, mkGroups(), nil)
+	total := heap.Len()
+	txs := ArrayifyByCount(heap, limit)
+	hashes := func(txs []*types.Transaction) []common.Hash {
+		ret := make([]common.Hash, len(txs))
+		for i, tx := range txs {
+			ret[i] = tx.Hash()
+		}
+		return ret
+	}
+
+	assert.Len(t, txs, limit)
+	assert.Equal(t, total-limit, heap.Len())
+	assert.False(t, heap.Empty())
+	require.Equal(t, hashes(fullOrder[:limit]), hashes(txs))
+	assert.Equal(t, hashes(fullOrder[limit:]), hashes(Arrayify(heap)))
+}
+
 func TestIsConflict(t *testing.T) {
 	txs := make([]*types.Transaction, 4)
 	for i := range txs {

--- a/work/builder/builder_test.go
+++ b/work/builder/builder_test.go
@@ -232,7 +232,7 @@ func TestArrayify(t *testing.T) {
 	for i := range txs {
 		assert.Equal(t, true, hashes[txs[i].Hash()])
 	}
-	assert.False(t, heap.Empty()) // don't modify the original heap
+	assert.True(t, heap.Empty()) // Arrayify drains the heap
 }
 
 func TestIsConflict(t *testing.T) {

--- a/work/mocks/txpool_mock.go
+++ b/work/mocks/txpool_mock.go
@@ -82,6 +82,20 @@ func (mr *MockTxPoolMockRecorder) Content() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Content", reflect.TypeOf((*MockTxPool)(nil).Content))
 }
 
+// CurrentBlockNumber mocks base method.
+func (m *MockTxPool) CurrentBlockNumber() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentBlockNumber")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// CurrentBlockNumber indicates an expected call of CurrentBlockNumber.
+func (mr *MockTxPoolMockRecorder) CurrentBlockNumber() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentBlockNumber", reflect.TypeOf((*MockTxPool)(nil).CurrentBlockNumber))
+}
+
 // GasPrice mocks base method.
 func (m *MockTxPool) GasPrice() *big.Int {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -67,6 +67,9 @@ type TxPool interface {
 	// NewTxsEvent and send events to the given channel.
 	SubscribeNewTxsEvent(chan<- blockchain.NewTxsEvent) event.Subscription
 
+	// CurrentBlockNumber returns the head block number the pool last reset to.
+	CurrentBlockNumber() uint64
+
 	GetPendingNonce(addr common.Address) uint64
 	AddLocal(tx *types.Transaction) error
 	GasPrice() *big.Int

--- a/work/worker.go
+++ b/work/worker.go
@@ -59,6 +59,9 @@ const (
 	chainSideChanSize = 10
 	// maxResendSize is the size of resending transactions to peer in order to prevent the txs from missing.
 	maxResendTxSize = 1000
+	// maxPoolResetWait bounds how long commitNewWork waits for the txpool to
+	// reset to the parent block before snapshotting pending transactions.
+	maxPoolResetWait = 100 * time.Millisecond
 )
 
 var (
@@ -356,6 +359,21 @@ func (self *worker) waitForIdealBlockTime(parent *types.Block) {
 	}
 }
 
+// waitPoolReset blocks until the txpool has reset to the parent block, so the
+// pending snapshot excludes its mined txs. Normally immediate (the pool resets
+// on ChainPreCommitEvent during the block write); bounded to never stall mining.
+func (self *worker) waitPoolReset(parent *types.Block) {
+	start := time.Now()
+	for self.backend.TxPool().CurrentBlockNumber() < parent.NumberU64() {
+		if time.Since(start) > maxPoolResetWait {
+			logger.Warn("TxPool reset wait timed out, pending snapshot may be stale",
+				"parent", parent.NumberU64(), "poolHead", self.backend.TxPool().CurrentBlockNumber())
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func (self *worker) commitNewWork() {
 	self.mu.Lock()
 	defer self.mu.Unlock()
@@ -371,6 +389,8 @@ func (self *worker) commitNewWork() {
 	// istanbul's behavior of always proposing a normally-timed block.
 	self.waitForIdealBlockTime(parent)
 	tstart := time.Now()
+
+	self.waitPoolReset(parent)
 
 	var pending map[common.Address]types.Transactions
 	var err error

--- a/work/worker.go
+++ b/work/worker.go
@@ -613,15 +613,15 @@ func (env *Task) CommitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 }
 
 func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc BlockChain, nodeAddr common.Address, txBundlingModules []builder.TxBundlingModule) []*types.Log {
-	var (
-		arrayTxs                 = builder.Arrayify(txs)
-		incorporatedTxs, bundles = builder.ExtractBundlesAndIncorporate(arrayTxs, txBundlingModules)
-		totalTxs                 = len(incorporatedTxs)
-		totalBundles             = len(bundles)
-		coalescedLogs            []*types.Log
-	)
+	// Capture first tx hash and total count before heap draining.
+	totalTxs := txs.Len()
+	var firstTxHash common.Hash
+	if txs.Peek() != nil {
+		firstTxHash = txs.Peek().Hash()
+	}
 
-	// Limit the execution time of all transactions in a block
+	// Limit the execution time of all transactions in a block.
+	// Timer covers Arrayify + ExtractBundles + CommitTransactionLoop.
 	var abort int32 = 0                   // To break the below `CommitTransactionLoop` for loop when timed out
 	var isExecutingBundleTxs atomic.Int32 // To wait for abort while the bundle is running
 	chDone := make(chan bool)             // To stop the goroutine below when processing txs is completed
@@ -655,12 +655,12 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc Bl
 				if env.tcount > 0 && isExecutingBundleTxs.Load() == 0 {
 					// The total time limit reached, thus we stop the currently running EVM.
 					evm.Cancel(vm.CancelByTotalTimeLimit)
-				} else if env.tcount == 0 && len(arrayTxs) > 0 {
+				} else if env.tcount == 0 && totalTxs > 0 {
 					// Case 'Single long tx':
 					//   T0 (executing tx) ------- T_limit --> abort=1 (but let T0 finish)
 					//   Result: tcount=0 → Log "A single transaction exceeds limit" and "unexecuted transactions due to time limit"
 					//
-					logger.Warn("A single transaction exceeds total time limit", "hash", arrayTxs[0].Hash().String())
+					logger.Warn("A single transaction exceeds total time limit", "hash", firstTxHash.String())
 					tooLongTxCounter.Inc(1)
 				}
 				evm = nil
@@ -671,6 +671,12 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc Bl
 	vmConfig := &vm.Config{
 		RunningEVM: chEVM,
 	}
+
+	arrayTxs := builder.Arrayify(txs)
+	incorporatedTxs, bundles := builder.ExtractBundlesAndIncorporate(arrayTxs, txBundlingModules)
+	totalBundles := len(bundles)
+
+	var coalescedLogs []*types.Log
 
 	var numTxsChecked int64 = 0
 	var numTxsNonceTooLow int64 = 0

--- a/work/worker.go
+++ b/work/worker.go
@@ -423,8 +423,7 @@ func (self *worker) commitNewWork() {
 		header.ExcessBlobGas = &excessBlobGas
 	}
 	// Could potentially happen if starting to mine in an odd state.
-	err = self.makeCurrent(parent, header)
-	if err != nil {
+	if err := self.makeCurrent(parent, header); err != nil {
 		logger.Error("Failed to create mining context", "err", err)
 		return
 	}
@@ -672,7 +671,8 @@ func (env *Task) ApplyTransactions(txs *types.TransactionsByPriceAndNonce, bc Bl
 		RunningEVM: chEVM,
 	}
 
-	arrayTxs := builder.Arrayify(txs)
+	txLimit := params.BlockGenerationTxLimit
+	arrayTxs := builder.ArrayifyByCount(txs, txLimit)
 	incorporatedTxs, bundles := builder.ExtractBundlesAndIncorporate(arrayTxs, txBundlingModules)
 	totalBundles := len(bundles)
 
@@ -714,6 +714,9 @@ CommitTransactionLoop:
 				builder.PopTxs(&incorporatedTxs, numShift, &bundles, env.signer)
 				continue
 			}
+		}
+		if txLimit > 0 && numTxsChecked+int64(numShift) > int64(txLimit) {
+			break
 		}
 
 		tx, err := txOrGen.GetTx(env.state.GetNonce(nodeAddr))
@@ -852,7 +855,6 @@ CommitTransactionLoop:
 			)
 		}
 	}
-
 	// Update the number of transactions checked and dropped during ApplyTransactions.
 	checkedTxsGauge.Update(numTxsChecked)
 	nonceTooLowTxsGauge.Update(numTxsNonceTooLow)


### PR DESCRIPTION
## Proposed changes

Block-building and transaction-pool throughput optimizations for the kaiabft path.

- **Drain heap directly in `Arrayify`** — avoids an extra slice copy when materializing the price/nonce heap during block building.
- **Bounded tx selection during block building** — caps the number of transactions considered per block build via a new configurable limit, preventing unbounded selection cost under heavy mempool load.
- **Warm AddTx sender from pool** — on `AddTx`, adopts the sender from pool-known state and recovers synchronously for single-tx batches, cutting ecrecover work on the admission hot path.
- **Pre-commit path for txpool reset** — a new `ChainPreCommitEvent` fires after `ValidateState` succeeds, letting the txpool reset against the new head in parallel with `writeBlockWithState`. The existing `reset()` path is untouched; a separate `resetPreCommit` handles only the no-reorg fast path, and the post-commit reset becomes a cheap no-op when the pre-commit reset already covered the head.

**Pure diff (this PR's commits only):**
https://github.com/hyeonLewis/kaia/compare/kbft-opt-2-specexec-warming...kbft-opt-3-work-txpool

Commits:
- `work: drain heap directly in Arrayify to avoid copy`
- `work: bounded tx selection during block building`
- `txpool: warm AddTx sender from pool, sync recover for single-tx`
- `txpool: introduce pre-commit path for txpool reset`

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- kaiabft speculative-execution optimization series -->

## Further comments

**Stacked PR (3/3).** Depends on PR (1/3) and PR (2/3) — `Arrayify`/builder changes sit on top of the consensus and spec-exec warming work (shared `work/worker.go`, `blockchain/types/transaction.go`). Merge last, after PR (2/3).

The "Files changed" view shows the lower stack's commits until they merge; the pure-diff link above isolates the four commits this PR introduces.
