### PR TITLE
blockchain, node/cn: store blob sidecar at canonical tx location

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -2028,14 +2028,14 @@ func (pool *TxPool) SubscribeMissingBlobSidecars() <-chan *MissingBlobSidecar {
 	return pool.missingBlobSidecarsCh
 }
 
-func (pool *TxPool) SaveBlobSidecar(blockNum *big.Int, txIndex int, txHash common.Hash, sidecar *types.BlobTxSidecar) error {
-	if pool.blobStorage == nil || blockNum == nil {
+func (pool *TxPool) SaveBlobSidecar(txHash common.Hash, sidecar *types.BlobTxSidecar) error {
+	if pool.blobStorage == nil {
 		return errors.New("blob storage not initialized")
 	}
 	if sidecar == nil {
 		return errors.New("sidecar is nil")
 	}
-	tx, _, _, _ := pool.chain.GetTxAndLookupInfo(txHash)
+	tx, _, blockNumber, txIndex := pool.chain.GetTxAndLookupInfo(txHash)
 	if tx == nil {
 		return errors.New("tx not found")
 	}
@@ -2045,7 +2045,7 @@ func (pool *TxPool) SaveBlobSidecar(blockNum *big.Int, txIndex int, txHash commo
 	if err := sidecar.ValidateWithBlobHashes(tx.BlobHashes()); err != nil {
 		return err
 	}
-	return pool.blobStorage.Save(blockNum, txIndex, sidecar)
+	return pool.blobStorage.Save(new(big.Int).SetUint64(blockNumber), int(txIndex), sidecar)
 }
 
 // saveAndPruneBlobStorage saves and prunes blob storage.

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -85,6 +85,9 @@ type testBlockChain struct {
 	gasLimit      uint64
 	chainHeadFeed *event.Feed
 	txMap         map[common.Hash]*types.Transaction
+
+	txLookupBlockNum uint64
+	txLookupIndex    uint64
 }
 
 func (pool *TxPool) SetBaseFee(baseFee *big.Int) {
@@ -111,7 +114,7 @@ func (bc *testBlockChain) GetTxAndLookupInfo(hash common.Hash) (*types.Transacti
 	if !ok {
 		return nil, common.Hash{}, 0, 0
 	}
-	return tx, common.Hash{}, 0, 0
+	return tx, common.Hash{}, bc.txLookupBlockNum, bc.txLookupIndex
 }
 
 func (bc *testBlockChain) addTransaction(tx *types.Transaction) {
@@ -3926,8 +3929,10 @@ func TestTxPool_SaveBlobSidecar(t *testing.T) {
 			name: "success-save-blob-sidecar",
 			setup: func(t *testing.T) (*TxPool, *testBlockChain, *types.Transaction, *types.BlobTxSidecar, *big.Int, int, common.Hash) {
 				pool, blockchain, key, _ := setupTxPoolWithBlobStorage(t)
+				blockchain.txLookupBlockNum = 1000
+				blockchain.txLookupIndex = 2
 				blockNum := big.NewInt(1000)
-				txIndex := 0
+				txIndex := 2
 
 				// Create a blob transaction
 				tx := blobTransaction(0, 100000, big.NewInt(1000), big.NewInt(100), big.NewInt(10), key, 1, nil)
@@ -3974,18 +3979,6 @@ func TestTxPool_SaveBlobSidecar(t *testing.T) {
 				blockchain.addTransaction(tx)
 
 				return pool, blockchain, tx, sidecar, big.NewInt(1000), 0, tx.Hash()
-			},
-			expectedError: "blob storage not initialized",
-		},
-		{
-			name: "error-block-num-nil",
-			setup: func(t *testing.T) (*TxPool, *testBlockChain, *types.Transaction, *types.BlobTxSidecar, *big.Int, int, common.Hash) {
-				pool, blockchain, key, _ := setupTxPoolWithBlobStorage(t)
-				tx := blobTransaction(0, 100000, big.NewInt(1000), big.NewInt(100), big.NewInt(10), key, 1, nil)
-				sidecar := tx.BlobTxSidecar()
-				blockchain.addTransaction(tx)
-
-				return pool, blockchain, tx, sidecar, nil, 0, tx.Hash()
 			},
 			expectedError: "blob storage not initialized",
 		},
@@ -4083,12 +4076,12 @@ func TestTxPool_SaveBlobSidecar(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			pool, _, _, sidecar, blockNum, txIndex, txHash := tc.setup(t)
+			pool, _, _, sidecar, expBlockNum, expTxIndex, txHash := tc.setup(t)
 			if pool != nil {
 				defer pool.Stop()
 			}
 
-			err := pool.SaveBlobSidecar(blockNum, txIndex, txHash, sidecar)
+			err := pool.SaveBlobSidecar(txHash, sidecar)
 
 			if tc.expectedError != "" {
 				require.Error(t, err)
@@ -4096,7 +4089,7 @@ func TestTxPool_SaveBlobSidecar(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				if tc.verify != nil {
-					tc.verify(t, pool, blockNum, txIndex, sidecar)
+					tc.verify(t, pool, expBlockNum, expTxIndex, sidecar)
 				}
 			}
 		})

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1350,8 +1350,11 @@ func handleBlobSidecarsMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 			continue
 		}
 
-		if err := pm.txpool.SaveBlobSidecar(big.NewInt(int64(sidecar.BlockNum)), int(sidecar.TxIndex), sidecar.TxHash, sidecar.Sidecar); err != nil {
-			logger.Warn("Saved blob sidecar", "blockNum", sidecar.BlockNum, "txIndex", sidecar.TxIndex, "txHash", sidecar.TxHash)
+		// The peer-supplied sidecar.BlockNum/TxIndex are intentionally ignored:
+		// SaveBlobSidecar derives the canonical storage location from the
+		// transaction itself.
+		if err := pm.txpool.SaveBlobSidecar(sidecar.TxHash, sidecar.Sidecar); err != nil {
+			logger.Warn("Failed to save blob sidecar", "txHash", sidecar.TxHash, "err", err)
 			continue
 		}
 

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -982,8 +982,6 @@ func TestHandleBlobSidecarsMsg(t *testing.T) {
 		// Setup expected save call
 		mockTxPool := mocks.NewMockTxPool(mockCtrl)
 		mockTxPool.EXPECT().SaveBlobSidecar(
-			big.NewInt(int64(d.BlockNum)),
-			int(d.TxIndex),
 			d.TxHash,
 			d.Sidecar,
 		).Return(nil).Times(1)
@@ -1018,8 +1016,6 @@ func TestHandleBlobSidecarsMsg(t *testing.T) {
 		}
 		mockTxPool := mocks.NewMockTxPool(mockCtrl)
 		mockTxPool.EXPECT().SaveBlobSidecar(
-			big.NewInt(int64(d.BlockNum)),
-			int(d.TxIndex),
 			d.TxHash,
 			d.Sidecar,
 		).Return(errors.New("expected error")).Times(1)

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -270,6 +270,11 @@ type blobSidecarsRequestData struct {
 }
 
 type blobSidecarsData struct {
+	// BlockNum and TxIndex are deprecated: the receiver no longer reads them.
+	// SaveBlobSidecar derives the canonical storage location from TxHash, so a
+	// peer cannot dictate where the sidecar is stored. They are retained only
+	// for wire compatibility with existing peers and should be removed in a
+	// future protocol version bump.
 	BlockNum hexutil.Uint64
 	TxIndex  hexutil.Uint
 	TxHash   common.Hash

--- a/work/mocks/txpool_mock.go
+++ b/work/mocks/txpool_mock.go
@@ -198,17 +198,17 @@ func (mr *MockTxPoolMockRecorder) RegisterTxPoolModule(arg0 ...interface{}) *gom
 }
 
 // SaveBlobSidecar mocks base method.
-func (m *MockTxPool) SaveBlobSidecar(arg0 *big.Int, arg1 int, arg2 common.Hash, arg3 *types.BlobTxSidecar) error {
+func (m *MockTxPool) SaveBlobSidecar(arg0 common.Hash, arg1 *types.BlobTxSidecar) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveBlobSidecar", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SaveBlobSidecar", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveBlobSidecar indicates an expected call of SaveBlobSidecar.
-func (mr *MockTxPoolMockRecorder) SaveBlobSidecar(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockTxPoolMockRecorder) SaveBlobSidecar(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveBlobSidecar", reflect.TypeOf((*MockTxPool)(nil).SaveBlobSidecar), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveBlobSidecar", reflect.TypeOf((*MockTxPool)(nil).SaveBlobSidecar), arg0, arg1)
 }
 
 // SetGasPrice mocks base method.

--- a/work/work.go
+++ b/work/work.go
@@ -82,7 +82,7 @@ type TxPool interface {
 	GetBlobSidecarFromStorage(blockNum *big.Int, txIndex int) (*types.BlobTxSidecar, error)
 	GetBlobSidecarFromPool(txHash common.Hash) (*types.BlobTxSidecar, error)
 	SubscribeMissingBlobSidecars() <-chan *blockchain.MissingBlobSidecar
-	SaveBlobSidecar(blockNum *big.Int, txIndex int, txHash common.Hash, sidecar *types.BlobTxSidecar) error
+	SaveBlobSidecar(txHash common.Hash, sidecar *types.BlobTxSidecar) error
 
 	kaiax.TxPoolModuleHost
 }


### PR DESCRIPTION
## Proposed changes

- On the P2P missing-sidecar path, SaveBlobSidecar stored a fetched blob sidecar at a caller-/peer-supplied (blockNum, txIndex). The sidecar content was validated against the requested tx hash, but its storage location was never bound to that hash
- Derive the storage location from the transaction itself and drop the now-unused `blockNum`/`txIndex` parameters
- The wire format is unchanged, so no protocol-version bump is needed

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
