### PR TITLE
p2p: lower "Discovery table refreshed" log to Debug

### DIFF
--- a/networks/p2p/discover/table_lookup.go
+++ b/networks/p2p/discover/table_lookup.go
@@ -58,7 +58,7 @@ func (tab *Table2) doRefresh() {
 		tab.simpleRefresh(NodeTypeCN)
 		tab.simpleRefresh(NodeTypePN)
 		tab.simpleRefresh(NodeTypeBN)
-		logger.Info("Discovery table refreshed", "counts", tab.lenByNodeTypes())
+		logger.Debug("Discovery table refreshed", "counts", tab.lenByNodeTypes())
 		return nil, nil
 	})
 }


### PR DESCRIPTION
## Proposed changes

This log was emitted at Info level on every discovery table refresh, appearing too frequently.
Lower it to Debug to match the paired "Discovery table refreshing" log right above it.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

