### PR TITLE
common, networks/p2p: validate connection type at peer admission

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -482,11 +482,9 @@ const (
 	UNKNOWNNODE // For error case
 )
 
+// Valid reports whether ct is a defined connection role.
 func (ct ConnType) Valid() bool {
-	if int(ct) > 255 {
-		return false
-	}
-	return true
+	return ct >= CONSENSUSNODE && ct <= BOOTNODE
 }
 
 func (ct ConnType) String() string {

--- a/common/types.go
+++ b/common/types.go
@@ -484,7 +484,7 @@ const (
 
 // Valid reports whether ct is a defined connection role.
 func (ct ConnType) Valid() bool {
-	return ct >= CONSENSUSNODE && ct <= BOOTNODE
+	return ct >= CONSENSUSNODE && ct < UNKNOWNNODE
 }
 
 func (ct ConnType) String() string {

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -278,3 +278,12 @@ func TestMixedcaseAccount_Address(t *testing.T) {
 
 }
 */
+
+func TestConnTypeValid(t *testing.T) {
+	for _, ct := range []ConnType{CONSENSUSNODE, ENDPOINTNODE, PROXYNODE, BOOTNODE} {
+		assert.True(t, ct.Valid(), "defined role %d should be valid", int(ct))
+	}
+	for _, ct := range []ConnType{UNKNOWNNODE, ConnTypeUndefined, ConnType(5), ConnType(42), ConnType(255)} {
+		assert.False(t, ct.Valid(), "undefined value %d should be invalid", int(ct))
+	}
+}

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -293,6 +293,8 @@ func (srv *BaseServer) encHandshakeChecks(peers map[discover.NodeID]*Peer, c *co
 		return DiscTooManyPeers
 	case !c.is(trustedConn) && c.is(inboundConn) && countInboundPeers(peers) >= srv.maxInboundConns():
 		return DiscTooManyPeers
+	case !srv.admissiblePeerType(c):
+		return DiscUselessPeer
 	case srv.exceedsPeerTarget(peers, c):
 		return DiscTooManyPeers
 	case peers[c.id] != nil:
@@ -325,6 +327,22 @@ func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *con
 		return EffectiveConnType(p.ConnType()) != peerType
 	})
 	return len(peersByType) >= target
+}
+
+// admissiblePeerType reports whether the server accepts a peer of this type.
+// A CN/EN server meshes only with CN/EN peers (keeping others out of the
+// uncapped path in exceedsPeerTarget); trusted/static and non-CN/EN servers
+// accept any type.
+func (srv *BaseServer) admissiblePeerType(c *conn) bool {
+	if c.isTrustedOrStatic() {
+		return true
+	}
+	selfType := EffectiveConnType(srv.ConnectionType)
+	if selfType != common.CONSENSUSNODE && selfType != common.ENDPOINTNODE {
+		return true
+	}
+	peerType := EffectiveConnType(c.conntype)
+	return peerType == common.CONSENSUSNODE || peerType == common.ENDPOINTNODE
 }
 
 // countInboundPeers returns how many peers are connected via an inbound

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -326,6 +326,8 @@ func TestServerAtCap(t *testing.T) {
 	srv := &SingleChannelServer{
 		BaseServer: &BaseServer{
 			Config: Config{
+				// BOOTNODE: no per-type reservation, isolates the global cap.
+				ConnectionType:         common.BOOTNODE,
 				PrivateKey:             newkey(),
 				MaxPhysicalConnections: 10,
 				NoDial:                 true,
@@ -445,6 +447,41 @@ func TestServerPeerTargets(t *testing.T) {
 	enPeers := newPeers(common.CONSENSUSNODE, common.CONSENSUSNODE)
 	if !enSrv.exceedsPeerTarget(enPeers, &conn{conntype: common.CONSENSUSNODE}) {
 		t.Fatal("EN should reject CN when CN peer target is full")
+	}
+}
+
+// CN/EN servers reject untrusted non-CN/EN peers (which would escape the
+// per-type cap); trusted/static and non-CN/EN servers accept any type.
+func TestAdmissiblePeerType(t *testing.T) {
+	cnSrv := &BaseServer{Config: Config{ConnectionType: common.CONSENSUSNODE}}
+	enSrv := &BaseServer{Config: Config{ConnectionType: common.ENDPOINTNODE}}
+	bnSrv := &BaseServer{Config: Config{ConnectionType: common.BOOTNODE}}
+
+	for _, peerType := range []common.ConnType{common.CONSENSUSNODE, common.ENDPOINTNODE, common.PROXYNODE} {
+		if !cnSrv.admissiblePeerType(&conn{conntype: peerType, flags: inboundConn}) {
+			t.Fatalf("CN server should admit peer type %v", peerType)
+		}
+		if !enSrv.admissiblePeerType(&conn{conntype: peerType, flags: inboundConn}) {
+			t.Fatalf("EN server should admit peer type %v", peerType)
+		}
+	}
+
+	if cnSrv.admissiblePeerType(&conn{conntype: common.BOOTNODE, flags: inboundConn}) {
+		t.Fatal("CN server should reject an inbound bootnode peer")
+	}
+	if enSrv.admissiblePeerType(&conn{conntype: common.UNKNOWNNODE, flags: inboundConn}) {
+		t.Fatal("EN server should reject an inbound unknown-type peer")
+	}
+
+	if !cnSrv.admissiblePeerType(&conn{conntype: common.BOOTNODE, flags: trustedConn}) {
+		t.Fatal("trusted peer should bypass the peer-type check")
+	}
+	if !cnSrv.admissiblePeerType(&conn{conntype: common.BOOTNODE, flags: staticDialedConn}) {
+		t.Fatal("static outbound peer should bypass the peer-type check")
+	}
+
+	if !bnSrv.admissiblePeerType(&conn{conntype: common.BOOTNODE, flags: inboundConn}) {
+		t.Fatal("bootnode server should keep accepting any peer type")
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

A peer's connection type is self-declared before the RLPx identity handshake, and
`ConnType.Valid` accepted any byte value. An undefined or non-CN/EN type therefore
bypassed the role-based admission limits: it took an uncapped slot in
`exceedsPeerTarget` and skipped the CN allowlist in `admitByCNPeers`.

- `ConnType.Valid` now accepts only the defined roles; undefined values are rejected.
- A CN/EN server rejects untrusted non-CN/EN peers (`admissiblePeerType`). Trusted/static
  peers and non-CN/EN servers are unaffected.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
