### PR TITLE
kaiax/gov: apply DeprecatedAt policy to contract governance ingestion

### DIFF
--- a/kaiax/gov/contractgov/impl/getter.go
+++ b/kaiax/gov/contractgov/impl/getter.go
@@ -81,6 +81,17 @@ func (c *contractGovModule) contractGetAllParamsAtFromAddr(blockNum uint64, addr
 	}
 
 	ret := ParseContractCall(names, values)
+
+	rules := config.Rules(new(big.Int).SetUint64(blockNum))
+	if rules.IsPermissionless {
+		for name := range ret {
+			if gov.DeprecatedAt(name, rules) {
+				logger.Warn("Ignoring deprecated parameter from contract governance", "name", name, "blockNum", blockNum)
+				delete(ret, name)
+			}
+		}
+	}
+
 	return ret, nil
 }
 

--- a/kaiax/gov/contractgov/impl/getter.go
+++ b/kaiax/gov/contractgov/impl/getter.go
@@ -83,12 +83,10 @@ func (c *contractGovModule) contractGetAllParamsAtFromAddr(blockNum uint64, addr
 	ret := ParseContractCall(names, values)
 
 	rules := config.Rules(new(big.Int).SetUint64(blockNum))
-	if rules.IsPermissionless {
-		for name := range ret {
-			if gov.DeprecatedAt(name, rules) {
-				logger.Warn("Ignoring deprecated parameter from contract governance", "name", name, "blockNum", blockNum)
-				delete(ret, name)
-			}
+	for name := range ret {
+		if gov.DeprecatedAt(name, rules) {
+			logger.Warn("Ignoring deprecated parameter from contract governance", "name", name, "blockNum", blockNum)
+			delete(ret, name)
 		}
 	}
 

--- a/kaiax/gov/contractgov/impl/getter_test.go
+++ b/kaiax/gov/contractgov/impl/getter_test.go
@@ -95,8 +95,7 @@ func TestGetParamSet(t *testing.T) {
 	assert.Equal(t, uint64(125), cgm.GetParamSet(2000).UnitPrice)
 }
 
-// reward.deferredtxfee (gov.AlwaysDeprecated): contract-gov enforcement is gated by the
-// Permissionless fork — applied before the fork, dropped after.
+// reward.deferredtxfee (gov.AlwaysDeprecated): always dropped from contract governance.
 func TestGetParamSetIgnoresDeprecatedParam(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlError)
 	accounts, sim, addr, gp := createSimulateBackend(t)
@@ -105,8 +104,9 @@ func TestGetParamSetIgnoresDeprecatedParam(t *testing.T) {
 
 	setParam(t, sim, gp, accounts[0], string(gov.RewardDeferredTxFee), []byte{0x01}, 200)
 
-	assert.True(t, cgm.GetParamSet(1500).DeferredTxFee)                                                    // before fork: applied
-	assert.Equal(t, gov.GetDefaultGovernanceParamSet().DeferredTxFee, cgm.GetParamSet(2500).DeferredTxFee) // after fork: ignored
+	deferredTxFee := gov.GetDefaultGovernanceParamSet().DeferredTxFee
+	assert.Equal(t, deferredTxFee, cgm.GetParamSet(1500).DeferredTxFee) // ignored
+	assert.Equal(t, deferredTxFee, cgm.GetParamSet(2500).DeferredTxFee) // ignored
 }
 
 // istanbul.committeesize is in gov.PermissionlessDeprecated: allowed before the Permissionless fork, ignored after.

--- a/kaiax/gov/contractgov/impl/getter_test.go
+++ b/kaiax/gov/contractgov/impl/getter_test.go
@@ -57,11 +57,15 @@ func createSimulateBackend(t *testing.T) ([]*bind.TransactOpts, *backends.Simula
 }
 
 func prepareContractGovModule(t *testing.T, bc *blockchain.BlockChain, addr common.Address) *contractGovModule {
+	return prepareContractGovModuleWithConfig(t, bc, addr, &params.ChainConfig{KoreCompatibleBlock: big.NewInt(100)})
+}
+
+func prepareContractGovModuleWithConfig(t *testing.T, bc *blockchain.BlockChain, addr common.Address, config *params.ChainConfig) *contractGovModule {
 	mockHGM := headergov_mock.NewMockHeaderGovModule(gomock.NewController(t))
 	cgm := NewContractGovModule()
 	err := cgm.Init(&InitOpts{
 		Chain:       bc,
-		ChainConfig: &params.ChainConfig{KoreCompatibleBlock: big.NewInt(100)},
+		ChainConfig: config,
 		Hgm:         mockHGM,
 	})
 	require.Nil(t, err)
@@ -69,41 +73,52 @@ func prepareContractGovModule(t *testing.T, bc *blockchain.BlockChain, addr comm
 	return cgm
 }
 
+func setParam(t *testing.T, sim *backends.SimulatedBackend, gp *govcontract.GovParam, owner *bind.TransactOpts, name string, val []byte, activation int64) {
+	tx, err := gp.SetParam(owner, name, true, val, big.NewInt(activation))
+	require.Nil(t, err)
+	sim.Commit()
+	receipt, _ := sim.TransactionReceipt(nil, tx.Hash())
+	require.NotNil(t, receipt)
+	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+}
+
 func TestGetParamSet(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlError)
-	paramName := string(gov.GovernanceUnitPrice)
+	name := string(gov.GovernanceUnitPrice)
 	accounts, sim, addr, gp := createSimulateBackend(t)
 	cgm := prepareContractGovModule(t, sim.BlockChain(), addr)
 
-	{
-		activation := big.NewInt(1000)
-		val := []byte{0, 0, 0, 0, 0, 0, 0, 25}
-		tx, err := gp.SetParam(accounts[0], paramName, true, val, activation)
-		require.Nil(t, err)
-		sim.Commit()
+	setParam(t, sim, gp, accounts[0], name, []byte{0, 0, 0, 0, 0, 0, 0, 25}, 1000)
+	assert.Equal(t, uint64(25), cgm.GetParamSet(1000).UnitPrice)
 
-		receipt, _ := sim.TransactionReceipt(nil, tx.Hash())
-		require.NotNil(t, receipt)
-		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	setParam(t, sim, gp, accounts[0], name, []byte{0, 0, 0, 0, 0, 0, 0, 125}, 2000)
+	assert.Equal(t, uint64(125), cgm.GetParamSet(2000).UnitPrice)
+}
 
-		ps := cgm.GetParamSet(activation.Uint64())
-		assert.NotNil(t, ps)
-		assert.Equal(t, uint64(25), ps.UnitPrice)
-	}
+// reward.deferredtxfee (gov.AlwaysDeprecated): contract-gov enforcement is gated by the
+// Permissionless fork — applied before the fork, dropped after.
+func TestGetParamSetIgnoresDeprecatedParam(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
+	accounts, sim, addr, gp := createSimulateBackend(t)
+	cgm := prepareContractGovModuleWithConfig(t, sim.BlockChain(), addr,
+		&params.ChainConfig{KoreCompatibleBlock: big.NewInt(100), PermissionlessCompatibleBlock: big.NewInt(2000)})
 
-	{
-		activation := big.NewInt(2000)
-		val := []byte{0, 0, 0, 0, 0, 0, 0, 125}
-		tx, err := gp.SetParam(accounts[0], paramName, true, val, activation)
-		require.Nil(t, err)
-		sim.Commit()
+	setParam(t, sim, gp, accounts[0], string(gov.RewardDeferredTxFee), []byte{0x01}, 200)
 
-		receipt, _ := sim.TransactionReceipt(nil, tx.Hash())
-		require.NotNil(t, receipt)
-		require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	assert.True(t, cgm.GetParamSet(1500).DeferredTxFee)                                                    // before fork: applied
+	assert.Equal(t, gov.GetDefaultGovernanceParamSet().DeferredTxFee, cgm.GetParamSet(2500).DeferredTxFee) // after fork: ignored
+}
 
-		ps := cgm.GetParamSet(activation.Uint64())
-		assert.NotNil(t, ps)
-		assert.Equal(t, uint64(125), ps.UnitPrice)
-	}
+// istanbul.committeesize is in gov.PermissionlessDeprecated: allowed before the Permissionless fork, ignored after.
+func TestGetParamSetIgnoresPermissionlessDeprecatedParam(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlError)
+	accounts, sim, addr, gp := createSimulateBackend(t)
+	cgm := prepareContractGovModuleWithConfig(t, sim.BlockChain(), addr,
+		&params.ChainConfig{KoreCompatibleBlock: big.NewInt(100), PermissionlessCompatibleBlock: big.NewInt(2000)})
+
+	committeeSize := uint64(50)
+	setParam(t, sim, gp, accounts[0], string(gov.IstanbulCommitteeSize), new(big.Int).SetUint64(committeeSize).Bytes(), 200)
+
+	assert.Equal(t, committeeSize, cgm.GetParamSet(1500).CommitteeSize)                                    // before fork: applied
+	assert.Equal(t, gov.GetDefaultGovernanceParamSet().CommitteeSize, cgm.GetParamSet(2500).CommitteeSize) // after fork: ignored
 }


### PR DESCRIPTION
## Proposed changes

Contract governance applied `GovParam` params without `gov.DeprecatedAt`, so it could
override immutable params like `reward.deferredtxfee` — desyncing reward finalization
(param set) from tx execution (genesis), corrupting fee accounting. Now contract-gov
drops deprecated params via `gov.DeprecatedAt` — always-deprecated params at any block,
permissionless-deprecated ones after the fork.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues


## Further comments

Deprecated/to-be-deprecated params must never be set via `GovParam` (operational
invariant); contract-gov drops them defensively if present.
