### PR TITLE
Cherry-pick #938 txpool queue fixes and lower kaiabft time limit to 400ms

### DIFF
--- a/blockchain/tx_list.go
+++ b/blockchain/tx_list.go
@@ -652,8 +652,10 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 		logger.Error("Pricing query for empty pool") // This cannot happen, print to catch programming errors
 		return false
 	}
+	// Equal price is not underpriced: the only caller admits a missing-nonce tx
+	// by evicting the same account's max queued tx, so no third party is displaced.
 	cheapest := []*types.Transaction(*l.items)[0]
-	return cheapest.GasPrice().Cmp(tx.GasPrice()) >= 0
+	return cheapest.GasPrice().Cmp(tx.GasPrice()) > 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1202,9 +1202,9 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 
 	// If the transaction pool is full and new Tx is valid,
 	// (1) discard a new Tx if there is no room for the account of the Tx
-	// (2) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
-	// (3) discard a new Tx if the new Tx does not have a missing nonce
-	// (4) discard underpriced transactions
+	// (2) discard a new Tx if the new Tx does not have a missing nonce
+	// (3) discard underpriced transactions
+	// (4) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
 	if uint64(pool.all.Slots()+numSlots(tx)) > pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll {
 		// (1) discard a new Tx if there is no room for the account of the Tx
 		from, _ := types.Sender(pool.signer, tx)
@@ -1215,30 +1215,35 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 		}
 
 		maxTx := pool.getMaxTxFromQueueWhenNonceIsMissing(tx, &from)
-		if maxTx != tx {
-			// (2) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
-			pool.removeTx(maxTx.Hash(), true)
-			logger.Trace("Removing an old Tx with the max nonce to insert a new Tx with missing nonce, because TxPool is full", "account", from, "new nonce(previously missing)", tx.Nonce(), "removed max nonce", maxTx.Nonce())
-		} else {
-			// (3) discard a new Tx if the new Tx does not have a missing nonce
+		if maxTx == tx {
+			// (2) discard a new Tx if the new Tx does not have a missing nonce
 			logger.Trace("Rejecting a new Tx, because TxPool is full and a new TX does not have missing nonce", "hash", tx.Hash())
 			refusedTxCounter.Inc(1)
 			return false, fmt.Errorf("txpool is full and the new tx does not have missing nonce: %d", uint64(pool.all.Count()))
 		}
 
-		// (4) discard underpriced transactions
-		// If the new transaction is underpriced, don't accept it
+		// (3) discard underpriced transactions, before the eviction in (4): a refused
+		// tx must leave the sender's queue untouched, so the eviction only runs once
+		// the tx is certain to be admitted.
 		if !local && pool.priced.Underpriced(tx, pool.locals) {
 			logger.Trace("Discarding underpriced transaction", "hash", hash, "price", tx.GasPrice())
 			underpricedTxCounter.Inc(1)
 			return false, ErrUnderpriced
 		}
-		// New transaction is better than our worse ones, make room for it
-		drop := pool.priced.Discard(pool.all.Slots()-int(pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll)+numSlots(tx), pool.locals)
-		for _, tx := range drop {
-			logger.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "price", tx.GasPrice())
-			underpricedTxCounter.Inc(1)
-			pool.removeTx(tx.Hash(), false)
+
+		// (4) remove an old Tx with the largest nonce from queue to make a room for a new Tx with missing nonce
+		pool.removeTx(maxTx.Hash(), true)
+		logger.Trace("Removing an old Tx with the max nonce to insert a new Tx with missing nonce, because TxPool is full", "account", from, "new nonce(previously missing)", tx.Nonce(), "removed max nonce", maxTx.Nonce())
+
+		// New transaction is better than our worse ones, make room for it.
+		// Guarded: a multi-slot maxTx makes the count negative, which panics in Discard's make.
+		if count := pool.all.Slots() - int(pool.config.ExecSlotsAll+pool.config.NonExecSlotsAll) + numSlots(tx); count > 0 {
+			drop := pool.priced.Discard(count, pool.locals)
+			for _, tx := range drop {
+				logger.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "price", tx.GasPrice())
+				underpricedTxCounter.Inc(1)
+				pool.removeTx(tx.Hash(), false)
+			}
 		}
 	}
 	// If the transaction is replacing an already pending one, do directly

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -119,6 +119,10 @@ var (
 	underpricedTxCounter = metrics.NewRegisteredCounter("txpool/underpriced", nil)
 	refusedTxCounter     = metrics.NewRegisteredCounter("txpool/refuse", nil)
 	slotsGauge           = metrics.NewRegisteredGauge("txpool/slots", nil)
+
+	// Queue eviction metrics, split by path.
+	queueCapEvictionCounter = metrics.NewRegisteredCounter("txpool/queued/capevict", nil)
+	lifetimeEvictionCounter = metrics.NewRegisteredCounter("txpool/queued/lifetimeevict", nil)
 )
 
 // TxStatus is the current status of a transaction as seen by the pool.
@@ -437,6 +441,7 @@ func (pool *TxPool) loop() {
 					if pool.queue[addr] != nil {
 						for _, tx := range pool.queue[addr].Flatten() {
 							pool.removeTx(tx.Hash(), true)
+							lifetimeEvictionCounter.Inc(1)
 						}
 					}
 					delete(pool.beats, addr)
@@ -1285,6 +1290,9 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 	from, _ := types.Sender(pool.signer, tx) // already validated
 	if pool.queue[from] == nil {
 		pool.queue[from] = newTxList(false)
+		// Refresh the beat on (re)creation so the account doesn't inherit a
+		// stale one and become the next eviction victim.
+		pool.beats[from] = time.Now()
 	}
 	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump, pool.rules.IsMagma)
 	if !inserted {
@@ -1304,8 +1312,6 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 		pool.all.Add(tx)
 		pool.priced.Put(tx)
 	}
-
-	pool.checkAndSetBeat(from)
 	return old != nil, nil
 }
 
@@ -1696,15 +1702,6 @@ func (pool *TxPool) GetBlobSidecarFromPool(txHash common.Hash) (*types.BlobTxSid
 	return sidecar, nil
 }
 
-// checkAndSetBeat sets the beat of the account if there is no beat of the account.
-func (pool *TxPool) checkAndSetBeat(addr common.Address) {
-	_, exist := pool.beats[addr]
-
-	if !exist {
-		pool.beats[addr] = time.Now()
-	}
-}
-
 // removeTx removes a single transaction from the queue, moving all subsequent
 // transactions back to the future queue.
 func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
@@ -1905,37 +1902,29 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 	queued := pool.queuedCount
 
 	if queued > pool.config.NonExecSlotsAll {
-		// Sort all accounts with queued transactions by heartbeat
+		// Sort by heartbeat with the stalest account last: the eviction loop below
+		// pops from the tail, so the least-recently-active accounts are dropped first.
 		addresses := make(addresssByHeartbeat, 0, len(pool.queue))
 		for addr := range pool.queue {
 			if !pool.locals.contains(addr) { // don't drop locals
 				addresses = append(addresses, addressByHeartbeat{addr, pool.beats[addr]})
 			}
 		}
-		sort.Sort(addresses)
+		sort.Sort(sort.Reverse(addresses))
 
-		// Drop transactions until the total is below the limit or only locals remain
+		// Drop highest-nonce txs from the stalest accounts, keeping each
+		// account's lowest queued tx so missing-nonce admission can heal it.
 		for drop := queued - pool.config.NonExecSlotsAll; drop > 0 && len(addresses) > 0; {
 			addr := addresses[len(addresses)-1]
 			list := pool.queue[addr.address]
 
 			addresses = addresses[:len(addresses)-1]
 
-			// Drop all transactions if they are less than the overflow
-			if size := uint64(list.Len()); size <= drop {
-				for _, tx := range list.Flatten() {
-					pool.removeTx(tx.Hash(), true)
-				}
-				drop -= size
-				queuedRateLimitCounter.Inc(int64(size))
-				continue
-			}
-			// Otherwise drop only last few transactions
 			txs := list.Flatten()
-			for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
+			for i := len(txs) - 1; i >= 1 && drop > 0; i-- {
 				pool.removeTx(txs[i].Hash(), true)
 				drop--
-				queuedRateLimitCounter.Inc(1)
+				queueCapEvictionCounter.Inc(1)
 			}
 		}
 	}

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -1337,6 +1337,76 @@ func TestQueueCapEvictionStalestTailDrop(t *testing.T) {
 	}
 }
 
+// Tests the missing-nonce fill at full pool: a strictly cheaper tx is refused
+// without evicting the account's max queued tx, and an equal-price tx
+// swap-admits and heals the account.
+func TestTransactionFullPoolRefuseBeforeEvict(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	blockchain := &testBlockChain{statedb: statedb, gasLimit: 10000000, chainHeadFeed: new(event.Feed), txMap: make(map[common.Hash]*types.Transaction)}
+
+	config := testTxPoolConfig
+	config.ExecSlotsAccount = 8
+	config.ExecSlotsAll = 4
+	config.NonExecSlotsAccount = 8
+	config.NonExecSlotsAll = 4
+
+	pool := NewTxPool(config, params.TestChainConfig.Copy(), blockchain, &dummyGovModule{chainConfig: params.TestChainConfig.Copy()})
+	defer pool.Stop()
+
+	keyA, _ := crypto.GenerateKey()
+	keyB, _ := crypto.GenerateKey()
+	addrB := crypto.PubkeyToAddress(keyB.PublicKey)
+	testAddBalance(pool, crypto.PubkeyToAddress(keyA.PublicKey), big.NewInt(10000000))
+	testAddBalance(pool, addrB, big.NewInt(10000000))
+
+	// Account A: 4 pending (0..3). Account B: 4 queued (1..4, missing 0). Pool full.
+	for nonce := uint64(0); nonce <= 3; nonce++ {
+		if err := pool.AddRemote(pricedTransaction(nonce, 100000, big.NewInt(2), keyA)); err != nil {
+			t.Fatalf("pending filler nonce %d: %v", nonce, err)
+		}
+	}
+	for nonce := uint64(1); nonce <= 4; nonce++ {
+		if err := pool.AddRemote(pricedTransaction(nonce, 100000, big.NewInt(2), keyB)); err != nil {
+			t.Fatalf("queued filler nonce %d: %v", nonce, err)
+		}
+	}
+	if pool.all.Count() != 8 {
+		t.Fatalf("pool not full: have %d, want 8", pool.all.Count())
+	}
+	maxHash := pricedTransaction(4, 100000, big.NewInt(2), keyB).Hash()
+
+	// Cheaper missing-nonce tx: refused as underpriced without collateral damage.
+	if err := pool.AddRemote(pricedTransaction(0, 100000, big.NewInt(1), keyB)); err != ErrUnderpriced {
+		t.Fatalf("refusal error mismatch: have %v, want %v", err, ErrUnderpriced)
+	}
+	if pool.all.Get(maxHash) == nil {
+		t.Fatalf("max queued tx destroyed by a refused missing-nonce tx")
+	}
+	if pool.queue[addrB] == nil || pool.queue[addrB].Len() != 4 {
+		t.Fatalf("account B queue mutated by a refused missing-nonce tx")
+	}
+
+	// Equal-price missing-nonce tx: swap-admits and heals the account.
+	if err := pool.AddRemote(pricedTransaction(0, 100000, big.NewInt(2), keyB)); err != nil {
+		t.Fatalf("equal-price missing-nonce tx refused: %v", err)
+	}
+	if pool.all.Get(maxHash) != nil {
+		t.Fatalf("max queued tx should have been swapped out")
+	}
+	if pool.pending[addrB] == nil || pool.pending[addrB].Len() != 4 {
+		have := 0
+		if pool.pending[addrB] != nil {
+			have = pool.pending[addrB].Len()
+		}
+		t.Fatalf("account B not healed: pending %d, want 4", have)
+	}
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}
+
 // Tests that if an account remains idle for a prolonged amount of time, any
 // non-executable transactions queued up are dropped to prevent wasting resources
 // on shuffling them around.

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -1259,14 +1259,81 @@ func testTransactionQueueGlobalLimiting(t *testing.T, nolocals bool) {
 			t.Fatalf("total transactions overflow allowance: %d > %d", queued, config.NonExecSlotsAll)
 		}
 	} else {
-		// Local exemptions are enabled, make sure the local account owned the queue
-		if len(pool.queue) != 1 {
-			t.Errorf("multiple accounts in queue: have %v, want %v", len(pool.queue), 1)
+		// Local exemptions are enabled: remote accounts are tail-dropped down to
+		// their lowest queued tx, never deleted outright.
+		localAddr := crypto.PubkeyToAddress(local.PublicKey)
+		for addr, list := range pool.queue {
+			if addr != localAddr && list.Len() != 1 {
+				t.Errorf("remote account %x not tail-dropped to its frontier: have %d, want 1", addr, list.Len())
+			}
 		}
 		// Also ensure no local transactions are ever dropped, even if above global limits
-		if queued := pool.queue[crypto.PubkeyToAddress(local.PublicKey)].Len(); uint64(queued) != 3*config.NonExecSlotsAll {
+		if queued := pool.queue[localAddr].Len(); uint64(queued) != 3*config.NonExecSlotsAll {
 			t.Fatalf("local account queued transaction count mismatch: have %v, want %v", queued, 3*config.NonExecSlotsAll)
 		}
+	}
+}
+
+// Tests that the queue-cap eviction drops the stalest-beat accounts' tails
+// first and never removes an account's lowest queued tx or its queue entry.
+func TestQueueCapEvictionStalestTailDrop(t *testing.T) {
+	t.Parallel()
+
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	blockchain := &testBlockChain{statedb: statedb, gasLimit: 10000000, chainHeadFeed: new(event.Feed), txMap: make(map[common.Hash]*types.Transaction)}
+
+	config := testTxPoolConfig
+	config.NonExecSlotsAccount = 8
+	config.NonExecSlotsAll = 4
+
+	pool := NewTxPool(config, params.TestChainConfig.Copy(), blockchain, &dummyGovModule{chainConfig: params.TestChainConfig.Copy()})
+	defer pool.Stop()
+
+	keyStale, _ := crypto.GenerateKey()
+	keyFresh, _ := crypto.GenerateKey()
+	stale := crypto.PubkeyToAddress(keyStale.PublicKey)
+	fresh := crypto.PubkeyToAddress(keyFresh.PublicKey)
+	testAddBalance(pool, stale, big.NewInt(10000000))
+	testAddBalance(pool, fresh, big.NewInt(10000000))
+
+	// Grow the queue past the cap through enqueueTx directly, mirroring
+	// demote-driven growth that bypasses AddRemote's capacity checks.
+	pool.mu.Lock()
+	for nonce := uint64(1); nonce <= 4; nonce++ {
+		staleTx := transaction(nonce, 100000, keyStale)
+		freshTx := transaction(nonce, 100000, keyFresh)
+		if _, err := pool.enqueueTx(staleTx.Hash(), staleTx); err != nil {
+			pool.mu.Unlock()
+			t.Fatalf("enqueue stale acct nonce %d: %v", nonce, err)
+		}
+		if _, err := pool.enqueueTx(freshTx.Hash(), freshTx); err != nil {
+			pool.mu.Unlock()
+			t.Fatalf("enqueue fresh acct nonce %d: %v", nonce, err)
+		}
+	}
+	pool.beats[stale] = time.Now().Add(-time.Hour)
+	pool.beats[fresh] = time.Now()
+	pool.promoteExecutables(nil) // 8 queued > cap 4 triggers the eviction
+	pool.mu.Unlock()
+
+	if pool.queuedCount != 4 {
+		t.Fatalf("queued count after eviction: have %d, want 4", pool.queuedCount)
+	}
+	if pool.queue[stale] == nil || pool.queue[stale].Len() != 1 {
+		t.Fatalf("stale account not tail-dropped to its frontier")
+	}
+	if pool.queue[stale].txs.Get(1) == nil {
+		t.Fatalf("stale account lost its lowest queued tx")
+	}
+	if pool.queue[fresh] == nil || pool.queue[fresh].Len() != 3 {
+		have := 0
+		if pool.queue[fresh] != nil {
+			have = pool.queue[fresh].Len()
+		}
+		t.Fatalf("fresh account dropped before stale exhausted: have %d, want 3", have)
+	}
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2023,7 +2023,7 @@ var (
 	BlockGenerationTimeLimitFlag = &cli.DurationFlag{
 		Name: "block-generation-time-limit",
 		Usage: "(experimental option) Override the tx execution time limit during block generation. " +
-			"Default is 250ms (istanbul) or 500ms (kaiabft) and should not be changed in normal operation. " +
+			"Default is 250ms (istanbul) or 400ms (kaiabft) and should not be changed in normal operation. " +
 			"Only applicable to CN.",
 		Value:    params.DefaultBlockGenerationTimeLimit,
 		Aliases:  []string{"experimental.block-generation-time-limit"},

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -233,7 +233,7 @@ const (
 	// KaiaBFTBlockGenerationTimeLimit is the default tx execution time limit
 	// for kaiabft. Speculative execution lets non-proposers overlap execution
 	// with consensus, so the proposer can use a larger execution window.
-	KaiaBFTBlockGenerationTimeLimit = 500 * time.Millisecond
+	KaiaBFTBlockGenerationTimeLimit = 400 * time.Millisecond
 )
 
 var Bls12381G1MultiExpDiscountTable = [128]uint64{1000, 949, 848, 797, 764, 750, 738, 728, 719, 712, 705, 698, 692, 687, 682, 677, 673, 669, 665, 661, 658, 654, 651, 648, 645, 642, 640, 637, 635, 632, 630, 627, 625, 623, 621, 619, 617, 615, 613, 611, 609, 608, 606, 604, 603, 601, 599, 598, 596, 595, 593, 592, 591, 589, 588, 586, 585, 584, 582, 581, 580, 579, 577, 576, 575, 574, 573, 572, 570, 569, 568, 567, 566, 565, 564, 563, 562, 561, 560, 559, 558, 557, 556, 555, 554, 553, 552, 551, 550, 549, 548, 547, 547, 546, 545, 544, 543, 542, 541, 540, 540, 539, 538, 537, 536, 536, 535, 534, 533, 532, 532, 531, 530, 529, 528, 528, 527, 526, 525, 525, 524, 523, 522, 522, 521, 520, 520, 519}

--- a/tests/executor_test.go
+++ b/tests/executor_test.go
@@ -582,12 +582,12 @@ func TestKaiaBFT_EngineFactory(t *testing.T) {
 func TestKaiaBFT_BlockGenerationTimeLimit(t *testing.T) {
 	// Verify the constants are defined with expected values.
 	assert.Equal(t, 250*time.Millisecond, params.DefaultBlockGenerationTimeLimit)
-	assert.Equal(t, 500*time.Millisecond, params.KaiaBFTBlockGenerationTimeLimit)
+	assert.Equal(t, 400*time.Millisecond, params.KaiaBFTBlockGenerationTimeLimit)
 
 	// Verify the global can be set to the kaiabft value and restored.
 	original := params.BlockGenerationTimeLimit
 	defer func() { params.BlockGenerationTimeLimit = original }()
 
 	params.BlockGenerationTimeLimit = params.KaiaBFTBlockGenerationTimeLimit
-	assert.Equal(t, 500*time.Millisecond, params.BlockGenerationTimeLimit)
+	assert.Equal(t, 400*time.Millisecond, params.BlockGenerationTimeLimit)
 }


### PR DESCRIPTION
## Summary

- **Cherry-picks #938** (`txpool: fix queue eviction order and missing-nonce fill at full pool`) onto `kaiabft`, preserving both original commits:
  - `txpool: evict stalest accounts first and keep queue frontier`
  - `txpool: fix missing-nonce fill at full pool`
- **Lowers the kaiabft default block generation time limit from 500ms to 400ms** (`params.KaiaBFTBlockGenerationTimeLimit`), and updates the `--block-generation-time-limit` flag help text and the `TestKaiaBFT_BlockGenerationTimeLimit` assertions to match. The 250ms istanbul default is unchanged.

## Notes

- Both #938 commits cherry-picked cleanly via 3-way auto-merge against kaiabft's divergent txpool (`pendingCount`/`queuedCount` counters, pre-commit reset path); no conflicts.

## Test

- `go build ./...`
- `go test ./blockchain/ -run 'TestQueueCapEvictionStalestTailDrop|TestTransactionFullPoolRefuseBeforeEvict|TestTransactionQueue|TestTransactionPendingMinimumAllowance|TestTransactionPoolUnderpricing'`
- `go test ./tests/ -run TestKaiaBFT_BlockGenerationTimeLimit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
