### PR TITLE
blockchain: Fix blob sidecar store validation

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -2075,15 +2075,20 @@ func (pool *TxPool) saveAndPruneBlobStorage(newHead *types.Block) {
 			continue
 		}
 
-		// try to get blob sidecar from tx
+		// persist an inline sidecar only if it matches the tx's blob hashes;
+		// otherwise fall through to the pool / validated fetch path
 		if sidecar := tx.BlobTxSidecar(); sidecar != nil {
-			logger.Debug("saving blob sidecar from tx in finalized block", "blockNumber", newHead.Number(), "txIndex", i, "txHash", tx.Hash())
-			go func() {
-				if err := pool.blobStorage.Save(newHead.Number(), i, sidecar); err != nil {
-					logger.Warn("failed to save blob sidecar", "err", err)
-				}
-			}()
-			continue
+			if err := sidecar.ValidateWithBlobHashes(tx.BlobHashes()); err != nil {
+				logger.Warn("discarding invalid inline blob sidecar", "blockNumber", newHead.Number(), "txIndex", i, "txHash", tx.Hash(), "err", err)
+			} else {
+				logger.Debug("saving blob sidecar from tx in finalized block", "blockNumber", newHead.Number(), "txIndex", i, "txHash", tx.Hash())
+				go func() {
+					if err := pool.blobStorage.Save(newHead.Number(), i, sidecar); err != nil {
+						logger.Warn("failed to save blob sidecar", "err", err)
+					}
+				}()
+				continue
+			}
 		}
 
 		// try to get blob sidecar from local

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -4479,6 +4479,68 @@ func TestTxPool_saveAndPruneBlobStorage(t *testing.T) {
 	}
 }
 
+// TestTxPool_saveAndPruneBlobStorage_inlineSidecarValidation verifies that a
+// block's inline blob sidecar is persisted only when it matches the tx's blob
+// hashes; an invalid one is discarded and refetched through the validated path.
+func TestTxPool_saveAndPruneBlobStorage_inlineSidecarValidation(t *testing.T) {
+	t.Parallel()
+
+	newPool := func(t *testing.T) *TxPool {
+		statedb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+		bc := &testBlockChain{statedb: statedb, gasLimit: 1000000, chainHeadFeed: new(event.Feed), txMap: make(map[common.Hash]*types.Transaction)}
+		config := testTxPoolConfig
+		blobConfig := DefaultBlobStorageConfig(t.TempDir())
+		config.BlobStorageConfig = &blobConfig
+		return NewTxPool(config, params.TestChainConfig, bc, &dummyGovModule{chainConfig: params.TestChainConfig})
+	}
+
+	t.Run("invalid inline sidecar is not persisted", func(t *testing.T) {
+		pool := newPool(t)
+		defer pool.Stop()
+
+		key, _ := crypto.GenerateKey()
+		// blob hashes commit to the original commitment; corrupt the attached
+		// sidecar so it no longer matches.
+		tx := blobTransaction(0, 100000, big.NewInt(1000), big.NewInt(100), big.NewInt(100), key, 1,
+			func(sc *types.BlobTxSidecar) { sc.Commitments[0][0] ^= 0x01 })
+		block := createTestBlock(big.NewInt(1000), big.NewInt(time.Now().Unix()), types.Transactions{tx})
+
+		ch := pool.SubscribeMissingBlobSidecars()
+		pool.saveAndPruneBlobStorage(block)
+		time.Sleep(10 * time.Millisecond)
+
+		// not persisted
+		_, err := pool.GetBlobSidecarFromStorage(block.Number(), 0)
+		require.Error(t, err)
+
+		// falls through to the validated fetch path
+		select {
+		case missing := <-ch:
+			assert.Equal(t, block.Number(), missing.BlockNum)
+			assert.Equal(t, 0, missing.TxIndex)
+			assert.Equal(t, tx.Hash(), missing.TxHash)
+		case <-time.After(time.Second):
+			t.Fatal("expected a missing blob sidecar request after discarding the invalid one")
+		}
+	})
+
+	t.Run("valid inline sidecar is persisted", func(t *testing.T) {
+		pool := newPool(t)
+		defer pool.Stop()
+
+		key, _ := crypto.GenerateKey()
+		tx := blobTransaction(0, 100000, big.NewInt(1000), big.NewInt(100), big.NewInt(100), key, 1, nil)
+		block := createTestBlock(big.NewInt(1000), big.NewInt(time.Now().Unix()), types.Transactions{tx})
+
+		pool.saveAndPruneBlobStorage(block)
+		time.Sleep(10 * time.Millisecond)
+
+		saved, err := pool.GetBlobSidecarFromStorage(block.Number(), 0)
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+	})
+}
+
 // sumPendingQueued recomputes pendingCount/queuedCount from the source-of-truth
 // per-sender lists. It runs under pool.mu RLock to keep the snapshot consistent.
 func sumPendingQueued(pool *TxPool) (uint64, uint64) {


### PR DESCRIPTION
## Proposed changes

Blob sidecars are meant to arrive only through the dedicated, validated fetch path, and a block body should never carry one. But if a peer attaches one to an imported block, `saveAndPruneBlobStorage` persisted it without checking it against the transaction's committed blob hashes.
- Now it validates an inline sidecar first: on mismatch it's discarded and the node falls back to the validated fetch path; valid ones (self-produced / CN-relayed) persist as before.
- Adds a unit test covering both cases — invalid inline sidecar is discarded (and a fetch request is emitted), valid one is persisted.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
