### PR TITLE
kaiax/valset: align permissionless idle/pause timeout with KIP-286

### DIFF
--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -187,8 +187,10 @@ func (ctx *TransitionContext) applyEpochTransition(m valset.NodeMap) valset.Node
 		if val.StakingAmount >= ctx.MinStake {
 			activeValCompetitors = append(activeValCompetitors, sortableValidator{addr, val}) // T3a
 		} else {
+			if val.State != valset.ValReady {
+				val.IdleTimeout = ctx.BlockTime.Add(ctx.IdleTimeout)
+			}
 			val.State = valset.ValInactive // T3b
-			val.IdleTimeout = ctx.BlockTime.Add(ctx.IdleTimeout)
 		}
 	}
 	for addr, val := range newValidators {
@@ -227,8 +229,10 @@ func (ctx *TransitionContext) applyEpochTransition(m valset.NodeMap) valset.Node
 				potentialActiveVal.PausedTimeout = time.Time{}
 			}
 		} else {
+			if potentialActiveVal.State != valset.ValReady {
+				potentialActiveVal.IdleTimeout = ctx.BlockTime.Add(ctx.IdleTimeout)
+			}
 			potentialActiveVal.State = valset.ValInactive // T3b
-			potentialActiveVal.IdleTimeout = ctx.BlockTime.Add(ctx.IdleTimeout)
 		}
 	}
 	return newValidators
@@ -308,7 +312,6 @@ func (ctx *TransitionContext) applyViolationTransition(m valset.NodeMap) valset.
 			// ValReady → ValInactive (no slot check, not in active set)
 			logger.Trace("MinStake violation: ValReady → ValInactive", "addr", addr, "staking", val.StakingAmount, "minStake", ctx.MinStake)
 			val.State = valset.ValInactive
-			val.IdleTimeout = ctx.BlockTime.Add(ctx.IdleTimeout)
 		}
 	}
 
@@ -364,7 +367,7 @@ func (ctx *TransitionContext) applyTimeoutTransition(m valset.NodeMap) valset.No
 			if val.IdleTimeout.IsZero() {
 				val.IdleTimeout = ctx.BlockTime.Add(ctx.IdleTimeout)
 			}
-			if ctx.BlockTime.After(val.IdleTimeout) {
+			if !ctx.BlockTime.Before(val.IdleTimeout) {
 				val.State = valset.Registered
 				val.IdleTimeout = time.Time{}
 			}
@@ -372,7 +375,7 @@ func (ctx *TransitionContext) applyTimeoutTransition(m valset.NodeMap) valset.No
 			if val.PausedTimeout.IsZero() {
 				val.PausedTimeout = ctx.BlockTime.Add(ctx.PauseTimeout)
 			}
-			if ctx.BlockTime.After(val.PausedTimeout) {
+			if !ctx.BlockTime.Before(val.PausedTimeout) {
 				val.State = valset.ValInactive
 				val.PausedTimeout = time.Time{}
 				val.IdleTimeout = ctx.BlockTime.Add(ctx.IdleTimeout)

--- a/kaiax/valset/impl/transition_context_test.go
+++ b/kaiax/valset/impl/transition_context_test.go
@@ -176,7 +176,7 @@ func TestApplyEpochTransition_StateTransitions(t *testing.T) {
 		{"ValActive + stake above → ValActive (preserved)", ValActive, aboveMinStake, ValActive, false},
 		{"ValPaused + stake above → ValPaused (preserved)", ValPaused, aboveMinStake, ValPaused, false},
 		{"T3b: ValActive + stake below → ValInactive", ValActive, belowMinStake, ValInactive, true},
-		{"T3b: ValReady + stake below → ValInactive", ValReady, belowMinStake, ValInactive, true},
+		{"T3b: ValReady + stake below → ValInactive", ValReady, belowMinStake, ValInactive, false},
 		{"T3b: ValPaused + stake below → ValInactive", ValPaused, belowMinStake, ValInactive, true},
 	}
 	for _, tc := range cases {
@@ -199,11 +199,12 @@ func TestApplyEpochTransition_StateTransitions(t *testing.T) {
 // are demoted to VI at epoch (T3b), so newSF is computed only from validators
 // with sufficient stake.
 func TestApplyEpochTransition_BelowMinStakeDemoted(t *testing.T) {
+	vrIdle := testBlockTime.Add(5 * time.Hour) // ValReady's already-accumulating idle deadline
 	m := NodeMap{
-		addr1: {State: ValActive, StakingAmount: aboveMinStake}, // above-min: stays VA
-		addr2: {State: ValActive, StakingAmount: belowMinStake}, // T3b → VI
-		addr3: {State: ValReady, StakingAmount: belowMinStake},  // T3b → VI
-		addr4: {State: ValPaused, StakingAmount: belowMinStake}, // T3b → VI
+		addr1: {State: ValActive, StakingAmount: aboveMinStake},                     // above-min: stays VA
+		addr2: {State: ValActive, StakingAmount: belowMinStake},                     // T3b → VI (fresh idle)
+		addr3: {State: ValReady, StakingAmount: belowMinStake, IdleTimeout: vrIdle}, // T3b → VI (idle preserved)
+		addr4: {State: ValPaused, StakingAmount: belowMinStake},                     // T3b → VI (fresh idle)
 	}
 	ctx := epochCtx(t, nil, testMaxValCount)
 	out := ctx.applyEpochTransition(m)
@@ -213,15 +214,17 @@ func TestApplyEpochTransition_BelowMinStakeDemoted(t *testing.T) {
 	assert.Equal(t, ValInactive, out[addr3].State)
 	assert.Equal(t, ValInactive, out[addr4].State)
 	assert.False(t, out[addr2].IdleTimeout.IsZero())
-	assert.False(t, out[addr3].IdleTimeout.IsZero())
+	assert.Equal(t, vrIdle, out[addr3].IdleTimeout) // VR carries its idle timer through the demotion
 	assert.False(t, out[addr4].IdleTimeout.IsZero())
 }
 
 func TestApplyEpochTransition_MaxValActivePausedCount(t *testing.T) {
+	vrIdle := testBlockTime.Add(2 * time.Hour) // ValReady competitor's already-accumulating idle deadline
 	m := NodeMap{
 		addr1: {State: ValActive, StakingAmount: highStake},
 		addr2: {State: ValActive, StakingAmount: midStake},
 		addr3: {State: ValActive, StakingAmount: lowStake},
+		addr4: {State: ValReady, StakingAmount: testMinStake + 1, IdleTimeout: vrIdle}, // competitor, ranks last → loses top-N
 	}
 	ctx := epochCtx(t, nil, 2)
 	out := ctx.applyEpochTransition(m)
@@ -229,6 +232,8 @@ func TestApplyEpochTransition_MaxValActivePausedCount(t *testing.T) {
 	assert.Equal(t, ValActive, out[addr2].State)
 	assert.Equal(t, ValInactive, out[addr3].State)
 	assert.False(t, out[addr3].IdleTimeout.IsZero())
+	assert.Equal(t, ValInactive, out[addr4].State)
+	assert.Equal(t, vrIdle, out[addr4].IdleTimeout) // VR that loses top-N keeps its idle timer
 }
 
 func TestApplyEpochTransition_TieBreakingByAddress(t *testing.T) {
@@ -366,6 +371,7 @@ func TestApplyViolationTransition_Deterministic(t *testing.T) {
 }
 
 func TestApplyViolationTransition_MinStakeMigrated(t *testing.T) {
+	vrIdleViol := testBlockTime.Add(3 * time.Hour) // ValReady's already-accumulating idle deadline
 	cases := []struct {
 		name           string
 		validators     NodeMap
@@ -376,7 +382,7 @@ func TestApplyViolationTransition_MinStakeMigrated(t *testing.T) {
 		{
 			"ValReady + low staking → ValInactive",
 			NodeMap{
-				addr1: {State: ValReady, StakingAmount: belowMinStake},
+				addr1: {State: ValReady, StakingAmount: belowMinStake, IdleTimeout: vrIdleViol},
 				addr2: {State: ValReady, StakingAmount: aboveMinStake},
 			},
 			noSlotLimit,
@@ -414,7 +420,7 @@ func TestApplyViolationTransition_MinStakeMigrated(t *testing.T) {
 				assert.Equal(t, expected, out[addr].State, "addr=%s", addr.Hex())
 			}
 			if tc.checkTimeout != nil {
-				assert.False(t, out[*tc.checkTimeout].IdleTimeout.IsZero(), "IdleTimeout should be set")
+				assert.Equal(t, vrIdleViol, out[*tc.checkTimeout].IdleTimeout, "VR idle timer preserved through violation demotion")
 			}
 		})
 	}
@@ -664,6 +670,8 @@ func TestApplyTimeoutTransition(t *testing.T) {
 		{"ValReady: preserve existing idle timeout", &Node{State: ValReady, IdleTimeout: futureTimeout}, ValReady, true, false, &futureTimeout},
 		{"ValInactive: idle expired → Registered", &Node{State: ValInactive, IdleTimeout: expiredTimeout}, Registered, false, false, nil},
 		{"ValReady: idle expired → Registered", &Node{State: ValReady, IdleTimeout: expiredTimeout}, Registered, false, false, nil},
+		{"ValInactive: idle exactly at deadline → Registered", &Node{State: ValInactive, IdleTimeout: testBlockTime}, Registered, false, false, nil},
+		{"ValPaused: paused exactly at deadline → ValInactive", &Node{State: ValPaused, PausedTimeout: testBlockTime}, ValInactive, true, false, nil},
 		{"ValPaused: set paused timeout", &Node{State: ValPaused}, ValPaused, false, true, nil},
 		{"ValPaused: preserve existing paused timeout", &Node{State: ValPaused, PausedTimeout: futureTimeout}, ValPaused, false, true, nil},
 		{"ValPaused: paused expired → ValInactive + idle set", &Node{State: ValPaused, PausedTimeout: expiredTimeout}, ValInactive, true, false, nil},


### PR DESCRIPTION
## Proposed changes

Fix two KIP-286 conformance bugs in the permissionless idle/pause timeout
(`kaiax/valset/impl/transition_context.go`):

**1. The idle timer was reset whenever the system demoted a `ValReady` validator
back to `ValInactive`.** Per KIP-286 the idle timer keeps accumulating while a
validator bounces between `ValInactive` and `ValReady` (it resets only at
`Registered`/`ValActive`), and the AddressBookV2 contract already preserves it —
but the core's epoch/violation demotions reset it, so an oscillating validator
never timed out. Now the timer is preserved on `ValReady → ValInactive`.

**2. The timeout fired one block late.** The check was `BlockTime > deadline`
(strict), but KIP-286 and the AddressBookV2 contract both use `>=`. Changed to
`>=`.

Unit tests cover both fixes.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

