### PR TITLE
params: reject fork schedules that skip a mandatory fork

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -616,7 +616,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		name  string
 		block *big.Int
 	}
-	var lastFork fork
+	var lastFork, skipped fork
 	for _, cur := range []fork{
 		{name: "istanbulBlock", block: c.IstanbulCompatibleBlock},
 		{name: "londonBlock", block: c.LondonCompatibleBlock},
@@ -631,23 +631,23 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "osakaBlock", block: c.OsakaCompatibleBlock},
 		{name: "permissionlessBlock", block: c.PermissionlessCompatibleBlock},
 	} {
-		if lastFork.name != "" {
-			// Next one must be higher number
-			if lastFork.block == nil && cur.block != nil {
-				return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at %v",
-					lastFork.name, cur.name, cur.block)
+		if cur.block == nil {
+			// Remember the first skipped mandatory fork; enabling a later one is then invalid.
+			if skipped.name == "" {
+				skipped = cur
 			}
-			if lastFork.block != nil && cur.block != nil {
-				if lastFork.block.Cmp(cur.block) > 0 {
-					return fmt.Errorf("unsupported fork ordering: %v enabled at %v, but %v enabled at %v",
-						lastFork.name, lastFork.block, cur.name, cur.block)
-				}
-			}
+			continue
 		}
-		// If it was not set, then ignore it
-		if cur.block != nil {
-			lastFork = cur
+		if skipped.name != "" {
+			return fmt.Errorf("unsupported fork ordering: %v not enabled, but %v enabled at %v",
+				skipped.name, cur.name, cur.block)
 		}
+		// Next one must be higher number
+		if lastFork.block != nil && lastFork.block.Cmp(cur.block) > 0 {
+			return fmt.Errorf("unsupported fork ordering: %v enabled at %v, but %v enabled at %v",
+				lastFork.name, lastFork.block, cur.name, cur.block)
+		}
+		lastFork = cur
 	}
 	return nil
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -26,8 +26,17 @@ import (
 )
 
 func TestChainConfig_CheckConfigForkOrder(t *testing.T) {
+	// Real configs have nil only at the trailing (unscheduled) forks, so they pass.
 	assert.Nil(t, KairosChainConfig.CheckConfigForkOrder())
 	assert.Nil(t, MainnetChainConfig.CheckConfigForkOrder())
+
+	// A skipped mandatory fork with a later enabled fork must be rejected.
+	gap := &ChainConfig{
+		IstanbulCompatibleBlock:  big.NewInt(0),
+		LondonCompatibleBlock:    nil, // skipped
+		EthTxTypeCompatibleBlock: big.NewInt(10),
+	}
+	assert.Error(t, gap.CheckConfigForkOrder())
 }
 
 func TestChainConfig_Copy(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

`CheckConfigForkOrder` only updated `lastFork` when a fork block was non-nil, so `lastFork.block` was never nil and the skip-detection branch was unreachable. Track the first skipped mandatory fork and reject any later enabled fork. Real configs are unaffected — their only nil entries are the trailing unscheduled forks.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments