### PR TITLE
headergov: dedupe concurrent slow-path vote scans with singleflight

### DIFF
--- a/kaiax/gov/headergov/impl/header.go
+++ b/kaiax/gov/headergov/impl/header.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"reflect"
 	"slices"
+	"strconv"
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/blockchain/types/account"
@@ -258,6 +259,11 @@ func (h *headerGovModule) getVotesInEpoch(epochIdx uint64) map[uint64]headergov.
 		return votes
 	} else {
 		logger.Debug("Scanning votes slowpath")
-		return h.scanAllVotesInEpoch(epochIdx)
+		// Deduplicate concurrent slow-path scans of the same epoch.
+		// The returned map is read-only for all callers, so sharing one instance is safe.
+		votes, _, _ := h.scanGroup.Do(strconv.FormatUint(epochIdx, 10), func() (interface{}, error) {
+			return h.scanAllVotesInEpoch(epochIdx), nil
+		})
+		return votes.(map[uint64]headergov.VoteData)
 	}
 }

--- a/kaiax/gov/headergov/impl/header_test.go
+++ b/kaiax/gov/headergov/impl/header_test.go
@@ -2,13 +2,19 @@ package impl
 
 import (
 	"math/big"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	gomock "github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -153,6 +159,69 @@ func TestGetVotesInEpoch(t *testing.T) {
 
 	assert.Equal(t, map[uint64]headergov.VoteData{50: v1}, h.getVotesInEpoch(0))
 	assert.Equal(t, map[uint64]headergov.VoteData{150: v2}, h.getVotesInEpoch(1))
+}
+
+// TestGetVotesInEpochSingleflight verifies that concurrent slow-path scans of
+// the same unscanned epoch are deduplicated: many simultaneous requests trigger
+// only a single header scan instead of one scan each.
+func TestGetVotesInEpochSingleflight(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlCrit)
+
+	const (
+		epoch        = uint64(10)
+		queriedEpoch = uint64(0)
+		concurrency  = 20
+	)
+
+	var (
+		scanCalls int32 // number of times a scan actually started
+		release   = make(chan struct{})
+		entered   = make(chan struct{}, 1)
+	)
+
+	chain := mocks.NewMockBlockChain(gomock.NewController(t))
+	chain.EXPECT().CurrentBlock().
+		Return(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1000)})).AnyTimes()
+	// Block the leader scan on the first block of the epoch so that the other
+	// concurrent callers pile up inside singleflight before the scan returns.
+	chain.EXPECT().GetHeaderByNumber(gomock.Any()).
+		DoAndReturn(func(num uint64) *types.Header {
+			if num == 0 {
+				if atomic.AddInt32(&scanCalls, 1) == 1 {
+					entered <- struct{}{}
+				}
+				<-release
+			}
+			return &types.Header{Number: new(big.Int).SetUint64(num)}
+		}).AnyTimes()
+
+	db := database.NewMemDB()
+	WriteLowestVoteScannedEpochIdx(db, 5) // border > queriedEpoch => slow path
+
+	h := &headerGovModule{
+		ChainKv:      db,
+		Chain:        chain,
+		epoch:        epoch,
+		mu:           &sync.RWMutex{},
+		groupedVotes: make(headergov.GroupedVotesMap),
+	}
+
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h.getVotesInEpoch(queriedEpoch)
+		}()
+	}
+
+	<-entered                          // a scan has started and is blocked
+	time.Sleep(100 * time.Millisecond) // let the other callers block in singleflight
+	close(release)                     // unblock the scan
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&scanCalls),
+		"concurrent slow-path scans of the same epoch should be deduplicated to one")
 }
 
 func TestGetExpectedGovernance(t *testing.T) {

--- a/kaiax/gov/headergov/impl/init.go
+++ b/kaiax/gov/headergov/impl/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
+	"golang.org/x/sync/singleflight"
 )
 
 var (
@@ -54,6 +55,11 @@ type headerGovModule struct {
 	governances  headergov.GovDataMap
 	history      headergov.History
 	mu           *sync.RWMutex
+
+	// scanGroup deduplicates concurrent slow-path epoch scans so that
+	// multiple simultaneous requests for the same unscanned epoch trigger
+	// only a single header scan.
+	scanGroup singleflight.Group
 
 	epoch uint64
 


### PR DESCRIPTION
## Proposed changes

- This PR wraps the slow-path vote scan in singleflight (keyed by epoch index) so simultaneous requests for the same epoch share one scan. Fast path and consensus-internal callers are unchanged; the slow path is unreachable once migration completes, so there's no steady-state overhead.
- Add test that fires 20 concurrent requests at one unscanned epoch and asserts only a single scan runs.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
