### PR TITLE
consensus/istanbul, blockchain: bind committed seal to consensus round

### DIFF
--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -252,6 +252,11 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		if err != nil {
 			return err
 		}
+		// Committed seals bind the round post-permissionless.
+		committers, err := v.sealer.CommittersWithRound(header)
+		if err != nil {
+			return err
+		}
 		proposer, err := v.mValset.GetProposer(blockNum, uint64(round))
 		if err != nil {
 			return err

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -227,19 +227,26 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	if err != nil {
 		return err
 	}
-	committers, err := v.sealer.Committers(header)
-	if err != nil {
-		return err
-	}
-	if len(committers) == 0 {
-		return istanbul.ErrEmptyCommittedSeals
-	}
 
 	blockNum := header.Number.Uint64()
 
 	var rules params.Rules
 	if v.config != nil {
 		rules = v.config.Rules(new(big.Int).SetUint64(blockNum))
+	}
+
+	// Post-permissionless committed seals bind the round, so recover with the matching preimage.
+	var committers []common.Address
+	if rules.IsPermissionless {
+		committers, err = v.sealer.CommittersWithRound(header)
+	} else {
+		committers, err = v.sealer.Committers(header)
+	}
+	if err != nil {
+		return err
+	}
+	if len(committers) == 0 {
+		return istanbul.ErrEmptyCommittedSeals
 	}
 
 	// Skip module-dependent seal validation when gov/valset modules are not registered.
@@ -249,11 +256,6 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 
 	if rules.IsPermissionless {
 		round, err := v.sealer.Round(header)
-		if err != nil {
-			return err
-		}
-		// Committed seals bind the round post-permissionless.
-		committers, err := v.sealer.CommittersWithRound(header)
 		if err != nil {
 			return err
 		}
@@ -296,14 +298,12 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		return consensus.ErrUnauthorized
 	}
 
-	signerSet := qualifiedSet.Copy()
-	if !rules.IsPermissionless {
-		council, err := v.mValset.GetCouncil(blockNum)
-		if err != nil {
-			return err
-		}
-		signerSet = valset.NewAddressSet(council).Copy()
+	// Reached only pre-permissionless (post-fork returns above); count seals against the council.
+	council, err := v.mValset.GetCouncil(blockNum)
+	if err != nil {
+		return err
 	}
+	signerSet := valset.NewAddressSet(council).Copy()
 	validSeal, err := countValidCommittedSeals(committers, signerSet)
 	if err != nil {
 		return err

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -235,13 +235,8 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		rules = v.config.Rules(new(big.Int).SetUint64(blockNum))
 	}
 
-	// Post-permissionless committed seals bind the round, so recover with the matching preimage.
-	var committers []common.Address
-	if rules.IsPermissionless {
-		committers, err = v.sealer.CommittersWithRound(header)
-	} else {
-		committers, err = v.sealer.Committers(header)
-	}
+	// Committers is fork-aware: post-permissionless it recovers with the round-bound preimage.
+	committers, err := v.sealer.Committers(header)
 	if err != nil {
 		return err
 	}

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -63,6 +63,10 @@ func (s *verifySealsTestSealer) Committers(*types.Header) ([]common.Address, err
 	return s.committers, nil
 }
 
+func (s *verifySealsTestSealer) CommittersWithRound(*types.Header) ([]common.Address, error) {
+	return s.committers, nil
+}
+
 func (s *verifySealsTestSealer) Round(*types.Header) (byte, error) {
 	return 0, nil
 }

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -48,13 +48,12 @@ import (
 
 type verifySealsTestSealer struct {
 	consensus.Sealer
-	author              common.Address
-	committers          []common.Address
-	committersWithRound []common.Address // recovered set post-permissionless; falls back to committers if nil
-	quorum              int
-	f                   int
-	qualifiedLen        int
-	committeeSize       int
+	author        common.Address
+	committers    []common.Address
+	quorum        int
+	f             int
+	qualifiedLen  int
+	committeeSize int
 }
 
 func (s *verifySealsTestSealer) Author(*types.Header) (common.Address, error) {
@@ -62,13 +61,6 @@ func (s *verifySealsTestSealer) Author(*types.Header) (common.Address, error) {
 }
 
 func (s *verifySealsTestSealer) Committers(*types.Header) ([]common.Address, error) {
-	return s.committers, nil
-}
-
-func (s *verifySealsTestSealer) CommittersWithRound(*types.Header) ([]common.Address, error) {
-	if s.committersWithRound != nil {
-		return s.committersWithRound, nil
-	}
 	return s.committers, nil
 }
 
@@ -441,79 +433,6 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
 	}
 
 	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
-}
-
-// Post-permissionless verifySeals uses CommittersWithRound; the legacy set is invalid, so NoError proves it.
-func TestVerifySealsPermissionlessUsesRoundBoundCommitters(t *testing.T) {
-	var (
-		author    = common.HexToAddress("0x0001")
-		b         = common.HexToAddress("0x0002")
-		c         = common.HexToAddress("0x0003")
-		outsider  = common.HexToAddress("0x0009")
-		blockNum  = uint64(7)
-		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
-		committee = []common.Address{author, b, c}
-		sealer    = &verifySealsTestSealer{
-			Sealer:              faker.NewFaker(),
-			author:              author,
-			committers:          []common.Address{outsider},     // legacy: invalid if used
-			committersWithRound: []common.Address{author, b, c}, // round-bound: valid committee
-			quorum:              3,
-		}
-	)
-
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	mGov := mock_gov.NewMockGovModule(ctrl)
-	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
-	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
-
-	validator := &BlockValidator{
-		config:  params.TestKaiaConfig("permissionless"),
-		sealer:  sealer,
-		mGov:    mGov,
-		mValset: mValset,
-	}
-
-	assert.NoError(t, validator.verifySeals(header))
-}
-
-// Pre-permissionless verifySeals uses legacy Committers; the round-bound set is invalid, so NoError proves it.
-func TestVerifySealsPrePermissionlessUsesLegacyCommitters(t *testing.T) {
-	var (
-		author   = common.HexToAddress("0x0001")
-		outsider = common.HexToAddress("0x0009")
-		blockNum = uint64(7)
-		header   = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
-		config   = params.TestKaiaConfig("permissionless").Copy()
-		sealer   = &verifySealsTestSealer{
-			Sealer:              faker.NewFaker(),
-			author:              author,
-			committers:          []common.Address{author},   // legacy: valid council
-			committersWithRound: []common.Address{outsider}, // round-bound: invalid if used
-		}
-	)
-	config.PermissionlessCompatibleBlock = big.NewInt(10) // blockNum 7 < 10 => pre-permissionless
-
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
-	mGov := mock_gov.NewMockGovModule(ctrl)
-	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author}, nil)
-	mValset.EXPECT().GetCouncil(blockNum).Return([]common.Address{author}, nil)
-	mGov.EXPECT().GetParamSet(blockNum).Return(gov.ParamSet{CommitteeSize: 1})
-
-	validator := &BlockValidator{
-		config:  config,
-		sealer:  sealer,
-		mGov:    mGov,
-		mValset: mValset,
-	}
-
-	assert.NoError(t, validator.verifySeals(header))
 }
 
 func TestVerifyBlockBody(t *testing.T) {

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -23,6 +23,7 @@
 package blockchain
 
 import (
+	"crypto/ecdsa"
 	"fmt"
 	"math/big"
 	"runtime"
@@ -44,6 +45,7 @@ import (
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type verifySealsTestSealer struct {
@@ -432,6 +434,68 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
 		mValset: mValset,
 	}
 
+	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+}
+
+// roundBoundSealer stands in for the post-permissionless dynamicSealer: it always recovers
+// with the round-bound preimage. The per-fork selection itself is covered by consensus/engine,
+// which this package cannot import (engine -> istanbul/backend -> blockchain).
+type roundBoundSealer struct {
+	*istanbul.IstanbulSealer
+}
+
+func (s *roundBoundSealer) Committers(header *types.Header) ([]common.Address, error) {
+	return s.IstanbulSealer.CommittersWithRound(header)
+}
+
+// TestVerifySealsPermissionlessRejectsMutatedRound runs real committer recovery through
+// verifySeals: the round byte lives in the vanity that HeaderHash zeroes, so mutating it
+// leaves the block hash and the author seal intact and only the committed-seal preimage
+// changes. Post-permissionless that must cost the block its committers.
+func TestVerifySealsPermissionlessRejectsMutatedRound(t *testing.T) {
+	const round = int64(3)
+	var (
+		blockNum = uint64(7)
+		keys     = make([]*ecdsa.PrivateKey, 4) // Quorum(4, 4) == 3, so 4 valid seals pass
+		addrs    = make([]common.Address, 4)
+	)
+	for i := range keys {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		keys[i], addrs[i] = key, crypto.PubkeyToAddress(key.PublicKey)
+	}
+
+	config := params.TestKaiaConfig("permissionless")
+	sealer := &roundBoundSealer{istanbul.NewSealerImpl(keys[0])} // keys[0] proposes
+
+	header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+	require.NoError(t, sealer.WriteValidators(header, addrs))
+	sealer.WriteRound(header, round)
+	authorSeal, err := sealer.MakeAuthorSeal(header)
+	require.NoError(t, err)
+	require.NoError(t, sealer.WriteAuthorSeal(header, authorSeal))
+
+	seals := make([][]byte, len(keys))
+	for i, key := range keys {
+		preimage := istanbul.PrepareCommittedSealWithRound(sealer.HeaderHash(header), byte(round))
+		seals[i], err = crypto.Sign(crypto.Keccak256(preimage), key)
+		require.NoError(t, err)
+	}
+	require.NoError(t, sealer.WriteCommittedSeals(header, seals))
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetProposer(blockNum, gomock.Any()).Return(addrs[0], nil).AnyTimes()
+	mValset.EXPECT().GetCommittee(blockNum, gomock.Any()).Return(addrs, nil).AnyTimes()
+
+	validator := &BlockValidator{config: config, sealer: sealer, mGov: mGov, mValset: mValset}
+
+	require.NoError(t, validator.verifySeals(header))
+
+	sealer.WriteRound(header, round+1)
 	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
 }
 

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -48,11 +48,13 @@ import (
 
 type verifySealsTestSealer struct {
 	consensus.Sealer
-	author        common.Address
-	committers    []common.Address
-	quorum        int
-	qualifiedLen  int
-	committeeSize int
+	author              common.Address
+	committers          []common.Address
+	committersWithRound []common.Address // recovered set post-permissionless; falls back to committers if nil
+	quorum              int
+	f                   int
+	qualifiedLen        int
+	committeeSize       int
 }
 
 func (s *verifySealsTestSealer) Author(*types.Header) (common.Address, error) {
@@ -64,6 +66,9 @@ func (s *verifySealsTestSealer) Committers(*types.Header) ([]common.Address, err
 }
 
 func (s *verifySealsTestSealer) CommittersWithRound(*types.Header) ([]common.Address, error) {
+	if s.committersWithRound != nil {
+		return s.committersWithRound, nil
+	}
 	return s.committers, nil
 }
 
@@ -75,6 +80,10 @@ func (s *verifySealsTestSealer) Quorum(_ uint64, qualifiedLen, committeeSize int
 	s.qualifiedLen = qualifiedLen
 	s.committeeSize = committeeSize
 	return s.quorum
+}
+
+func (s *verifySealsTestSealer) F(_ uint64, _, _ int) int {
+	return s.f
 }
 
 func TestCountValidCommittedSeals(t *testing.T) {
@@ -432,6 +441,79 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
 	}
 
 	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+}
+
+// Post-permissionless verifySeals uses CommittersWithRound; the legacy set is invalid, so NoError proves it.
+func TestVerifySealsPermissionlessUsesRoundBoundCommitters(t *testing.T) {
+	var (
+		author    = common.HexToAddress("0x0001")
+		b         = common.HexToAddress("0x0002")
+		c         = common.HexToAddress("0x0003")
+		outsider  = common.HexToAddress("0x0009")
+		blockNum  = uint64(7)
+		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		committee = []common.Address{author, b, c}
+		sealer    = &verifySealsTestSealer{
+			Sealer:              faker.NewFaker(),
+			author:              author,
+			committers:          []common.Address{outsider},     // legacy: invalid if used
+			committersWithRound: []common.Address{author, b, c}, // round-bound: valid committee
+			quorum:              3,
+		}
+	)
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
+
+	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.NoError(t, validator.verifySeals(header))
+}
+
+// Pre-permissionless verifySeals uses legacy Committers; the round-bound set is invalid, so NoError proves it.
+func TestVerifySealsPrePermissionlessUsesLegacyCommitters(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		outsider = common.HexToAddress("0x0009")
+		blockNum = uint64(7)
+		header   = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		config   = params.TestKaiaConfig("permissionless").Copy()
+		sealer   = &verifySealsTestSealer{
+			Sealer:              faker.NewFaker(),
+			author:              author,
+			committers:          []common.Address{author},   // legacy: valid council
+			committersWithRound: []common.Address{outsider}, // round-bound: invalid if used
+		}
+	)
+	config.PermissionlessCompatibleBlock = big.NewInt(10) // blockNum 7 < 10 => pre-permissionless
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author}, nil)
+	mValset.EXPECT().GetCouncil(blockNum).Return([]common.Address{author}, nil)
+	mGov.EXPECT().GetParamSet(blockNum).Return(gov.ParamSet{CommitteeSize: 1})
+
+	validator := &BlockValidator{
+		config:  config,
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	assert.NoError(t, validator.verifySeals(header))
 }
 
 func TestVerifyBlockBody(t *testing.T) {

--- a/cmd/utils/nodecmd/util.go
+++ b/cmd/utils/nodecmd/util.go
@@ -183,6 +183,10 @@ func decodeExtra(headerFile string) (map[string]interface{}, error) {
 	// scheme implementation is available. If a new scheme is introduced later,
 	// this command should inspect the chainConfig from DB and reintroduce a
 	// scheme option so DecodeExtra uses the correct implementation.
+	//
+	// NOTE: Committers() picks its recovery preimage by fork, and this config enables
+	// permissionless, so the reported committers hold only for post-fork headers.
+	// TODO-permissionless: take the fork identity as an argument so pre-fork headers decode too.
 	s := engine.NewSealer(params.TestChainConfig.Copy(), nil)
 	validators, err := s.Validators(header)
 	if err != nil {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -93,6 +93,7 @@ type Sealer interface {
 	// Read information from header.Extra.
 	Author(header *types.Header) (common.Address, error)
 	Committers(header *types.Header) ([]common.Address, error)
+	CommittersWithRound(header *types.Header) ([]common.Address, error)
 	Vanity(header *types.Header) ([]byte, error)
 	RawSeals(header *types.Header) ([]byte, [][]byte, error)
 	Round(header *types.Header) (byte, error)

--- a/consensus/engine/sealer.go
+++ b/consensus/engine/sealer.go
@@ -73,6 +73,10 @@ func (s *dynamicSealer) Committers(header *types.Header) ([]common.Address, erro
 	if header == nil || header.Number == nil {
 		return nil, consensus.ErrUnknownBlock
 	}
+	// Post-permissionless committed seals bind the round; recover with the matching preimage.
+	if s.chainConfig.IsPermissionlessForkEnabled(header.Number) {
+		return s.implAt(header.Number.Uint64()).CommittersWithRound(header)
+	}
 	return s.implAt(header.Number.Uint64()).Committers(header)
 }
 

--- a/consensus/engine/sealer.go
+++ b/consensus/engine/sealer.go
@@ -76,6 +76,13 @@ func (s *dynamicSealer) Committers(header *types.Header) ([]common.Address, erro
 	return s.implAt(header.Number.Uint64()).Committers(header)
 }
 
+func (s *dynamicSealer) CommittersWithRound(header *types.Header) ([]common.Address, error) {
+	if header == nil || header.Number == nil {
+		return nil, consensus.ErrUnknownBlock
+	}
+	return s.implAt(header.Number.Uint64()).CommittersWithRound(header)
+}
+
 func (s *dynamicSealer) Vanity(header *types.Header) ([]byte, error) {
 	if header == nil || header.Number == nil {
 		return nil, consensus.ErrUnknownBlock

--- a/consensus/engine/sealer_test.go
+++ b/consensus/engine/sealer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
 	"github.com/stretchr/testify/assert"
@@ -74,4 +75,32 @@ func TestBlockHash_PreIstanbulCompatibleBlockUsesIstanbulHeaderHash(t *testing.T
 	assert.Equal(t, expectedHash, header.Hash())
 	assert.Equal(t, uint64(75373312), params.KairosChainConfig.IstanbulCompatibleBlock.Uint64())
 	assert.Less(t, header.Number.Uint64(), params.KairosChainConfig.IstanbulCompatibleBlock.Uint64())
+}
+
+// TestCommittersForkGating: the engine sealer recovers committed seals with the round-bound
+// preimage post-permissionless and the legacy preimage before it.
+func TestCommittersForkGating(t *testing.T) {
+	defer types.SetHeaderHashFn(nil)
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+
+	// header carrying a round-bound committed seal
+	impl := istanbul.NewSealerImpl(key)
+	header := &types.Header{Number: big.NewInt(1)}
+	require.NoError(t, impl.WriteValidators(header, []common.Address{addr}))
+	impl.WriteRound(header, 0)
+	seal, err := impl.MakeCommittedSealFromHashWithRound(impl.HeaderHash(header), 0)
+	require.NoError(t, err)
+	require.NoError(t, impl.WriteCommittedSeals(header, [][]byte{seal}))
+
+	// post-fork routes to round-bound recovery (finds the signer); pre-fork stays legacy (misses it)
+	got, err := NewSealer(&params.ChainConfig{PermissionlessCompatibleBlock: big.NewInt(0)}, nil).Committers(header)
+	require.NoError(t, err)
+	assert.Equal(t, []common.Address{addr}, got)
+
+	got, err = NewSealer(&params.ChainConfig{}, nil).Committers(header)
+	require.NoError(t, err)
+	assert.NotEqual(t, []common.Address{addr}, got)
 }

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -181,6 +181,10 @@ func (f *Faker) Committers(header *types.Header) ([]common.Address, error) {
 	return []common.Address{f.address}, nil
 }
 
+func (f *Faker) CommittersWithRound(header *types.Header) ([]common.Address, error) {
+	return f.Committers(header)
+}
+
 func (f *Faker) Vanity(header *types.Header) ([]byte, error) {
 	if err := f.verifyFailure(header); err != nil {
 		return nil, err

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -75,4 +75,7 @@ type Backend interface {
 	SetCurrentView(view *bft.View)
 
 	NodeType() common.ConnType
+
+	// IsPermissionlessAt reports whether the permissionless fork is enabled at num.
+	IsPermissionlessAt(num uint64) bool
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -145,6 +145,13 @@ func (sb *backend) NodeType() common.ConnType {
 	return sb.nodetype
 }
 
+func (sb *backend) IsPermissionlessAt(num uint64) bool {
+	if sb.chain == nil {
+		return false
+	}
+	return sb.chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num))
+}
+
 // initSealState initializes state for Seal operation.
 // Returns the commitCh channel to wait on, or nil if the block was already committed.
 func (sb *backend) initSealState(number uint64, blockHash common.Hash) chan *types.Result {

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -146,9 +146,6 @@ func (sb *backend) NodeType() common.ConnType {
 }
 
 func (sb *backend) IsPermissionlessAt(num uint64) bool {
-	if sb.chain == nil {
-		return false
-	}
 	return sb.chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num))
 }
 

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -98,7 +98,11 @@ func (c *core) handleCommit(msg *bft.Message, src common.Address) error {
 	// Verify msg.CommittedSeal is the sender's signature over the proposal's
 	// committed-seal preimage. Without this, an arbitrary seal would be copied verbatim into the sealed block.
 	// commit.Digest is the proposal hash, already validated by verifyCommit above.
-	committer, err := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSeal(commit.Digest), msg.CommittedSeal)
+	committedSealPreimage := istanbul.PrepareCommittedSeal(commit.Digest)
+	if c.backend.IsPermissionlessAt(commit.View.Sequence.Uint64()) {
+		committedSealPreimage = istanbul.PrepareCommittedSealWithRound(commit.Digest, byte(commit.View.Round.Uint64()))
+	}
+	committer, err := istanbul.GetSignatureAddress(committedSealPreimage, msg.CommittedSeal)
 	if err != nil || committer != src {
 		logger.Warn("invalid committed seal in commit message", "sender", src.String(), "recovered", committer.String(), "err", err)
 		return errInvalidCommittedSeal

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -96,6 +96,7 @@ func TestSendCommitForOldBlockSealMatchesDigest(t *testing.T) {
 	mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
 	mockBackend.EXPECT().Address().Return(sealAddr).AnyTimes()
 	mockBackend.EXPECT().Sealer().Return(istanbul.NewSealerImpl(sealKey)).AnyTimes()
+	mockBackend.EXPECT().IsPermissionlessAt(gomock.Any()).Return(false).AnyTimes()
 	mockBackend.EXPECT().Sign(gomock.Any()).Return([]byte{0x01}, nil).AnyTimes() // message-payload signature, unused here
 	mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any()).DoAndReturn(func(_ common.Hash, p []byte) error {
 		payload = append([]byte(nil), p...)

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -48,7 +48,7 @@ func TestCore_sendCommit(t *testing.T) {
 		{"invalid case - not committee", 2, false},
 	} {
 		{
-			mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+			mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 			if tc.valid {
 				mockBackend.EXPECT().Sign(gomock.Any()).Return(nil, nil).AnyTimes()
 				mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -124,4 +124,49 @@ func TestSendCommitForOldBlockSealMatchesDigest(t *testing.T) {
 	// ...and must NOT recover to the sealer over an unrelated current proposal digest.
 	wrong, _ := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSeal(currentProposalHash), msg.CommittedSeal)
 	assert.NotEqual(t, sealAddr, wrong, "CommittedSeal must not attest to an unrelated (current proposal) digest")
+}
+
+// TestFinalizeMessagePermissionlessBindsRound checks that post-permissionless, finalizeMessage
+// produces a committed seal over the round-bound preimage, not the legacy one.
+func TestFinalizeMessagePermissionlessBindsRound(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	sealKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	sealAddr := crypto.PubkeyToAddress(sealKey.PublicKey)
+
+	var payload []byte
+	mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
+	mockBackend.EXPECT().Address().Return(sealAddr).AnyTimes()
+	mockBackend.EXPECT().Sealer().Return(istanbul.NewSealerImpl(sealKey)).AnyTimes()
+	mockBackend.EXPECT().IsPermissionlessAt(gomock.Any()).Return(true).AnyTimes()
+	mockBackend.EXPECT().Sign(gomock.Any()).Return([]byte{0x01}, nil).AnyTimes()
+	mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any()).DoAndReturn(func(_ common.Hash, p []byte) error {
+		payload = append([]byte(nil), p...)
+		return nil
+	}).AnyTimes()
+
+	istCore := New(mockBackend, istanbul.DefaultConfig.Copy()).(*core)
+
+	blockHash := common.HexToHash("0xa11d")
+	round := int64(2)
+	view := &bft.View{Round: big.NewInt(round), Sequence: big.NewInt(1)}
+
+	istCore.sendCommitForOldBlock(view, blockHash, common.HexToHash("0xc33d"))
+
+	require.NotNil(t, payload, "a COMMIT must have been broadcast")
+	var msg bft.Message
+	require.NoError(t, rlp.DecodeBytes(payload, &msg))
+
+	// The committed seal must recover to the sealer over the round-bound preimage...
+	got, err := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSealWithRound(blockHash, byte(round)), msg.CommittedSeal)
+	require.NoError(t, err)
+	assert.Equal(t, sealAddr, got, "CommittedSeal must be round-bound post-permissionless")
+
+	// ...and NOT over the legacy (non-round) preimage or a different round.
+	legacy, _ := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSeal(blockHash), msg.CommittedSeal)
+	assert.NotEqual(t, sealAddr, legacy, "CommittedSeal must not match the legacy (non-round) preimage")
+	wrongRound, _ := istanbul.GetSignatureAddress(istanbul.PrepareCommittedSealWithRound(blockHash, byte(round+1)), msg.CommittedSeal)
+	assert.NotEqual(t, sealAddr, wrongRound, "CommittedSeal must not match a different round")
 }

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -191,7 +191,13 @@ func (c *core) finalizeMessage(msg *bft.Message) ([]byte, error) {
 		if err = msg.Decode(&sub); err != nil {
 			return nil, err
 		}
-		if msg.CommittedSeal, err = c.backend.Sealer().MakeCommittedSealFromHash(sub.Digest); err != nil {
+		// Post-permissionless: bind the round into the committed seal.
+		if c.backend.IsPermissionlessAt(sub.View.Sequence.Uint64()) {
+			msg.CommittedSeal, err = c.backend.Sealer().MakeCommittedSealFromHashWithRound(sub.Digest, byte(sub.View.Round.Uint64()))
+		} else {
+			msg.CommittedSeal, err = c.backend.Sealer().MakeCommittedSealFromHash(sub.Digest)
+		}
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -101,6 +101,7 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 	mockBackend.EXPECT().Sealer().Return(istanbul.NewSealerImpl(sealerKey)).AnyTimes()
 	mockBackend.EXPECT().LastProposal().Return(initBlock, validatorAddrs[0]).AnyTimes()
 	mockBackend.EXPECT().NodeType().Return(common.CONSENSUSNODE).AnyTimes()
+	mockBackend.EXPECT().IsPermissionlessAt(gomock.Any()).Return(false).AnyTimes()
 
 	// Set an eventMux in which istanbul core will subscribe istanbul events
 	mockBackend.EXPECT().EventMux().Return(eventMux).AnyTimes()

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -49,7 +49,7 @@ import (
 
 // newMockBackend create a mock-backend and mock valset/gov modules initialized with default values.
 // Caller must call istCore.RegisterKaiaxModules(mockValset, mockGov) after New().
-func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanbul.MockBackend, *gomock.Controller, *valset_mock.MockValsetModule, *mock_gov.MockGovModule) {
+func newMockBackend(t *testing.T, validatorAddrs []common.Address, permissionless bool) (*mock_istanbul.MockBackend, *gomock.Controller, *valset_mock.MockValsetModule, *mock_gov.MockGovModule) {
 	committeeSize := uint64(len(validatorAddrs) / 3)
 
 	istExtra := &istanbul.IstanbulExtra{
@@ -101,7 +101,7 @@ func newMockBackend(t *testing.T, validatorAddrs []common.Address) (*mock_istanb
 	mockBackend.EXPECT().Sealer().Return(istanbul.NewSealerImpl(sealerKey)).AnyTimes()
 	mockBackend.EXPECT().LastProposal().Return(initBlock, validatorAddrs[0]).AnyTimes()
 	mockBackend.EXPECT().NodeType().Return(common.CONSENSUSNODE).AnyTimes()
-	mockBackend.EXPECT().IsPermissionlessAt(gomock.Any()).Return(false).AnyTimes()
+	mockBackend.EXPECT().IsPermissionlessAt(gomock.Any()).Return(permissionless).AnyTimes()
 
 	// Set an eventMux in which istanbul core will subscribe istanbul events
 	mockBackend.EXPECT().EventMux().Return(eventMux).AnyTimes()
@@ -252,68 +252,70 @@ func genIstanbulMsg(msgType uint64, prevHash common.Hash, proposal *types.Block,
 // from signerKey forges the committed seal.
 func genIstanbulMsgWithSealKey(msgType uint64, prevHash common.Hash, proposal *types.Block, signerAddr common.Address, signerKey, sealKey *ecdsa.PrivateKey) (istanbul.MessageEvent, error) {
 	var subject interface{}
-
 	if msgType == bft.MsgPreprepare {
 		subject = &bft.Preprepare{
-			View: &bft.View{
-				Round:    big.NewInt(0),
-				Sequence: proposal.Number(),
-			},
+			View:     &bft.View{Round: big.NewInt(0), Sequence: proposal.Number()},
 			Proposal: proposal,
 		}
 	} else {
 		subject = &bft.Subject{
-			View: &bft.View{
-				Round:    big.NewInt(0),
-				Sequence: proposal.Number(),
-			},
+			View:     &bft.View{Round: big.NewInt(0), Sequence: proposal.Number()},
 			Digest:   proposal.Hash(),
 			PrevHash: prevHash,
 		}
 	}
 
+	// A COMMIT carries a CommittedSeal: the sender's signature over the proposal's
+	// committed-seal preimage, which handleCommit verifies.
+	var seal []byte
+	if msgType == bft.MsgCommit {
+		var err error
+		if seal, err = crypto.Sign(crypto.Keccak256(istanbul.PrepareCommittedSeal(proposal.Hash())), sealKey); err != nil {
+			return istanbul.MessageEvent{}, err
+		}
+	}
+	return signIstanbulMsg(prevHash, msgType, subject, signerAddr, signerKey, seal)
+}
+
+// genIstanbulCommitWithRoundBoundSeal builds a COMMIT with a round-bound committed seal (post-permissionless).
+func genIstanbulCommitWithRoundBoundSeal(prevHash common.Hash, proposal *types.Block, signerAddr common.Address, signerKey *ecdsa.PrivateKey, round byte) (istanbul.MessageEvent, error) {
+	subject := &bft.Subject{
+		View:     &bft.View{Round: big.NewInt(int64(round)), Sequence: proposal.Number()},
+		Digest:   proposal.Hash(),
+		PrevHash: prevHash,
+	}
+	seal, err := crypto.Sign(crypto.Keccak256(istanbul.PrepareCommittedSealWithRound(proposal.Hash(), round)), signerKey)
+	if err != nil {
+		return istanbul.MessageEvent{}, err
+	}
+	return signIstanbulMsg(prevHash, bft.MsgCommit, subject, signerAddr, signerKey, seal)
+}
+
+// signIstanbulMsg assembles a bft.Message carrying committedSeal and signs it with signerKey.
+func signIstanbulMsg(prevHash common.Hash, code uint64, subject interface{}, signerAddr common.Address, signerKey *ecdsa.PrivateKey, committedSeal []byte) (istanbul.MessageEvent, error) {
 	encodedSubject, err := bft.Encode(subject)
 	if err != nil {
 		return istanbul.MessageEvent{}, err
 	}
-
 	msg := &bft.Message{
-		Hash:    prevHash,
-		Code:    msgType,
-		Msg:     encodedSubject,
-		Address: signerAddr,
+		Hash:          prevHash,
+		Code:          code,
+		Msg:           encodedSubject,
+		Address:       signerAddr,
+		CommittedSeal: committedSeal,
 	}
-
-	// A COMMIT carries a CommittedSeal: the sender's signature over the proposal's
-	// committed-seal preimage, which handleCommit verifies.
-	if msgType == bft.MsgCommit {
-		msg.CommittedSeal, err = crypto.Sign(crypto.Keccak256(istanbul.PrepareCommittedSeal(proposal.Hash())), sealKey)
-		if err != nil {
-			return istanbul.MessageEvent{}, err
-		}
-	}
-
 	data, err := msg.PayloadNoSig()
 	if err != nil {
 		return istanbul.MessageEvent{}, err
 	}
-
-	msg.Signature, err = crypto.Sign(crypto.Keccak256([]byte(data)), signerKey)
-	if err != nil {
+	if msg.Signature, err = crypto.Sign(crypto.Keccak256([]byte(data)), signerKey); err != nil {
 		return istanbul.MessageEvent{}, err
 	}
-
 	encodedPayload, err := msg.Payload()
 	if err != nil {
 		return istanbul.MessageEvent{}, err
 	}
-
-	istMsg := istanbul.MessageEvent{
-		Hash:    msg.Hash,
-		Payload: encodedPayload,
-	}
-
-	return istMsg, nil
+	return istanbul.MessageEvent{Hash: msg.Hash, Payload: encodedPayload}, nil
 }
 
 // TestCore_handleEvents_scenario_invalidSender tests `handleEvents` function of `istanbul.core` with a scenario.
@@ -323,7 +325,7 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 	defer fork.ClearHardForkBlockNumberConfig()
 
 	validatorAddrs, validatorKeyMap := genValidators(30)
-	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 	defer mockCtrl.Finish()
 
 	istConfig := istanbul.DefaultConfig
@@ -506,83 +508,85 @@ func TestCore_handleEvents_scenario_invalidSender(t *testing.T) {
 	}
 }
 
-// TestCore_handleCommit_RejectsForgedCommittedSeal checks that a COMMIT from a
-// committee member whose CommittedSeal is signed by a different key (a forged seal)
-// is rejected, while a correctly-signed COMMIT is accepted.
-func TestCore_handleCommit_RejectsForgedCommittedSeal(t *testing.T) {
+// startCoreAtPreprepare starts a core, drives a preprepare, and returns the core plus a committee
+// sender (≠ proposer) with its key, ready to send COMMITs. permissionless sets the backend fork status.
+func startCoreAtPreprepare(t *testing.T, permissionless bool) (c *core, prevHash common.Hash, proposal *types.Block, sender common.Address, senderKey *ecdsa.PrivateKey) {
+	t.Helper()
 	fork.SetHardForkBlockNumberConfig(&params.ChainConfig{})
-	defer fork.ClearHardForkBlockNumberConfig()
+	t.Cleanup(fork.ClearHardForkBlockNumberConfig)
 
-	validatorAddrs, validatorKeyMap := genValidators(30)
-	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
-	defer mockCtrl.Finish()
+	addrs, keys := genValidators(30)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, addrs, permissionless)
+	t.Cleanup(mockCtrl.Finish)
 
 	istConfig := istanbul.DefaultConfig
 	istConfig.ProposerPolicy = istanbul.WeightedRandom
+	c = New(mockBackend, istConfig).(*core)
+	c.RegisterKaiaxModules(mockValset, mockGov)
+	require.NoError(t, c.Start())
+	t.Cleanup(func() { c.Stop() })
 
-	istCore := New(mockBackend, istConfig).(*core)
-	istCore.RegisterKaiaxModules(mockValset, mockGov)
-	if err := istCore.Start(); err != nil {
-		t.Fatal(err)
-	}
-	defer istCore.Stop()
-
-	eventMux := mockBackend.EventMux()
 	lastProposal, _ := mockBackend.LastProposal()
 	lastBlock := lastProposal.(*types.Block)
-	committeeSize := uint64(len(validatorAddrs) / 3)
-
-	// Establish a proposal via a valid preprepare from the proposer.
-	_, committee, proposer, _ := getTestCommitteeState(validatorAddrs, committeeSize, istCore.currentView().Sequence.Uint64(), istCore.currentView().Round.Uint64())
-	proposerKey := validatorKeyMap[proposer]
-	newProposal, err := genBlock(lastBlock, proposerKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	preprepareMsg, err := genIstanbulMsg(bft.MsgPreprepare, lastBlock.Hash(), newProposal, proposer, proposerKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := eventMux.Post(preprepareMsg); err != nil {
-		t.Fatal(err)
-	}
+	_, committee, proposer, _ := getTestCommitteeState(addrs, uint64(len(addrs)/3), c.currentView().Sequence.Uint64(), c.currentView().Round.Uint64())
+	cand, err := genBlock(lastBlock, keys[proposer])
+	require.NoError(t, err)
+	pp, err := genIstanbulMsg(bft.MsgPreprepare, lastBlock.Hash(), cand, proposer, keys[proposer])
+	require.NoError(t, err)
+	require.NoError(t, mockBackend.EventMux().Post(pp))
 	time.Sleep(time.Second)
-	require.NotNil(t, istCore.current.Preprepare)
-	proposalBlock := istCore.current.Preprepare.Proposal.(*types.Block)
+	require.NotNil(t, c.current.Preprepare)
 
-	// Pick a committee member distinct from the proposer to send the commits.
-	var sender common.Address
 	for i := 0; i < committee.Len(); i++ {
 		if committee.At(i) != proposer {
 			sender = committee.At(i)
 			break
 		}
 	}
-	senderKey := validatorKeyMap[sender]
+	return c, lastBlock.Hash(), c.current.Preprepare.Proposal.(*types.Block), sender, keys[sender]
+}
 
-	// A committed seal signed by the proposer's key (not the sender's) is forged:
-	// the recovered signer != sender, so handleCommit must reject it.
-	forged, err := genIstanbulMsgWithSealKey(bft.MsgCommit, lastBlock.Hash(), proposalBlock, sender, senderKey, proposerKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := eventMux.Post(forged); err != nil {
-		t.Fatal(err)
-	}
-	time.Sleep(time.Second)
-	assert.Equal(t, 0, len(istCore.current.Commits.messages), "forged committed seal must be rejected")
+// TestCore_handleCommit_RejectsForgedCommittedSeal checks that a COMMIT from a committee member
+// whose CommittedSeal is signed by a different key (a forged seal) is rejected, while a
+// correctly-signed COMMIT is accepted.
+func TestCore_handleCommit_RejectsForgedCommittedSeal(t *testing.T) {
+	c, prevHash, proposal, sender, senderKey := startCoreAtPreprepare(t, false)
 
-	// A correctly-signed committed seal from the same sender is accepted, proving
-	// it was specifically the forged seal (not the sender) that caused rejection.
-	valid, err := genIstanbulMsg(bft.MsgCommit, lastBlock.Hash(), proposalBlock, sender, senderKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := eventMux.Post(valid); err != nil {
-		t.Fatal(err)
-	}
+	// Seal signed by a key other than the sender's: recovered signer != sender, so it is rejected.
+	forgeKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	forged, err := genIstanbulMsgWithSealKey(bft.MsgCommit, prevHash, proposal, sender, senderKey, forgeKey)
+	require.NoError(t, err)
+	require.NoError(t, c.backend.EventMux().Post(forged))
 	time.Sleep(time.Second)
-	assert.Equal(t, 1, len(istCore.current.Commits.messages), "valid committed seal must be accepted")
+	assert.Equal(t, 0, len(c.current.Commits.messages), "forged committed seal must be rejected")
+
+	// A correctly-signed seal from the same sender is accepted (so it was the seal, not the sender).
+	valid, err := genIstanbulMsg(bft.MsgCommit, prevHash, proposal, sender, senderKey)
+	require.NoError(t, err)
+	require.NoError(t, c.backend.EventMux().Post(valid))
+	time.Sleep(time.Second)
+	assert.Equal(t, 1, len(c.current.Commits.messages), "valid committed seal must be accepted")
+}
+
+// TestCore_handleCommit_PermissionlessRoundBoundSeal checks that post-permissionless handleCommit
+// rejects a legacy committed seal and accepts a round-bound one from the same committee member.
+func TestCore_handleCommit_PermissionlessRoundBoundSeal(t *testing.T) {
+	c, prevHash, proposal, sender, senderKey := startCoreAtPreprepare(t, true)
+
+	// A legacy (non-round-bound) committed seal must be rejected post-permissionless.
+	legacy, err := genIstanbulMsg(bft.MsgCommit, prevHash, proposal, sender, senderKey)
+	require.NoError(t, err)
+	require.NoError(t, c.backend.EventMux().Post(legacy))
+	time.Sleep(time.Second)
+	assert.Equal(t, 0, len(c.current.Commits.messages), "legacy committed seal must be rejected post-permissionless")
+
+	// A round-bound committed seal from the same sender is accepted.
+	roundBound, err := genIstanbulCommitWithRoundBoundSeal(prevHash, proposal, sender, senderKey, 0)
+	require.NoError(t, err)
+	require.NoError(t, c.backend.EventMux().Post(roundBound))
+	time.Sleep(time.Second)
+	assert.Equal(t, 1, len(c.current.Commits.messages), "round-bound committed seal must be accepted post-permissionless")
 }
 
 func TestCore_handlerMsg(t *testing.T) {
@@ -590,7 +594,7 @@ func TestCore_handlerMsg(t *testing.T) {
 	defer fork.ClearHardForkBlockNumberConfig()
 
 	validatorAddrs, validatorKeyMap := genValidators(10)
-	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 	defer mockCtrl.Finish()
 
 	istConfig := istanbul.DefaultConfig.Copy()
@@ -663,7 +667,7 @@ func TestCore_postPrepreparedEvent(t *testing.T) {
 	defer fork.ClearHardForkBlockNumberConfig()
 
 	validatorAddrs, validatorKeyMap := genValidators(10)
-	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 	defer mockCtrl.Finish()
 
 	istConfig := istanbul.DefaultConfig.Copy()
@@ -762,7 +766,7 @@ func simulateMaliciousCN(t *testing.T, numValidators int, numMalicious int) Stat
 	validatorAddrs, validatorKeyMap := genValidators(numValidators * 3)
 
 	// Add more EXPECT()s to remove unexpected call error
-	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 	mockBackend.EXPECT().Commit(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockBackend.EXPECT().HasBadProposal(gomock.Any()).Return(true).AnyTimes()
 	defer mockCtrl.Finish()
@@ -858,7 +862,7 @@ func simulateChainSplit(t *testing.T, numValidators int) (State, State) {
 	validatorAddrs, validatorKeyMap := genValidators(numValidators * 3)
 
 	// Add more EXPECT()s to remove unexpected call error
-	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 	mockBackend.EXPECT().Commit(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockBackend.EXPECT().HasBadProposal(gomock.Any()).Return(true).AnyTimes()
 	defer mockCtrl.Finish()
@@ -997,7 +1001,7 @@ func TestCore_handleTimeoutMsg_race(t *testing.T) {
 	}
 
 	validatorAddrs, validatorKeys := genValidators(10)
-	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+	mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 	defer mockCtrl.Finish()
 
 	istConfig := istanbul.DefaultConfig

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -46,7 +46,7 @@ func TestCore_sendPrepare(t *testing.T) {
 		{"valid case", 0, true},
 		{"invalid case - not committee", 2, false},
 	} {
-		mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs)
+		mockBackend, mockCtrl, mockValset, mockGov := newMockBackend(t, validatorAddrs, false)
 		if tc.valid {
 			mockBackend.EXPECT().Sign(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/consensus/istanbul/mocks/backend_mock.go
+++ b/consensus/istanbul/mocks/backend_mock.go
@@ -178,6 +178,20 @@ func (mr *MockBackendMockRecorder) NodeType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeType", reflect.TypeOf((*MockBackend)(nil).NodeType))
 }
 
+// IsPermissionlessAt mocks base method.
+func (m *MockBackend) IsPermissionlessAt(num uint64) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPermissionlessAt", num)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPermissionlessAt indicates an expected call of IsPermissionlessAt.
+func (mr *MockBackendMockRecorder) IsPermissionlessAt(num interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPermissionlessAt", reflect.TypeOf((*MockBackend)(nil).IsPermissionlessAt), num)
+}
+
 // Sealer mocks base method.
 func (m *MockBackend) Sealer() *istanbul.IstanbulSealer {
 	m.ctrl.T.Helper()

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -150,6 +150,15 @@ func PrepareCommittedSeal(hash common.Hash) []byte {
 	return buf.Bytes()
 }
 
+// PrepareCommittedSealWithRound binds the final round into the committed-seal preimage.
+func PrepareCommittedSealWithRound(hash common.Hash, round byte) []byte {
+	var buf bytes.Buffer
+	buf.Write(hash.Bytes())
+	buf.Write([]byte{byte(2)}) // keep in sync with bft.MsgCommit
+	buf.Write([]byte{round})
+	return buf.Bytes()
+}
+
 func (m *IstanbulSealer) Author(header *types.Header) (common.Address, error) {
 	extra, err := m.parseIstanbulExtra(header.Extra)
 	if err != nil {
@@ -166,6 +175,19 @@ func (m *IstanbulSealer) Author(header *types.Header) (common.Address, error) {
 }
 
 func (m *IstanbulSealer) Committers(header *types.Header) ([]common.Address, error) {
+	return m.committers(header, PrepareCommittedSeal(m.HeaderHash(header)))
+}
+
+// CommittersWithRound recovers committers using the round-bound preimage.
+func (m *IstanbulSealer) CommittersWithRound(header *types.Header) ([]common.Address, error) {
+	round, err := m.Round(header)
+	if err != nil {
+		return nil, err
+	}
+	return m.committers(header, PrepareCommittedSealWithRound(m.HeaderHash(header), round))
+}
+
+func (m *IstanbulSealer) committers(header *types.Header, proposalSeal []byte) ([]common.Address, error) {
 	extra, err := m.parseIstanbulExtra(header.Extra)
 	if err != nil {
 		return nil, err
@@ -174,7 +196,6 @@ func (m *IstanbulSealer) Committers(header *types.Header) ([]common.Address, err
 		return []common.Address{}, nil
 	}
 
-	proposalSeal := PrepareCommittedSeal(m.HeaderHash(header)) // bft.MsgCommit
 	committers := make([]common.Address, 0, len(extra.CommittedSeal))
 	for _, seal := range extra.CommittedSeal {
 		addr, err := cacheSignatureAddress(proposalSeal, seal)
@@ -323,6 +344,11 @@ func (m *IstanbulSealer) Quorum(_ uint64, qualifiedlen, committeeSize int) int {
 // MakeCommittedSealFromHash signs the COMMIT committed-seal for the given block hash.
 func (m *IstanbulSealer) MakeCommittedSealFromHash(hash common.Hash) ([]byte, error) {
 	return crypto.Sign(crypto.Keccak256(PrepareCommittedSeal(hash)), m.privateKey)
+}
+
+// MakeCommittedSealFromHashWithRound signs the round-bound COMMIT committed-seal.
+func (m *IstanbulSealer) MakeCommittedSealFromHashWithRound(hash common.Hash, round byte) ([]byte, error) {
+	return crypto.Sign(crypto.Keccak256(PrepareCommittedSealWithRound(hash, round)), m.privateKey)
 }
 
 func (m *IstanbulSealer) MakeCommittedSeal(header *types.Header) ([]byte, error) {

--- a/consensus/istanbul/sealer_test.go
+++ b/consensus/istanbul/sealer_test.go
@@ -43,6 +43,57 @@ func TestCommitters(t *testing.T) {
 	assert.NotEmpty(t, committedSeals)
 }
 
+// singleValidatorHeader builds a header whose validator set is {addr} with the
+// given round written; the caller adds the committed seal.
+func singleValidatorHeader(t *testing.T, round int64) (common.Address, *IstanbulSealer, *types.Header) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	sealer := NewSealerImpl(key)
+
+	header := &types.Header{Number: big.NewInt(1)}
+	require.NoError(t, sealer.WriteValidators(header, []common.Address{addr}))
+	sealer.WriteRound(header, round)
+	return addr, sealer, header
+}
+
+// TestCommittersWithRoundDetectsRoundMutation: a round-bound committed seal is
+// recovered correctly, but mutating the header round byte changes the committers.
+func TestCommittersWithRoundDetectsRoundMutation(t *testing.T) {
+	addr, sealer, header := singleValidatorHeader(t, 0)
+	seal, err := sealer.MakeCommittedSealFromHashWithRound(sealer.HeaderHash(header), 0)
+	require.NoError(t, err)
+	require.NoError(t, sealer.WriteCommittedSeals(header, [][]byte{seal}))
+
+	got, err := sealer.CommittersWithRound(header)
+	require.NoError(t, err)
+	assert.Equal(t, []common.Address{addr}, got)
+
+	header.Extra[IstanbulExtraVanity-1] = 1
+	mutated, err := sealer.CommittersWithRound(header)
+	require.NoError(t, err)
+	assert.NotEqual(t, []common.Address{addr}, mutated)
+}
+
+// TestCommittersRoundIndependent: the legacy Committers ignores the round byte,
+// so pre-fork blocks validate the same regardless of it.
+func TestCommittersRoundIndependent(t *testing.T) {
+	addr, sealer, header := singleValidatorHeader(t, 0)
+	seal, err := sealer.MakeCommittedSeal(header)
+	require.NoError(t, err)
+	require.NoError(t, sealer.WriteCommittedSeals(header, [][]byte{seal}))
+
+	got, err := sealer.Committers(header)
+	require.NoError(t, err)
+	assert.Equal(t, []common.Address{addr}, got)
+
+	header.Extra[IstanbulExtraVanity-1] = 1
+	got2, err := sealer.Committers(header)
+	require.NoError(t, err)
+	assert.Equal(t, []common.Address{addr}, got2)
+}
+
 // TestCacheSignatureAddress_BindsData checks that the cache binds data: a signature
 // cached for one data must not be returned as the signer when queried with different
 // data (which would let a forged header reuse a cached recovery).


### PR DESCRIPTION
## Proposed changes

The final consensus round is stored in a header vanity byte excluded from the block hash and seal preimages, so it is unauthenticated and a peer can alter it on an otherwise-valid block. From the permissionless fork, bind the round into the committed seal so a mutated round byte fails committer recovery and the block is rejected.

- `PrepareCommittedSealWithRound` / `MakeCommittedSealFromHashWithRound` / `CommittersWithRound`
- `finalizeMessage`/`handleCommit` sign/verify the round-bound seal, `verifySeals` recovers with it (post-fork)
- `Backend.IsPermissionlessAt` gates it; pre-fork keeps the legacy preimage; the block hash stays round-independent

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
