### PR TITLE
node/cn, kaiax/vrank: register vrank as execution and rewindable module

### DIFF
--- a/kaiax/vrank/impl/execution.go
+++ b/kaiax/vrank/impl/execution.go
@@ -20,7 +20,10 @@ import (
 	"math/big"
 
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/kaiax"
 )
+
+var _ kaiax.ExecutionModule = (*VRankModule)(nil)
 
 func (v *VRankModule) PostInsertBlock(block *types.Block) error {
 	blockNum := block.NumberU64()

--- a/kaiax/vrank/impl/rewind.go
+++ b/kaiax/vrank/impl/rewind.go
@@ -19,7 +19,10 @@ package impl
 import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax"
 )
+
+var _ kaiax.RewindableModule = (*VRankModule)(nil)
 
 func (v *VRankModule) RewindTo(newBlock *types.Block) {
 	v.pfsCache.Purge()

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -53,6 +53,8 @@ type RoundReader interface {
 type VRankModule interface {
 	kaiax.BaseModule
 	kaiax.HeaderModule
+	kaiax.ExecutionModule
+	kaiax.RewindableModule
 
 	HandleIstanbulPreprepare(block *types.Block, view *bft.View)
 	HandleVRankPreprepare(msg *VRankPreprepare) error

--- a/kaiax/vrank/mock/module.go
+++ b/kaiax/vrank/mock/module.go
@@ -138,6 +138,20 @@ func (mr *MockVRankModuleMockRecorder) HandleVRankPreprepare(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleVRankPreprepare", reflect.TypeOf((*MockVRankModule)(nil).HandleVRankPreprepare), arg0)
 }
 
+// PostInsertBlock mocks base method.
+func (m *MockVRankModule) PostInsertBlock(arg0 *types.Block) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostInsertBlock", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PostInsertBlock indicates an expected call of PostInsertBlock.
+func (mr *MockVRankModuleMockRecorder) PostInsertBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostInsertBlock", reflect.TypeOf((*MockVRankModule)(nil).PostInsertBlock), arg0)
+}
+
 // PrepareHeader mocks base method.
 func (m *MockVRankModule) PrepareHeader(arg0 *types.Header) error {
 	m.ctrl.T.Helper()
@@ -150,6 +164,30 @@ func (m *MockVRankModule) PrepareHeader(arg0 *types.Header) error {
 func (mr *MockVRankModuleMockRecorder) PrepareHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareHeader", reflect.TypeOf((*MockVRankModule)(nil).PrepareHeader), arg0)
+}
+
+// RewindDelete mocks base method.
+func (m *MockVRankModule) RewindDelete(arg0 common.Hash, arg1 uint64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RewindDelete", arg0, arg1)
+}
+
+// RewindDelete indicates an expected call of RewindDelete.
+func (mr *MockVRankModuleMockRecorder) RewindDelete(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RewindDelete", reflect.TypeOf((*MockVRankModule)(nil).RewindDelete), arg0, arg1)
+}
+
+// RewindTo mocks base method.
+func (m *MockVRankModule) RewindTo(arg0 *types.Block) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RewindTo", arg0)
+}
+
+// RewindTo indicates an expected call of RewindTo.
+func (mr *MockVRankModuleMockRecorder) RewindTo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RewindTo", reflect.TypeOf((*MockVRankModule)(nil).RewindTo), arg0)
 }
 
 // Start mocks base method.

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -594,11 +594,11 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 	}
 
 	mBase := []kaiax.BaseModule{s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao, mSystem, mVRank}
-	mExecution := []kaiax.ExecutionModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao}
+	mExecution := []kaiax.ExecutionModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao, mVRank}
 	mTxBundling := []kaiax.TxBundlingModule{}
 	mTxPool := []kaiax.TxPoolModule{}
 	mJsonRpc := []kaiax.JsonRpcModule{s.stakingModule, mReward, mSupply, s.govModule, mValset, mRandao}
-	mRewindable := []kaiax.RewindableModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao}
+	mRewindable := []kaiax.RewindableModule{s.stakingModule, mSupply, s.govModule, mValset, mRandao, mVRank}
 	mHeader := []kaiax.HeaderModule{mReward, s.govModule, mRandao, mValset, mVRank}
 	mBlockState := []kaiax.BlockStateModule{mReward, mSystem, mValset}
 


### PR DESCRIPTION
## Proposed changes

The vrank module implements `PostInsertBlock`, `RewindTo`, and `RewindDelete`
but was missing from the execution and rewindable module lists, so the hooks
never ran — checkpoints were never written, caches were never advanced per
block, and rewinds never purged stale cache/checkpoint state.

- Register `mVRank` in `mExecution` and `mRewindable` (`node/cn/backend.go`).
- Embed `ExecutionModule` / `RewindableModule` in `VRankModule` (as valset/supply),
  regenerate the mock, add compile-time assertions.

Gated on the permissionless fork, so it is a no-op until activation. Existing
hook unit tests cover the behavior.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments