### PR TITLE
kaiax/reward: fix reward overwrite under address collision

### DIFF
--- a/kaiax/reward/impl/getter.go
+++ b/kaiax/reward/impl/getter.go
@@ -418,6 +418,14 @@ func calcRemainder(total *big.Int, parts ...*big.Int) *big.Int {
 	return remaining
 }
 
+// addAlloc accumulates amount into alloc[addr], initializing the entry if absent.
+func addAlloc(alloc map[common.Address]*big.Int, addr common.Address, amount *big.Int) {
+	if alloc[addr] == nil {
+		alloc[addr] = new(big.Int)
+	}
+	alloc[addr].Add(alloc[addr], amount)
+}
+
 // assignStakingRewardsFlex assigns staking rewards to stakers according to their staking amounts.
 // Returns the allocation and the remainder.
 func assignStakingRewardsFlex(config *reward.RewardConfig, budget *big.Int, si *staking.StakingInfo) (map[common.Address]*big.Int, *big.Int) {
@@ -473,10 +481,10 @@ func assignStakingRewardsFlex(config *reward.RewardConfig, budget *big.Int, si *
 		// If Prague and CL is configured for this CN, split the reward between CN and CL.
 		if isPrague && cn.CLStakingInfo != nil {
 			cnAmount, clAmount := cn.Split(reward)
-			alloc[cn.RewardAddr] = cnAmount
-			alloc[cn.CLStakingInfo.CLPoolAddr] = clAmount
+			addAlloc(alloc, cn.RewardAddr, cnAmount)
+			addAlloc(alloc, cn.CLStakingInfo.CLPoolAddr, clAmount)
 		} else {
-			alloc[cn.RewardAddr] = reward
+			addAlloc(alloc, cn.RewardAddr, reward)
 		}
 		remaining.Sub(remaining, reward)
 	}
@@ -521,10 +529,10 @@ func assignStakingRewards(config *reward.RewardConfig, stakersReward *big.Int, s
 				if isPrague && cn.CLStakingInfo != nil {
 					// The remaining amount will be added to the cnAmount.
 					cnAmount, clAmount := cn.Split(reward)
-					alloc[cn.RewardAddr] = cnAmount
-					alloc[cn.CLStakingInfo.CLPoolAddr] = clAmount
+					addAlloc(alloc, cn.RewardAddr, cnAmount)
+					addAlloc(alloc, cn.CLStakingInfo.CLPoolAddr, clAmount)
 				} else {
-					alloc[cn.RewardAddr] = reward
+					addAlloc(alloc, cn.RewardAddr, reward)
 				}
 				remaining.Sub(remaining, reward)
 			}

--- a/kaiax/reward/impl/getter_test.go
+++ b/kaiax/reward/impl/getter_test.go
@@ -1258,6 +1258,42 @@ func TestAssignStakingRewards(t *testing.T) {
 	}
 }
 
+// TestAssignStakingRewards_AddressCollision verifies that rewards are accumulated,
+// not overwritten, when a CN's RewardAddr equals its CLPoolAddr. Direct assignment
+// would drop the CN reward; accumulation must yield cnAmount + clAmount = full reward.
+func TestAssignStakingRewards_AddressCollision(t *testing.T) {
+	var (
+		min          = uint64(5_000_000)
+		config       = &reward.RewardConfig{MinimumStake: big.NewInt(int64(min))}
+		stakerReward = big.NewInt(1e18)
+		collision    = common.HexToAddress("0xc01")
+	)
+	config.Rules.IsPrague = true
+
+	// Single eligible CN whose CL pool address equals its own reward address.
+	si := &staking.StakingInfo{
+		NodeIds:          []common.Address{common.HexToAddress("0xa01")},
+		StakingContracts: []common.Address{common.HexToAddress("0xb01")},
+		RewardAddrs:      []common.Address{collision},
+		StakingAmounts:   []uint64{5_000_001},
+		KIFAddr:          common.HexToAddress("0xd01"),
+		KEFAddr:          common.HexToAddress("0xd02"),
+		CLStakingInfos: staking.CLStakingInfos{
+			&staking.CLStakingInfo{
+				CLNodeId:        common.HexToAddress("0xa01"),
+				CLPoolAddr:      collision,
+				CLStakingAmount: 999_999,
+			},
+		},
+	}
+
+	alloc, remainder := assignStakingRewards(config, stakerReward, si)
+
+	// The full reward lands on the single colliding address; nothing is overwritten.
+	assert.Equal(t, map[common.Address]*big.Int{collision: big.NewInt(1e18)}, alloc)
+	assert.Equal(t, "0", remainder.String())
+}
+
 func TestSpecWithProposerAndFunds(t *testing.T) {
 	var (
 		zeroAddr   = common.Address{}
@@ -1633,6 +1669,7 @@ func TestGetDeferredRewardFull_BlobFee(t *testing.T) {
 	assert.Equal(t, new(big.Int).Add(execFee, blobFee), spec.BurntFee, "flex deferred BurntFee")
 	sanityCheckRewardSpec(t, spec, "flex deferred with blob")
 }
+
 func newRewardDistributionTestContext(t *testing.T, config *params.ChainConfig, mintingByBlock map[uint64]uint64) (*state.StateDB, common.Address, *RewardModule) {
 	config = config.Copy()
 	config.SetDefaults()


### PR DESCRIPTION
## Proposed changes

This PR fixes reward overwrite when CnStaking and CLStaking have a reward address collision.

Although this is an HF change, this will be applied retrospectively since the collision has been explicitly prevented, so there has been no overwrite.
 
## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
