### PR TITLE
p2p: count inbound peers, not sockets, against inbound capacity

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1134,7 +1134,7 @@ var (
 	}
 	MaxConnectionsFlag = &cli.IntFlag{
 		Name:     "maxconnections",
-		Usage:    "Maximum number of physical connections. All single channel peers can be maxconnections peers. All multi channel peers can be maxconnections/2 peers. (network disabled if set to 0)",
+		Usage:    "Maximum number of peers, inbound and outbound combined. A multi-channel peer counts once regardless of how many sockets it uses. (network disabled if set to 0)",
 		Value:    node.DefaultMaxPhysicalConnections,
 		Aliases:  []string{"p2p.max-connections"},
 		EnvVars:  []string{"KLAYTN_MAXCONNECTIONS", "KAIA_MAXCONNECTIONS"},

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -330,6 +330,9 @@ func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *con
 // countInboundPeers returns how many peers are connected via an inbound
 // connection. A multichannel peer holds several sockets but counts once, so
 // inbound capacity is measured in peers (per KIP-311), not physical sockets.
+// Direction is taken from the peer's default channel (Peer.Inbound); a peer
+// whose channels are of mixed direction (a rare simultaneous-dial race) is
+// classified by that channel.
 func countInboundPeers(peers map[discover.NodeID]*Peer) int {
 	n := 0
 	for _, p := range peers {

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -277,21 +277,21 @@ func (srv *BaseServer) startListening() error {
 	return nil
 }
 
-func (srv *BaseServer) protoHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCount int, c *conn) error {
+func (srv *BaseServer) protoHandshakeChecks(peers map[discover.NodeID]*Peer, c *conn) error {
 	// Drop connections with no matching protocols.
 	if len(srv.Protocols) > 0 && countMatchingProtocols(srv.Protocols, c.caps) == 0 {
 		return DiscUselessPeer
 	}
 	// Repeat the encryption handshake checks because the
 	// peer set might have changed between the handshakes.
-	return srv.encHandshakeChecks(peers, inboundCount, c)
+	return srv.encHandshakeChecks(peers, c)
 }
 
-func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCount int, c *conn) error {
+func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, c *conn) error {
 	switch {
 	case !c.isTrustedOrStatic() && len(peers) >= srv.Config.MaxPhysicalConnections:
 		return DiscTooManyPeers
-	case !c.is(trustedConn) && c.is(inboundConn) && inboundCount >= srv.maxInboundConns():
+	case !c.is(trustedConn) && c.is(inboundConn) && countInboundPeers(peers) >= srv.maxInboundConns():
 		return DiscTooManyPeers
 	case srv.exceedsPeerTarget(peers, c):
 		return DiscTooManyPeers
@@ -325,6 +325,19 @@ func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *con
 		return EffectiveConnType(p.ConnType()) != peerType
 	})
 	return len(peersByType) >= target
+}
+
+// countInboundPeers returns how many peers are connected via an inbound
+// connection. A multichannel peer holds several sockets but counts once, so
+// inbound capacity is measured in peers (per KIP-311), not physical sockets.
+func countInboundPeers(peers map[discover.NodeID]*Peer) int {
+	n := 0
+	for _, p := range peers {
+		if p.Inbound() {
+			n++
+		}
+	}
+	return n
 }
 
 func (srv *BaseServer) admitByCNPeers(c *conn) error {
@@ -570,7 +583,7 @@ func (srv *BaseServer) handlePostHandshake(c *conn) error {
 	if srv.trusted[c.id] {
 		c.flags |= trustedConn
 	}
-	return srv.encHandshakeChecks(srv.peers, srv.inboundCount, c)
+	return srv.encHandshakeChecks(srv.peers, c)
 }
 
 func (srv *BaseServer) handleAddPeerConn(c *conn) error {
@@ -580,7 +593,7 @@ func (srv *BaseServer) handleAddPeerConn(c *conn) error {
 	if !srv.running {
 		return errServerStopped
 	}
-	err := srv.protoHandshakeChecks(srv.peers, srv.inboundCount, c)
+	err := srv.protoHandshakeChecks(srv.peers, c)
 	if err != nil {
 		return err
 	}

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -338,7 +338,7 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 	if !srv.running {
 		return errServerStopped
 	}
-	err := srv.protoHandshakeChecks(srv.peers, srv.inboundCount, c)
+	err := srv.protoHandshakeChecks(srv.peers, c)
 	if err != nil {
 		return err
 	}

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -367,22 +367,24 @@ func TestServerAtCap(t *testing.T) {
 }
 
 func TestCountInboundPeers(t *testing.T) {
-	// A multichannel peer holds multiple sockets but must count once: inbound
-	// capacity is measured in peers, not physical connections (KIP-311).
-	withChannels := func(flag connFlag, channels int) *Peer {
-		rws := make([]*conn, channels)
-		for i := range rws {
-			rws[i] = &conn{flags: flag}
+	// Inbound capacity is measured in peers, not sockets: a multichannel peer
+	// counts once, and a mixed-direction peer is classified by its default
+	// channel (ConnDefault), matching Peer.Inbound.
+	peer := func(channelFlags ...connFlag) *Peer {
+		rws := make([]*conn, len(channelFlags))
+		for i, f := range channelFlags {
+			rws[i] = &conn{flags: f}
 		}
 		return &Peer{rws: rws}
 	}
 	peers := map[discover.NodeID]*Peer{
-		randomID(): withChannels(inboundConn, 2),   // multichannel inbound
-		randomID(): withChannels(inboundConn, 2),   // multichannel inbound
-		randomID(): withChannels(inboundConn, 1),   // single-channel inbound
-		randomID(): withChannels(dynDialedConn, 2), // multichannel outbound (not counted)
+		randomID(): peer(inboundConn, inboundConn),     // multichannel inbound -> counts
+		randomID(): peer(inboundConn),                  // single-channel inbound -> counts
+		randomID(): peer(inboundConn, dynDialedConn),   // default inbound, sub outbound -> counts
+		randomID(): peer(dynDialedConn, dynDialedConn), // multichannel outbound -> not counted
+		randomID(): peer(dynDialedConn, inboundConn),   // default outbound, sub inbound -> not counted
 	}
-	// 3 inbound peers spread over 5 inbound sockets; the count is by peer.
+	// Counted: the three peers whose default channel is inbound.
 	if got := countInboundPeers(peers); got != 3 {
 		t.Errorf("countInboundPeers = %d, want 3", got)
 	}

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -366,6 +366,28 @@ func TestServerAtCap(t *testing.T) {
 	}
 }
 
+func TestCountInboundPeers(t *testing.T) {
+	// A multichannel peer holds multiple sockets but must count once: inbound
+	// capacity is measured in peers, not physical connections (KIP-311).
+	withChannels := func(flag connFlag, channels int) *Peer {
+		rws := make([]*conn, channels)
+		for i := range rws {
+			rws[i] = &conn{flags: flag}
+		}
+		return &Peer{rws: rws}
+	}
+	peers := map[discover.NodeID]*Peer{
+		randomID(): withChannels(inboundConn, 2),   // multichannel inbound
+		randomID(): withChannels(inboundConn, 2),   // multichannel inbound
+		randomID(): withChannels(inboundConn, 1),   // single-channel inbound
+		randomID(): withChannels(dynDialedConn, 2), // multichannel outbound (not counted)
+	}
+	// 3 inbound peers spread over 5 inbound sockets; the count is by peer.
+	if got := countInboundPeers(peers); got != 3 {
+		t.Errorf("countInboundPeers = %d, want 3", got)
+	}
+}
+
 func TestServerPeerTargets(t *testing.T) {
 	newPeerWithType := func(connType common.ConnType) *Peer {
 		return &Peer{rws: []*conn{{conntype: connType}}}


### PR DESCRIPTION
## Proposed changes

The inbound admission check counted **sockets** (`srv.inboundCount`, summed over each
peer's channels) while the main cap and dial scheduler count **peers**. On a multichannel
node a peer holds 2 sockets, so inbound capacity was effectively halved — a CN with
`maxconnections=N` accepted only ~N/2 inbound peers. This diverges from KIP-311's
peer-based budgets and, at production scale, can cap the CN full mesh below intent.

This PR counts inbound **peers** from the peer set instead of summing sockets, so channel
mode no longer affects inbound capacity. `srv.inboundCount` stays socket-based for the
`ConnectionInCountGauge` metric.

Verified on a 4-CN local net (inbound-only CN, `maxconnections=4`, `--reserved-cross-type-slots 1`):

| binary | multichannel | cn1 peers | inbound sockets |
|--------|--------------|-----------|-----------------|
| before | on           | 2         | 4 (capped)      |
| before | off          | 3         | 3               |
| after  | on           | **3**     | 6               |

`after/on` matches single-channel and lifts sockets past the old cap → capacity is now peer-based.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

Follow-up to #939 (cross-type slot reservation). No tracking issue.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
