### PR TITLE
gasless: fix no-limit queue check rejecting all bundle txs

### DIFF
--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -44,7 +44,10 @@ func (g *GaslessModule) PreAddTx(tx *types.Transaction, local bool) error {
 	}
 
 	if g.IsBundleTx(tx) {
-		if g.knownTxs.numQueue() >= int(g.GetMaxBundleTxsInQueue()) {
+		// numQueue() is always non-negative, so compare in uint space to avoid the
+		// uint->int cast overflowing the math.MaxUint64 "no limit" sentinel to -1
+		// (which would reject every bundle tx). See GetMaxBundleTxsInQueue / config.go.
+		if uint(g.knownTxs.numQueue()) >= g.GetMaxBundleTxsInQueue() {
 			return ErrBundleTxQueueFull
 		}
 		g.knownTxs.add(tx, TxStatusQueue)

--- a/kaiax/gasless/impl/tx_pool.go
+++ b/kaiax/gasless/impl/tx_pool.go
@@ -44,9 +44,6 @@ func (g *GaslessModule) PreAddTx(tx *types.Transaction, local bool) error {
 	}
 
 	if g.IsBundleTx(tx) {
-		// numQueue() is always non-negative, so compare in uint space to avoid the
-		// uint->int cast overflowing the math.MaxUint64 "no limit" sentinel to -1
-		// (which would reject every bundle tx). See GetMaxBundleTxsInQueue / config.go.
 		if uint(g.knownTxs.numQueue()) >= g.GetMaxBundleTxsInQueue() {
 			return ErrBundleTxQueueFull
 		}

--- a/kaiax/gasless/impl/tx_pool_test.go
+++ b/kaiax/gasless/impl/tx_pool_test.go
@@ -17,6 +17,7 @@
 package impl
 
 import (
+	"math"
 	"math/big"
 	"math/rand/v2"
 	"testing"
@@ -80,6 +81,48 @@ func TestIsModuleTx(t *testing.T) {
 		ok := g.IsModuleTx(tc.tx)
 		require.Equal(t, tc.ok, ok)
 	}
+}
+
+func TestPreAddTxQueueLimit(t *testing.T) {
+	log.EnableLogForTest(log.LvlError, log.LvlTrace)
+
+	newModule := func(maxQueue uint) *GaslessModule {
+		cfg := *gasless.DefaultGaslessConfig()
+		cfg.MaxBundleTxsInQueue = maxQueue
+		g := NewGaslessModule()
+		dbm := database.NewMemoryDBManager()
+		backend := backends.NewSimulatedBackendWithDatabase(dbm, testAllocStorage(), testChainConfig)
+		nodekey, _ := crypto.GenerateKey()
+		require.NoError(t, g.Init(&InitOpts{
+			ChainConfig:   testChainConfig,
+			GaslessConfig: &cfg,
+			NodeKey:       nodekey,
+			Chain:         backend.BlockChain(),
+			NodeType:      common.ENDPOINTNODE,
+		}))
+		return g
+	}
+
+	bundleTx := func() *types.Transaction {
+		privkey, _ := crypto.GenerateKey()
+		return makeApproveTx(t, privkey, 0, ApproveArgs{Spender: common.HexToAddress("0x1234"), Amount: abi.MaxUint256})
+	}
+
+	// --gasless.max-bundle-txs-in-queue <= 0 maps to the math.MaxUint64 "no limit"
+	// sentinel (config.go).
+	t.Run("no limit sentinel accepts on empty queue", func(t *testing.T) {
+		g := newModule(math.MaxUint64)
+		tx := bundleTx()
+		require.True(t, g.IsBundleTx(tx))
+		require.NoError(t, g.PreAddTx(tx, false))
+		require.Equal(t, 1, g.knownTxs.numQueue())
+	})
+
+	t.Run("finite limit still enforced", func(t *testing.T) {
+		g := newModule(1)
+		require.NoError(t, g.PreAddTx(bundleTx(), false))
+		require.ErrorIs(t, g.PreAddTx(bundleTx(), false), ErrBundleTxQueueFull)
+	})
 }
 
 func TestIsReady(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

- `PreAddTx` cast the `uint` queue limit to `int`, overflowing the `math.MaxUint64` (the "no limit" sentinel) to `-1`, making `numQueue() >= -1` always `true` and rejecting every gasless bundle tx with `ErrBundleTxQueueFull`, even on an empty queue
- Now compares in `uint` space so the sentinel correctly means unlimited while finite limits are still enforced

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
