### PR TITLE
cmd: add valops generate-keys for validator onboarding keys

### DIFF
--- a/cmd/kcn/README.md
+++ b/cmd/kcn/README.md
@@ -1,6 +1,6 @@
 # kcn valops - Validator Operations CLI
 
-Command-line interface for interacting with the AddressBookV2 contract (`0x400`) on-chain.
+Command-line interface for interacting with the AddressBookV2 contract (`0x400`) on-chain, plus an offline `generate-keys` helper for creating validator onboarding keys.
 
 ## Usage
 
@@ -8,7 +8,9 @@ Command-line interface for interacting with the AddressBookV2 contract (`0x400`)
 kcn valops <command> [flags] [args]
 ```
 
-## Flags (all commands)
+## Flags (on-chain commands)
+
+These apply to every command except the offline `generate-keys` (see [Key generation](#key-generation-offline)).
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -51,6 +53,49 @@ kcn valops offboard
 
 No extra arguments. The node-id is derived from the private key.
 
+### Key generation (offline)
+
+`generate-keys` creates the full validator onboarding key set. It is offline (no chain interaction) and uses `--datadir` instead of `--endpoint`/`--private-key`.
+
+```
+kcn valops generate-keys --datadir <path>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--datadir` | Node data directory; keys are written under `<datadir>/klay` |
+
+Existing files are never overwritten — the command aborts if any target already exists. It writes:
+
+```
+<datadir>/klay/
+├── nodekey                          raw hex   (node loads this)
+├── bls-nodekey                      raw hex   (node loads this)
+└── operator-keys/
+    ├── nodekey.json + .pass         v3 keystore
+    ├── manager.json + .pass         v3 keystore
+    ├── voter.json + .pass           v3 keystore
+    ├── reward.json + .pass          v3 keystore
+    ├── cnstaking-owner.json + .pass v3 keystore
+    ├── mev-reward.json + .pass      v3 keystore
+    ├── bls-nodekey.json + .pass     EIP-2335 keystore
+    └── bls-pub / bls-pop            raw hex   (public; createNode blsInfo)
+```
+
+Key roles:
+
+| Key | Role |
+|-----|------|
+| `nodekey` | node identity (p2p) + createNode `nodeId`; signs state transitions (onlyNodeId) |
+| `bls-nodekey` | consensus BLS (randao/vrank) + createNode `blsInfo` (pub/pop) |
+| `manager` | deploys CnStaking, stakes, and sends createNode (becomes NodeInfo.manager); holds ≥ 5M KAIA |
+| `cnstaking-owner` | owner of the deployed CnStaking |
+| `voter` | createNode `voterAddress` (on-chain governance) |
+| `reward` | createNode `rewardAddress` (unused when PublicDelegation is enabled) |
+| `mev-reward` | reward recipient for the auction (MEV) contract; not a createNode argument |
+
+ECDSA keys are encrypted as Web3 Secret Storage **v3** keystores; the BLS key as an **EIP-2335** keystore. Each keystore's password is a random value written to the adjacent `.pass` file. `nodekey`/`bls-nodekey` are also kept as raw hex because the node loads them directly; `bls-pub`/`bls-pop` are public values for createNode.
+
 ## Examples
 
 ```sh
@@ -65,11 +110,14 @@ kcn valops pause --endpoint http://localhost:8551
 
 # Use a custom private key and endpoint
 kcn valops ready-validator --private-key 0x1234... --endpoint /tmp/klay.ipc
+
+# Generate a fresh validator key set (offline)
+kcn valops generate-keys --datadir /var/kcnd/data
 ```
 
 ## Output
 
-Each command prints the transaction hash immediately upon submission, then waits for the receipt:
+Each on-chain command prints the transaction hash immediately upon submission, then waits for the receipt (`generate-keys` instead prints the generated key summary):
 
 ```
 tx: 0xabc123...

--- a/cmd/kcn/abv2.go
+++ b/cmd/kcn/abv2.go
@@ -131,6 +131,7 @@ var ValOpsCommand = &cli.Command{
 			Flags:  abv2Flags(),
 			Action: abv2NodeOperatorAction((*addressbookv2.AddressBookV2Transactor).Offboard),
 		},
+		GenerateKeysCommand,
 	},
 }
 

--- a/cmd/kcn/genkeys.go
+++ b/cmd/kcn/genkeys.go
@@ -46,10 +46,10 @@ var ecdsaKeyNames = []string{"nodekey", "manager", "voter", "reward", "cnstaking
 
 // GenerateKeysCommand generates the full validator onboarding key set offline.
 var GenerateKeysCommand = &cli.Command{
-	Name:     "generate-keys",
-	Usage:    "Generate all validator onboarding keys into <datadir>/klay (offline)",
-	Flags:    []cli.Flag{genkeysDatadirFlag},
-	Action:   generateKeysAction,
+	Name:   "generate-keys",
+	Usage:  "Generate all validator onboarding keys into <datadir>/klay (offline)",
+	Flags:  []cli.Flag{genkeysDatadirFlag},
+	Action: generateKeysAction,
 }
 
 func writeFile(path, content string, perm os.FileMode) error {

--- a/cmd/kcn/genkeys.go
+++ b/cmd/kcn/genkeys.go
@@ -50,7 +50,6 @@ var GenerateKeysCommand = &cli.Command{
 	Usage:    "Generate all validator onboarding keys into <datadir>/klay (offline)",
 	Flags:    []cli.Flag{genkeysDatadirFlag},
 	Action:   generateKeysAction,
-	Category: "PERMISSIONLESS COMMANDS",
 }
 
 func writeFile(path, content string, perm os.FileMode) error {

--- a/cmd/kcn/genkeys.go
+++ b/cmd/kcn/genkeys.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/kaiachain/kaia/accounts/keystore"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/bls"
+	"github.com/urfave/cli/v2"
+)
+
+var genkeysDatadirFlag = &cli.StringFlag{
+	Name:     "datadir",
+	Usage:    "Node data directory; keys are written under <datadir>/klay",
+	Required: true,
+}
+
+// ecdsaKeyNames are the secp256k1 keys written to klay/operator-keys as v3
+// keystores. nodekey is also kept as raw hex in klay/ for the node to load.
+// reward is unused under PublicDelegation; mev-reward is for the auction
+// contract, not createNode.
+var ecdsaKeyNames = []string{"nodekey", "manager", "voter", "reward", "cnstaking-owner", "mev-reward"}
+
+// GenerateKeysCommand generates the full validator onboarding key set offline.
+var GenerateKeysCommand = &cli.Command{
+	Name:     "generate-keys",
+	Usage:    "Generate all validator onboarding keys into <datadir>/klay (offline)",
+	Flags:    []cli.Flag{genkeysDatadirFlag},
+	Action:   generateKeysAction,
+	Category: "PERMISSIONLESS COMMANDS",
+}
+
+func writeFile(path, content string, perm os.FileMode) error {
+	if err := os.WriteFile(path, []byte(content), perm); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// randomPassword returns a fresh high-entropy password for one keystore.
+func randomPassword() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// writeV3 writes an ECDSA key as a v3 keystore JSON plus its random password file.
+func writeV3(opDir, name string, priv *ecdsa.PrivateKey) error {
+	pw, err := randomPassword()
+	if err != nil {
+		return err
+	}
+	k := &keystore.KeyV3{Id: uuid.New(), Address: crypto.PubkeyToAddress(priv.PublicKey), PrivateKey: priv}
+	js, err := keystore.EncryptKeyV3(k, pw, keystore.StandardScryptN, keystore.StandardScryptP)
+	if err != nil {
+		return fmt.Errorf("encrypt %s: %w", name, err)
+	}
+	if err := writeFile(filepath.Join(opDir, name+".json"), string(js), 0o600); err != nil {
+		return err
+	}
+	return writeFile(filepath.Join(opDir, name+".pass"), pw, 0o600)
+}
+
+func generateKeysAction(ctx *cli.Context) error {
+	datadir := ctx.String("datadir")
+	klayDir := filepath.Join(datadir, "klay")
+	opDir := filepath.Join(klayDir, "operator-keys")
+
+	nodekeyHexPath := filepath.Join(klayDir, "nodekey")
+	blsNodekeyHexPath := filepath.Join(klayDir, "bls-nodekey")
+	blsPubPath := filepath.Join(opDir, "bls-pub")
+	blsPopPath := filepath.Join(opDir, "bls-pop")
+
+	// No-overwrite precheck (atomic): if any target exists, write nothing.
+	targets := []string{
+		nodekeyHexPath, blsNodekeyHexPath, blsPubPath, blsPopPath,
+		filepath.Join(opDir, "bls-nodekey.json"), filepath.Join(opDir, "bls-nodekey.pass"),
+	}
+	for _, n := range ecdsaKeyNames {
+		targets = append(targets, filepath.Join(opDir, n+".json"), filepath.Join(opDir, n+".pass"))
+	}
+	for _, p := range targets {
+		if _, err := os.Stat(p); err == nil {
+			return fmt.Errorf("refusing to overwrite existing file: %s (use a fresh --datadir or remove existing keys)", p)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("stat %s: %w", p, err)
+		}
+	}
+
+	// Generate all keys before writing, so a generation failure leaves nothing.
+	ecdsaKeys := make(map[string]*ecdsa.PrivateKey, len(ecdsaKeyNames))
+	for _, n := range ecdsaKeyNames {
+		k, err := crypto.GenerateKey()
+		if err != nil {
+			return fmt.Errorf("generate %s key: %w", n, err)
+		}
+		ecdsaKeys[n] = k
+	}
+	blsKey, err := bls.RandKey()
+	if err != nil {
+		return fmt.Errorf("generate bls key: %w", err)
+	}
+
+	if err := os.MkdirAll(opDir, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", opDir, err)
+	}
+
+	// ECDSA keys -> v3 keystore (+ .pass) in operator-keys; nodekey also raw hex in klay/.
+	for _, n := range ecdsaKeyNames {
+		if err := writeV3(opDir, n, ecdsaKeys[n]); err != nil {
+			return err
+		}
+	}
+	nodeKey := ecdsaKeys["nodekey"]
+	if err := writeFile(nodekeyHexPath, hex.EncodeToString(crypto.FromECDSA(nodeKey)), 0o600); err != nil {
+		return err
+	}
+
+	// BLS -> raw hex in klay/, EIP-2335 keystore (+ .pass), and public pub/pop hex.
+	if err := writeFile(blsNodekeyHexPath, hex.EncodeToString(blsKey.Marshal()), 0o600); err != nil {
+		return err
+	}
+	blsPw, err := randomPassword()
+	if err != nil {
+		return err
+	}
+	blsJSON, err := keystore.EncryptKeyEIP2335(keystore.NewKeyEIP2335(blsKey), blsPw, keystore.StandardScryptN, keystore.StandardScryptP)
+	if err != nil {
+		return fmt.Errorf("encrypt bls-nodekey: %w", err)
+	}
+	if err := writeFile(filepath.Join(opDir, "bls-nodekey.json"), string(blsJSON), 0o600); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(opDir, "bls-nodekey.pass"), blsPw, 0o600); err != nil {
+		return err
+	}
+	blsPub := hex.EncodeToString(blsKey.PublicKey().Marshal())
+	blsPop := hex.EncodeToString(bls.PopProve(blsKey).Marshal())
+	if err := writeFile(blsPubPath, blsPub, 0o644); err != nil {
+		return err
+	}
+	if err := writeFile(blsPopPath, blsPop, 0o644); err != nil {
+		return err
+	}
+
+	// Print public values needed for createNode / onboarding; secrets stay in files.
+	nodeID := crypto.PubkeyToAddress(nodeKey.PublicKey).Hex()
+	fmt.Printf("Generated validator keys under %s\n\n", klayDir)
+	fmt.Println("node:")
+	fmt.Printf("  hex        : %s\n", nodekeyHexPath)
+	fmt.Printf("  keystore   : %s (+ .pass)\n", filepath.Join(opDir, "nodekey.json"))
+	fmt.Printf("  nodeId     : %s\n", nodeID)
+	fmt.Println("bls:")
+	fmt.Printf("  hex        : %s\n", blsNodekeyHexPath)
+	fmt.Printf("  keystore   : %s (+ .pass, EIP-2335)\n", filepath.Join(opDir, "bls-nodekey.json"))
+	fmt.Printf("  publicKey  : 0x%s\n", blsPub)
+	fmt.Printf("  pop        : 0x%s\n", blsPop)
+	for _, n := range ecdsaKeyNames {
+		if n == "nodekey" {
+			continue
+		}
+		fmt.Printf("%s:\n", n)
+		fmt.Printf("  keystore   : %s (+ .pass)\n", filepath.Join(opDir, n+".json"))
+		fmt.Printf("  address    : %s\n", crypto.PubkeyToAddress(ecdsaKeys[n].PublicKey).Hex())
+	}
+	fmt.Println("\nNote: reward is unused when PublicDelegation is enabled. Each .pass holds that keystore's password.")
+	return nil
+}


### PR DESCRIPTION
## Proposed changes

Adds `kcn valops generate-keys` — an offline command that generates a new validator's full onboarding key set (createNode + node operation) in one step, in the layout the node and onboarding flow expect.

`generate-keys --datadir <path>` writes under `<datadir>/klay` (never overwrites existing files):

```
klay/
├── nodekey / bls-nodekey            raw hex (node loads these)
└── operator-keys/
    ├── {nodekey,manager,voter,reward,cnstaking-owner,mev-reward}.json + .pass   v3 keystore
    ├── bls-nodekey.json + .pass      EIP-2335 keystore
    └── bls-pub / bls-pop             raw hex (createNode blsInfo)
```

- ECDSA keys → v3 keystore, BLS → EIP-2335; each with a random password in an adjacent `.pass`.
- `nodekey`/`bls-nodekey` are also kept as raw hex since the node loads them directly.

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

ECDSA keys use the **v3** keystore (not Kaia's default v4): foundry/cast cannot read the v4 `keyring` format, while Kaia reads both — so v3 keeps the keys usable by both toolchains. BLS uses **EIP-2335**. Per-key random passwords follow the homi `keys_test` convention.

Example output:

```
$ kcn valops generate-keys --datadir .
Generated validator keys under klay

node:
  hex        : klay/nodekey
  keystore   : klay/operator-keys/nodekey.json (+ .pass)
  nodeId     : 0x03d171a5f9C29932F30f637600E9b6FC0aFA6Bc4
bls:
  hex        : klay/bls-nodekey
  keystore   : klay/operator-keys/bls-nodekey.json (+ .pass, EIP-2335)
  publicKey  : 0x93c3faea956726f1e2b57e4a57fe573e9b1881a6605c5d18aac6ba09f62e1cb3…
  pop        : 0xb3b762d05bb42337d1d7c6bb6b82707e160241475eda5dd67ac307470b12ced9…
manager:
  keystore   : klay/operator-keys/manager.json (+ .pass)
  address    : 0x91283F49438b4B1B2De9Ce724Af197e52CD9dcA6
voter:
  keystore   : klay/operator-keys/voter.json (+ .pass)
  address    : 0xF1a593e690dc00D7B0c2536A7351f0a61c056D76
reward:
  keystore   : klay/operator-keys/reward.json (+ .pass)
  address    : 0x6D9c04e93281BfA72fe221CAE69232E520B0e5E5
cnstaking-owner:
  keystore   : klay/operator-keys/cnstaking-owner.json (+ .pass)
  address    : 0x19a3b51E6f58d0E170fc0F46207cd14f609f0753
mev-reward:
  keystore   : klay/operator-keys/mev-reward.json (+ .pass)
  address    : 0x620ccEae6AEDe97b0E16eaA37B366BB1DB4EB8DA

Note: reward is unused when PublicDelegation is enabled. Each .pass holds that keystore's password.
```
