### PR TITLE
valset: avoid mutating cached council snapshots

### DIFF
--- a/kaiax/valset/impl/getter_council.go
+++ b/kaiax/valset/impl/getter_council.go
@@ -140,7 +140,7 @@ func (v *ValsetModule) getCouncilFromIstanbulSnapshot(targetNum uint64, write bo
 	// Try to get from cache first
 	cached, ok := v.councilCache.Get(targetNum - 1)
 	if ok {
-		council = cached.(*valset.AddressSet)
+		council = cached.(*valset.AddressSet).Copy()
 		if err := v.applyBlock(council, targetNum-1, write); err != nil {
 			return nil, 0, err
 		}

--- a/kaiax/valset/impl/getter_council_test.go
+++ b/kaiax/valset/impl/getter_council_test.go
@@ -17,6 +17,7 @@
 package impl
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -26,10 +27,12 @@ import (
 	"github.com/kaiachain/kaia/consensus/engine"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
+	gov_mock "github.com/kaiachain/kaia/kaiax/gov/mock"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/storage/database"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCouncilGenesis(t *testing.T) {
@@ -120,6 +123,37 @@ func TestGetCouncilDB(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetCouncilFromIstanbulSnapshotCopiesCachedCouncil(t *testing.T) {
+	var (
+		ctrl       = gomock.NewController(t)
+		mockChain  = chain_mock.NewMockBlockChain(ctrl)
+		mockGov    = gov_mock.NewMockGovModule(ctrl)
+		v          = NewValsetModule()
+		block9     = uint64(9)
+		councilAt9 = numsToAddrs(1, 2)
+	)
+	v.Chain = mockChain
+	v.GovModule = mockGov
+
+	v.councilCache.Add(block9, valset.NewAddressSet(councilAt9))
+
+	vote, err := headergov.NewVoteData(numToAddr(1), string(gov.AddValidator), numToAddr(3)).ToVoteBytes()
+	require.NoError(t, err)
+	mockChain.EXPECT().GetHeaderByNumber(block9).Return(&types.Header{
+		Number: big.NewInt(int64(block9)),
+		Vote:   vote,
+	})
+	mockGov.EXPECT().GetParamSet(block9).Return(gov.ParamSet{})
+
+	councilAt10, _, err := v.getCouncilFromIstanbulSnapshot(block9+1, false)
+	require.NoError(t, err)
+	require.Equal(t, numsToAddrs(1, 2, 3), councilAt10.List())
+
+	cached, ok := v.councilCache.Get(block9)
+	require.True(t, ok)
+	require.Equal(t, councilAt9, cached.(*valset.AddressSet).List())
 }
 
 func TestParseValidatorVote(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Copy cached council sets before applying validator votes to avoid corrupting historical cache entries.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
