### PR TITLE
kaiabft/opt: block execution path optimization

### DIFF
--- a/blockchain/state/statedb.go
+++ b/blockchain/state/statedb.go
@@ -1266,31 +1266,35 @@ func (s *StateDB) GetContractStorageRoot(contractAddr common.Address) (common.Ex
 // Potential EIPs:
 // - Reset transient storage(1153)
 func (s *StateDB) Prepare(rules params.Rules, sender, feepayer, coinbase common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
+	// The initial population below bypasses the journal: the list is rebuilt
+	// wholesale here on every transaction and is never read between a cross-
+	// Prepare revert and the next Prepare, so the entries need no undo.
 	if rules.IsKore {
 		// Clear out any leftover from previous executions
-		s.accessList = newAccessList()
+		al := newAccessList()
+		s.accessList = al
 
-		s.AddAddressToAccessList(sender)
+		al.AddAddress(sender)
 		if !common.EmptyAddress(feepayer) {
-			s.AddAddressToAccessList(feepayer)
+			al.AddAddress(feepayer)
 		}
 		if dst != nil {
-			s.AddAddressToAccessList(*dst)
+			al.AddAddress(*dst)
 			// If it's a create-tx, the destination will be added inside evm.create
 		}
 		for _, addr := range precompiles {
-			s.AddAddressToAccessList(addr)
+			al.AddAddress(addr)
 		}
 	}
 	if rules.IsShanghai {
-		s.AddAddressToAccessList(coinbase)
+		s.accessList.AddAddress(coinbase)
 	}
 	if rules.IsCancun {
 		// Optional accessList is the accessList mentioned through tx args.
 		for _, el := range list {
-			s.AddAddressToAccessList(el.Address)
+			s.accessList.AddAddress(el.Address)
 			for _, key := range el.StorageKeys {
-				s.AddSlotToAccessList(el.Address, key)
+				s.accessList.AddSlot(el.Address, key)
 			}
 		}
 	}

--- a/blockchain/state_processor.go
+++ b/blockchain/state_processor.go
@@ -25,6 +25,7 @@ package blockchain
 import (
 	"context"
 	"errors"
+	"math/big"
 	"time"
 
 	"github.com/kaiachain/kaia/blockchain/state"
@@ -100,8 +101,9 @@ func (p *StateProcessor) Process(ctx context.Context, block *types.Block, stated
 	}
 	processStats.AfterApplyTxs = time.Now()
 
-	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
-	if _, err := p.FinalizeState(header, statedb, block.Transactions(), receipts); err != nil {
+	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards).
+	// Block assembly is skipped: insertion/speculative paths never use the assembled block.
+	if err := p.finalizeStateRoot(header, statedb, block.Transactions(), receipts); err != nil {
 		return nil, nil, 0, nil, processStats, err
 	}
 	processStats.AfterFinalize = time.Now()
@@ -130,27 +132,64 @@ func (p *StateProcessor) RegisterBlockStateModule(modules ...kaiax.BlockStateMod
 
 // FinalizeState runs post-transaction state modifications and assembles final block.
 func (p *StateProcessor) FinalizeState(header *types.Header, statedb *state.StateDB, txs []*types.Transaction, receipts types.Receipts) (*types.Block, error) {
+	if err := p.finalizeStateModules(header, statedb, txs, receipts); err != nil {
+		return nil, err
+	}
+
+	// Derive roots/bloom concurrently with state-root hashing; txs/receipts are
+	// immutable here. number is passed in so the goroutine never reads header,
+	// whose Root field IntermediateRoot writes concurrently.
+	var (
+		txRoot, receiptRoot common.Hash
+		bloom               types.Bloom
+		derived             = make(chan struct{})
+	)
+	go func(number *big.Int) {
+		defer close(derived)
+		if len(txs) > 0 {
+			txRoot = types.DeriveTransactionsRoot(txs, number)
+		}
+		if len(receipts) > 0 {
+			receiptRoot = types.DeriveReceiptsRoot(receipts, number)
+			bloom = types.CreateBloom(receipts)
+		}
+	}(header.Number)
+
+	header.Root = statedb.IntermediateRoot(true)
+	<-derived
+
+	// Assemble and return the final block for sealing
+	return types.NewBlockWithRoots(header, txs, receipts, txRoot, receiptRoot, bloom), nil
+}
+
+// finalizeStateRoot is FinalizeState without block assembly, for callers that
+// only need the post-block state and header root (Process).
+func (p *StateProcessor) finalizeStateRoot(header *types.Header, statedb *state.StateDB, txs []*types.Transaction, receipts types.Receipts) error {
+	if err := p.finalizeStateModules(header, statedb, txs, receipts); err != nil {
+		return err
+	}
+	header.Root = statedb.IntermediateRoot(true)
+	return nil
+}
+
+func (p *StateProcessor) finalizeStateModules(header *types.Header, statedb *state.StateDB, txs []*types.Transaction, receipts types.Receipts) error {
 	// We can assure that if the magma hard forked block should have the field of base fee
 	if p.config.IsMagmaForkEnabled(header.Number) {
 		if header.BaseFee == nil {
 			logger.Error("Magma hard forked block should have baseFee", "blockNum", header.Number.Uint64())
-			return nil, errors.New("Invalid Magma block without baseFee")
+			return errors.New("Invalid Magma block without baseFee")
 		}
 	} else if header.BaseFee != nil {
 		logger.Error("A block before Magma hardfork shouldn't have baseFee", "blockNum", header.Number.Uint64())
-		return nil, ErrInvalidBaseFee
+		return ErrInvalidBaseFee
 	}
 
 	for _, module := range p.blockStateModules {
 		if err := module.FinalizeState(header, statedb, txs, receipts); err != nil {
-			return nil, err
+			return err
 		}
 	}
-
-	header.Root = statedb.IntermediateRoot(true)
-
-	// Assemble and return the final block for sealing
-	return types.NewBlock(header, txs, receipts), nil
+	return nil
 }
 
 // ProcessParentBlockHash stores the parent block hash in the history storage contract

--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -244,6 +244,30 @@ func NewBlock(header *Header, txs []*Transaction, receipts []*Receipt) *Block {
 	return b
 }
 
+// NewBlockWithRoots is NewBlock with txRoot/receiptRoot/bloom precomputed by
+// the caller (e.g. concurrently with state-root hashing). The given values are
+// only used for the non-empty cases, mirroring NewBlock exactly.
+func NewBlockWithRoots(header *Header, txs []*Transaction, receipts []*Receipt, txRoot, receiptRoot common.Hash, bloom Bloom) *Block {
+	b := &Block{header: CopyHeader(header), td: new(big.Int)}
+
+	if len(txs) == 0 {
+		b.header.TxHash = GetEmptyRootHash(header.Number)
+	} else {
+		b.header.TxHash = txRoot
+		b.transactions = make(Transactions, len(txs))
+		copy(b.transactions, txs)
+	}
+
+	if len(receipts) == 0 {
+		b.header.ReceiptHash = GetEmptyRootHash(header.Number)
+	} else {
+		b.header.ReceiptHash = receiptRoot
+		b.header.Bloom = bloom
+	}
+
+	return b
+}
+
 // NewBlockWithHeader creates a block with the given header data. The
 // header data is copied, changes to header and to the field values
 // will not affect the block.

--- a/blockchain/types/block_test.go
+++ b/blockchain/types/block_test.go
@@ -35,6 +35,69 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestNewBlockWithRootsMatchesNewBlock guards the consensus-critical invariant
+// that NewBlockWithRoots (fed precomputed roots) produces a header byte-identical
+// to NewBlock for every empty/non-empty combination of txs and receipts.
+func TestNewBlockWithRootsMatchesNewBlock(t *testing.T) {
+	// Stub the derivesha hooks (normally wired by the derivesha subpackage);
+	// both constructors use the same pointers, so equivalence still holds.
+	oldDerive, oldEmpty := DeriveShaImpl, GetEmptyRootHash
+	DeriveShaImpl = func(list DerivableList, num *big.Int) common.Hash {
+		return common.Hash{0x01, byte(list.Len())}
+	}
+	GetEmptyRootHash = func(num *big.Int) common.Hash { return common.Hash{0x02} }
+	defer func() { DeriveShaImpl, GetEmptyRootHash = oldDerive, oldEmpty }()
+
+	num := big.NewInt(7)
+	mkTxs := func(n int) Transactions {
+		txs := make(Transactions, n)
+		for i := 0; i < n; i++ {
+			txs[i], _ = NewTransactionWithMap(TxTypeValueTransfer, map[TxValueKeyType]interface{}{
+				TxValueKeyNonce:    uint64(i),
+				TxValueKeyTo:       common.Address{byte(i + 1)},
+				TxValueKeyAmount:   big.NewInt(1),
+				TxValueKeyGasLimit: uint64(21000),
+				TxValueKeyGasPrice: big.NewInt(1),
+				TxValueKeyFrom:     common.Address{0xaa},
+			})
+		}
+		return txs
+	}
+	mkReceipts := func(n int) Receipts {
+		rs := make(Receipts, n)
+		for i := 0; i < n; i++ {
+			rs[i] = NewReceipt(ReceiptStatusSuccessful, common.Hash{byte(i)}, 21000)
+		}
+		return rs
+	}
+
+	for _, tc := range []struct{ nTx, nRcpt int }{{0, 0}, {3, 0}, {0, 3}, {3, 3}} {
+		txs, receipts := mkTxs(tc.nTx), mkReceipts(tc.nRcpt)
+		h := &Header{Number: num}
+		want := NewBlock(h, txs, receipts)
+
+		var txRoot, receiptRoot common.Hash
+		var bloom Bloom
+		if tc.nTx > 0 {
+			txRoot = DeriveTransactionsRoot(txs, num)
+		}
+		if tc.nRcpt > 0 {
+			receiptRoot = DeriveReceiptsRoot(receipts, num)
+			bloom = CreateBloom(receipts)
+		}
+		got := NewBlockWithRoots(&Header{Number: num}, txs, receipts, txRoot, receiptRoot, bloom)
+
+		if got.Hash() != want.Hash() {
+			t.Fatalf("nTx=%d nRcpt=%d: block hash mismatch", tc.nTx, tc.nRcpt)
+		}
+		if got.Header().TxHash != want.Header().TxHash ||
+			got.Header().ReceiptHash != want.Header().ReceiptHash ||
+			got.Header().Bloom != want.Header().Bloom {
+			t.Fatalf("nTx=%d nRcpt=%d: header root/bloom mismatch", tc.nTx, tc.nRcpt)
+		}
+	}
+}
+
 type testBlockEncodingTC struct {
 	encoded    string   // RLP encoded block; debug.getBlockRlp(num)
 	header     *Header  // expected header fields

--- a/blockchain/vm/precompiles.go
+++ b/blockchain/vm/precompiles.go
@@ -180,8 +180,17 @@ var (
 	PrecompiledAddressOsaka       []common.Address
 	PrecompiledAddressPrague      []common.Address
 	PrecompiledAddressCancun      []common.Address
+	PrecompiledAddressKore        []common.Address
 	PrecompiledAddressIstanbul    []common.Address
 	PrecompiledAddressesByzantium []common.Address
+
+	// Per-fork address lists with the vmversion0 compatibility addresses
+	// appended, prebuilt so ActivePrecompiles avoids a per-call map walk.
+	activeAddressesOsaka    []common.Address
+	activeAddressesPrague   []common.Address
+	activeAddressesCancun   []common.Address
+	activeAddressesKore     []common.Address
+	activeAddressesIstanbul []common.Address
 )
 
 func init() {
@@ -190,6 +199,9 @@ func init() {
 	}
 	for k := range PrecompiledContractsIstanbul {
 		PrecompiledAddressIstanbul = append(PrecompiledAddressIstanbul, k)
+	}
+	for k := range PrecompiledContractsKore {
+		PrecompiledAddressKore = append(PrecompiledAddressKore, k)
 	}
 	for k := range PrecompiledContractsCancun {
 		PrecompiledAddressCancun = append(PrecompiledAddressCancun, k)
@@ -200,24 +212,37 @@ func init() {
 	for k := range PrecompiledContractsOsaka {
 		PrecompiledAddressOsaka = append(PrecompiledAddressOsaka, k)
 	}
+
+	vmVersion0Compat := []common.Address{common.BytesToAddress([]byte{10}), common.BytesToAddress([]byte{11})}
+	withCompat := func(addrs []common.Address) []common.Address {
+		return append(append(make([]common.Address, 0, len(addrs)+2), addrs...), vmVersion0Compat...)
+	}
+	activeAddressesOsaka = withCompat(PrecompiledAddressOsaka)
+	activeAddressesPrague = withCompat(PrecompiledAddressPrague)
+	activeAddressesCancun = withCompat(PrecompiledAddressCancun)
+	activeAddressesKore = withCompat(PrecompiledAddressKore)
+	activeAddressesIstanbul = withCompat(PrecompiledAddressIstanbul)
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 // This is a variable so that it can be overridden in tests (e.g. EEST) to exclude
 // the vmversion0 compatibility addresses from the access list.
 var ActivePrecompiles = func(rules params.Rules) []common.Address {
-	var precompiledContractAddrs []common.Address
-	for addr := range ActivePrecompiledContracts(rules) {
-		precompiledContractAddrs = append(precompiledContractAddrs, addr)
-	}
-	// After istanbulCompatible hf, need to support for vmversion0 contracts, too.
-	// VmVersion0 contracts are deployed before istanbulCompatible and they use byzantiumCompatible precompiled contracts.
-	// VmVersion0 contracts are the contracts deployed before istanbulCompatible hf.
-	if rules.IsIstanbul {
-		return append(precompiledContractAddrs,
-			[]common.Address{common.BytesToAddress([]byte{10}), common.BytesToAddress([]byte{11})}...)
-	} else {
-		return precompiledContractAddrs
+	// Prebuilt per-fork slices; the >=istanbul ones carry the vmversion0
+	// compatibility addresses appended at init. Callers must not mutate.
+	switch {
+	case rules.IsOsaka:
+		return activeAddressesOsaka
+	case rules.IsPrague:
+		return activeAddressesPrague
+	case rules.IsCancun:
+		return activeAddressesCancun
+	case rules.IsKore:
+		return activeAddressesKore
+	case rules.IsIstanbul:
+		return activeAddressesIstanbul
+	default:
+		return PrecompiledAddressesByzantium
 	}
 }
 

--- a/blockchain/vm/precompiles_active_test.go
+++ b/blockchain/vm/precompiles_active_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"bytes"
+	"sort"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/params"
+)
+
+// legacyActivePrecompiles mirrors the pre-prebuilt implementation: collect the
+// active contract map's keys, then append the vmversion0 compat addresses for
+// istanbul+ rules. Guards the prebuilt slices against fork-behavior drift.
+func legacyActivePrecompiles(rules params.Rules) []common.Address {
+	contracts := ActivePrecompiledContracts(rules)
+	addrs := make([]common.Address, 0, len(contracts))
+	for addr := range contracts {
+		addrs = append(addrs, addr)
+	}
+	if rules.IsIstanbul {
+		return append(addrs,
+			[]common.Address{common.BytesToAddress([]byte{10}), common.BytesToAddress([]byte{11})}...)
+	}
+	return addrs
+}
+
+func sortedAddrs(addrs []common.Address) []common.Address {
+	out := append([]common.Address{}, addrs...)
+	sort.Slice(out, func(i, j int) bool { return bytes.Compare(out[i][:], out[j][:]) < 0 })
+	return out
+}
+
+func TestActivePrecompilesMatchesLegacy(t *testing.T) {
+	forks := []struct {
+		name  string
+		rules params.Rules
+	}{
+		{"byzantium", params.Rules{}},
+		{"istanbul", params.Rules{IsIstanbul: true}},
+		{"kore", params.Rules{IsIstanbul: true, IsKore: true}},
+		{"shanghai", params.Rules{IsIstanbul: true, IsKore: true, IsShanghai: true}},
+		{"cancun", params.Rules{IsIstanbul: true, IsKore: true, IsShanghai: true, IsCancun: true}},
+		{"prague", params.Rules{IsIstanbul: true, IsKore: true, IsShanghai: true, IsCancun: true, IsPrague: true}},
+		{"osaka", params.Rules{IsIstanbul: true, IsKore: true, IsShanghai: true, IsCancun: true, IsPrague: true, IsOsaka: true}},
+	}
+	for _, f := range forks {
+		got := sortedAddrs(ActivePrecompiles(f.rules))
+		want := sortedAddrs(legacyActivePrecompiles(f.rules))
+		if len(got) != len(want) {
+			t.Fatalf("%s: address count mismatch: got %d, want %d", f.name, len(got), len(want))
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("%s: address[%d] mismatch: got %v, want %v", f.name, i, got[i], want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #935 (review the top 3 commits).

Execution-path optimizations, validated at 11k RPS on a 4-CN cluster (1.000s interval, 0 round changes / spec-validation fallbacks):

- **Process: skip discarded block assembly** — `Process()` no longer builds the `types.Block` it discards; tx/receipt roots + bloom are derived concurrently with state-root hashing in `FinalizeState`. Validator insert `finalize` ~65→19ms, proposer `finalizeTime` ~60-93→30-47ms.
- **Prebuilt precompile address lists + unjournaled `Prepare` population** — drops per-tx map iteration and ~23 journal allocs/tx; the access-list initial population is rebuilt wholesale per tx and never read across a revert, so journaling is unneeded (matches upstream geth).

State-root / gas / block-bytes equivalence verified per commit; fork-stage precompile equivalence covered by an added test. No consensus-observable change.