### PR TITLE
kaiax/vrank, blockchain/types: reject present-but-empty VRank and count it in header size

### DIFF
--- a/blockchain/types/block.go
+++ b/blockchain/types/block.go
@@ -143,7 +143,7 @@ func (h *Header) HashNoNonce() common.Hash {
 // to approximate and limit the memory consumption of various caches.
 func (h *Header) Size() common.StorageSize {
 	constantSize := common.StorageSize(reflect.TypeFor[Header]().Size())
-	byteSize := common.StorageSize(len(h.Extra) + len(h.Governance) + len(h.Vote) + len(h.RandomReveal) + len(h.MixHash))
+	byteSize := common.StorageSize(len(h.Extra) + len(h.Governance) + len(h.Vote) + len(h.RandomReveal) + len(h.MixHash) + len(h.VRank))
 	bigIntSize := common.StorageSize((h.BlockScore.BitLen() + h.Number.BitLen() + h.Time.BitLen()) / 8)
 	if h.BaseFee != nil {
 		return constantSize + byteSize + bigIntSize + common.StorageSize(h.BaseFee.BitLen()/8)

--- a/blockchain/types/block_test.go
+++ b/blockchain/types/block_test.go
@@ -220,6 +220,11 @@ func TestHeaderSizeCalc(t *testing.T) {
 	h.BaseFee = big.NewInt(0x5d21dba00) // 35 bits ~= 4 bytes
 	expectSize += 4
 	assert.Equal(t, expectSize, int(h.Size()))
+
+	// VRank byte length is added as-is
+	h.VRank = hexutil.MustDecode("0xc80102030405060708")
+	expectSize += len(h.VRank)
+	assert.Equal(t, expectSize, int(h.Size()))
 }
 
 func TestHeaderJSON(t *testing.T) {

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -27,7 +27,7 @@ import (
 )
 
 // VerifyHeader checks the VRank field in the header:
-//   - Before the permissionless fork: VRank must be empty.
+//   - Before the permissionless fork: VRank must be absent.
 //   - At epoch-start blocks: VRank must be RLPEncode(CandTesting(N)) or RLPEncode([]).
 //   - Otherwise: VRank must be a valid encoded report whose addresses are sorted,
 //     deduplicated, and all present in GetCandTesting(N-1), because header(N).VRank
@@ -37,7 +37,8 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 	permissionless := v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(number))
 
 	if !permissionless {
-		if len(header.VRank) > 0 {
+		// Reject presence, not content: an explicit empty RLP string decodes to a non-nil zero-length slice.
+		if header.VRank != nil {
 			return vrank.ErrUnexpectedVRankBeforePermissionless
 		}
 		return nil

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -55,11 +55,14 @@ func TestVerifyHeader(t *testing.T) {
 	candidates := []common.Address{C1, C2, C3}
 	const num = uint64(100)
 
-	t.Run("pre-fork: VRank must be empty", func(t *testing.T) {
+	t.Run("pre-fork: VRank must be absent", func(t *testing.T) {
 		v := newCN(t, withHardfork("osaka"), withoutStart()).VRankModule
 		h := &types.Header{Number: big.NewInt(100)}
 		assert.NoError(t, v.VerifyHeader(h, nil))
 		h = makeVRankHeader(t, 100, []common.Address{C1})
+		assert.ErrorIs(t, v.VerifyHeader(h, nil), vrank.ErrUnexpectedVRankBeforePermissionless)
+		// A non-nil zero-length VRank is present and must be rejected.
+		h = &types.Header{Number: big.NewInt(100), VRank: []byte{}}
 		assert.ErrorIs(t, v.VerifyHeader(h, nil), vrank.ErrUnexpectedVRankBeforePermissionless)
 	})
 


### PR DESCRIPTION
## Proposed changes

- Pre-fork VRank guard checked `len(header.VRank) > 0`, but an explicit empty RLP
  string decodes to a non-nil zero-length slice — passes the length check yet
  re-encodes as a trailing element. Check presence (`!= nil`) instead.
- `Header.Size()` omitted the VRank payload; add `len(h.VRank)`.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments