### PR TITLE
kaiax/gov: fix pending governance API block number

### DIFF
--- a/kaiax/gov/impl/api.go
+++ b/kaiax/gov/impl/api.go
@@ -79,13 +79,18 @@ func patchDeprecatedParams(gp gov.ParamSet, rule params.Rules) gov.ParamSet {
 	return gp
 }
 
-func getChainConfig(g *GovModule, num *rpc.BlockNumber) *params.ChainConfig {
-	var blocknum uint64
-	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blocknum = g.Chain.CurrentBlock().NumberU64()
+func apiBlockNumber(g *GovModule, num *rpc.BlockNumber) uint64 {
+	if num == nil || *num == rpc.LatestBlockNumber {
+		return g.Chain.CurrentBlock().NumberU64()
+	} else if *num == rpc.PendingBlockNumber {
+		return g.Chain.CurrentBlock().NumberU64() + 1
 	} else {
-		blocknum = num.Uint64()
+		return num.Uint64()
 	}
+}
+
+func getChainConfig(g *GovModule, num *rpc.BlockNumber) *params.ChainConfig {
+	blocknum := apiBlockNumber(g, num)
 
 	ret := g.Chain.Config().Copy()
 	pset := g.GetParamSet(blocknum)
@@ -126,12 +131,7 @@ func getChainConfig(g *GovModule, num *rpc.BlockNumber) *params.ChainConfig {
 }
 
 func getParams(g *GovModule, num *rpc.BlockNumber) (gov.PartialParamSet, error) {
-	blockNumber := uint64(0)
-	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = g.Chain.CurrentBlock().NumberU64()
-	} else {
-		blockNumber = uint64(num.Int64())
-	}
+	blockNumber := apiBlockNumber(g, num)
 
 	rule := g.Chain.Config().Rules(new(big.Int).SetUint64(blockNumber))
 	gp := g.GetParamSet(blockNumber)

--- a/kaiax/gov/impl/api_test.go
+++ b/kaiax/gov/impl/api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/blockchain/forkid"
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	contractgov_mock "github.com/kaiachain/kaia/kaiax/gov/contractgov/mock"
@@ -64,6 +65,52 @@ func generateRandomValue(name gov.ParamName) any {
 		panic(fmt.Errorf("unknown type %s: %T", name, param.DefaultValue))
 	}
 	return randomValue
+}
+
+func TestAPI_apiBlockNumber(t *testing.T) {
+	head := uint64(10)
+	latest, pending, explicit := rpc.LatestBlockNumber, rpc.PendingBlockNumber, rpc.BlockNumber(3)
+
+	tests := []struct {
+		name      string
+		num       *rpc.BlockNumber
+		want      uint64
+		needsHead bool
+	}{
+		{
+			name:      "nil uses current block",
+			want:      head,
+			needsHead: true,
+		},
+		{
+			name:      "latest uses current block",
+			num:       &latest,
+			want:      head,
+			needsHead: true,
+		},
+		{
+			name:      "pending uses next block",
+			num:       &pending,
+			want:      head + 1,
+			needsHead: true,
+		},
+		{
+			name: "explicit block uses requested block",
+			num:  &explicit,
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, mockChain, _, _ := newGovModule(t, params.TestChainConfig.Copy())
+			if tt.needsHead {
+				mockChain.EXPECT().CurrentBlock().Return(types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(head)})).Times(1)
+			}
+
+			require.Equal(t, tt.want, apiBlockNumber(g, tt.num))
+		})
+	}
 }
 
 // TestAPI_kaia_getChainConfig_CompatibleBlocksCompleteness ensures that


### PR DESCRIPTION
## Proposed changes

- Make pending governance parameter APIs use CurrentBlock + 1.
- Keep latest and omitted block number behavior mapped to the current canonical block.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

