### PR TITLE
consensus/istanbul: enforce block size cap in `backend.Verify`

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/params"
 )
 
 const (
@@ -386,6 +387,13 @@ func (sb *backend) Verify(proposal bft.Proposal) (time.Duration, error) {
 				return 0, istanbul.ErrInvalidBlobTxWithSidecar
 			}
 		}
+	}
+
+	// check EIP-7934 RLP-encoded block size cap, mirroring BlockValidator.ValidateBody
+	// so an oversized proposal is rejected here instead of being PREPARE/COMMIT-ed and
+	// then refused on the import path.
+	if sb.chain.Config().IsOsakaForkEnabled(block.Number()) && block.Size() > params.MaxBlockSize {
+		return 0, blockchain.ErrBlockOversized
 	}
 
 	// verify the header of proposed block

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
@@ -226,4 +227,85 @@ func TestCommit(t *testing.T) {
 		}
 		engine.Stop()
 	}
+}
+
+// buildOversizedBlock returns a sealed block whose RLP-encoded size exceeds
+// params.MaxBlockSize, built on top of the chain's current head. Verify does not
+// execute transactions, so the injected tx only needs to inflate the encoded size.
+func buildOversizedBlock(t *testing.T, chain *blockchain.BlockChain, engine *backend) *types.Block {
+	t.Helper()
+	parent := chain.CurrentBlock()
+	header := makeHeader(parent, chain.Config())
+	if err := chain.PrepareHeader(header); err != nil {
+		t.Fatal(err)
+	}
+	state, err := chain.StateAt(parent.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyBlock, err := chain.Processor().FinalizeState(header, state, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recipient := common.Address{}
+	tx := types.NewTx(&types.TxInternalDataLegacy{
+		AccountNonce: 0,
+		Price:        big.NewInt(1),
+		GasLimit:     1,
+		Recipient:    &recipient,
+		Amount:       big.NewInt(0),
+		Payload:      make([]byte, params.MaxBlockSize), // pushes the whole block past the cap
+	})
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(chain.Config().ChainID), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// NewBlock recomputes the header TxHash from the supplied txs, so Verify's
+	// tx-root check still passes and the test isolates the size cap.
+	block := sealBlock(engine, types.NewBlock(emptyBlock.Header(), []*types.Transaction{signedTx}, nil))
+	if block.Size() <= params.MaxBlockSize {
+		t.Fatalf("test setup: block is not oversized (size=%d, cap=%d)", uint64(block.Size()), params.MaxBlockSize)
+	}
+	return block
+}
+
+// TestBackend_VerifyEnforcesBlockSizeCap checks that backend.Verify applies the
+// EIP-7934 RLP block-size cap (params.MaxBlockSize) on Osaka-enabled blocks, the
+// same rule the import path enforces in BlockValidator.ValidateBody. Without this,
+// honest validators would PREPARE/COMMIT an oversized proposal and only reject it
+// later on import.
+func TestBackend_VerifyEnforcesBlockSizeCap(t *testing.T) {
+	// Osaka enabled: the cap applies.
+	t.Run("osaka", func(t *testing.T) {
+		chain, engine := newBlockChain(t, 1, osakaCompatibleBlock(big.NewInt(0)))
+		defer chain.Stop()
+		defer engine.Stop()
+
+		// A normal-sized block must not be rejected by the size cap.
+		normal := makeBlockWithSeal(chain, engine, chain.CurrentBlock())
+		_, err := engine.Verify(normal)
+		assert.NotErrorIs(t, err, blockchain.ErrBlockOversized)
+
+		// An oversized proposal must be rejected up front in Verify.
+		oversized := buildOversizedBlock(t, chain, engine)
+		_, err = engine.Verify(oversized)
+		assert.ErrorIs(t, err, blockchain.ErrBlockOversized)
+	})
+
+	// Pre-Osaka: the cap is gated on IsOsakaForkEnabled, so it must not apply.
+	t.Run("pre-osaka", func(t *testing.T) {
+		chain, engine := newBlockChain(t, 1, osakaCompatibleBlock(nil))
+		defer chain.Stop()
+		defer engine.Stop()
+
+		oversized := buildOversizedBlock(t, chain, engine)
+		_, err := engine.Verify(oversized)
+		assert.NotErrorIs(t, err, blockchain.ErrBlockOversized)
+	})
 }


### PR DESCRIPTION
## Proposed changes

- `backend.Verify` validated only the header and transaction root, so honest validators would `PREPARE`/`COMMIT` a proposal exceeding params.MaxBlockSize and only reject it later on import (`ValidateBody` → `ErrBlockOversized`)
- This PR applies the same EIP-7934 size cap during proposal verification (Osaka-gated), keeping Verify consistent with the import path.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
