### PR TITLE
kaiax/valset: validate VRankEpoch against AddressBookV2 epoch

### DIFF
--- a/blockchain/system/addressbook_v2.go
+++ b/blockchain/system/addressbook_v2.go
@@ -235,6 +235,19 @@ func ReadEpochVACount(backend bind.ContractCaller, num *big.Int) (uint64, error)
 	return n.Uint64(), nil
 }
 
+// ReadABv2EpochBlockInterval reads the epoch block interval baked into AddressBookV2.
+func ReadABv2EpochBlockInterval(backend bind.ContractCaller, num *big.Int) (uint64, error) {
+	caller, err := abv2contracts.NewAddressBookV2Caller(AddressBookAddr, backend)
+	if err != nil {
+		return 0, err
+	}
+	n, err := caller.EpochBlockInterval(&bind.CallOpts{BlockNumber: num})
+	if err != nil {
+		return 0, err
+	}
+	return n.Uint64(), nil
+}
+
 // ReadAddressBookV2BlsAll reads BLS public key info for all nodes from
 // AddressBookV2. Used post-permissionless-fork where ABv2 — not KIP113 — is
 // the BLS source of truth.

--- a/kaiax/valset/impl/init.go
+++ b/kaiax/valset/impl/init.go
@@ -133,6 +133,10 @@ func (v *ValsetModule) initSchema() error {
 func (v *ValsetModule) Start() error {
 	logger.Info("ValsetModule Started")
 
+	if err := v.verifyVRankEpochAtHead(); err != nil {
+		return err
+	}
+
 	// Reset all caches
 	v.proposerListCache.Purge()
 	v.removeVotesCache.Purge()

--- a/kaiax/valset/impl/init_test.go
+++ b/kaiax/valset/impl/init_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
 	gov_mock "github.com/kaiachain/kaia/kaiax/gov/mock"
 	staking_mock "github.com/kaiachain/kaia/kaiax/staking/mock"
+	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/storage/database"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,7 @@ func TestStartStop(t *testing.T) {
 
 	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{}).AnyTimes()
 	mockChain.EXPECT().CurrentBlock().Return(current).AnyTimes()
+	mockChain.EXPECT().Config().Return(&params.ChainConfig{}).AnyTimes()
 	mockChain.EXPECT().Sealer().Return(engine.NewSealer(nil, nil)).AnyTimes()
 	mockChain.EXPECT().GetHeaderByNumber(uint64(0)).Return(genesis).AnyTimes()
 	for i := uint64(1); i <= current.NumberU64(); i++ {

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -310,5 +310,43 @@ func (v *ValsetModule) installAndInitializeABv2(
 	}
 
 	logger.Info("Initialized AddressBookV2", "number", header.Number)
+
+	// config.VRankEpoch must equal the epoch baked into AddressBookV2 (only the
+	// contract value is authenticated by the genesis hash).
+	if err := v.verifyVRankEpoch(statedb, nil); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// verifyVRankEpoch errors if the configured VRankEpoch differs from the epoch
+// baked into AddressBookV2, read from the given state.
+func (v *ValsetModule) verifyVRankEpoch(statedb *state.StateDB, num *big.Int) error {
+	backend, err := backends.NewStateBlockchainContractBackend(v.Chain, statedb)
+	if err != nil {
+		return fmt.Errorf("create contract backend: %w", err)
+	}
+	onchainEpoch, err := system.ReadABv2EpochBlockInterval(backend, num)
+	if err != nil {
+		return fmt.Errorf("read ABv2 epochBlockInterval: %w", err)
+	}
+	if cfgEpoch := v.Chain.Config().VRankEpoch; cfgEpoch != onchainEpoch {
+		return fmt.Errorf("VRankEpoch mismatch: config has %d, AddressBookV2 has %d", cfgEpoch, onchainEpoch)
+	}
+	return nil
+}
+
+// verifyVRankEpochAtHead validates the epoch against head state once past the
+// permissionless fork; no-op before it (AddressBookV2 not yet installed).
+func (v *ValsetModule) verifyVRankEpochAtHead() error {
+	head := v.Chain.CurrentBlock()
+	if head == nil || !v.Chain.Config().IsPermissionlessForkEnabled(head.Number()) {
+		return nil
+	}
+	statedb, err := v.Chain.StateAt(head.Root())
+	if err != nil {
+		return fmt.Errorf("StateAt(head) failed: %w", err)
+	}
+	return v.verifyVRankEpoch(statedb, head.Number())
 }


### PR DESCRIPTION
## Proposed changes

`VRankEpoch` (chain config) and the epoch baked into AddressBookV2 (`epochBlockInterval`) must agree — both drive epoch boundaries, but only the contract value is authenticated by the genesis hash, and `VRankEpoch` has no runtime override. This validates they match once past the permissionless fork (at the AddressBookV2 install block and at node start) and fails fast on a mismatch, instead of it surfacing later as a cryptic block-verification failure.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
