### PR TITLE
reward: fix unsafe gas conversions in reward calculation

### DIFF
--- a/kaiax/reward/errors.go
+++ b/kaiax/reward/errors.go
@@ -19,6 +19,7 @@ package reward
 import (
 	"errors"
 	"fmt"
+	"math/big"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 	ErrInvalidBlockRange     = errors.New("invalid block number range")
 	ErrBlockRangeLimit       = errors.New("exceeds block number range limit")
 	ErrInvalidRewardbase     = errors.New("rewardbase mismatches with expected address")
+	ErrNegativeRewardAmount  = errors.New("negative reward amount")
 )
 
 func errMalformedRewardRatio(ratio string) error {
@@ -37,4 +39,8 @@ func errMalformedRewardRatio(ratio string) error {
 
 func errMalformedRewardKip82Ratio(ratio string) error {
 	return fmt.Errorf("malformed reward.kip82ratio: %s", ratio)
+}
+
+func errNegativeRewardAmount(addr fmt.Stringer, amount *big.Int) error {
+	return fmt.Errorf("%w: addr %s amount %s", ErrNegativeRewardAmount, addr.String(), amount.String())
 }

--- a/kaiax/reward/impl/blockstate.go
+++ b/kaiax/reward/impl/blockstate.go
@@ -47,6 +47,9 @@ func (r *RewardModule) FinalizeState(header *types.Header, state *state.StateDB,
 	if err != nil {
 		return err
 	}
+	if err := spec.Validate(); err != nil {
+		return err
+	}
 	for addr, amount := range spec.Rewards {
 		state.AddBalance(addr, amount)
 	}

--- a/kaiax/reward/impl/getter.go
+++ b/kaiax/reward/impl/getter.go
@@ -206,18 +206,18 @@ func getExecFee(config *reward.RewardConfig, header *types.Header, txs []*types.
 		if len(txs) != len(receipts) {
 			return nil, reward.ErrTxReceiptsLenMismatch
 		}
-		execFee := new(big.Int).Mul(big.NewInt(int64(header.GasUsed)), header.BaseFee)
+		execFee := new(big.Int).Mul(new(big.Int).SetUint64(header.GasUsed), header.BaseFee)
 		for i, tx := range txs {
-			tip := new(big.Int).Mul(big.NewInt(int64(receipts[i].GasUsed)), tx.EffectiveGasTip(header.BaseFee))
+			tip := new(big.Int).Mul(new(big.Int).SetUint64(receipts[i].GasUsed), tx.EffectiveGasTip(header.BaseFee))
 			execFee = execFee.Add(execFee, tip)
 		}
 		return execFee, nil
 	} else if config.Rules.IsMagma {
 		// Optimized to block.gasUsed * block.baseFeePerGas
-		return new(big.Int).Mul(big.NewInt(int64(header.GasUsed)), header.BaseFee), nil
+		return new(big.Int).Mul(new(big.Int).SetUint64(header.GasUsed), header.BaseFee), nil
 	} else {
 		// Optimized to block.gasUsed * governance.unitprice
-		return new(big.Int).Mul(big.NewInt(int64(header.GasUsed)), config.UnitPrice), nil
+		return new(big.Int).Mul(new(big.Int).SetUint64(header.GasUsed), config.UnitPrice), nil
 	}
 }
 

--- a/kaiax/reward/impl/getter_test.go
+++ b/kaiax/reward/impl/getter_test.go
@@ -428,6 +428,8 @@ func TestGetDeferredReward(t *testing.T) {
 }
 
 func TestGetExecFee(t *testing.T) {
+	largeGas := uint64(1 << 63)
+
 	testcases := []struct {
 		desc     string
 		config   *reward.RewardConfig
@@ -489,6 +491,34 @@ func TestGetExecFee(t *testing.T) {
 				{GasUsed: 400_000},
 			},
 			big.NewInt(0.0376e18), // sum{ (effectiveGasTip[i] + baseFee) * gasUsed[i] }
+		},
+		{
+			"pre-magma large gas",
+			&reward.RewardConfig{UnitPrice: big.NewInt(2)},
+			&types.Header{BaseFee: nil, GasUsed: largeGas},
+			nil,
+			nil,
+			new(big.Int).Mul(new(big.Int).SetUint64(largeGas), big.NewInt(2)),
+		},
+		{
+			"magma large gas",
+			&reward.RewardConfig{Rules: params.Rules{IsMagma: true}, UnitPrice: big.NewInt(25e9)},
+			&types.Header{BaseFee: big.NewInt(2), GasUsed: largeGas},
+			nil,
+			nil,
+			new(big.Int).Mul(new(big.Int).SetUint64(largeGas), big.NewInt(2)),
+		},
+		{
+			"kaia large gas",
+			&reward.RewardConfig{Rules: params.Rules{IsMagma: true, IsKaia: true}, UnitPrice: big.NewInt(25e9)},
+			&types.Header{BaseFee: big.NewInt(2), GasUsed: largeGas},
+			[]*types.Transaction{
+				makeTestTx_type2(3, 1, 1), // effectiveTip = 1
+			},
+			[]*types.Receipt{
+				{GasUsed: largeGas},
+			},
+			new(big.Int).Mul(new(big.Int).SetUint64(largeGas), big.NewInt(3)),
 		},
 	}
 	for _, tc := range testcases {

--- a/kaiax/reward/spec.go
+++ b/kaiax/reward/spec.go
@@ -115,6 +115,15 @@ func (spec *RewardSpec) IncRecipient(addr common.Address, amount *big.Int) {
 	spec.Rewards[addr].Add(spec.Rewards[addr], amount)
 }
 
+func (spec *RewardSpec) Validate() error {
+	for addr, amount := range spec.Rewards {
+		if amount.Sign() < 0 {
+			return errNegativeRewardAmount(addr, amount)
+		}
+	}
+	return nil
+}
+
 // RewardResponse is the response type for the kaia_getReward API.
 // TODO-kaiax: RewardResponse to use hexutil.Big for big.Int fields.
 type RewardResponse = RewardSpec


### PR DESCRIPTION
## Proposed changes

This PR hardens reward finalization against malformed upstream inputs.
* It converts header and receipt gas values to big.Int with SetUint64 instead of int64 casts.
* It validates reward amounts before AddBalance so negative rewards are rejected.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
