### PR TITLE
vm: fix data race on CallTracer interruptReason

### DIFF
--- a/blockchain/vm/call_tracer.go
+++ b/blockchain/vm/call_tracer.go
@@ -224,13 +224,16 @@ func (t *CallTracer) GetResult() (CallFrame, error) {
 		return CallFrame{}, errors.New("incorrect number of top-level calls")
 	}
 
-	// Return with interrupt reason if any
-	return t.callstack[0], t.interruptReason
+	// Read interruptReason only after observing the flag, so Stop()'s write happens-before this read.
+	if t.interrupt.Load() {
+		return t.callstack[0], t.interruptReason
+	}
+	return t.callstack[0], nil
 }
 
 // Stop terminates execution of the tracer at the first opportune moment.
 // For CallTracer, it stops at CaptureEnter, which is the most repetitive operation.
 func (t *CallTracer) Stop(err error) {
-	t.interrupt.Store(true)
 	t.interruptReason = err
+	t.interrupt.Store(true)
 }


### PR DESCRIPTION
## Proposed changes

- `CallTracer.Stop()` is called from the trace-timeout goroutine while the main goroutine reads `interruptReason` in `GetResult()`; the timeout goroutine is never joined, so the two accesses race
- Fixed by mirroring the JS tracer's publish ordering: `Stop()` writes `interruptReason` before the release `interrupt.Store(true)`, and `GetResult()` reads it only after an acquire `interrupt.Load()`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
