### PR TITLE
kaiax/staking: read effective stake from AddressBookV2 after Permissionless

### DIFF
--- a/blockchain/system/constant.go
+++ b/blockchain/system/constant.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kaiachain/kaia/contracts/bindings/multicall"
 	proxycontract "github.com/kaiachain/kaia/contracts/bindings/proxyv4"
 	proxyv5contract "github.com/kaiachain/kaia/contracts/bindings/proxyv5"
+	permlesstestcontract "github.com/kaiachain/kaia/contracts/bindings/testing"
 	"github.com/kaiachain/kaia/contracts/bindings/testing/reward"
 	testcontract "github.com/kaiachain/kaia/contracts/bindings/testing/system_contracts"
 	"github.com/kaiachain/kaia/log"
@@ -92,8 +93,9 @@ var (
 	AddressBookMockTwoCNCode = hexutil.MustDecode("0x" + reward.AddressBookMockTwoCNBinRuntime)
 	Kip113MockThreeCNCode    = hexutil.MustDecode("0x" + testcontract.KIP113MockThreeCNBinRuntime)
 
-	MultiCallCode     = hexutil.MustDecode("0x" + multicall.MultiCallContractBinRuntime)
-	MultiCallMockCode = hexutil.MustDecode("0x" + testcontract.MultiCallContractMockBinRuntime)
+	MultiCallCode             = hexutil.MustDecode("0x" + multicall.MultiCallContractBinRuntime)
+	MultiCallMockCode         = hexutil.MustDecode("0x" + testcontract.MultiCallContractMockBinRuntime)
+	MultiCallPermlessMockCode = hexutil.MustDecode("0x" + permlesstestcontract.MultiCallContractMockPermissionlessBinRuntime)
 
 	// Mock for CLRegistry testing
 	CLRegistryMockThreeCLAddr = common.HexToAddress("0x0000000000000000000000000000000000000Ff0")

--- a/kaiax/staking/impl/getter.go
+++ b/kaiax/staking/impl/getter.go
@@ -194,12 +194,10 @@ func parsePermissionlessCallResult(num uint64, profiles []multicall.Profile, amo
 		return nil, staking.ErrCLRegistryResult
 	}
 
-	var (
-		nodeIds          []common.Address
-		stakingContracts []common.Address
-		rewardAddrs      []common.Address
-		stakingAmounts   []uint64
-	)
+	nodeIds := make([]common.Address, 0, len(profiles))
+	stakingContracts := make([]common.Address, 0, len(profiles))
+	rewardAddrs := make([]common.Address, 0, len(profiles))
+	stakingAmounts := make([]uint64, 0, len(profiles))
 	for i, p := range profiles {
 		if !valset.NodeState(p.State).IsRewardEligible() {
 			continue

--- a/kaiax/staking/impl/getter.go
+++ b/kaiax/staking/impl/getter.go
@@ -25,7 +25,9 @@ import (
 	"github.com/kaiachain/kaia/blockchain/system"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/contracts/bindings/multicall"
 	"github.com/kaiachain/kaia/kaiax/staking"
+	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/params"
 )
 
@@ -100,6 +102,7 @@ func (s *StakingModule) getFromStateByNumber(num uint64) (*staking.StakingInfo, 
 // Works by temporarily injecting the MultiCallContract to a copied state.
 func (s *StakingModule) getFromState(header *types.Header, statedb *state.StateDB) (*staking.StakingInfo, error) {
 	isForPrague := s.ChainConfig.IsPragueForkEnabled(new(big.Int).Add(header.Number, common.Big1))
+	isForPermissionless := s.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).Add(header.Number, common.Big1))
 	num := header.Number.Uint64()
 
 	// Bail out if AddressBook is not installed.
@@ -115,29 +118,54 @@ func (s *StakingModule) getFromState(header *types.Header, statedb *state.StateD
 		return nil, staking.ErrMultiCallCall(err)
 	}
 
-	// Get staking info from AddressBook
 	callOpts := &bind.CallOpts{BlockNumber: header.Number}
-	abRes, err := contract.MultiCallStakingInfo(callOpts)
-	if err != nil {
-		return nil, staking.ErrAddressBookCall(err)
-	}
 
-	// Get CL registry info if staking info is for Prague block
-	var clRes clRegistryResult
-	if isForPrague {
+	// Helper to read CL registry info, shared by permissioned and permissionless paths.
+	// Permissionless is ordered after Prague (Randao <= Kaia <= Prague <= Permissionless),
+	// so permissionless blocks always need CL registry info too.
+	readCLInfo := func() (clRegistryResult, error) {
+		var clRes clRegistryResult
 		// If Registry is not installed, do not handle CL staking info.
 		// In private network, Randao and Prague hardfork can be activated at the same block.
 		// It leads to staking info inconsistency between block processing and rpc query since the Registry hasn't been installed when finalizing the header.
 		// Note that Randao can't be activated after Prague according to fork ordering (Randao <= Kaia <= Prague).
 		if statedb.GetCode(system.RegistryAddr) == nil || s.ChainConfig.IsRandaoForkBlockParent(header.Number) {
 			logger.Trace("Registry not installed", "sourceNum", num)
-		} else {
-			// Note that if CLRegistry is not registered in Registry,
-			// it will return empty result and no error.
-			clRes, err = contract.MultiCallDPStakingInfo(callOpts)
-			if err != nil {
-				return nil, staking.ErrCLRegistryCall(err)
-			}
+			return clRes, nil
+		}
+		// Note that if CLRegistry is not registered in Registry,
+		// it will return empty result and no error.
+		clRes, err = contract.MultiCallDPStakingInfo(callOpts)
+		if err != nil {
+			return clRes, staking.ErrCLRegistryCall(err)
+		}
+		return clRes, nil
+	}
+
+	// Permissionless: read from AddressBookV2 (effective stake, reward-eligible only).
+	if isForPermissionless {
+		res, err := contract.MultiCallStakingInfoPermissionless(callOpts)
+		if err != nil {
+			return nil, staking.ErrAddressBookCall(err)
+		}
+		clRes, err := readCLInfo()
+		if err != nil {
+			return nil, err
+		}
+		return parsePermissionlessCallResult(num, res.Profiles, res.StakingAmounts, res.KefAddr, res.KifAddr, res.KpfAddr, clRes)
+	}
+
+	// Permissioned: read from legacy AddressBook.
+	abRes, err := contract.MultiCallStakingInfo(callOpts)
+	if err != nil {
+		return nil, staking.ErrAddressBookCall(err)
+	}
+
+	var clRes clRegistryResult
+	if isForPrague {
+		clRes, err = readCLInfo()
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -149,6 +177,62 @@ func (s *StakingModule) getFromState(header *types.Header, statedb *state.StateD
 		clRes,
 		abRes.SpareAddress,
 	)
+}
+
+// parsePermissionlessCallResult converts ABv2 multicall results into StakingInfo,
+// keeping only reward-eligible nodes (KIP-286); amounts are effective stake (KIP-287).
+func parsePermissionlessCallResult(num uint64, profiles []multicall.Profile, amounts []*big.Int, kefAddr, kifAddr, kpfAddr common.Address, clRes clRegistryResult) (*staking.StakingInfo, error) {
+	if len(profiles) == 0 {
+		return emptyStakingInfo(num), nil
+	}
+	if len(profiles) != len(amounts) {
+		logger.Error("length of profiles and amounts differ", "sourceNum", num, "profileLen", len(profiles), "amountLen", len(amounts))
+		return nil, staking.ErrAddressBookResult
+	}
+	if len(clRes.NodeIds) != len(clRes.ClPools) || len(clRes.NodeIds) != len(clRes.StakingAmounts) {
+		logger.Error("length of CL registry result fields differ", "sourceNum", num, "nodeLen", len(clRes.NodeIds), "poolLen", len(clRes.ClPools), "amountLen", len(clRes.StakingAmounts))
+		return nil, staking.ErrCLRegistryResult
+	}
+
+	var (
+		nodeIds          []common.Address
+		stakingContracts []common.Address
+		rewardAddrs      []common.Address
+		stakingAmounts   []uint64
+	)
+	for i, p := range profiles {
+		if !valset.NodeState(p.State).IsRewardEligible() {
+			continue
+		}
+		nodeIds = append(nodeIds, p.NodeId)
+		stakingContracts = append(stakingContracts, p.StakingContract)
+		rewardAddrs = append(rewardAddrs, p.RewardAddress)
+		stakingAmounts = append(stakingAmounts, new(big.Int).Div(amounts[i], big.NewInt(params.KAIA)).Uint64())
+	}
+
+	var clStakingInfos staking.CLStakingInfos
+	if len(clRes.NodeIds) > 0 {
+		clStakingInfos = make(staking.CLStakingInfos, len(clRes.NodeIds))
+		for i := range clRes.NodeIds {
+			clStakingInfos[i] = &staking.CLStakingInfo{
+				CLNodeId:        clRes.NodeIds[i],
+				CLPoolAddr:      clRes.ClPools[i],
+				CLStakingAmount: big.NewInt(0).Div(clRes.StakingAmounts[i], big.NewInt(params.KAIA)).Uint64(),
+			}
+		}
+	}
+
+	return &staking.StakingInfo{
+		SourceBlockNum:   num,
+		NodeIds:          nodeIds,
+		StakingContracts: stakingContracts,
+		RewardAddrs:      rewardAddrs,
+		KEFAddr:          kefAddr,
+		KIFAddr:          kifAddr,
+		KPFAddr:          kpfAddr,
+		StakingAmounts:   stakingAmounts,
+		CLStakingInfos:   clStakingInfos,
+	}, nil
 }
 
 func parseCallResult(num uint64,

--- a/kaiax/staking/impl/getter_test.go
+++ b/kaiax/staking/impl/getter_test.go
@@ -277,3 +277,55 @@ func TestSourceBlockNum(t *testing.T) {
 		assert.Equal(t, tc.expected, actual, i)
 	}
 }
+
+// Post-permissionless-fork, GetStakingInfo must source effective stake from
+// AddressBookV2 (MultiCallStakingInfoPermissionless) and keep only reward-eligible
+// (ValActive) nodes per KIP-286/287. The mock returns 6 profiles across states;
+// only the two ValActive ones (0xF00 5M, 0x4000 9M) should remain.
+func TestGetStakingInfo_Permissionless_OnlyValActive(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+
+	// MultiCallContractMockPermissionless.multiCallStakingInfoPermissionless returns 6 profiles:
+	//   [0] node=0xF00  staking=0xF01  reward=0xF02  ValActive    5M  <- kept
+	//   [1] node=0xF03  staking=0xF04  reward=0xF05  ValPaused   10M
+	//   [2] node=0x1000 staking=0x1001 reward=0x1002 ValReady     8M
+	//   [3] node=0x2000 staking=0x2001 reward=0x2002 ValExiting   7M
+	//   [4] node=0x3000 staking=0x3001 reward=0x3002 CandReady    6M
+	//   [5] node=0x4000 staking=0x4001 reward=0x4002 ValActive    9M  <- kept
+	// Only the two ValActive entries are reward-eligible (KIP-286).
+	originCode := system.MultiCallCode
+	system.MultiCallCode = system.MultiCallPermlessMockCode
+	defer func() { system.MultiCallCode = originCode }()
+
+	db := database.NewMemoryDBManager()
+	config := testPragueForkChainConfig(big.NewInt(0))
+	config.PermissionlessCompatibleBlock = big.NewInt(0)
+
+	alloc := blockchain.GenesisAlloc{
+		system.AddressBookAddr: {Code: []byte{0x01}, Balance: big.NewInt(0)}, // non-nil to pass bail-out check
+	}
+	backend := backends.NewSimulatedBackendWithDatabase(db, alloc, config)
+
+	mStaking := NewStakingModule()
+	mStaking.Init(&InitOpts{
+		ChainKv:     db.GetMiscDB(),
+		ChainConfig: config,
+		Chain:       backend.BlockChain(),
+	})
+	si, err := mStaking.GetStakingInfo(0)
+	assert.NoError(t, err)
+
+	// ValPaused / ValReady / ValExiting / CandReady are all excluded.
+	assert.Len(t, si.NodeIds, 2)
+	assert.Equal(t, common.HexToAddress("0xF00"), si.NodeIds[0])
+	assert.Equal(t, common.HexToAddress("0x4000"), si.NodeIds[1])
+	assert.Equal(t, common.HexToAddress("0xF01"), si.StakingContracts[0])
+	assert.Equal(t, common.HexToAddress("0x4001"), si.StakingContracts[1])
+	assert.Equal(t, common.HexToAddress("0xF02"), si.RewardAddrs[0])
+	assert.Equal(t, common.HexToAddress("0x4002"), si.RewardAddrs[1])
+	assert.Equal(t, uint64(5_000_000), si.StakingAmounts[0])
+	assert.Equal(t, uint64(9_000_000), si.StakingAmounts[1])
+	assert.Equal(t, common.HexToAddress("0x0a01"), si.KEFAddr)
+	assert.Equal(t, common.HexToAddress("0x0a02"), si.KIFAddr)
+	assert.Equal(t, common.HexToAddress("0x0a03"), si.KPFAddr)
+}


### PR DESCRIPTION
## Proposed changes

After the Permissionless fork, `StakingModule.GetStakingInfo` still called the legacy `MultiCallStakingInfo` (AddressBook balance, includes unstaking) instead of `MultiCallStakingInfoPermissionless`. Reward distribution therefore used legacy balances rather than the KIP-287 effective stake (`staking() - unstaking()`), and non-`ValActive` nodes were not filtered out.

`getFromState` now branches on `IsPermissionlessForkEnabled`, calling `MultiCallStakingInfoPermissionless` and parsing via `parsePermissionlessCallResult` (keeps only reward-eligible `ValActive` nodes, per KIP-286).

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues


## Further comments
