### PR TITLE
docs: clarify single-mode header governance ratification

### DIFF
--- a/kaiax/gov/headergov/README.md
+++ b/kaiax/gov/headergov/README.md
@@ -44,7 +44,7 @@ It contains a JSON object of `{name: value}` for each ratified parameter.
 The ratification condition is determined by the `governance.governancemode` parameter. Mainnet and Kairos both operate in `single` mode. There are two governance modes:
 
 - `none` mode: all members of the GC can vote. For each governance parameter, the last vote in the epoch will be ratified.
-- `single` mode: only one member of the GC, stipulated in the parameter `governance.governingnode`, can vote. The vote will be ratified if it is the only vote in the epoch.
+- `single` mode: only one member of the GC, stipulated in the parameter `governance.governingnode`, can vote. All valid votes from the governing node in the epoch are ratified in block order. For each governance parameter, the last vote in the epoch will be ratified.
 
 Parameter change ratified at `k*epoch` block takes effect starting from `(k+1)*epoch` block.
 It is worth noting that the effective time of the ratification is `(k+1)*epoch + 1` before Kore.


### PR DESCRIPTION
## Proposed changes

- Update docs to state that single mode restricts voter identity, not the number of votes per epoch.
- Clarify that multiple valid votes in an epoch are aggregated by block order with last-vote-wins behavior.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)
