### PR TITLE
kaiax/gov: Remove unreachable nil vote check

### DIFF
--- a/kaiax/gov/headergov/impl/error.go
+++ b/kaiax/gov/headergov/impl/error.go
@@ -14,7 +14,6 @@ var (
 	ErrDeprecatedVote       = errors.New("vote parameter is deprecated at the current rules")
 
 	ErrGovInNonEpochBlock = errors.New("governance is not allowed in non-epoch block")
-	ErrNilVote            = errors.New("vote is nil")
 	ErrGovVerification    = errors.New("header.Governance does not match the vote in previous epoch")
 
 	ErrGovParamNotAccount       = errors.New("govparamcontract is not an account")

--- a/kaiax/gov/headergov/impl/header.go
+++ b/kaiax/gov/headergov/impl/header.go
@@ -54,9 +54,6 @@ func (h *headerGovModule) VerifyVote(header *types.Header) error {
 	if len(header.Vote) == 0 {
 		return nil
 	}
-	if header.Vote == nil {
-		return ErrNilVote
-	}
 
 	var (
 		vb       headergov.VoteBytes = header.Vote


### PR DESCRIPTION
## Proposed changes

- Removed the unreachable header.Vote == nil check from VerifyVote.
- Removed the now-unused ErrNilVote error constant.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
