### PR TITLE
blockchain: gate zero-threshold WeightedMultiSig checks behind Permissionless

### DIFF
--- a/blockchain/types/accountkey/account_key_test.go
+++ b/blockchain/types/accountkey/account_key_test.go
@@ -262,7 +262,11 @@ func TestAccountKeyWeightedMultiSig_Validate(t *testing.T) {
 }
 
 func TestAccountKeyWeightedMultiSig_CheckInstallable_ZeroThreshold(t *testing.T) {
-	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)})
+	const permissionlessBlock = 100
+	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{
+		IstanbulCompatibleBlock:       big.NewInt(0),
+		PermissionlessCompatibleBlock: big.NewInt(permissionlessBlock),
+	})
 
 	k, _ := crypto.GenerateKey()
 	keys := WeightedPublicKeys{
@@ -270,12 +274,13 @@ func TestAccountKeyWeightedMultiSig_CheckInstallable_ZeroThreshold(t *testing.T)
 	}
 	m := NewAccountKeyWeightedMultiSigWithValues(0, keys)
 
-	// CheckInstallable must reject threshold=0 to prevent signature bypass via Validate().
-	assert.EqualError(t, m.CheckInstallable(0), "threshold is zero")
+	// Before Permissionless: zero threshold still accepted, so historical blocks don't diverge.
+	assert.NoError(t, m.CheckInstallable(permissionlessBlock-1))
+	assert.True(t, m.Validate(permissionlessBlock-1, RoleTransaction, []*ecdsa.PublicKey{}, common.Address{}))
 
-	// Validate() also rejects threshold=0 directly, covering any pre-existing accounts
-	// that may have been installed before CheckInstallable began enforcing this.
-	assert.False(t, m.Validate(0, RoleTransaction, []*ecdsa.PublicKey{}, common.Address{}))
+	// After Permissionless: rejected by both CheckInstallable and Validate.
+	assert.EqualError(t, m.CheckInstallable(permissionlessBlock), "threshold is zero")
+	assert.False(t, m.Validate(permissionlessBlock, RoleTransaction, []*ecdsa.PublicKey{}, common.Address{}))
 }
 
 func TestAccountKeyWeightedMultiSig_SigValidationGas(t *testing.T) {

--- a/blockchain/types/accountkey/account_key_weighted_multi_sig.go
+++ b/blockchain/types/accountkey/account_key_weighted_multi_sig.go
@@ -84,10 +84,12 @@ func (a *AccountKeyWeightedMultiSig) Equal(b AccountKey) bool {
 }
 
 func (a *AccountKeyWeightedMultiSig) Validate(currentBlockNumber uint64, r RoleType, recoveredKeys []*ecdsa.PublicKey, from common.Address) bool {
-	if a.Threshold == 0 {
+	rules := fork.Rules(new(big.Int).SetUint64(currentBlockNumber))
+	// Reject zero threshold, but only after Permissionless so historical blocks don't diverge.
+	if rules.IsPermissionless && a.Threshold == 0 {
 		return false
 	}
-	isIstanbul := fork.Rules(new(big.Int).SetUint64(currentBlockNumber)).IsIstanbul
+	isIstanbul := rules.IsIstanbul
 
 	// Validation 1. if isIstanbul is true, check whether the signature number exceeds key number
 	if isIstanbul && len(recoveredKeys) > len(a.Keys) {
@@ -183,7 +185,8 @@ func (a *AccountKeyWeightedMultiSig) CheckInstallable(currentBlockNumber uint64)
 	if len(a.Keys) == 0 {
 		return kerrors.ErrZeroLength
 	}
-	if a.Threshold == 0 {
+	// Reject zero threshold, but only after Permissionless so historical blocks don't diverge.
+	if fork.Rules(new(big.Int).SetUint64(currentBlockNumber)).IsPermissionless && a.Threshold == 0 {
 		return kerrors.ErrZeroThreshold
 	}
 	if uint64(len(a.Keys)) > MaxNumKeysForMultiSig {

--- a/blockchain/vm/contracts.go
+++ b/blockchain/vm/contracts.go
@@ -50,6 +50,7 @@ import (
 	"github.com/kaiachain/kaia/crypto/bn256"
 	"github.com/kaiachain/kaia/crypto/kzg4844"
 	"github.com/kaiachain/kaia/crypto/secp256r1"
+	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/kerrors"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
@@ -899,7 +900,8 @@ func (c *validateSender) validateSender(input []byte, picker types.AccountKeyPic
 	}
 
 	numSigs := len(ptr) / common.SignatureLength
-	if numSigs == 0 {
+	// Reject zero signatures, but only after Permissionless so historical blocks don't diverge.
+	if fork.Rules(new(big.Int).SetUint64(currentBlockNumber)).IsPermissionless && numSigs == 0 {
 		return errNoSignatures
 	}
 	pubs := make([]*ecdsa.PublicKey, numSigs)

--- a/blockchain/vm/contracts_test.go
+++ b/blockchain/vm/contracts_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/common/math"
 	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
@@ -132,6 +133,12 @@ func prepare(reqGas uint64) (*Contract, *EVM, error) {
 	txhash := common.HexToHash("0xc6a37e155d3fa480faea012a68ad35fd53c8cc3cd8263a434c697755985a6577")
 	stateDb.SetTxContext(txhash, common.Hash{}, 0)
 	evm := NewEVM(BlockContext{BlockNumber: big.NewInt(0)}, TxContext{}, stateDb, &params.ChainConfig{IstanbulCompatibleBlock: big.NewInt(0)}, &Config{})
+
+	// validateSender consults fork.Rules, so the global hardfork config must be initialized.
+	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{
+		IstanbulCompatibleBlock:       big.NewInt(0),
+		PermissionlessCompatibleBlock: big.NewInt(0),
+	})
 
 	// Only stdout logging is tested to avoid file handling. It is used at vmLog test.
 	params.VMLogTarget = params.VMLogToStdout
@@ -628,8 +635,13 @@ func TestConsoleLog(t *testing.T) {
 }
 
 // TestValidateSenderPrecompile_ZeroSignatures verifies that the validateSender precompile
-// (0x400) rejects inputs that carry no signatures.
+// (0x3ff) rejects inputs that carry no signatures once the Permissionless fork is active.
 func TestValidateSenderPrecompile_ZeroSignatures(t *testing.T) {
+	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{
+		IstanbulCompatibleBlock:       big.NewInt(0),
+		PermissionlessCompatibleBlock: big.NewInt(0),
+	})
+
 	stateDb, _ := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
 
 	k, err := crypto.HexToECDSA("98275a145bc1726eb0445433088f5f882f8a4a9499135239cfb4040e78991dab")


### PR DESCRIPTION
## Proposed changes

- Gate the zero-threshold WeightedMultiSig checks (`CheckInstallable`/`Validate`) and the validateSender zero-signature check behind the Permissionless fork, so that an account already installed a `Threshold=0` key would not diverge when replaying historical blocks.
- Update tests to assert both pre-fork (accepted, replayable) and post-fork (rejected) behavior.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
