### PR TITLE
p2p/downloader: include kaia68 peers in idle-peer selection

### DIFF
--- a/datasync/downloader/peer.go
+++ b/datasync/downloader/peer.go
@@ -537,7 +537,7 @@ func (ps *peerSet) HeaderIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.headerThroughput
 	}
-	return ps.idlePeers(62, 67, idleCheck, throughput)
+	return ps.idlePeers(62, 68, idleCheck, throughput)
 }
 
 // BodyIdlePeers retrieves a flat list of all the currently body-idle peers within
@@ -551,7 +551,7 @@ func (ps *peerSet) BodyIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.blockThroughput
 	}
-	return ps.idlePeers(62, 67, idleCheck, throughput)
+	return ps.idlePeers(62, 68, idleCheck, throughput)
 }
 
 // ReceiptIdlePeers retrieves a flat list of all the currently receipt-idle peers
@@ -565,7 +565,7 @@ func (ps *peerSet) ReceiptIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.receiptThroughput
 	}
-	return ps.idlePeers(63, 67, idleCheck, throughput)
+	return ps.idlePeers(63, 68, idleCheck, throughput)
 }
 
 func (ps *peerSet) StakingInfoIdlePeers() ([]*peerConnection, int) {
@@ -577,7 +577,7 @@ func (ps *peerSet) StakingInfoIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.stakingInfoThroughput
 	}
-	return ps.idlePeers(65, 67, idleCheck, throughput)
+	return ps.idlePeers(65, 68, idleCheck, throughput)
 }
 
 // NodeDataIdlePeers retrieves a flat list of all the currently node-data-idle
@@ -591,7 +591,7 @@ func (ps *peerSet) NodeDataIdlePeers() ([]*peerConnection, int) {
 		defer p.lock.RUnlock()
 		return p.stateThroughput
 	}
-	return ps.idlePeers(63, 67, idleCheck, throughput)
+	return ps.idlePeers(63, 68, idleCheck, throughput)
 }
 
 // TODO-Kaia-Downloader when idlePeers is called magic numbers are used for minProtocol and maxProtocol. Use a constant instead.


### PR DESCRIPTION
## Proposed changes

`kaia68` is the highest negotiated protocol version, but the downloader's idle-peer filters cap `maxProtocol` at `67`, so every v68 peer is excluded from content fetch (`numTotalPeers=0` → `no peers available or all tried for download`).

Fix: bump `maxProtocol` `67`→`68` in the five `idlePeers(...)` callers in `datasync/downloader/peer.go`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments
