### PR TITLE
consensus: break Start/NewChainHead deadlock on coreMu

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -69,7 +69,6 @@ func New(opts *BackendOpts) consensus.Engine {
 		logger:           logger.NewWith(),
 		commitCh:         make(chan *types.Result, 1),
 		candidates:       make(map[common.Address]bool),
-		coreStarted:      false,
 		recentMessages:   recentMessages,
 		knownMessages:    knownMessages,
 		sealer:           istanbul.NewSealerImpl(opts.PrivateKey),
@@ -98,7 +97,7 @@ type backend struct {
 	proposedBlockHash common.Hash
 	sealMu            sync.Mutex
 	sealSkippedNum    uint64 // block number that was committed before Seal started (0 = none)
-	coreStarted       bool
+	coreStarted       atomic.Bool
 	coreMu            sync.RWMutex
 
 	// Current list of candidates we are pushing

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -154,7 +154,7 @@ func (sb *backend) RegisterKaiaxModules(mGov gov.GovModule, mValset valset.Valse
 func (sb *backend) Start(chain consensus.ChainReader, executor consensus.Executor) error {
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
-	if sb.coreStarted {
+	if sb.coreStarted.Load() {
 		return istanbul.ErrStartedEngine
 	}
 
@@ -183,7 +183,7 @@ func (sb *backend) Start(chain consensus.ChainReader, executor consensus.Executo
 		return err
 	}
 
-	sb.coreStarted = true
+	sb.coreStarted.Store(true)
 	return nil
 }
 
@@ -193,7 +193,7 @@ func (sb *backend) Stop() error {
 	defer sb.coreMu.Unlock()
 	// Unblock any peers waiting in ValidatePeerType during shutdown.
 	sb.SignalPeerRegistrable()
-	if !sb.coreStarted {
+	if !sb.coreStarted.Load() {
 		return istanbul.ErrStoppedEngine
 	}
 	// Close commitCh to stop any pending Seal() calls
@@ -207,7 +207,7 @@ func (sb *backend) Stop() error {
 	if err := sb.core.Stop(); err != nil {
 		return err
 	}
-	sb.coreStarted = false
+	sb.coreStarted.Store(false)
 	return nil
 }
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -54,7 +54,7 @@ func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 	defer sb.coreMu.Unlock()
 
 	if msg.Code == consensus.ConsensusMsgCode {
-		if !sb.coreStarted {
+		if !sb.coreStarted.Load() {
 			return true, istanbul.ErrStoppedEngine
 		}
 
@@ -138,9 +138,9 @@ func (sb *backend) SetBroadcaster(broadcaster consensus.Broadcaster) {
 }
 
 func (sb *backend) NewChainHead() error {
-	sb.coreMu.RLock()
-	defer sb.coreMu.RUnlock()
-	if !sb.coreStarted {
+	// Do not take coreMu here. NewChainHead runs on the worker loop, and a
+	// coreMu holder can block waiting on that loop, so locking risks a deadlock.
+	if !sb.coreStarted.Load() {
 		return istanbul.ErrStoppedEngine
 	}
 


### PR DESCRIPTION
## Proposed changes

`backend.Start` holds `coreMu` (write) while `core.Start → startNewRound` synchronously posts `NewSequenceEvent` to the worker loop and waits for it to be consumed. That same loop, handling a `ChainHeadEvent`, calls `NewChainHead` which took `coreMu.RLock`. On the sync→mine transition the two deadlock: `Start` holds the write lock waiting for the worker, while the worker is blocked acquiring the read lock and never returns to its `select` to consume the event. The node freezes; afterwards `HandleMsg` and even `Stop` block on `coreMu`, so it can only be SIGKILLed.

Fix: `NewChainHead` only needed `coreMu` to read the `coreStarted` flag before an already-async event post. Make `coreStarted` an `atomic.Bool` and read it locklessly in `NewChainHead`, so the worker loop never blocks on `coreMu`. `Start`/`Stop`/`HandleMsg` keep their existing `coreMu` usage; no consensus event ordering/timing change.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

Pre-existing, not permissionless-specific; introduced on `dev` via #868. Triggers only on mining nodes (CN) at the sync→mine transition. Rejected alternatives: posting `NewSequenceEvent` asynchronously (changes consensus event ordering); dropping `coreMu` across `core.Start` in `backend.Start` (widens the Start/Stop lifecycle race).
