### PR TITLE
docs: fix kaia-system-contracts submodule link

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -51,7 +51,7 @@ Generated Go wrappers for all system contracts. Regenerated via `go generate`.
 
 ### `kaia-system-contracts/`
 
-Git submodule pointing to [kaia-system-contract](https://github.com/kaiachain/kaia-system-contract).
+Git submodule pointing to [kaia-system-contracts](https://github.com/kaiachain/kaia-system-contracts).
 Contains compiled artifacts used by `go generate`.
 
 ### `libs/`


### PR DESCRIPTION
## Proposed changes

Fix the `kaia-system-contracts` submodule link in `contracts/README.md`; it pointed to the singular repo name, now corrected to the actual repository.

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues


## Further comments

