### PR TITLE
blockchain/types: guard tx JSON decoders against empty signatures

### DIFF
--- a/api/api_kaia_transaction_test.go
+++ b/api/api_kaia_transaction_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"math/big"
 	"reflect"
 	"testing"
@@ -63,6 +64,34 @@ var (
 	senderPrvKey, _   = crypto.HexToECDSA("95a21e86efa290d6665a9dbce06ae56319335540d13540fb1b01e28a5b2c8460")
 	feePayerPrvKey, _ = crypto.HexToECDSA("aebb680a5e596c1d1a01bac78a3985b62c685c5e995d780c176138cb2679ba3e")
 )
+
+func TestSendTxArgsUnmarshalSignatures(t *testing.T) {
+	testcases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"missing", `{}`, false},
+		{"null", `{"signatures":null}`, false},
+		{"empty", `{"signatures":[]}`, false},
+		{"null_element", `{"signatures":[null]}`, true},
+		{"empty_element", `{"signatures":[{}]}`, true},
+		{"partial_element", `{"signatures":[{"V":"0x1"}]}`, true},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var args SendTxArgs
+			err := json.Unmarshal([]byte(tc.input), &args)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Empty(t, args.TxSignatures)
+			}
+		})
+	}
+}
 
 // TestTxTypeSupport tests tx type support of APIs in KaiaTransactionAPI.
 func TestTxTypeSupport(t *testing.T) {

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -110,6 +110,7 @@ var (
 	errUndefinedTxType                        = errors.New("undefined tx type")
 	errCannotBeSignedByFeeDelegator           = errors.New("this transaction type cannot be signed by a fee delegator")
 	errUndefinedKeyRemains                    = errors.New("undefined key remains")
+	errEmptyTxSignatures                      = errors.New("tx signatures must not be empty")
 
 	errValueKeyHumanReadableMustBool     = errors.New("HumanReadable must be a type of bool")
 	errValueKeyAccountKeyMustAccountKey  = errors.New("AccountKey must be a type of AccountKey")

--- a/blockchain/types/tx_internal_data.go
+++ b/blockchain/types/tx_internal_data.go
@@ -111,6 +111,7 @@ var (
 	errCannotBeSignedByFeeDelegator           = errors.New("this transaction type cannot be signed by a fee delegator")
 	errUndefinedKeyRemains                    = errors.New("undefined key remains")
 	errEmptyTxSignatures                      = errors.New("tx signatures must not be empty")
+	errInvalidTxSignatureJSON                 = errors.New("invalid tx signature JSON")
 
 	errValueKeyHumanReadableMustBool     = errors.New("HumanReadable must be a type of bool")
 	errValueKeyAccountKeyMustAccountKey  = errors.New("AccountKey must be a type of AccountKey")

--- a/blockchain/types/tx_internal_data_ethereum_access_list.go
+++ b/blockchain/types/tx_internal_data_ethereum_access_list.go
@@ -391,6 +391,9 @@ func (t *TxInternalDataEthereumAccessList) UnmarshalJSON(bytes []byte) error {
 	t.Amount = (*big.Int)(js.Amount)
 	t.Payload = js.Payload
 	t.AccessList = js.AccessList
+	if len(js.TxSignatures) == 0 || js.TxSignatures[0] == nil {
+		return errEmptyTxSignatures
+	}
 	t.V = (*big.Int)(js.TxSignatures[0].V)
 	t.R = (*big.Int)(js.TxSignatures[0].R)
 	t.S = (*big.Int)(js.TxSignatures[0].S)

--- a/blockchain/types/tx_internal_data_ethereum_blob.go
+++ b/blockchain/types/tx_internal_data_ethereum_blob.go
@@ -738,6 +738,9 @@ func (t *TxInternalDataEthereumBlob) UnmarshalJSON(bytes []byte) error {
 	t.AccessList = js.AccessList
 	t.BlobFeeCap = (*uint256.Int)(js.BlobFeeCap)
 	t.BlobHashes = js.BlobHashes
+	if len(js.TxSignatures) == 0 || js.TxSignatures[0] == nil {
+		return errEmptyTxSignatures
+	}
 	t.V = (*big.Int)(js.TxSignatures[0].V)
 	t.R = (*big.Int)(js.TxSignatures[0].R)
 	t.S = (*big.Int)(js.TxSignatures[0].S)

--- a/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
+++ b/blockchain/types/tx_internal_data_ethereum_dynamic_fee.go
@@ -396,6 +396,9 @@ func (t *TxInternalDataEthereumDynamicFee) UnmarshalJSON(bytes []byte) error {
 	t.Amount = (*big.Int)(js.Amount)
 	t.Payload = js.Payload
 	t.AccessList = js.AccessList
+	if len(js.TxSignatures) == 0 || js.TxSignatures[0] == nil {
+		return errEmptyTxSignatures
+	}
 	t.V = (*big.Int)(js.TxSignatures[0].V)
 	t.R = (*big.Int)(js.TxSignatures[0].R)
 	t.S = (*big.Int)(js.TxSignatures[0].S)

--- a/blockchain/types/tx_internal_data_ethereum_set_code.go
+++ b/blockchain/types/tx_internal_data_ethereum_set_code.go
@@ -430,6 +430,9 @@ func (t *TxInternalDataEthereumSetCode) UnmarshalJSON(bytes []byte) error {
 	t.Payload = js.Payload
 	t.AccessList = js.AccessList
 	t.AuthorizationList = js.AuthorizationList
+	if len(js.TxSignatures) == 0 || js.TxSignatures[0] == nil {
+		return errEmptyTxSignatures
+	}
 	t.V = (*big.Int)(js.TxSignatures[0].V)
 	t.R = (*big.Int)(js.TxSignatures[0].R)
 	t.S = (*big.Int)(js.TxSignatures[0].S)

--- a/blockchain/types/tx_internal_data_json_signatures_test.go
+++ b/blockchain/types/tx_internal_data_json_signatures_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the kaia library.
+//
+// The kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTxInternalDataUnmarshalJSONEmptySignatures ensures that decoding a JSON
+// transaction with a missing, empty, or null "signatures" field returns an
+// error instead of panicking. Such payloads can be produced by a malicious or
+// tampered JSON-RPC endpoint, and the decoders must not index into an empty
+// TxSignatures slice.
+func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
+	types := []struct {
+		name string
+		gen  func() TxInternalData
+	}{
+		{"Legacy", genLegacyTransaction},
+		{"EthereumAccessList", genAccessListTransaction},
+		{"EthereumDynamicFee", genDynamicFeeTransaction},
+		{"EthereumSetCode", genSetCodeTransaction},
+		{"EthereumBlob", genBlobTransaction},
+	}
+
+	// Each malformed "signatures" value that must be rejected gracefully.
+	malformed := map[string]interface{}{
+		"empty":   []interface{}{},    // "signatures": []
+		"null":    []interface{}{nil}, // "signatures": [null]
+		"missing": nil,                // "signatures" key absent
+	}
+
+	for _, tt := range types {
+		for sigName, sigValue := range malformed {
+			t.Run(tt.name+"/"+sigName, func(t *testing.T) {
+				// Marshal a well-formed transaction, then tamper the signatures field.
+				raw, err := json.Marshal(tt.gen())
+				require.NoError(t, err)
+
+				var m map[string]interface{}
+				require.NoError(t, json.Unmarshal(raw, &m))
+				if sigName == "missing" {
+					delete(m, "signatures")
+				} else {
+					m["signatures"] = sigValue
+				}
+				tampered, err := json.Marshal(m)
+				require.NoError(t, err)
+
+				// Decoding must not panic and must be rejected specifically
+				// by the empty-signatures guard.
+				dec := newTxInternalDataSerializer()
+				require.NotPanics(t, func() {
+					err = json.Unmarshal(tampered, dec)
+				})
+				require.ErrorIs(t, err, errEmptyTxSignatures)
+			})
+		}
+	}
+}

--- a/blockchain/types/tx_internal_data_json_signatures_test.go
+++ b/blockchain/types/tx_internal_data_json_signatures_test.go
@@ -23,11 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTxInternalDataUnmarshalJSONEmptySignatures ensures that decoding a JSON
-// transaction with a missing, empty, or null "signatures" field returns an
-// error instead of panicking. Such payloads can be produced by a malicious or
-// tampered JSON-RPC endpoint, and the decoders must not index into an empty
-// TxSignatures slice.
 func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
 	types := []struct {
 		name string
@@ -38,19 +33,19 @@ func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
 		{"EthereumDynamicFee", genDynamicFeeTransaction},
 		{"EthereumSetCode", genSetCodeTransaction},
 		{"EthereumBlob", genBlobTransaction},
+		{"ValueTransfer", genValueTransferTransaction},
+		{"FeeDelegatedValueTransfer", genFeeDelegatedValueTransferTransaction},
 	}
 
-	// Each malformed "signatures" value that must be rejected gracefully.
 	malformed := map[string]interface{}{
-		"empty":   []interface{}{},    // "signatures": []
-		"null":    []interface{}{nil}, // "signatures": [null]
-		"missing": nil,                // "signatures" key absent
+		"empty":   []interface{}{},
+		"null":    []interface{}{nil},
+		"missing": nil,
 	}
 
 	for _, tt := range types {
 		for sigName, sigValue := range malformed {
 			t.Run(tt.name+"/"+sigName, func(t *testing.T) {
-				// Marshal a well-formed transaction, then tamper the signatures field.
 				raw, err := json.Marshal(tt.gen())
 				require.NoError(t, err)
 
@@ -64,8 +59,6 @@ func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
 				tampered, err := json.Marshal(m)
 				require.NoError(t, err)
 
-				// Decoding must not panic and must be rejected specifically
-				// by the empty-signatures guard.
 				dec := newTxInternalDataSerializer()
 				require.NotPanics(t, func() {
 					err = json.Unmarshal(tampered, dec)
@@ -73,5 +66,36 @@ func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
 				require.ErrorIs(t, err, errEmptyTxSignatures)
 			})
 		}
+	}
+}
+
+func TestTxInternalDataUnmarshalJSONEmptyFeePayerSignatures(t *testing.T) {
+	malformed := map[string]interface{}{
+		"empty":   []interface{}{},
+		"null":    []interface{}{nil},
+		"missing": nil,
+	}
+
+	for sigName, sigValue := range malformed {
+		t.Run(sigName, func(t *testing.T) {
+			raw, err := json.Marshal(genFeeDelegatedValueTransferTransaction())
+			require.NoError(t, err)
+
+			var m map[string]interface{}
+			require.NoError(t, json.Unmarshal(raw, &m))
+			if sigName == "missing" {
+				delete(m, "feePayerSignatures")
+			} else {
+				m["feePayerSignatures"] = sigValue
+			}
+			tampered, err := json.Marshal(m)
+			require.NoError(t, err)
+
+			dec := newTxInternalDataSerializer()
+			require.NotPanics(t, func() {
+				err = json.Unmarshal(tampered, dec)
+			})
+			require.ErrorIs(t, err, errEmptyTxSignatures)
+		})
 	}
 }

--- a/blockchain/types/tx_internal_data_json_signatures_test.go
+++ b/blockchain/types/tx_internal_data_json_signatures_test.go
@@ -37,14 +37,19 @@ func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
 		{"FeeDelegatedValueTransfer", genFeeDelegatedValueTransferTransaction},
 	}
 
-	malformed := map[string]interface{}{
-		"empty":   []interface{}{},
-		"null":    []interface{}{nil},
-		"missing": nil,
+	testcases := map[string]struct {
+		value       interface{}
+		expectedErr error
+	}{
+		"empty":           {[]interface{}{}, errEmptyTxSignatures},
+		"null_element":    {[]interface{}{nil}, errInvalidTxSignatureJSON},
+		"empty_element":   {[]interface{}{map[string]interface{}{}}, errInvalidTxSignatureJSON},
+		"partial_element": {[]interface{}{map[string]interface{}{"V": "0x1"}}, errInvalidTxSignatureJSON},
+		"missing":         {nil, errEmptyTxSignatures},
 	}
 
 	for _, tt := range types {
-		for sigName, sigValue := range malformed {
+		for sigName, tc := range testcases {
 			t.Run(tt.name+"/"+sigName, func(t *testing.T) {
 				raw, err := json.Marshal(tt.gen())
 				require.NoError(t, err)
@@ -54,7 +59,7 @@ func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
 				if sigName == "missing" {
 					delete(m, "signatures")
 				} else {
-					m["signatures"] = sigValue
+					m["signatures"] = tc.value
 				}
 				tampered, err := json.Marshal(m)
 				require.NoError(t, err)
@@ -63,20 +68,25 @@ func TestTxInternalDataUnmarshalJSONEmptySignatures(t *testing.T) {
 				require.NotPanics(t, func() {
 					err = json.Unmarshal(tampered, dec)
 				})
-				require.ErrorIs(t, err, errEmptyTxSignatures)
+				require.ErrorIs(t, err, tc.expectedErr)
 			})
 		}
 	}
 }
 
 func TestTxInternalDataUnmarshalJSONEmptyFeePayerSignatures(t *testing.T) {
-	malformed := map[string]interface{}{
-		"empty":   []interface{}{},
-		"null":    []interface{}{nil},
-		"missing": nil,
+	testcases := map[string]struct {
+		value       interface{}
+		expectedErr error
+	}{
+		"empty":           {[]interface{}{}, errEmptyTxSignatures},
+		"null_element":    {[]interface{}{nil}, errInvalidTxSignatureJSON},
+		"empty_element":   {[]interface{}{map[string]interface{}{}}, errInvalidTxSignatureJSON},
+		"partial_element": {[]interface{}{map[string]interface{}{"V": "0x1"}}, errInvalidTxSignatureJSON},
+		"missing":         {nil, errEmptyTxSignatures},
 	}
 
-	for sigName, sigValue := range malformed {
+	for sigName, tc := range testcases {
 		t.Run(sigName, func(t *testing.T) {
 			raw, err := json.Marshal(genFeeDelegatedValueTransferTransaction())
 			require.NoError(t, err)
@@ -86,7 +96,7 @@ func TestTxInternalDataUnmarshalJSONEmptyFeePayerSignatures(t *testing.T) {
 			if sigName == "missing" {
 				delete(m, "feePayerSignatures")
 			} else {
-				m["feePayerSignatures"] = sigValue
+				m["feePayerSignatures"] = tc.value
 			}
 			tampered, err := json.Marshal(m)
 			require.NoError(t, err)
@@ -95,7 +105,7 @@ func TestTxInternalDataUnmarshalJSONEmptyFeePayerSignatures(t *testing.T) {
 			require.NotPanics(t, func() {
 				err = json.Unmarshal(tampered, dec)
 			})
-			require.ErrorIs(t, err, errEmptyTxSignatures)
+			require.ErrorIs(t, err, tc.expectedErr)
 		})
 	}
 }

--- a/blockchain/types/tx_internal_data_legacy.go
+++ b/blockchain/types/tx_internal_data_legacy.go
@@ -291,6 +291,9 @@ func (t *TxInternalDataLegacy) UnmarshalJSON(b []byte) error {
 	t.Recipient = js.Recipient
 	t.Amount = (*big.Int)(js.Amount)
 	t.Payload = js.Payload
+	if len(js.TxSignatures) == 0 || js.TxSignatures[0] == nil {
+		return errEmptyTxSignatures
+	}
 	t.V = (*big.Int)(js.TxSignatures[0].V)
 	t.R = (*big.Int)(js.TxSignatures[0].R)
 	t.S = (*big.Int)(js.TxSignatures[0].S)

--- a/blockchain/types/tx_internal_data_serializer.go
+++ b/blockchain/types/tx_internal_data_serializer.go
@@ -33,7 +33,9 @@ type TxInternalDataSerializer struct {
 
 // txInternalDataJSON is an internal object for JSON serialization.
 type txInternalDataJSON struct {
-	TxType TxType `json:"typeInt"`
+	TxType             TxType           `json:"typeInt"`
+	TxSignatures       TxSignaturesJSON `json:"signatures"`
+	FeePayerSignatures TxSignaturesJSON `json:"feePayerSignatures"`
 }
 
 // newTxInternalDataSerializerWithValues creates a new TxInternalDataSerializer object with the given TxInternalData object.
@@ -109,6 +111,12 @@ func (serializer *TxInternalDataSerializer) UnmarshalJSON(b []byte) error {
 
 	if err := json.Unmarshal(b, &dec); err != nil {
 		return err
+	}
+	if len(dec.TxSignatures) == 0 {
+		return errEmptyTxSignatures
+	}
+	if dec.TxType.IsFeeDelegatedTransaction() && len(dec.FeePayerSignatures) == 0 {
+		return errEmptyTxSignatures
 	}
 
 	if dec.TxType == TxTypeLegacyTransaction {

--- a/blockchain/types/tx_signatures.go
+++ b/blockchain/types/tx_signatures.go
@@ -169,12 +169,9 @@ func (t *TxSignaturesJSON) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &sigs); err != nil {
 		return err
 	}
-	if len(sigs) == 0 {
-		return errEmptyTxSignatures
-	}
 	for _, sig := range sigs {
 		if sig == nil || sig.V == nil || sig.R == nil || sig.S == nil {
-			return errEmptyTxSignatures
+			return errInvalidTxSignatureJSON
 		}
 	}
 	*t = sigs

--- a/blockchain/types/tx_signatures.go
+++ b/blockchain/types/tx_signatures.go
@@ -164,6 +164,23 @@ func (t TxSignatures) ToJSON() TxSignaturesJSON {
 // TxSignaturesJSON is an array of *TxSignatureJSON. This structure is for JSON marshalling.
 type TxSignaturesJSON []*TxSignatureJSON
 
+func (t *TxSignaturesJSON) UnmarshalJSON(b []byte) error {
+	var sigs []*TxSignatureJSON
+	if err := json.Unmarshal(b, &sigs); err != nil {
+		return err
+	}
+	if len(sigs) == 0 {
+		return errEmptyTxSignatures
+	}
+	for _, sig := range sigs {
+		if sig == nil || sig.V == nil || sig.R == nil || sig.S == nil {
+			return errEmptyTxSignatures
+		}
+	}
+	*t = sigs
+	return nil
+}
+
 func (t TxSignaturesJSON) ToTxSignatures() TxSignatures {
 	sigs := make(TxSignatures, len(t))
 


### PR DESCRIPTION
## Proposed changes

Return an error instead of panicking when the "signatures" field is missing, empty, or null while decoding a JSON transaction.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
