### PR TITLE
cmd/kcn: add valops sign-create-node for the createNode nodeId proof

### DIFF
--- a/cmd/kcn/abv2.go
+++ b/cmd/kcn/abv2.go
@@ -146,6 +146,7 @@ var ValOpsCommand = &cli.Command{
 			Action: abv2NodeOperatorAction(methodOffboard, (*addressbookv2.AddressBookV2Transactor).Offboard),
 		},
 		GenerateKeysCommand,
+		SignCreateNodeCommand,
 	},
 }
 

--- a/cmd/kcn/createnode_sig.go
+++ b/cmd/kcn/createnode_sig.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/kaiachain/kaia/blockchain/system"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/urfave/cli/v2"
+)
+
+// createNodeTag domain-separates the createNode proof; must match NodeVerifier.CREATE_NODE_TAG.
+var createNodeTag = crypto.Keccak256Hash([]byte("KAIA_ADDRESS_BOOK_V2_CREATE_NODE_V1"))
+
+var (
+	signChainIDFlag = &cli.Int64Flag{
+		Name:     "chain-id",
+		Usage:    "Chain ID the node runs on (8217 mainnet, 1001 kairos)",
+		Required: true,
+	}
+	signStakingFlag = &cli.StringFlag{
+		Name:     "staking-contract",
+		Usage:    "CnStaking contract address bound into the proof",
+		Required: true,
+	}
+	signManagerFlag = &cli.StringFlag{
+		Name:     "manager",
+		Usage:    "Address that will send createNode (becomes the node's manager)",
+		Required: true,
+	}
+	signNodeIdFlag = &cli.StringFlag{
+		Name:  "node-id",
+		Usage: "Node ID address (default: derived from the signing key)",
+	}
+)
+
+// SignCreateNodeCommand produces the nodeId-ownership signature that
+// AddressBookV2.createNode requires. Offline: signs with the nodekey and needs
+// no live endpoint (pass --chain-id explicitly).
+var SignCreateNodeCommand = &cli.Command{
+	Name:   "sign-create-node",
+	Usage:  "Sign the nodeId-ownership proof required by AddressBookV2.createNode (offline)",
+	Flags:  []cli.Flag{abv2PrivateKeyFlag, signChainIDFlag, signStakingFlag, signManagerFlag, signNodeIdFlag},
+	Action: signCreateNodeAction,
+}
+
+func signCreateNodeAction(ctx *cli.Context) error {
+	key, err := loadKey(ctx)
+	if err != nil {
+		return fmt.Errorf("load key: %w (use --private-key to specify explicitly)", err)
+	}
+	nodeId := crypto.PubkeyToAddress(key.PublicKey)
+	if v := ctx.String("node-id"); v != "" {
+		nodeId = common.HexToAddress(v)
+	}
+	digest := createNodeDigest(
+		big.NewInt(ctx.Int64("chain-id")),
+		common.HexToAddress(ctx.String("manager")),
+		nodeId,
+		common.HexToAddress(ctx.String("staking-contract")),
+	)
+	sig, err := crypto.Sign(digest, key)
+	if err != nil {
+		return err
+	}
+	sig[64] += 27 // AddressBookV2 verifies via OZ ECDSA.tryRecover, which expects v in {27,28}
+	fmt.Println(hexutil.Encode(sig))
+	return nil
+}
+
+// createNodeDigest reproduces NodeVerifier._verifyNodeIdProof:
+// keccak256(abi.encode(TAG, chainId, addressBook, manager, nodeId, stakingContract)).
+// Every field is static, so abi.encode is the 32-byte-word concatenation below.
+func createNodeDigest(chainID *big.Int, manager, nodeId, staking common.Address) []byte {
+	word := func(b []byte) []byte { return common.LeftPadBytes(b, 32) }
+	buf := make([]byte, 0, 32*6)
+	buf = append(buf, createNodeTag.Bytes()...)
+	buf = append(buf, word(chainID.Bytes())...)
+	buf = append(buf, word(system.AddressBookAddr.Bytes())...)
+	buf = append(buf, word(manager.Bytes())...)
+	buf = append(buf, word(nodeId.Bytes())...)
+	buf = append(buf, word(staking.Bytes())...)
+	return crypto.Keccak256(buf)
+}

--- a/cmd/kcn/createnode_sig_test.go
+++ b/cmd/kcn/createnode_sig_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+)
+
+// Reference digest computed with foundry `cast` over the same abi.encode + keccak256
+// as NodeVerifier._verifyNodeIdProof / NodeIdSigUtil — pins the Go digest to Solidity.
+func TestCreateNodeDigest_MatchesSolidity(t *testing.T) {
+	got := common.BytesToHash(createNodeDigest(
+		big.NewInt(8217),
+		common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		common.HexToAddress("0x3333333333333333333333333333333333333333"),
+	))
+	want := common.HexToHash("0x775bb349c16c3946915d91b60fbc33faa61328af564b025623ba955cc2b678b2")
+	if got != want {
+		t.Fatalf("digest mismatch:\n got  %s\n want %s", got.Hex(), want.Hex())
+	}
+}
+
+// The produced signature must recover to nodeId once the v+27 offset is undone,
+// mirroring the contract's ecrecover.
+func TestCreateNodeSig_RecoversNodeId(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeId := crypto.PubkeyToAddress(key.PublicKey)
+	digest := createNodeDigest(big.NewInt(1001), common.HexToAddress("0xAbCd"), nodeId, common.HexToAddress("0xBeeF"))
+
+	sig, err := crypto.Sign(digest, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig[64] += 27
+
+	recSig := make([]byte, 65)
+	copy(recSig, sig)
+	recSig[64] -= 27 // crypto.SigToPub wants v in {0,1}
+	pub, err := crypto.SigToPub(digest, recSig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if crypto.PubkeyToAddress(*pub) != nodeId {
+		t.Fatalf("recovered %s, want %s", crypto.PubkeyToAddress(*pub).Hex(), nodeId.Hex())
+	}
+}


### PR DESCRIPTION
## Proposed changes

`AddressBookV2.createNode` now requires an ECDSA signature proving control of the
`nodeId` key. This adds `kcn valops sign-create-node`, which produces that
signature offline with the node's key:

    kcn valops sign-create-node \
      --chain-id 8217 --staking-contract 0x… --manager 0x… \
      [--node-id 0x…] [--private-key … | default: nodekey]

It prints the 65-byte `0x…` signature to pass as `createNode`'s `nodeIdSig`.
Signs the domain-separated digest
`keccak256(TAG, chainId, addressBook, manager, nodeId, staking)`

## Types of changes

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

Depends on kaiachain/kaia-system-contracts#15 (adds the `createNode` nodeId signature requirement).

## Further comments