### PR TITLE
rpc: reject invalid RPC block numbers

### DIFF
--- a/kaiax/gov/contractgov/impl/api.go
+++ b/kaiax/gov/contractgov/impl/api.go
@@ -26,7 +26,10 @@ func NewContractGovAPI(c *contractGovModule) *contractGovAPI {
 }
 
 func (api *contractGovAPI) GetContractParams(num rpc.BlockNumber, govParam *common.Address) (gov.PartialParamSet, error) {
-	blockNum := num.Uint64()
+	blockNum, err := api.blockNumber(num)
+	if err != nil {
+		return nil, err
+	}
 	var govParamAddr common.Address
 	if govParam != nil {
 		govParamAddr = *govParam
@@ -41,4 +44,15 @@ func (api *contractGovAPI) GetContractParams(num rpc.BlockNumber, govParam *comm
 	}
 
 	return params, nil
+}
+
+func (api *contractGovAPI) blockNumber(num rpc.BlockNumber) (uint64, error) {
+	head := api.c.Chain.CurrentBlock().NumberU64()
+	if num == rpc.LatestBlockNumber || num == rpc.PendingBlockNumber {
+		return head, nil
+	}
+	if num.Int64() < 0 || num.Uint64() > head {
+		return 0, gov.ErrUnknownBlock
+	}
+	return num.Uint64(), nil
 }

--- a/kaiax/gov/contractgov/impl/getter_test.go
+++ b/kaiax/gov/contractgov/impl/getter_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/gov"
 	headergov_mock "github.com/kaiachain/kaia/kaiax/gov/headergov/mock"
 	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
@@ -80,6 +81,18 @@ func setParam(t *testing.T, sim *backends.SimulatedBackend, gp *govcontract.GovP
 	receipt, _ := sim.TransactionReceipt(nil, tx.Hash())
 	require.NotNil(t, receipt)
 	require.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+}
+
+func TestGetContractParamsInvalidBlockNumber(t *testing.T) {
+	_, sim, addr, _ := createSimulateBackend(t)
+	api := NewContractGovAPI(prepareContractGovModule(t, sim.BlockChain(), addr))
+
+	_, err := api.GetContractParams(rpc.BlockNumber(-3), nil)
+	require.ErrorIs(t, err, gov.ErrUnknownBlock)
+
+	future := rpc.BlockNumber(sim.BlockChain().CurrentBlock().NumberU64() + 1)
+	_, err = api.GetContractParams(future, nil)
+	require.ErrorIs(t, err, gov.ErrUnknownBlock)
 }
 
 func TestGetParamSet(t *testing.T) {

--- a/kaiax/gov/impl/api.go
+++ b/kaiax/gov/impl/api.go
@@ -51,7 +51,7 @@ func NewKaiaAPI(g *GovModule) *KaiaAPI {
 	return &KaiaAPI{g}
 }
 
-func (api *KaiaAPI) GetChainConfig(num *rpc.BlockNumber) *params.ChainConfig {
+func (api *KaiaAPI) GetChainConfig(num *rpc.BlockNumber) (*params.ChainConfig, error) {
 	return getChainConfig(api.g, num)
 }
 
@@ -79,12 +79,21 @@ func patchDeprecatedParams(gp gov.ParamSet, rule params.Rules) gov.ParamSet {
 	return gp
 }
 
-func getChainConfig(g *GovModule, num *rpc.BlockNumber) *params.ChainConfig {
-	var blocknum uint64
+func apiBlockNumber(g *GovModule, num *rpc.BlockNumber) (uint64, error) {
+	head := g.Chain.CurrentBlock().NumberU64()
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blocknum = g.Chain.CurrentBlock().NumberU64()
-	} else {
-		blocknum = num.Uint64()
+		return head, nil
+	}
+	if num.Int64() < 0 || num.Uint64() > head {
+		return 0, gov.ErrUnknownBlock
+	}
+	return num.Uint64(), nil
+}
+
+func getChainConfig(g *GovModule, num *rpc.BlockNumber) (*params.ChainConfig, error) {
+	blocknum, err := apiBlockNumber(g, num)
+	if err != nil {
+		return nil, err
 	}
 
 	ret := g.Chain.Config().Copy()
@@ -122,15 +131,13 @@ func getChainConfig(g *GovModule, num *rpc.BlockNumber) *params.ChainConfig {
 			BaseFeeDenominator:        pset.BaseFeeDenominator,
 		},
 	}
-	return ret
+	return ret, nil
 }
 
 func getParams(g *GovModule, num *rpc.BlockNumber) (gov.PartialParamSet, error) {
-	blockNumber := uint64(0)
-	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
-		blockNumber = g.Chain.CurrentBlock().NumberU64()
-	} else {
-		blockNumber = uint64(num.Int64())
+	blockNumber, err := apiBlockNumber(g, num)
+	if err != nil {
+		return nil, err
 	}
 
 	rule := g.Chain.Config().Rules(new(big.Int).SetUint64(blockNumber))

--- a/kaiax/gov/impl/api_test.go
+++ b/kaiax/gov/impl/api_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/blockchain/forkid"
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	contractgov_mock "github.com/kaiachain/kaia/kaiax/gov/contractgov/mock"
@@ -66,6 +67,40 @@ func generateRandomValue(name gov.ParamName) any {
 	return randomValue
 }
 
+func TestAPI_apiBlockNumber(t *testing.T) {
+	head := uint64(10)
+	latest, pending, explicit, future, negative := rpc.LatestBlockNumber, rpc.PendingBlockNumber, rpc.BlockNumber(3), rpc.BlockNumber(11), rpc.BlockNumber(-3)
+
+	tests := []struct {
+		name string
+		num  *rpc.BlockNumber
+		want uint64
+		err  error
+	}{
+		{name: "nil uses current block", want: head},
+		{name: "latest uses current block", num: &latest, want: head},
+		{name: "pending uses current block", num: &pending, want: head},
+		{name: "explicit block uses requested block", num: &explicit, want: 3},
+		{name: "future block is rejected", num: &future, err: gov.ErrUnknownBlock},
+		{name: "negative non-sentinel block is rejected", num: &negative, err: gov.ErrUnknownBlock},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, mockChain, _, _ := newGovModule(t, params.TestChainConfig.Copy())
+			mockChain.EXPECT().CurrentBlock().Return(types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(head)})).Times(1)
+
+			got, err := apiBlockNumber(g, tt.num)
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestAPI_kaia_getChainConfig_CompatibleBlocksCompleteness ensures that
 // no hardfork block is omitted from the API output.
 // In other words, the test fails if API has not been synced
@@ -79,10 +114,12 @@ func TestAPI_kaia_getChainConfig_CompatibleBlocksCompleteness(t *testing.T) {
 
 	mockHgm.EXPECT().GetPartialParamSet(uint64(0)).Return(gov.PartialParamSet{}).Times(1)
 	mockCgm.EXPECT().GetPartialParamSet(uint64(0)).Return(gov.PartialParamSet{}).Times(1)
+	mockChain.EXPECT().CurrentBlock().Return(types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(0)})).Times(1)
 	mockChain.EXPECT().Config().Return(config).Times(2) // isKore, getChainConfig
 
 	// Call the API
-	apiConfig := api.GetChainConfig(&apiArg)
+	apiConfig, err := api.GetChainConfig(&apiArg)
+	require.NoError(t, err)
 	require.NotNil(t, apiConfig, "kaia_getChainConfig should not return nil")
 
 	apiForks := forkid.GatherForks(apiConfig)
@@ -112,10 +149,12 @@ func TestAPI_kaia_getChainConfig_ParameterCompleteness(t *testing.T) {
 
 		mockHgm.EXPECT().GetPartialParamSet(uint64(0)).Return(latestParams).Times(1)
 		mockCgm.EXPECT().GetPartialParamSet(uint64(0)).Return(gov.PartialParamSet{}).Times(1)
+		mockChain.EXPECT().CurrentBlock().Return(types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(0)})).Times(1)
 		mockChain.EXPECT().Config().Return(config).Times(2) // isKore, getChainConfig
 
 		// Call the API
-		apiChainConfig := api.GetChainConfig(&apiArg)
+		apiChainConfig, err := api.GetChainConfig(&apiArg)
+		require.NoError(t, err)
 		require.NotNil(t, apiChainConfig, "kaia_getChainConfig should not return nil")
 
 		// Check the values are the latest

--- a/networks/rpc/types.go
+++ b/networks/rpc/types.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/pkg/errors"
 )
 
 // API describes the set of methods offered over the RPC interface
@@ -92,7 +93,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	err := json.Unmarshal(data, &decimalInput)
 	if err == nil {
 		if decimalInput > math.MaxInt64 {
-			return fmt.Errorf("blocknumber too high")
+			return errors.New("blocknumber too high")
 		}
 		*bn = BlockNumber(decimalInput)
 		return nil
@@ -128,11 +129,11 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 }
 
 func (bn BlockNumber) Int64() int64 {
-	return (int64)(bn)
+	return int64(bn)
 }
 
 func (bn BlockNumber) Uint64() uint64 {
-	return (uint64)(bn)
+	return uint64(bn)
 }
 
 type BlockNumberOrHash struct {
@@ -159,7 +160,7 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	err = json.Unmarshal(data, &decimalInput)
 	if err == nil {
 		if decimalInput > math.MaxInt64 {
-			return fmt.Errorf("blocknumber too high")
+			return errors.New("blocknumber too high")
 		}
 		bn := BlockNumber(decimalInput)
 		bnh.BlockNumber = &bn

--- a/networks/rpc/types.go
+++ b/networks/rpc/types.go
@@ -91,6 +91,9 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	var decimalInput uint64
 	err := json.Unmarshal(data, &decimalInput)
 	if err == nil {
+		if decimalInput > math.MaxInt64 {
+			return fmt.Errorf("blocknumber too high")
+		}
 		*bn = BlockNumber(decimalInput)
 		return nil
 	}
@@ -155,6 +158,9 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	var decimalInput uint64
 	err = json.Unmarshal(data, &decimalInput)
 	if err == nil {
+		if decimalInput > math.MaxInt64 {
+			return fmt.Errorf("blocknumber too high")
+		}
 		bn := BlockNumber(decimalInput)
 		bnh.BlockNumber = &bn
 		return nil

--- a/networks/rpc/types_test.go
+++ b/networks/rpc/types_test.go
@@ -65,6 +65,8 @@ func TestBlockNumberJSONUnmarshal(t *testing.T) {
 		24: {"-3", true, BlockNumber(0)},
 		25: {"-4", true, BlockNumber(0)},
 		26: {"-5", true, BlockNumber(0)},
+		27: {"9223372036854775808", true, BlockNumber(0)},  // 2^63
+		28: {"18446744073709551615", true, BlockNumber(0)}, // 2^64 - 1, used to wrap to -1
 	}
 
 	for i, test := range tests {
@@ -128,6 +130,10 @@ func TestBlockNumberOrHash_UnmarshalJSON(t *testing.T) {
 		33: {`{"blockNumber":"-1"}`, true, BlockNumberOrHash{}},
 		34: {`{"blockNumber":"-2"}`, true, BlockNumberOrHash{}},
 		35: {`{"blockNumber":"-3"}`, true, BlockNumberOrHash{}},
+		36: {"9223372036854775808", true, BlockNumberOrHash{}},                  // 2^63
+		37: {"18446744073709551615", true, BlockNumberOrHash{}},                 // 2^64 - 1, used to wrap to -1
+		38: {`{"blockNumber":9223372036854775808}`, true, BlockNumberOrHash{}},  // 2^63
+		39: {`{"blockNumber":18446744073709551615}`, true, BlockNumberOrHash{}}, // 2^64 - 1, used to wrap to -1
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
## Proposed changes

- Reject oversized decimal block numbers that can wrap into negative rpc.BlockNumber values.
- Validate governance parameter RPC block numbers so impossible future heights are not accepted.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)
