### PR TITLE
consensus/istanbul: sign COMMIT seal over the message's subject digest

### DIFF
--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -21,11 +21,16 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/bft"
 	"github.com/kaiachain/kaia/consensus/istanbul"
+	mock_istanbul "github.com/kaiachain/kaia/consensus/istanbul/mocks"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/rlp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCore_sendCommit(t *testing.T) {
@@ -70,4 +75,52 @@ func TestCore_sendCommit(t *testing.T) {
 			mockCtrl.Finish()
 		}
 	}
+}
+
+// TestSendCommitForOldBlockSealMatchesDigest is a regression test for the COMMIT
+// committed-seal desync: finalizeMessage must sign the CommittedSeal over the
+// digest carried in the COMMIT message's own Subject (the block it votes for),
+// not over the node's current proposal. sendCommitForOldBlock rebroadcasts a
+// COMMIT whose Subject.Digest is an old block hash, so the produced seal must
+// attest to that old block hash.
+func TestSendCommitForOldBlockSealMatchesDigest(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	sealKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	sealAddr := crypto.PubkeyToAddress(sealKey.PublicKey)
+
+	// Capture the finalized COMMIT payload broadcast to peers.
+	var payload []byte
+	mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
+	mockBackend.EXPECT().Address().Return(sealAddr).AnyTimes()
+	mockBackend.EXPECT().Sealer().Return(istanbul.NewSealerImpl(sealKey)).AnyTimes()
+	mockBackend.EXPECT().Sign(gomock.Any()).Return([]byte{0x01}, nil).AnyTimes() // message-payload signature, unused here
+	mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any()).DoAndReturn(func(_ common.Hash, p []byte) error {
+		payload = append([]byte(nil), p...)
+		return nil
+	}).AnyTimes()
+
+	istCore := New(mockBackend, istanbul.DefaultConfig.Copy()).(*core)
+
+	oldBlockHash := common.HexToHash("0xa11d")        // digest the COMMIT votes for
+	currentProposalHash := common.HexToHash("0xb22d") // unrelated current proposal
+	view := &bft.View{Round: big.NewInt(0), Sequence: big.NewInt(1)}
+
+	istCore.sendCommitForOldBlock(view, oldBlockHash, common.HexToHash("0xc33d"))
+
+	require.NotNil(t, payload, "a COMMIT must have been broadcast")
+	var msg bft.Message
+	require.NoError(t, rlp.DecodeBytes(payload, &msg))
+
+	// The committed seal must recover to the sealer over the message's own
+	// (old block) digest...
+	got, err := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSeal(oldBlockHash), msg.CommittedSeal)
+	require.NoError(t, err)
+	assert.Equal(t, sealAddr, got, "CommittedSeal must attest to the message's own (old block) digest")
+
+	// ...and must NOT recover to the sealer over an unrelated current proposal digest.
+	wrong, _ := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSeal(currentProposalHash), msg.CommittedSeal)
+	assert.NotEqual(t, sealAddr, wrong, "CommittedSeal must not attest to an unrelated (current proposal) digest")
 }

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -179,10 +179,19 @@ func (c *core) finalizeMessage(msg *bft.Message) ([]byte, error) {
 
 	// Add proof of consensus
 	msg.CommittedSeal = []byte{}
-	// Assign the CommittedSeal if it's a COMMIT message and proposal is not nil
-	if msg.Code == bft.MsgCommit && c.current.Proposal() != nil {
-		msg.CommittedSeal, err = c.backend.Sealer().MakeCommittedSeal(c.current.Proposal().Header())
-		if err != nil {
+	// Assign the CommittedSeal if it's a COMMIT message.
+	// Sign over the digest carried in the message's own Subject (the block this
+	// COMMIT votes for) rather than the current proposal. For a normal COMMIT the
+	// subject digest equals the current proposal hash, so the produced seal is
+	// unchanged; for a rebroadcast COMMIT of an old block (sendCommitForOldBlock)
+	// this keeps the seal consistent with the message's digest instead of signing
+	// the current proposal.
+	if msg.Code == bft.MsgCommit {
+		var sub *bft.Subject
+		if err = msg.Decode(&sub); err != nil {
+			return nil, err
+		}
+		if msg.CommittedSeal, err = c.backend.Sealer().MakeCommittedSealFromHash(sub.Digest); err != nil {
 			return nil, err
 		}
 	}

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -320,8 +320,13 @@ func (m *IstanbulSealer) Quorum(_ uint64, qualifiedlen, committeeSize int) int {
 	return int(math.Ceil(float64(2*n) / 3))
 }
 
+// MakeCommittedSealFromHash signs the COMMIT committed-seal for the given block hash.
+func (m *IstanbulSealer) MakeCommittedSealFromHash(hash common.Hash) ([]byte, error) {
+	return crypto.Sign(crypto.Keccak256(PrepareCommittedSeal(hash)), m.privateKey)
+}
+
 func (m *IstanbulSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) {
-	return crypto.Sign(crypto.Keccak256(PrepareCommittedSeal(m.HeaderHash(header))), m.privateKey)
+	return m.MakeCommittedSealFromHash(m.HeaderHash(header))
 }
 
 func (m *IstanbulSealer) MakeAuthorSeal(header *types.Header) ([]byte, error) {


### PR DESCRIPTION
## Proposed changes

- `finalizeMessage` previously signed a `COMMIT` message's `CommittedSeal` over `c.current.Proposal()`, instead of the digest the message actually carried. For `sendCommitForOldBlock`, this produced an inconsistent COMMIT: CommittedSeal attests to the current proposal while the message's `Subject.Digest` referenced the old block.
- The seal is now signed over the digest in the message's own `Subject`; for a normal `COMMIT` this is byte-identical (subject digest == current proposal hash), so only the old-block rebroadcast path changes.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
