### PR TITLE
vrank: return empty report instead of erroring when `round > MaxRound`

### DIFF
--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -200,6 +200,17 @@ func TestPrepareHeader(t *testing.T) {
 		assert.Nil(t, header.VRank)
 	})
 
+	t.Run("high-round parent accepted in next header preparation", func(t *testing.T) {
+		// Regression: a parent committed at round > MaxRound must not make
+		// PrepareHeader fail.
+		parent := makeHeaderWithRound(10, int64(vrank.MaxRound+1)) // round 11
+		v := newCN(t, withCandidates(candidates), withHeaders(map[uint64]*types.Header{10: parent}), withoutStart()).VRankModule
+		header := &types.Header{Number: big.NewInt(11)}
+
+		require.NoError(t, v.PrepareHeader(header))
+		assert.Nil(t, header.VRank)
+	})
+
 	t.Run("non-epoch fills evaluated candidate failures", func(t *testing.T) {
 		parent := makeHeaderWithRound(10, 1)
 		parentBlock := types.NewBlockWithHeader(parent)

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -105,7 +105,11 @@ func (v *VRankModule) EvaluateCandidates(blockNum, round uint64) ([]common.Addre
 		return []common.Address{}, nil
 	}
 	if round > maxRound {
-		return nil, vrank.ErrRoundOutOfRange
+		// Candidate messages above maxRound are dropped on receipt, though the
+		// preprepare timestamp may still be recorded. Evaluating this view would
+		// then see no candidate responses and mark every candidate as failed, so
+		// return an empty report instead of that spurious result.
+		return []common.Address{}, nil
 	}
 
 	vk := vrank.ViewKey{N: blockNum, R: uint8(round)}

--- a/kaiax/vrank/impl/getter_test.go
+++ b/kaiax/vrank/impl/getter_test.go
@@ -318,16 +318,20 @@ func TestEvaluateCandidates_Errors(t *testing.T) {
 		assert.Empty(t, report)
 	})
 
-	t.Run("round out of range returns error", func(t *testing.T) {
+	t.Run("round above maxRound returns empty report", func(t *testing.T) {
 		cn := newCNWithDefaults()
 		cn.VRankModule.HandleIstanbulPreprepare(block1, view1_0)
 
+		// round > maxRound must degrade gracefully.
 		report, err := cn.VRankModule.EvaluateCandidates(1, 11) // maxRound is 10
-		require.ErrorIs(t, err, vrank.ErrRoundOutOfRange)
-		assert.Nil(t, report)
+		require.NoError(t, err)
+		assert.NotErrorIs(t, err, vrank.ErrRoundOutOfRange)
+		assert.Empty(t, report)
 
 		report, err = cn.VRankModule.EvaluateCandidates(1, 10)
+		require.NoError(t, err)
 		assert.NotErrorIs(t, err, vrank.ErrRoundOutOfRange)
+		assert.Empty(t, report)
 	})
 
 	t.Run("non-validator returns empty report", func(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

- `EvaluateCandidates` returned a fatal `ErrRoundOutOfRange` when the parent's committed round exceeded `MaxRound`; this propagated up through PrepareHeader and prevented production of the next block
- This PR updates `EvaluateCandidates` to return an empty report instead. VRank collects no candidate messages above `MaxRound`, so there is genuinely no in-window data to evaluate, matching the function's existing "no data" exits.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
