### PR TITLE
kaiax/valset: pin base proposer list to qualified set at updateNum+1

### DIFF
--- a/kaiax/valset/impl/getter_context_test.go
+++ b/kaiax/valset/impl/getter_context_test.go
@@ -108,12 +108,31 @@ func TestGetCommittee(t *testing.T) {
 	mockChain.EXPECT().GetHeaderByNumber(gomock.Any()).Return(c.prevHeader).AnyTimes()
 	mockStaking.EXPECT().GetStakingInfo(gomock.Any()).Return(si, nil).AnyTimes()
 
+	// calcBaseProposers derives the base list from the qualified set at updateNum+1, so the council DB,
+	// gov params and chain config must be available. Council@(updateNum+1) resolves to `qualified`.
+	writeLowestScannedVoteNum(v.ChainKv, 0)
+	writeCouncil(v.ChainKv, 0, qualified)
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		ProposerPolicy: uint64(istanbul.WeightedRandom),
+		MinimumStake:   big.NewInt(0),
+		GovernanceMode: "none",
+	}).AnyTimes()
+	chainConfig := &params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}
+	mockChain.EXPECT().Config().Return(chainConfig).AnyTimes()
+
 	for _, tc := range testcases {
 		c.pset.ProposerPolicy = uint64(tc.policy)
 		c.rules.IsKore = tc.isKore
 		c.rules.IsShanghai = tc.isRandao
 		c.rules.IsCancun = tc.isRandao
 		c.rules.IsRandao = tc.isRandao
+		// The uniform-vs-weighted choice is now pinned to the rule at updateNum+1, so toggle Kore on
+		// the chain config (not just c.rules) to match the test case.
+		if tc.isKore {
+			chainConfig.KoreCompatibleBlock = big.NewInt(0)
+		} else {
+			chainConfig.KoreCompatibleBlock = nil
+		}
 
 		v.proposerListCache.Purge()
 		v.removeVotesCache.Purge()
@@ -243,12 +262,31 @@ func TestGetProposer(t *testing.T) {
 	mockChain.EXPECT().GetHeaderByNumber(gomock.Any()).Return(c.prevHeader).AnyTimes()
 	mockStaking.EXPECT().GetStakingInfo(gomock.Any()).Return(si, nil).AnyTimes()
 
+	// calcBaseProposers derives the base list from the qualified set at updateNum+1, so the council DB,
+	// gov params and chain config must be available. Council@(updateNum+1) resolves to `qualified`.
+	writeLowestScannedVoteNum(v.ChainKv, 0)
+	writeCouncil(v.ChainKv, 0, qualified)
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		ProposerPolicy: uint64(istanbul.WeightedRandom),
+		MinimumStake:   big.NewInt(0),
+		GovernanceMode: "none",
+	}).AnyTimes()
+	chainConfig := &params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}
+	mockChain.EXPECT().Config().Return(chainConfig).AnyTimes()
+
 	for _, tc := range testcases {
 		c.pset.ProposerPolicy = uint64(tc.policy)
 		c.rules.IsKore = tc.isKore
 		c.rules.IsShanghai = tc.isRandao
 		c.rules.IsCancun = tc.isRandao
 		c.rules.IsRandao = tc.isRandao
+		// The uniform-vs-weighted choice is now pinned to the rule at updateNum+1, so toggle Kore on
+		// the chain config (not just c.rules) to match the test case.
+		if tc.isKore {
+			chainConfig.KoreCompatibleBlock = big.NewInt(0)
+		} else {
+			chainConfig.KoreCompatibleBlock = nil
+		}
 
 		v.proposerListCache.Purge()
 		v.removeVotesCache.Purge()

--- a/kaiax/valset/impl/getter_proposers.go
+++ b/kaiax/valset/impl/getter_proposers.go
@@ -18,7 +18,7 @@ func (v *ValsetModule) getProposerList(c *blockContext) ([]common.Address, uint6
 	)
 
 	// calculate base pList at updateNum
-	pList, err := v.calcBaseProposers(c, updateNum, useGini)
+	pList, err := v.calcBaseProposers(updateNum, useGini)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -30,7 +30,7 @@ func (v *ValsetModule) getProposerList(c *blockContext) ([]common.Address, uint6
 	return pList, updateNum, nil
 }
 
-func (v *ValsetModule) calcBaseProposers(c *blockContext, updateNum uint64, useGini bool) ([]common.Address, error) {
+func (v *ValsetModule) calcBaseProposers(updateNum uint64, useGini bool) ([]common.Address, error) {
 	// Lookup proposers at updateNum from cache
 	if list, ok := v.proposerListCache.Get(updateNum); ok {
 		return list.([]common.Address), nil
@@ -61,7 +61,7 @@ func (v *ValsetModule) calcBaseProposers(c *blockContext, updateNum uint64, useG
 		}
 		list = generateProposerListWeighted(qualified, si, useGini, updateHeader.Hash())
 	}
-	logger.Debug("GetProposerList", "number", c.num, "updateNum", updateNum, "list", valset.NewAddressSet(list).String())
+	logger.Debug("GetProposerList", "updateNum", updateNum, "list", valset.NewAddressSet(list).String())
 
 	// Store to cache
 	v.proposerListCache.Add(updateNum, list)

--- a/kaiax/valset/impl/getter_proposers.go
+++ b/kaiax/valset/impl/getter_proposers.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"math"
+	"math/big"
 	"slices"
 
 	"github.com/kaiachain/kaia/common"
@@ -40,17 +41,27 @@ func (v *ValsetModule) calcBaseProposers(c *blockContext, updateNum uint64, useG
 	if updateHeader == nil {
 		return nil, errNoHeader
 	}
+
+	// The base list is cached under updateNum and reused for the whole interval, so it must be a pure
+	// function of updateNum rather than of c.num (the block that first misses the cache). Legacy istanbul
+	// fixed it from the interval's first block (updateNum+1); reproduce that so sealed blocks stay reproducible
+	// and so the schedule cannot diverge on a mid-interval restart.
+	baseNum := updateNum + 1
+	qualified, err := v.getQualifiedPermissioned(baseNum)
+	if err != nil {
+		return nil, err
+	}
 	var list []common.Address
-	if c.rules.IsKore {
-		list = generateProposerListUniform(c.qualified, updateHeader.Hash())
+	if v.Chain.Config().Rules(new(big.Int).SetUint64(baseNum)).IsKore {
+		list = generateProposerListUniform(qualified, updateHeader.Hash())
 	} else {
 		si, err := v.StakingModule.GetStakingInfo(updateNum)
 		if err != nil {
 			return nil, err
 		}
-		list = generateProposerListWeighted(c.qualified, si, useGini, updateHeader.Hash())
+		list = generateProposerListWeighted(qualified, si, useGini, updateHeader.Hash())
 	}
-	logger.Debug("GetProposerList", "number", c.num, "list", valset.NewAddressSet(list).String())
+	logger.Debug("GetProposerList", "number", c.num, "updateNum", updateNum, "list", valset.NewAddressSet(list).String())
 
 	// Store to cache
 	v.proposerListCache.Add(updateNum, list)

--- a/kaiax/valset/impl/getter_proposers_test.go
+++ b/kaiax/valset/impl/getter_proposers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kaiachain/kaia/storage/database"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetProposers_GetRemoveVotesInInterval(t *testing.T) {
@@ -245,6 +246,91 @@ func TestWeightedRandomProposer_ListWeighted(t *testing.T) {
 			t.Logf("actual: %v", addrsToNums(proposerList))
 		}
 	}
+}
+
+// TestCalcBaseProposers_PinnedToUpdateNumPlus1 verifies that the cached base proposer list is a
+// pure function of updateNum — derived from the qualified set at updateNum+1 (the interval's first
+// block, matching legacy istanbul) — and does NOT depend on the requesting block's context
+// (c.num / c.qualified). Otherwise the per-interval schedule would depend on which block first
+// populates proposerListCache, diverging across restarts/sync.
+// See AUDIT_PROPOSER_LIST_NONDETERMINISM.md.
+func TestCalcBaseProposers_PinnedToUpdateNumPlus1(t *testing.T) {
+	const (
+		interval  = uint64(100)
+		updateNum = uint64(100)
+		minStake  = uint64(5000000)
+	)
+	var (
+		ctrl          = gomock.NewController(t)
+		mockChain     = chain_mock.NewMockBlockChain(ctrl)
+		mockGov       = gov_mock.NewMockGovModule(ctrl)
+		mockStaking   = staking_mock.NewMockStakingModule(ctrl)
+		pListCache, _ = lru.New(128)
+		rVoteCache, _ = lru.New(128)
+		v             = &ValsetModule{
+			InitOpts: InitOpts{
+				ChainKv:       database.NewMemoryDBManager().GetMiscDB(),
+				Chain:         mockChain,
+				GovModule:     mockGov,
+				StakingModule: mockStaking,
+			},
+			proposerListCache: pListCache,
+			removeVotesCache:  rVoteCache,
+		}
+		council      = numsToAddrs(1, 2, 3, 4)
+		updateHeader = &types.Header{Number: big.NewInt(int64(updateNum))}
+	)
+
+	// Migrated council DB: council [1,2,3,4] from genesis.
+	writeLowestScannedVoteNum(v.ChainKv, 0)
+	writeValidatorVoteBlockNums(v.ChainKv, []uint64{0})
+	writeCouncil(v.ChainKv, 0, council)
+
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		ProposerUpdateInterval: interval,
+		ProposerPolicy:         uint64(params.WeightedRandom),
+		MinimumStake:           big.NewInt(int64(minStake)),
+		GovernanceMode:         "none",
+	}).AnyTimes()
+	// Istanbul on (staking-based demotion active), Kore off (weighted path).
+	mockChain.EXPECT().Config().Return(&params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}).AnyTimes()
+	mockChain.EXPECT().GetHeaderByNumber(updateNum).Return(updateHeader).AnyTimes()
+
+	// Every validator is qualified at updateNum (weights) and updateNum+1 (demotion check).
+	fullStaking := &staking.StakingInfo{
+		NodeIds:          council,
+		StakingContracts: council,
+		RewardAddrs:      council,
+		StakingAmounts:   []uint64{minStake, minStake, minStake, minStake},
+	}
+	mockStaking.EXPECT().GetStakingInfo(updateNum).Return(fullStaking, nil).AnyTimes()
+	mockStaking.EXPECT().GetStakingInfo(updateNum+1).Return(fullStaking, nil).AnyTimes()
+	// At a late block validator 4 is understaked (demoted). This "poisoned" context must not leak
+	// into the cached base list.
+	mockStaking.EXPECT().GetStakingInfo(updateNum+50).Return(&staking.StakingInfo{
+		NodeIds:          council,
+		StakingContracts: council,
+		RewardAddrs:      council,
+		StakingAmounts:   []uint64{minStake, minStake, minStake, minStake - 1},
+	}, nil).AnyTimes()
+
+	// Reference: list built from qualified@(updateNum+1) = [1,2,3,4], weights from staking@updateNum.
+	reference := generateProposerListWeighted(valset.NewAddressSet(council), fullStaking, false, updateHeader.Hash())
+
+	// 1) First cache population from a poisoned late block whose c.qualified is the demoted set [1,2,3].
+	//    The result must still be the [1,2,3,4]-based reference list.
+	cLate := &blockContext{num: updateNum + 50, qualified: valset.NewAddressSet(numsToAddrs(1, 2, 3))}
+	listLate, err := v.calcBaseProposers(cLate, updateNum, false)
+	require.NoError(t, err)
+	assert.Equal(t, reference, listLate, "base list must derive from qualified@(updateNum+1), not c.qualified")
+	assert.Contains(t, listLate, numToAddr(4), "validator demoted mid-interval must remain in the base list")
+
+	// 2) Cache-population order must not matter: a fresh cache filled from updateNum+1 yields the same list.
+	v.proposerListCache.Purge()
+	cFirst := &blockContext{num: updateNum + 1, qualified: valset.NewAddressSet(council)}
+	listFirst, err := v.calcBaseProposers(cFirst, updateNum, false)
+	require.NoError(t, err)
+	assert.Equal(t, listLate, listFirst, "base list must be independent of cache-population order")
 }
 
 func TestWeightedRandomProposer_ListUniform(t *testing.T) {

--- a/kaiax/valset/impl/getter_proposers_test.go
+++ b/kaiax/valset/impl/getter_proposers_test.go
@@ -250,10 +250,9 @@ func TestWeightedRandomProposer_ListWeighted(t *testing.T) {
 
 // TestCalcBaseProposers_PinnedToUpdateNumPlus1 verifies that the cached base proposer list is a
 // pure function of updateNum — derived from the qualified set at updateNum+1 (the interval's first
-// block, matching legacy istanbul) — and does NOT depend on the requesting block's context
-// (c.num / c.qualified). Otherwise the per-interval schedule would depend on which block first
-// populates proposerListCache, diverging across restarts/sync.
-// See AUDIT_PROPOSER_LIST_NONDETERMINISM.md.
+// block, matching legacy istanbul). calcBaseProposers takes no block context, so the per-interval
+// schedule cannot depend on which block first populates proposerListCache (no divergence across
+// restarts/sync). See AUDIT_PROPOSER_LIST_NONDETERMINISM.md.
 func TestCalcBaseProposers_PinnedToUpdateNumPlus1(t *testing.T) {
 	const (
 		interval  = uint64(100)
@@ -305,32 +304,20 @@ func TestCalcBaseProposers_PinnedToUpdateNumPlus1(t *testing.T) {
 	}
 	mockStaking.EXPECT().GetStakingInfo(updateNum).Return(fullStaking, nil).AnyTimes()
 	mockStaking.EXPECT().GetStakingInfo(updateNum+1).Return(fullStaking, nil).AnyTimes()
-	// At a late block validator 4 is understaked (demoted). This "poisoned" context must not leak
-	// into the cached base list.
-	mockStaking.EXPECT().GetStakingInfo(updateNum+50).Return(&staking.StakingInfo{
-		NodeIds:          council,
-		StakingContracts: council,
-		RewardAddrs:      council,
-		StakingAmounts:   []uint64{minStake, minStake, minStake, minStake - 1},
-	}, nil).AnyTimes()
 
 	// Reference: list built from qualified@(updateNum+1) = [1,2,3,4], weights from staking@updateNum.
 	reference := generateProposerListWeighted(valset.NewAddressSet(council), fullStaking, false, updateHeader.Hash())
 
-	// 1) First cache population from a poisoned late block whose c.qualified is the demoted set [1,2,3].
-	//    The result must still be the [1,2,3,4]-based reference list.
-	cLate := &blockContext{num: updateNum + 50, qualified: valset.NewAddressSet(numsToAddrs(1, 2, 3))}
-	listLate, err := v.calcBaseProposers(cLate, updateNum, false)
+	// 1) Populate the cache. The list must derive from qualified@(updateNum+1).
+	list1, err := v.calcBaseProposers(updateNum, false)
 	require.NoError(t, err)
-	assert.Equal(t, reference, listLate, "base list must derive from qualified@(updateNum+1), not c.qualified")
-	assert.Contains(t, listLate, numToAddr(4), "validator demoted mid-interval must remain in the base list")
+	assert.Equal(t, reference, list1, "base list must derive from qualified@(updateNum+1)")
 
-	// 2) Cache-population order must not matter: a fresh cache filled from updateNum+1 yields the same list.
+	// 2) Cache-population order must not matter: a fresh cache yields the same list.
 	v.proposerListCache.Purge()
-	cFirst := &blockContext{num: updateNum + 1, qualified: valset.NewAddressSet(council)}
-	listFirst, err := v.calcBaseProposers(cFirst, updateNum, false)
+	list2, err := v.calcBaseProposers(updateNum, false)
 	require.NoError(t, err)
-	assert.Equal(t, listLate, listFirst, "base list must be independent of cache-population order")
+	assert.Equal(t, list1, list2, "base list must be independent of cache-population order")
 }
 
 func TestWeightedRandomProposer_ListUniform(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

# valset: pin base proposer list to qualified set at updateNum+1

## Summary

`valset.calcBaseProposers` caches the per-interval base proposer list under `updateNum` (first-writer-wins, purged on every `Start()`), but builds the list from `c.qualified` — the qualified validator set at the **requesting** block `c.num`, not at the proposer-update block. Because the qualified set changes within an interval (validator votes, staking-driven demotion/requalification), the cached list ends up depending on *which block first misses the cache* rather than on the canonical chain alone.

Two honest nodes — or one node before vs. after a mid-interval restart — can therefore cache different base lists for the same `updateNum` and compute different proposers for the same `(num, round)`. This is a determinism break in consensus-critical proposer selection.

Reachable only on the **WeightedRandom + pre-Randao** path (post-Randao live consensus uses the Randao committee path and never touches this cache). Practical exposure: a node that resumes sync mid-interval over a pre-Randao range where the validator set changed.

## Fix

Make the base list a pure function of `updateNum` by pinning the two `c`-dependent inputs to the interval's first block, `updateNum+1`:

- `qualified` ← `getQualifiedPermissioned(updateNum+1)` (was `c.qualified`)
- `IsKore` ← `Rules(updateNum+1).IsKore` (was `c.rules.IsKore`; otherwise the uniform-vs-weighted choice stays cache-order dependent in the Kore-boundary interval)

`GetStakingInfo(updateNum)` (weights), the seed (`hash@updateNum`) and `useGini` (immutable) are already deterministic and left untouched.

### Why `updateNum+1`, not `updateNum`

`updateNum+1` reproduces both the legacy istanbul behavior and the current code's correct path:

- Legacy `snapshot.apply` computed the list for interval `U` once, at header `N=U`, from `RefreshValSet(N+1)` = the validator set at `U+1`. That sealed every historical pre-Randao block.
- In sequential processing the first block to miss `cache[U]` is always `U+1` (block `U` belongs to the previous interval), so the current code already populates the cache with `qualified@(U+1)`.

`qualified@U` would differ from this whenever a validator vote lands exactly on a proposer-update block (`getCouncilDB` reflects a vote at `U` in `council@(U+1)`, not `council@U`) — i.e. that variant *would* change canonical results.

## Not a hardfork / no new state requirement

- **No hardfork:** the change is identical to the current code's sequential behavior. A fresh sequential re-sync (how nodes bootstrap) already uses `qualified@(U+1)`; mainnet re-syncs succeed today, so all history is already consistent with it. The fix only stops the poisoned-cache path from producing a non-canonical proposer.
- **No pruned-state dependency:** `getQualifiedPermissioned` is DB-backed (council from `ChainKv` / istanbul snapshot; demotion via `GetStakingInfo`, which for pre-Kaia reads cache → DB and persists, hitting account state only as a last-resort fallback). The weighted path already calls `GetStakingInfo(updateNum)` for an old block in production, proving old-interval staking is DB-resident.

## Testing

- New `TestCalcBaseProposers_PinnedToUpdateNumPlus1`: poisons the cache from a late block whose `c.qualified` is the demoted set and asserts the list is still derived from `qualified@(U+1)` and independent of cache-population order.
- Updated `TestGetProposer` / `TestGetCommittee` with the council-DB/gov/config setup the recompute now requires (expected proposers unchanged).
- `./kaiax/valset/...` green.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
