### PR TITLE
consensus/istanbul, blockchain: validate block number against view sequence and uint64 range

### DIFF
--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -47,6 +47,9 @@ var (
 	// ErrInvalidBlockScore is returned if the BlockScore of a block is not 1.
 	ErrInvalidBlockScore = errors.New("invalid blockscore")
 
+	// ErrInvalidBlockNumber is returned if a header's block number exceeds uint64 range.
+	ErrInvalidBlockNumber = errors.New("invalid block number: out of uint64 range")
+
 	// ErrInvalidBaseFee is returned if a block before Magma has a non-nil base fee.
 	ErrInvalidBaseFee = errors.New("invalid baseFee before fork")
 
@@ -150,6 +153,11 @@ func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Head
 	// Ensure that the block's blockscore is meaningful (may not be correct at this point)
 	if header.BlockScore == nil || header.BlockScore.Cmp(params.DefaultBlockScore) != 0 {
 		return ErrInvalidBlockScore
+	}
+
+	// Reject out-of-uint64 numbers before Uint64() aliases them to a lower height.
+	if header.Number == nil || !header.Number.IsUint64() {
+		return ErrInvalidBlockNumber
 	}
 
 	// The genesis block is the always valid dead-end

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -663,3 +663,13 @@ func testPreprocessHeaderVerification(t *testing.T, threads int) {
 		close(abort)
 	}
 }
+
+func TestValidateHeaderRejectsOutOfUint64Number(t *testing.T) {
+	v := &BlockValidator{}
+	h := &types.Header{
+		Number:     new(big.Int).Lsh(big.NewInt(1), 64), // 2^64, exceeds uint64
+		Time:       big.NewInt(1),
+		BlockScore: params.DefaultBlockScore,
+	}
+	assert.ErrorIs(t, v.ValidateHeader(h), ErrInvalidBlockNumber)
+}

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -71,6 +71,12 @@ func (c *core) handlePreprepare(msg *bft.Message, src common.Address) error {
 		return bft.ErrInvalidMessage
 	}
 
+	// Proposal number must equal the view sequence, else it can be aliased to another height.
+	if !proposalNumberMatchesView(preprepare) {
+		logger.Warn("Ignore preprepare whose proposal number does not match view sequence")
+		return bft.ErrInvalidMessage
+	}
+
 	// Ensure we have the same view with the PRE-PREPARE message
 	// If it is old message, see if we need to broadcast COMMIT
 	if err := c.checkMessage(bft.MsgPreprepare, preprepare.View); err != nil {
@@ -146,6 +152,15 @@ func (c *core) handlePreprepare(msg *bft.Message, src common.Address) error {
 	}
 
 	return nil
+}
+
+// proposalNumberMatchesView reports whether the proposal's block number equals the view sequence.
+func proposalNumberMatchesView(pp *bft.Preprepare) bool {
+	if pp == nil || pp.Proposal == nil || pp.Proposal.Number() == nil ||
+		pp.View == nil || pp.View.Sequence == nil {
+		return false
+	}
+	return pp.Proposal.Number().Cmp(pp.View.Sequence) == 0
 }
 
 func (c *core) acceptPreprepare(preprepare *bft.Preprepare) {

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProposalNumberMatchesView(t *testing.T) {
+	mk := func(num, seq *big.Int) *bft.Preprepare {
+		return &bft.Preprepare{
+			View:     &bft.View{Round: big.NewInt(0), Sequence: seq},
+			Proposal: types.NewBlockWithHeader(&types.Header{Number: num}),
+		}
+	}
+	overflow := new(big.Int).Add(new(big.Int).Lsh(big.NewInt(1), 64), big.NewInt(5)) // 2^64+5
+
+	assert.True(t, proposalNumberMatchesView(mk(big.NewInt(5), big.NewInt(5))), "matching number should pass")
+	assert.False(t, proposalNumberMatchesView(mk(big.NewInt(9), big.NewInt(5))), "in-range mismatch should fail")
+	assert.False(t, proposalNumberMatchesView(mk(overflow, big.NewInt(5))), "out-of-uint64 mismatch should fail")
+}


### PR DESCRIPTION
## Proposed changes

Block height lives in two places that were never checked against each other: the istanbul view sequence and `header.Number` (an arbitrary-width `big.Int` that consensus, ancestry, and indexing read via `Uint64()`). A proposal whose number differed from the view sequence — or exceeded `uint64` — was accepted and aliased to a different (lower) height for consensus, while the EVM (`NUMBER`) used the full value.

- `consensus/istanbul/core`: `handlePreprepare` rejects a proposal whose block number != view sequence.
- `blockchain`: `validateHeader` rejects header numbers that don't fit in `uint64` (`ErrInvalidBlockNumber`).

`header.Number` stays `*big.Int` (EVM `NUMBER` / RLP); this validates the range rather than changing the type.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
