### PR TITLE
consensus/istanbul: skip block production for non-qualified validators

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -448,6 +448,12 @@ func (sb *backend) SubmitTransactions(txs *types.TransactionsByPriceAndNonce, st
 			resultCh <- nil
 			return
 		}
+		// Only qualified validators produce a block. Others skip here instead of
+		// doing the execute/finalize work and then failing authorization at Seal.
+		if !valset.NewAddressSet(validators).Contains(sb.address) {
+			resultCh <- nil
+			return
+		}
 		if err := sb.sealer.WriteValidators(header, validators); err != nil {
 			resultCh <- nil
 			return


### PR DESCRIPTION
## Proposed changes

A CN outside the qualified validator set (e.g. `ValInactive`) kept building a full
block each round in `SubmitTransactions`, then failed authorization at `Seal` —
logging `Failed to seal block` every block and wasting execute/finalize work.

Fix: skip early in `SubmitTransactions` when the node is not in the qualified set
(the same set the `Seal` authorization uses), before execute/finalize/seal.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues
