### PR TITLE
kaiax/gov: handle header governance serialization error

### DIFF
--- a/kaiax/gov/headergov/impl/header.go
+++ b/kaiax/gov/headergov/impl/header.go
@@ -30,7 +30,11 @@ func (h *headerGovModule) VerifyHeader(header *types.Header, _ *types.Header) er
 func (h *headerGovModule) PrepareHeader(header *types.Header) error {
 	// if this node has a vote waiting to be casted, put Vote field.
 	if vote, ok := h.peekMyVote(); ok {
-		header.Vote, _ = vote.ToVoteBytes()
+		voteBytes, err := vote.ToVoteBytes()
+		if err != nil {
+			return err
+		}
+		header.Vote = voteBytes
 		logger.Debug("Prepare header with vote", "num", header.Number.Uint64(), "vote", hexutil.Encode(header.Vote))
 	}
 
@@ -38,7 +42,11 @@ func (h *headerGovModule) PrepareHeader(header *types.Header) error {
 	if header.Number.Uint64()%h.epoch == 0 {
 		gov := h.getExpectedGovernance(header.Number.Uint64())
 		if len(gov.Items()) > 0 {
-			header.Governance, _ = gov.ToGovBytes()
+			govBytes, err := gov.ToGovBytes()
+			if err != nil {
+				return err
+			}
+			header.Governance = govBytes
 			logger.Debug("Prepare header with governance", "num", header.Number.Uint64(), "governance", hexutil.Encode(header.Governance))
 		}
 	}


### PR DESCRIPTION
## Proposed changes

- Return errors from vote and governance serialization during PrepareHeader.
- Prevent block preparation from silently continuing with missing Vote or Governance header fields.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)
