### PR TITLE
txpool: fix queue eviction order and missing-nonce fill at full pool

### DIFF
--- a/blockchain/tx_list.go
+++ b/blockchain/tx_list.go
@@ -652,8 +652,10 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 		logger.Error("Pricing query for empty pool") // This cannot happen, print to catch programming errors
 		return false
 	}
+	// Equal price is not underpriced: the only caller admits a missing-nonce tx
+	// by evicting the same account's max queued tx, so no third party is displaced.
 	cheapest := []*types.Transaction(*l.items)[0]
-	return cheapest.GasPrice().Cmp(tx.GasPrice()) >= 0
+	return cheapest.GasPrice().Cmp(tx.GasPrice()) > 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -119,6 +119,10 @@ var (
 	underpricedTxCounter = metrics.NewRegisteredCounter("txpool/underpriced", nil)
 	refusedTxCounter     = metrics.NewRegisteredCounter("txpool/refuse", nil)
 	slotsGauge           = metrics.NewRegisteredGauge("txpool/slots", nil)
+
+	// Queue eviction metrics, split by path.
+	queueCapEvictionCounter = metrics.NewRegisteredCounter("txpool/queued/capevict", nil)
+	lifetimeEvictionCounter = metrics.NewRegisteredCounter("txpool/queued/lifetimeevict", nil)
 )
 
 // TxStatus is the current status of a transaction as seen by the pool.
@@ -411,6 +415,7 @@ func (pool *TxPool) loop() {
 					if pool.queue[addr] != nil {
 						for _, tx := range pool.queue[addr].Flatten() {
 							pool.removeTx(tx.Hash(), true)
+							lifetimeEvictionCounter.Inc(1)
 						}
 					}
 					delete(pool.beats, addr)
@@ -1245,6 +1250,9 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 	from, _ := types.Sender(pool.signer, tx) // already validated
 	if pool.queue[from] == nil {
 		pool.queue[from] = newTxList(false)
+		// Refresh the beat on (re)creation so the account doesn't inherit a
+		// stale one and become the next eviction victim.
+		pool.beats[from] = time.Now()
 	}
 	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump, pool.rules.IsMagma)
 	if !inserted {
@@ -1264,8 +1272,6 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 		pool.all.Add(tx)
 		pool.priced.Put(tx)
 	}
-
-	pool.checkAndSetBeat(from)
 	return old != nil, nil
 }
 
@@ -1640,15 +1646,6 @@ func (pool *TxPool) GetBlobSidecarFromPool(txHash common.Hash) (*types.BlobTxSid
 	return sidecar, nil
 }
 
-// checkAndSetBeat sets the beat of the account if there is no beat of the account.
-func (pool *TxPool) checkAndSetBeat(addr common.Address) {
-	_, exist := pool.beats[addr]
-
-	if !exist {
-		pool.beats[addr] = time.Now()
-	}
-}
-
 // removeTx removes a single transaction from the queue, moving all subsequent
 // transactions back to the future queue.
 func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
@@ -1849,37 +1846,29 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 	queued := pool.queuedCount
 
 	if queued > pool.config.NonExecSlotsAll {
-		// Sort all accounts with queued transactions by heartbeat
+		// Sort by heartbeat with the stalest account last: the eviction loop below
+		// pops from the tail, so the least-recently-active accounts are dropped first.
 		addresses := make(addresssByHeartbeat, 0, len(pool.queue))
 		for addr := range pool.queue {
 			if !pool.locals.contains(addr) { // don't drop locals
 				addresses = append(addresses, addressByHeartbeat{addr, pool.beats[addr]})
 			}
 		}
-		sort.Sort(addresses)
+		sort.Sort(sort.Reverse(addresses))
 
-		// Drop transactions until the total is below the limit or only locals remain
+		// Drop highest-nonce txs from the stalest accounts, keeping each
+		// account's lowest queued tx so missing-nonce admission can heal it.
 		for drop := queued - pool.config.NonExecSlotsAll; drop > 0 && len(addresses) > 0; {
 			addr := addresses[len(addresses)-1]
 			list := pool.queue[addr.address]
 
 			addresses = addresses[:len(addresses)-1]
 
-			// Drop all transactions if they are less than the overflow
-			if size := uint64(list.Len()); size <= drop {
-				for _, tx := range list.Flatten() {
-					pool.removeTx(tx.Hash(), true)
-				}
-				drop -= size
-				queuedRateLimitCounter.Inc(int64(size))
-				continue
-			}
-			// Otherwise drop only last few transactions
 			txs := list.Flatten()
-			for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
+			for i := len(txs) - 1; i >= 1 && drop > 0; i-- {
 				pool.removeTx(txs[i].Hash(), true)
 				drop--
-				queuedRateLimitCounter.Inc(1)
+				queueCapEvictionCounter.Inc(1)
 			}
 		}
 	}

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1162,9 +1162,9 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 
 	// If the transaction pool is full and new Tx is valid,
 	// (1) discard a new Tx if there is no room for the account of the Tx
-	// (2) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
-	// (3) discard a new Tx if the new Tx does not have a missing nonce
-	// (4) discard underpriced transactions
+	// (2) discard a new Tx if the new Tx does not have a missing nonce
+	// (3) discard underpriced transactions
+	// (4) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
 	if uint64(pool.all.Slots()+numSlots(tx)) > pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll {
 		// (1) discard a new Tx if there is no room for the account of the Tx
 		from, _ := types.Sender(pool.signer, tx)
@@ -1175,30 +1175,35 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 		}
 
 		maxTx := pool.getMaxTxFromQueueWhenNonceIsMissing(tx, &from)
-		if maxTx != tx {
-			// (2) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
-			pool.removeTx(maxTx.Hash(), true)
-			logger.Trace("Removing an old Tx with the max nonce to insert a new Tx with missing nonce, because TxPool is full", "account", from, "new nonce(previously missing)", tx.Nonce(), "removed max nonce", maxTx.Nonce())
-		} else {
-			// (3) discard a new Tx if the new Tx does not have a missing nonce
+		if maxTx == tx {
+			// (2) discard a new Tx if the new Tx does not have a missing nonce
 			logger.Trace("Rejecting a new Tx, because TxPool is full and a new TX does not have missing nonce", "hash", tx.Hash())
 			refusedTxCounter.Inc(1)
 			return false, fmt.Errorf("txpool is full and the new tx does not have missing nonce: %d", uint64(pool.all.Count()))
 		}
 
-		// (4) discard underpriced transactions
-		// If the new transaction is underpriced, don't accept it
+		// (3) discard underpriced transactions, before the eviction in (4): a refused
+		// tx must leave the sender's queue untouched, so the eviction only runs once
+		// the tx is certain to be admitted.
 		if !local && pool.priced.Underpriced(tx, pool.locals) {
 			logger.Trace("Discarding underpriced transaction", "hash", hash, "price", tx.GasPrice())
 			underpricedTxCounter.Inc(1)
 			return false, ErrUnderpriced
 		}
-		// New transaction is better than our worse ones, make room for it
-		drop := pool.priced.Discard(pool.all.Slots()-int(pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll)+numSlots(tx), pool.locals)
-		for _, tx := range drop {
-			logger.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "price", tx.GasPrice())
-			underpricedTxCounter.Inc(1)
-			pool.removeTx(tx.Hash(), false)
+
+		// (4) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
+		pool.removeTx(maxTx.Hash(), true)
+		logger.Trace("Removing an old Tx with the max nonce to insert a new Tx with missing nonce, because TxPool is full", "account", from, "new nonce(previously missing)", tx.Nonce(), "removed max nonce", maxTx.Nonce())
+
+		// New transaction is better than our worse ones, make room for it.
+		// Guarded: a multi-slot maxTx makes the count negative, which panics in Discard's make.
+		if count := pool.all.Slots() - int(pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll) + numSlots(tx); count > 0 {
+			drop := pool.priced.Discard(count, pool.locals)
+			for _, tx := range drop {
+				logger.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "price", tx.GasPrice())
+				underpricedTxCounter.Inc(1)
+				pool.removeTx(tx.Hash(), false)
+			}
 		}
 	}
 	// If the transaction is replacing an already pending one, do directly

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -1332,6 +1332,76 @@ func TestQueueCapEvictionStalestTailDrop(t *testing.T) {
 	}
 }
 
+// Tests the missing-nonce fill at full pool: a strictly cheaper tx is refused
+// without evicting the account's max queued tx, and an equal-price tx
+// swap-admits and heals the account.
+func TestTransactionFullPoolRefuseBeforeEvict(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	blockchain := &testBlockChain{statedb: statedb, gasLimit: 10000000, chainHeadFeed: new(event.Feed), txMap: make(map[common.Hash]*types.Transaction)}
+
+	config := testTxPoolConfig
+	config.ExecSlotsAccount = 8
+	config.ExecSlotsAll = 4
+	config.NonExecSlotsAccount = 8
+	config.NonExecSlotsAll = 4
+
+	pool := NewTxPool(config, params.TestChainConfig.Copy(), blockchain, &dummyGovModule{chainConfig: params.TestChainConfig.Copy()})
+	defer pool.Stop()
+
+	keyA, _ := crypto.GenerateKey()
+	keyB, _ := crypto.GenerateKey()
+	addrB := crypto.PubkeyToAddress(keyB.PublicKey)
+	testAddBalance(pool, crypto.PubkeyToAddress(keyA.PublicKey), big.NewInt(10000000))
+	testAddBalance(pool, addrB, big.NewInt(10000000))
+
+	// Account A: 4 pending (0..3). Account B: 4 queued (1..4, missing 0). Pool full.
+	for nonce := uint64(0); nonce <= 3; nonce++ {
+		if err := pool.AddRemote(pricedTransaction(nonce, 100000, big.NewInt(2), keyA)); err != nil {
+			t.Fatalf("pending filler nonce %d: %v", nonce, err)
+		}
+	}
+	for nonce := uint64(1); nonce <= 4; nonce++ {
+		if err := pool.AddRemote(pricedTransaction(nonce, 100000, big.NewInt(2), keyB)); err != nil {
+			t.Fatalf("queued filler nonce %d: %v", nonce, err)
+		}
+	}
+	if pool.all.Count() != 8 {
+		t.Fatalf("pool not full: have %d, want 8", pool.all.Count())
+	}
+	maxHash := pricedTransaction(4, 100000, big.NewInt(2), keyB).Hash()
+
+	// Cheaper missing-nonce tx: refused as underpriced without collateral damage.
+	if err := pool.AddRemote(pricedTransaction(0, 100000, big.NewInt(1), keyB)); err != ErrUnderpriced {
+		t.Fatalf("refusal error mismatch: have %v, want %v", err, ErrUnderpriced)
+	}
+	if pool.all.Get(maxHash) == nil {
+		t.Fatalf("max queued tx destroyed by a refused missing-nonce tx")
+	}
+	if pool.queue[addrB] == nil || pool.queue[addrB].Len() != 4 {
+		t.Fatalf("account B queue mutated by a refused missing-nonce tx")
+	}
+
+	// Equal-price missing-nonce tx: swap-admits and heals the account.
+	if err := pool.AddRemote(pricedTransaction(0, 100000, big.NewInt(2), keyB)); err != nil {
+		t.Fatalf("equal-price missing-nonce tx refused: %v", err)
+	}
+	if pool.all.Get(maxHash) != nil {
+		t.Fatalf("max queued tx should have been swapped out")
+	}
+	if pool.pending[addrB] == nil || pool.pending[addrB].Len() != 4 {
+		have := 0
+		if pool.pending[addrB] != nil {
+			have = pool.pending[addrB].Len()
+		}
+		t.Fatalf("account B not healed: pending %d, want 4", have)
+	}
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}
+
 // Tests that if an account remains idle for a prolonged amount of time, any
 // non-executable transactions queued up are dropped to prevent wasting resources
 // on shuffling them around.

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -1254,14 +1254,81 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 			t.Fatalf("total transactions overflow allowance: %d > %d", queued, config.NonExecSlotsAll)
 		}
 	} else {
-		// Local exemptions are enabled, make sure the local account owned the queue
-		if len(pool.queue) != 1 {
-			t.Errorf("multiple accounts in queue: have %v, want %v", len(pool.queue), 1)
+		// Local exemptions are enabled: remote accounts are tail-dropped down to
+		// their lowest queued tx, never deleted outright.
+		localAddr := crypto.PubkeyToAddress(local.PublicKey)
+		for addr, list := range pool.queue {
+			if addr != localAddr && list.Len() != 1 {
+				t.Errorf("remote account %x not tail-dropped to its frontier: have %d, want 1", addr, list.Len())
+			}
 		}
 		// Also ensure no local transactions are ever dropped, even if above global limits
-		if queued := pool.queue[crypto.PubkeyToAddress(local.PublicKey)].Len(); uint64(queued) != 3*config.NonExecSlotsAll {
+		if queued := pool.queue[localAddr].Len(); uint64(queued) != 3*config.NonExecSlotsAll {
 			t.Fatalf("local account queued transaction count mismatch: have %v, want %v", queued, 3*config.NonExecSlotsAll)
 		}
+	}
+}
+
+// Tests that the queue-cap eviction drops the stalest-beat accounts' tails
+// first and never removes an account's lowest queued tx or its queue entry.
+func TestQueueCapEvictionStalestTailDrop(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	blockchain := &testBlockChain{statedb: statedb, gasLimit: 10000000, chainHeadFeed: new(event.Feed), txMap: make(map[common.Hash]*types.Transaction)}
+
+	config := testTxPoolConfig
+	config.NonExecSlotsAccount = 8
+	config.NonExecSlotsAll = 4
+
+	pool := NewTxPool(config, params.TestChainConfig.Copy(), blockchain, &dummyGovModule{chainConfig: params.TestChainConfig.Copy()})
+	defer pool.Stop()
+
+	keyStale, _ := crypto.GenerateKey()
+	keyFresh, _ := crypto.GenerateKey()
+	stale := crypto.PubkeyToAddress(keyStale.PublicKey)
+	fresh := crypto.PubkeyToAddress(keyFresh.PublicKey)
+	testAddBalance(pool, stale, big.NewInt(10000000))
+	testAddBalance(pool, fresh, big.NewInt(10000000))
+
+	// Grow the queue past the cap through enqueueTx directly, mirroring
+	// demote-driven growth that bypasses AddRemote's capacity checks.
+	pool.mu.Lock()
+	for nonce := uint64(1); nonce <= 4; nonce++ {
+		staleTx := transaction(nonce, 100000, keyStale)
+		freshTx := transaction(nonce, 100000, keyFresh)
+		if _, err := pool.enqueueTx(staleTx.Hash(), staleTx); err != nil {
+			pool.mu.Unlock()
+			t.Fatalf("enqueue stale acct nonce %d: %v", nonce, err)
+		}
+		if _, err := pool.enqueueTx(freshTx.Hash(), freshTx); err != nil {
+			pool.mu.Unlock()
+			t.Fatalf("enqueue fresh acct nonce %d: %v", nonce, err)
+		}
+	}
+	pool.beats[stale] = time.Now().Add(-time.Hour)
+	pool.beats[fresh] = time.Now()
+	pool.promoteExecutables(nil) // 8 queued > cap 4 triggers the eviction
+	pool.mu.Unlock()
+
+	if pool.queuedCount != 4 {
+		t.Fatalf("queued count after eviction: have %d, want 4", pool.queuedCount)
+	}
+	if pool.queue[stale] == nil || pool.queue[stale].Len() != 1 {
+		t.Fatalf("stale account not tail-dropped to its frontier")
+	}
+	if pool.queue[stale].txs.Get(1) == nil {
+		t.Fatalf("stale account lost its lowest queued tx")
+	}
+	if pool.queue[fresh] == nil || pool.queue[fresh].Len() != 3 {
+		have := 0
+		if pool.queue[fresh] != nil {
+			have = pool.queue[fresh].Len()
+		}
+		t.Fatalf("fresh account dropped before stale exhausted: have %d, want 3", have)
+	}
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Two txpool bugs that together caused the CN queue explosion under sustained load: the queue ratcheted to `NonExecSlotsAll`, pending fluctuated, and mining degraded until restart.

**1. Queue-cap eviction evicted the freshest accounts first (`txpool: evict stalest accounts first and keep queue frontier`)**

`addresssByHeartbeat` sorts oldest-beat-first, but the eviction loop pops victims from the end of the slice — evicting the account with the *newest* heartbeat first. Since beats refresh on promotion, this deleted the queues of healthy, actively-promoting accounts while preserving stuck ones (upstream geth uses `sort.Reverse` here; the comment "drop oldest ones" describes the intended behavior). Each overflow event manufactured fresh nonce gaps in healthy accounts, feeding back into more queue growth.

Fixes:
- Restore stalest-first victim ordering (`sort.Reverse`).
- Evict from the highest nonce down and always keep the account's lowest queued tx and its queue entry. Deleting the entry closed the account's missing-nonce admission path at full pool (`queue[from] == nil` refusal), making the account unhealable.
- Refresh the beat when an account's queue entry is recreated, so it doesn't inherit a stale beat and become the immediate next victim.
- Add `txpool/queued/capevict` and `txpool/queued/lifetimeevict` counters (the lifetime eviction path previously had no metric).

**2. Missing-nonce fill at full pool destroyed the tx it was meant to help (`txpool: fix missing-nonce fill at full pool`)**

At full pool, a tx filling a missing nonce evicted the account's max queued tx *before* running the underpriced check. `Underpriced` treated equal gas price as underpriced (`>=`), so under uniform pricing every fill attempt deleted one queued tx and then got refused — and when the evicted tx was the account's last queued one, the queue entry was deleted as well, permanently closing the heal path. Redelivery (resend/gossip) repeated this, grinding the account's delivered lookahead to nothing.

Fixes:
- Decide the refusal before evicting (refuse-without-collateral).
- `Underpriced`: `>=` → `>`. Equal price is no longer refused; this is safe because the function's single caller admits via a strictly intra-account swap (the sender's own max queued tx is evicted), so no third party is displaced. With this, a redelivered missing-nonce tx heals the account at full pool.
- Guard the subsequent `Discard` call: a multi-slot evicted tx made its count negative, which panics in `make` (latent crash, reachable before this PR).

**Validation**: stress test (11k tx/s, 10k unique senders, 4 CN / 8 EN, fixed gas price) — No queue increasing > 1h. Please note that the queue explosion happens with higher load, which applies to KaiaBFT, so the stress test is done based on the KaiaBFT branch.

<img width="1347" height="1593" alt="image" src="https://github.com/user-attachments/assets/c809f9ca-cfe9-4b4a-b65a-3f664e7376b3" />

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

The `Underpriced` semantic change (`>=` → `>`) is intentional and reviewed: the function has exactly one production caller (the full-pool missing-nonce fill), where the eviction is confined to the sender's own queue. Equal-price churn is self-limiting — each swap consumes one of the sender's own queued txs and closes one of their own nonce holes, and new holes cannot be created at full pool since non-missing-nonce txs are refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)