### PR TITLE
cmd/kcn: pre-flight dry-run for valops with refined SlotsFull error

### DIFF
--- a/cmd/kcn/abv2.go
+++ b/cmd/kcn/abv2.go
@@ -22,6 +22,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 
 	kaia "github.com/kaiachain/kaia"
@@ -34,6 +35,7 @@ import (
 	"github.com/kaiachain/kaia/common/hexutil"
 	addressbookv2 "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
 	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
 	"github.com/urfave/cli/v2"
@@ -44,10 +46,22 @@ const (
 	defaultEndpoint    = "/var/kcnd/data/klay.ipc"
 )
 
-type (
-	abv2RunFn func(*addressbookv2.AddressBookV2Transactor, *bind.TransactOpts, *ecdsa.PrivateKey) (*types.Transaction, error)
-	abv2TxFn  func(*addressbookv2.AddressBookV2Transactor, *bind.TransactOpts, common.Address) (*types.Transaction, error)
+// AddressBookV2 method names, shared by the command wiring and the pre-flight
+// dry-run (which packs calldata by name).
+const (
+	methodSuspendValidator   = "suspendValidator"
+	methodUnsuspendValidator = "unsuspendValidator"
+	methodReadyCandidate     = "readyCandidate"
+	methodUnreadyCandidate   = "unreadyCandidate"
+	methodReadyValidator     = "readyValidator"
+	methodUnreadyValidator   = "unreadyValidator"
+	methodPause              = "pause"
+	methodResume             = "resume"
+	methodExit               = "exit"
+	methodOffboard           = "offboard"
 )
+
+type abv2TxFn func(*addressbookv2.AddressBookV2Transactor, *bind.TransactOpts, common.Address) (*types.Transaction, error)
 
 var (
 	abv2EndpointFlag = &cli.StringFlag{
@@ -75,61 +89,61 @@ var ValOpsCommand = &cli.Command{
 			Name:   "suspend-validator",
 			Usage:  "Suspend a validator (requires suspender role)",
 			Flags:  abv2SuspenderFlags(),
-			Action: abv2SuspenderAction((*addressbookv2.AddressBookV2Transactor).SuspendValidator),
+			Action: abv2SuspenderAction(methodSuspendValidator, (*addressbookv2.AddressBookV2Transactor).SuspendValidator),
 		},
 		{
 			Name:   "unsuspend-validator",
 			Usage:  "Unsuspend a validator (requires suspender role)",
 			Flags:  abv2SuspenderFlags(),
-			Action: abv2SuspenderAction((*addressbookv2.AddressBookV2Transactor).UnsuspendValidator),
+			Action: abv2SuspenderAction(methodUnsuspendValidator, (*addressbookv2.AddressBookV2Transactor).UnsuspendValidator),
 		},
 		{
 			Name:   "ready-candidate",
 			Usage:  "Transition node to CandReady state",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).ReadyCandidate),
+			Action: abv2NodeOperatorAction(methodReadyCandidate, (*addressbookv2.AddressBookV2Transactor).ReadyCandidate),
 		},
 		{
 			Name:   "unready-candidate",
 			Usage:  "Transition node out of CandReady state",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).UnreadyCandidate),
+			Action: abv2NodeOperatorAction(methodUnreadyCandidate, (*addressbookv2.AddressBookV2Transactor).UnreadyCandidate),
 		},
 		{
 			Name:   "ready-validator",
 			Usage:  "Transition node to ValReady state",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).ReadyValidator),
+			Action: abv2NodeOperatorAction(methodReadyValidator, (*addressbookv2.AddressBookV2Transactor).ReadyValidator),
 		},
 		{
 			Name:   "unready-validator",
 			Usage:  "Transition node out of ValReady state",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).UnreadyValidator),
+			Action: abv2NodeOperatorAction(methodUnreadyValidator, (*addressbookv2.AddressBookV2Transactor).UnreadyValidator),
 		},
 		{
 			Name:   "pause",
 			Usage:  "Pause the node",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).Pause),
+			Action: abv2NodeOperatorAction(methodPause, (*addressbookv2.AddressBookV2Transactor).Pause),
 		},
 		{
 			Name:   "resume",
 			Usage:  "Resume the node",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).Resume),
+			Action: abv2NodeOperatorAction(methodResume, (*addressbookv2.AddressBookV2Transactor).Resume),
 		},
 		{
 			Name:   "exit",
 			Usage:  "Exit the node from the validator set",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).Exit),
+			Action: abv2NodeOperatorAction(methodExit, (*addressbookv2.AddressBookV2Transactor).Exit),
 		},
 		{
 			Name:   "offboard",
 			Usage:  "Offboard the node",
 			Flags:  abv2Flags(),
-			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).Offboard),
+			Action: abv2NodeOperatorAction(methodOffboard, (*addressbookv2.AddressBookV2Transactor).Offboard),
 		},
 	},
 }
@@ -149,7 +163,7 @@ func loadKey(ctx *cli.Context) (*ecdsa.PrivateKey, error) {
 	return crypto.LoadECDSA(defaultNodeKeyPath)
 }
 
-func abv2Run(ctx *cli.Context, fn abv2RunFn) error {
+func abv2Run(ctx *cli.Context, method string, nodeIdFn func(*bind.TransactOpts) common.Address, fn abv2TxFn) error {
 	key, err := loadKey(ctx)
 	if err != nil {
 		return fmt.Errorf("load key: %w (use --private-key to specify explicitly)", err)
@@ -162,29 +176,117 @@ func abv2Run(ctx *cli.Context, fn abv2RunFn) error {
 
 	opts := bind.NewKeyedTransactor(key)
 	opts.GasLimit = params.UpperGasLimit
-	tx, err := fn(transactor, opts, key)
+	nodeId := nodeIdFn(opts)
+
+	// Pre-flight: fail fast on an inevitable revert (e.g. SlotsFull) without gas.
+	if reason := abv2DryRun(ec, method, opts.From, nodeId, opts.GasLimit); reason != "" {
+		return fmt.Errorf("pre-flight check reverted: %s (no transaction sent)", reason)
+	}
+
+	tx, err := fn(transactor, opts, nodeId)
 	if err != nil {
 		return err
 	}
 	return printAndWait(ec, tx, opts.From)
 }
 
+// abv2DryRun returns the simulated transition's revert reason, or "" if it would
+// succeed or can't be decoded (fail-open).
+func abv2DryRun(ec *client.KaiaClient, method string, from, nodeId common.Address, gas uint64) string {
+	abv2ABI, err := addressbookv2.AddressBookV2MetaData.GetAbi()
+	if err != nil {
+		return ""
+	}
+	data, err := abv2ABI.Pack(method, nodeId)
+	if err != nil {
+		return ""
+	}
+	to := system.AddressBookAddr
+	msg := kaia.CallMsg{From: from, To: &to, Gas: gas, Data: data}
+	if _, err := ec.CallContract(context.Background(), msg, nil); err != nil {
+		reason := revertReasonFromErr(err)
+		if reason == "SlotsFull" {
+			reason += abv2SlotInfo(ec, method, nodeId)
+		}
+		return reason
+	}
+	return ""
+}
+
+// abv2SlotInfo explains a SlotsFull revert in plain terms by re-checking, against
+// current chain state, the same guards the contract enforces and naming the ones
+// that are violated. Mirrors NodeActions.{readyCandidate,pause,exit}; returns ""
+// on any error or if no guard reproduces (fail-open).
+func abv2SlotInfo(ec *client.KaiaClient, method string, nodeId common.Address) string {
+	c, err := addressbookv2.NewAddressBookV2Caller(system.AddressBookAddr, ec)
+	if err != nil {
+		return ""
+	}
+	count := func(s valset.NodeState) (*big.Int, error) {
+		return c.GetStateCount(nil, s.ToUint8())
+	}
+	var reasons []string
+	switch method {
+	case methodReadyCandidate:
+		cand, e1 := count(valset.CandReady)
+		maxNode, maxCand, e2 := c.GetMaxCounts(nil)
+		nodes, e3 := c.GetAllNodesLength(nil)
+		if e1 != nil || e2 != nil || e3 != nil {
+			return ""
+		}
+		if cand.Cmp(maxCand) >= 0 {
+			reasons = append(reasons, fmt.Sprintf("candidate-ready slots full (CandReady %s/%s)", cand, maxCand))
+		}
+		if nodes.Cmp(maxNode) >= 0 {
+			reasons = append(reasons, fmt.Sprintf("max node count reached (%s/%s)", nodes, maxNode))
+		}
+	case methodPause:
+		paused, e1 := count(valset.ValPaused)
+		active, e2 := count(valset.ValActive)
+		limits, e3 := c.GetSlotLimits(nil)
+		if e1 != nil || e2 != nil || e3 != nil {
+			return ""
+		}
+		if paused.Cmp(limits.MaxSlotAvailable) >= 0 {
+			reasons = append(reasons, fmt.Sprintf("no pause slots available (ValPaused %s/%s)", paused, limits.MaxSlotAvailable))
+		}
+		if active.Cmp(limits.MinActiveCount) <= 0 {
+			reasons = append(reasons, fmt.Sprintf("too few active validators to pause one (ValActive %s, min %s)", active, limits.MinActiveCount))
+		}
+	case methodExit:
+		exiting, e1 := count(valset.ValExiting)
+		active, e2 := count(valset.ValActive)
+		limits, e3 := c.GetSlotLimits(nil)
+		state, e4 := c.GetNodeState(nil, nodeId)
+		if e1 != nil || e2 != nil || e3 != nil || e4 != nil {
+			return ""
+		}
+		if exiting.Cmp(limits.MaxSlotAvailable) >= 0 {
+			reasons = append(reasons, fmt.Sprintf("no exit slots available (ValExiting %s/%s)", exiting, limits.MaxSlotAvailable))
+		}
+		// The active-floor guard only applies when exiting from ValActive.
+		if state == valset.ValActive.ToUint8() && active.Cmp(limits.MinActiveCount) <= 0 {
+			reasons = append(reasons, fmt.Sprintf("too few active validators to exit one (ValActive %s, min %s)", active, limits.MinActiveCount))
+		}
+	}
+	if len(reasons) == 0 {
+		return ""
+	}
+	return ": " + strings.Join(reasons, "; ")
+}
+
 // abv2SuspenderAction wraps a suspender-role command; reads node-id from --node-id flag.
-func abv2SuspenderAction(fn abv2TxFn) cli.ActionFunc {
+func abv2SuspenderAction(method string, fn abv2TxFn) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		nodeId := common.HexToAddress(ctx.String("node-id"))
-		return abv2Run(ctx, func(t *addressbookv2.AddressBookV2Transactor, opts *bind.TransactOpts, _ *ecdsa.PrivateKey) (*types.Transaction, error) {
-			return fn(t, opts, nodeId)
-		})
+		return abv2Run(ctx, method, func(*bind.TransactOpts) common.Address { return nodeId }, fn)
 	}
 }
 
 // abv2NodeOperatorAction wraps a node-operator command; node-id is derived from the key.
-func abv2NodeOperatorAction(fn abv2TxFn) cli.ActionFunc {
+func abv2NodeOperatorAction(method string, fn abv2TxFn) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
-		return abv2Run(ctx, func(t *addressbookv2.AddressBookV2Transactor, opts *bind.TransactOpts, key *ecdsa.PrivateKey) (*types.Transaction, error) {
-			return fn(t, opts, crypto.PubkeyToAddress(key.PublicKey))
-		})
+		return abv2Run(ctx, method, func(opts *bind.TransactOpts) common.Address { return opts.From }, fn)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

- **Pre-flight dry-run**: `kcn valops` transitions now simulate the call via `eth_call` before submitting. If it would revert, the decoded reason is shown and no transaction is sent. `printAndWait` still decodes after submission as the authoritative fallback.
- **Refined `SlotsFull` error**: reports the actual violated guard(s) instead of a bare error name, re-checked against current state via `getStateCount` / `getMaxCounts` / `getSlotLimits`.

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

N/A

## Further comments

Example output (transition caught before submission, no tx sent):

```
$ kcn valops pause ...
pre-flight check reverted: SlotsFull: too few active validators to pause one (ValActive 3, min 3) (no transaction sent)

$ kcn valops exit ...
pre-flight check reverted: SlotsFull: no exit slots available (ValExiting 0/0); too few active validators to exit one (ValActive 3, min 3) (no transaction sent)
```
