### PR TITLE
kaiax/vrank, node/cn: bound VRankCandidate/Preprepare signatures to fixed size

### DIFF
--- a/crypto/bls/types/bls_types.go
+++ b/crypto/bls/types/bls_types.go
@@ -23,11 +23,14 @@ import (
 	"fmt"
 )
 
-var (
+const (
 	// For immediate clarity, using literal numbers instead of blst named constants
 	SecretKeyLength = 32
 	PublicKeyLength = 48
 	SignatureLength = 96
+)
+
+var (
 	// draft-irtf-cfrg-pairing-friendly-curves-11#4.2.1 BLS12_381
 	CurveOrderHex = "0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
 	// draft-irtf-cfrg-bls-signature-05#4.2.3

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -105,8 +105,8 @@ func (v *VRankModule) HandleVRankPreprepare(msg *vrank.VRankPreprepare) error {
 			BlockNumber: block.NumberU64(),
 			Round:       uint8(view.Round.Uint64()),
 			BlockHash:   block.Hash(),
-			Sig:         sig,
-			BlsSig:      blsSig,
+			Sig:         [65]byte(sig),
+			BlsSig:      [96]byte(blsSig),
 		})
 	}
 	return nil
@@ -141,7 +141,7 @@ func (v *VRankModule) HandleVRankCandidate(msg *vrank.VRankCandidate) error {
 	}
 
 	sigHash := v.vrankCandidateSigHash(msg.BlockNumber, msg.Round, msg.BlockHash)
-	sender, err := v.recoverVRankCandidateSender(sigHash, msg.Sig)
+	sender, err := v.recoverVRankCandidateSender(sigHash, msg.Sig[:])
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (v *VRankModule) HandleVRankCandidate(msg *vrank.VRankCandidate) error {
 	if err != nil {
 		return fmt.Errorf("%w: %v", vrank.ErrInvalidCandidateBlsSig, err)
 	}
-	ok, err := bls.VerifySignature(msg.BlsSig, sigHash, blsPub)
+	ok, err := bls.VerifySignature(msg.BlsSig[:], sigHash, blsPub)
 	if err != nil || !ok {
 		return vrank.ErrInvalidCandidateBlsSig
 	}
@@ -217,7 +217,7 @@ func (v *VRankModule) vrankPreprepareSigHash(blockNum uint64, round uint8, block
 
 func (v *VRankModule) recoverVRankPreprepareSender(msg *vrank.VRankPreprepare) (common.Address, error) {
 	sigHash := v.vrankPreprepareSigHash(msg.Block.NumberU64(), uint8(msg.View.Round.Uint64()), msg.Block.Hash())
-	pubkey, err := crypto.SigToPub(sigHash.Bytes(), msg.Sig)
+	pubkey, err := crypto.SigToPub(sigHash.Bytes(), msg.Sig[:])
 	if err != nil {
 		logger.Debug("SigToPub failed for VRankPreprepare", "err", err, "blockNum", msg.Block.NumberU64())
 		return common.Address{}, fmt.Errorf("%w: %v", vrank.ErrInvalidProposerSig, err)
@@ -281,7 +281,7 @@ func (v *VRankModule) BroadcastVRankPreprepare(vrankPreprepare *vrank.VRankPrepr
 		logger.Error("Sign VRankPreprepare failed", "blockNum", block.NumberU64())
 		return
 	}
-	vrankPreprepare.Sig = sig
+	vrankPreprepare.Sig = [65]byte(sig)
 	v.broadcast(candidates, vrankPreprepare)
 }
 

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kaiachain/kaia/consensus/bft"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/bls"
+	blstypes "github.com/kaiachain/kaia/crypto/bls/types"
 	"github.com/kaiachain/kaia/kaiax/vrank"
 )
 
@@ -105,8 +106,8 @@ func (v *VRankModule) HandleVRankPreprepare(msg *vrank.VRankPreprepare) error {
 			BlockNumber: block.NumberU64(),
 			Round:       uint8(view.Round.Uint64()),
 			BlockHash:   block.Hash(),
-			Sig:         [65]byte(sig),
-			BlsSig:      [96]byte(blsSig),
+			Sig:         [crypto.SignatureLength]byte(sig),
+			BlsSig:      [blstypes.SignatureLength]byte(blsSig),
 		})
 	}
 	return nil
@@ -281,7 +282,7 @@ func (v *VRankModule) BroadcastVRankPreprepare(vrankPreprepare *vrank.VRankPrepr
 		logger.Error("Sign VRankPreprepare failed", "blockNum", block.NumberU64())
 		return
 	}
-	vrankPreprepare.Sig = [65]byte(sig)
+	vrankPreprepare.Sig = [crypto.SignatureLength]byte(sig)
 	v.broadcast(candidates, vrankPreprepare)
 }
 

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -37,20 +37,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func signVRankCandidate(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blsKey bls.SecretKey, blockNum uint64, round uint8, blockHash common.Hash) (sig []byte, blsSig []byte) {
+func signVRankCandidate(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blsKey bls.SecretKey, blockNum uint64, round uint8, blockHash common.Hash) ([65]byte, [96]byte) {
 	t.Helper()
 	sigHash := m.vrankCandidateSigHash(blockNum, round, blockHash)
 	sig, err := crypto.Sign(sigHash.Bytes(), key)
 	require.NoError(t, err)
-	blsSig = bls.Sign(blsKey, sigHash.Bytes()).Marshal()
-	return sig, blsSig
+	blsSig := bls.Sign(blsKey, sigHash.Bytes()).Marshal()
+	return [65]byte(sig), [96]byte(blsSig)
 }
 
-func signVRankPreprepare(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blockNum uint64, round uint8, blockHash common.Hash) []byte {
+func signVRankPreprepare(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blockNum uint64, round uint8, blockHash common.Hash) [65]byte {
 	sigHash := m.vrankPreprepareSigHash(blockNum, round, blockHash)
 	sig, err := crypto.Sign(sigHash.Bytes(), key)
 	require.NoError(t, err)
-	return sig
+	return [65]byte(sig)
 }
 
 // newCNMulti builds n CNs sharing one fresh valset/randao mock. Each subtest gets its own
@@ -416,14 +416,14 @@ func TestHandleVRankCandidate(t *testing.T) {
 	)
 	t.Run("permissionless fork is disabled", func(t *testing.T) {
 		val := newCN(t, withHardfork("osaka"))
-		val.VRankModule.HandleVRankCandidate(&vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: []byte{}})
+		val.VRankModule.HandleVRankCandidate(&vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: [65]byte{}})
 		mustNotPop(t, val.sub)
 	})
 
 	t.Run("no nodes should broadcast", func(t *testing.T) {
 		cns, valset, _ := newCNMulti(t, 3)
 		proposer, nonProposer, candidate := cns[0], cns[1], cns[2]
-		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: []byte{}}
+		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: [65]byte{}}
 
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(3)
@@ -595,7 +595,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 
 	t.Run("corrupt BLS sig bytes are rejected", func(t *testing.T) {
 		val, cand := newBLSSetup()
-		randomBlsSig := make([]byte, 96)
+		randomBlsSig := [96]byte{}
 		sig, _ := signVRankCandidate(t, cand.VRankModule, cand.Key, cand.BlsKey, block1.NumberU64(), 0, block1.Hash())
 		msg := &vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: 0, BlockHash: block1.Hash(), Sig: sig, BlsSig: randomBlsSig}
 		assert.ErrorIs(t, val.VRankModule.HandleVRankCandidate(msg), vrank.ErrInvalidCandidateBlsSig)

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kaiachain/kaia/consensus/bft"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/bls"
+	blstypes "github.com/kaiachain/kaia/crypto/bls/types"
 	mock_randao "github.com/kaiachain/kaia/kaiax/randao/mock"
 	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/kaiax/vrank"
@@ -37,20 +38,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func signVRankCandidate(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blsKey bls.SecretKey, blockNum uint64, round uint8, blockHash common.Hash) ([65]byte, [96]byte) {
+func signVRankCandidate(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blsKey bls.SecretKey, blockNum uint64, round uint8, blockHash common.Hash) ([crypto.SignatureLength]byte, [blstypes.SignatureLength]byte) {
 	t.Helper()
 	sigHash := m.vrankCandidateSigHash(blockNum, round, blockHash)
 	sig, err := crypto.Sign(sigHash.Bytes(), key)
 	require.NoError(t, err)
 	blsSig := bls.Sign(blsKey, sigHash.Bytes()).Marshal()
-	return [65]byte(sig), [96]byte(blsSig)
+	return [crypto.SignatureLength]byte(sig), [blstypes.SignatureLength]byte(blsSig)
 }
 
-func signVRankPreprepare(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blockNum uint64, round uint8, blockHash common.Hash) [65]byte {
+func signVRankPreprepare(t *testing.T, m *VRankModule, key *ecdsa.PrivateKey, blockNum uint64, round uint8, blockHash common.Hash) [crypto.SignatureLength]byte {
 	sigHash := m.vrankPreprepareSigHash(blockNum, round, blockHash)
 	sig, err := crypto.Sign(sigHash.Bytes(), key)
 	require.NoError(t, err)
-	return [65]byte(sig)
+	return [crypto.SignatureLength]byte(sig)
 }
 
 // newCNMulti builds n CNs sharing one fresh valset/randao mock. Each subtest gets its own
@@ -416,14 +417,14 @@ func TestHandleVRankCandidate(t *testing.T) {
 	)
 	t.Run("permissionless fork is disabled", func(t *testing.T) {
 		val := newCN(t, withHardfork("osaka"))
-		val.VRankModule.HandleVRankCandidate(&vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: [65]byte{}})
+		val.VRankModule.HandleVRankCandidate(&vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: [crypto.SignatureLength]byte{}})
 		mustNotPop(t, val.sub)
 	})
 
 	t.Run("no nodes should broadcast", func(t *testing.T) {
 		cns, valset, _ := newCNMulti(t, 3)
 		proposer, nonProposer, candidate := cns[0], cns[1], cns[2]
-		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: [65]byte{}}
+		msg := vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: uint8(view1_0.Round.Uint64()), BlockHash: block1.Hash(), Sig: [crypto.SignatureLength]byte{}}
 
 		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{proposer.Addr, nonProposer.Addr}, nil).Times(3)
 		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).Times(3)
@@ -595,7 +596,7 @@ func TestHandleVRankCandidate(t *testing.T) {
 
 	t.Run("corrupt BLS sig bytes are rejected", func(t *testing.T) {
 		val, cand := newBLSSetup()
-		randomBlsSig := [96]byte{}
+		randomBlsSig := [blstypes.SignatureLength]byte{}
 		sig, _ := signVRankCandidate(t, cand.VRankModule, cand.Key, cand.BlsKey, block1.NumberU64(), 0, block1.Hash())
 		msg := &vrank.VRankCandidate{BlockNumber: block1.NumberU64(), Round: 0, BlockHash: block1.Hash(), Sig: sig, BlsSig: randomBlsSig}
 		assert.ErrorIs(t, val.VRankModule.HandleVRankCandidate(msg), vrank.ErrInvalidCandidateBlsSig)

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -81,15 +81,15 @@ type VRankBroadcastEvent struct {
 type VRankPreprepare struct {
 	Block *types.Block
 	View  *bft.View
-	Sig   []byte // Sign(vrankPreprepareSigHash(), nodeKey)
+	Sig   [65]byte // Sign(vrankPreprepareSigHash(), nodeKey)
 }
 
 type VRankCandidate struct {
 	BlockNumber uint64
 	Round       uint8
 	BlockHash   common.Hash
-	Sig         []byte // Sign(vrankCandidateSigHash(), nodeKey)
-	BlsSig      []byte // Sign(vrankCandidateSigHash(), blsKey)
+	Sig         [65]byte // Sign(vrankCandidateSigHash(), nodeKey)
+	BlsSig      [96]byte // Sign(vrankCandidateSigHash(), blsKey)
 }
 
 func EncodeReport(report []common.Address) ([]byte, error) {

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -22,6 +22,8 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/crypto"
+	blstypes "github.com/kaiachain/kaia/crypto/bls/types"
 	"github.com/kaiachain/kaia/rlp"
 )
 
@@ -81,15 +83,15 @@ type VRankBroadcastEvent struct {
 type VRankPreprepare struct {
 	Block *types.Block
 	View  *bft.View
-	Sig   [65]byte // Sign(vrankPreprepareSigHash(), nodeKey)
+	Sig   [crypto.SignatureLength]byte // Sign(vrankPreprepareSigHash(), nodeKey)
 }
 
 type VRankCandidate struct {
 	BlockNumber uint64
 	Round       uint8
 	BlockHash   common.Hash
-	Sig         [65]byte // Sign(vrankCandidateSigHash(), nodeKey)
-	BlsSig      [96]byte // Sign(vrankCandidateSigHash(), blsKey)
+	Sig         [crypto.SignatureLength]byte   // Sign(vrankCandidateSigHash(), nodeKey)
+	BlsSig      [blstypes.SignatureLength]byte // Sign(vrankCandidateSigHash(), blsKey)
 }
 
 func EncodeReport(report []common.Address) ([]byte, error) {

--- a/kaiax/vrank/types_test.go
+++ b/kaiax/vrank/types_test.go
@@ -18,11 +18,17 @@ package vrank
 
 import (
 	"bytes"
+	"math/big"
 	"testing"
 
+	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/crypto"
+	blstypes "github.com/kaiachain/kaia/crypto/bls/types"
 	"github.com/kaiachain/kaia/rlp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeDecodeReport(t *testing.T) {
@@ -65,34 +71,66 @@ func TestEncodeAddressList_EmptyList(t *testing.T) {
 	assert.Empty(t, dec)
 }
 
-func TestVRankCandidateRLPRejectsOversizedSignatures(t *testing.T) {
-	// fixed-length signatures round-trip
-	valid := VRankCandidate{
-		BlockNumber: 1,
-		Round:       0,
-		BlockHash:   common.HexToHash("0x42"),
-		Sig:         [65]byte{0x11},
-		BlsSig:      [96]byte{0x22},
-	}
-	enc, err := rlp.EncodeToBytes(&valid)
-	assert.NoError(t, err)
-	var back VRankCandidate
-	assert.NoError(t, rlp.DecodeBytes(enc, &back))
-	assert.Equal(t, valid, back)
+// The pre-fixed-size shapes. A wrong signature length is only expressible from here.
+type varSizeCandidate struct {
+	BlockNumber uint64
+	Round       uint8
+	BlockHash   common.Hash
+	Sig         []byte
+	BlsSig      []byte
+}
 
-	// oversized signature bytes fail to decode into the fixed-size fields
-	type wire struct {
-		BlockNumber uint64
-		Round       uint8
-		BlockHash   common.Hash
-		Sig         []byte
-		BlsSig      []byte
+type varSizePreprepare struct {
+	Block *types.Block
+	View  *bft.View
+	Sig   []byte
+}
+
+// The fixed-size fields are the only length guard: node/cn dropped its check for VRankCandidate
+// and never had one for VRankPreprepare.
+func TestVRankRLPSignatureLengths(t *testing.T) {
+	const (
+		sigLen = crypto.SignatureLength
+		blsLen = blstypes.SignatureLength
+	)
+	var (
+		block   = types.NewBlockWithHeader(&types.Header{Number: big.NewInt(1)})
+		view    = &bft.View{Sequence: big.NewInt(1), Round: big.NewInt(0)}
+		bytesOf = func(n int) []byte { return bytes.Repeat([]byte{0x11}, n) }
+		cand    = func(sig, bls int) any {
+			return &varSizeCandidate{BlockNumber: 1, Sig: bytesOf(sig), BlsSig: bytesOf(bls)}
+		}
+		prep = func(sig int) any { return &varSizePreprepare{Block: block, View: view, Sig: bytesOf(sig)} }
+	)
+
+	for _, tc := range []struct {
+		name    string
+		msg     any
+		target  any
+		wantErr bool
+	}{
+		{"candidate exact", cand(sigLen, blsLen), new(VRankCandidate), false},
+		{"candidate empty sig", cand(0, blsLen), new(VRankCandidate), true},
+		{"candidate empty BLS sig", cand(sigLen, 0), new(VRankCandidate), true},
+		{"candidate undersized sig", cand(sigLen-1, blsLen), new(VRankCandidate), true},
+		{"candidate undersized BLS sig", cand(sigLen, blsLen-1), new(VRankCandidate), true},
+		{"candidate oversized sig", cand(1<<20, blsLen), new(VRankCandidate), true},
+		{"candidate oversized BLS sig", cand(sigLen, blsLen+1), new(VRankCandidate), true},
+		{"preprepare exact", prep(sigLen), new(VRankPreprepare), false},
+		{"preprepare empty sig", prep(0), new(VRankPreprepare), true},
+		{"preprepare undersized sig", prep(sigLen - 1), new(VRankPreprepare), true},
+		{"preprepare oversized sig", prep(1 << 20), new(VRankPreprepare), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			enc, err := rlp.EncodeToBytes(tc.msg)
+			require.NoError(t, err)
+
+			err = rlp.DecodeBytes(enc, tc.target)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
-	oversized, err := rlp.EncodeToBytes(&wire{
-		BlockNumber: 1,
-		Sig:         bytes.Repeat([]byte{0x11}, 1<<20),
-		BlsSig:      bytes.Repeat([]byte{0x22}, 96),
-	})
-	assert.NoError(t, err)
-	assert.Error(t, rlp.DecodeBytes(oversized, new(VRankCandidate)))
 }

--- a/kaiax/vrank/types_test.go
+++ b/kaiax/vrank/types_test.go
@@ -17,9 +17,11 @@
 package vrank
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/rlp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -61,4 +63,36 @@ func TestEncodeAddressList_EmptyList(t *testing.T) {
 	dec, err := DecodeReport(enc)
 	assert.NoError(t, err)
 	assert.Empty(t, dec)
+}
+
+func TestVRankCandidateRLPRejectsOversizedSignatures(t *testing.T) {
+	// fixed-length signatures round-trip
+	valid := VRankCandidate{
+		BlockNumber: 1,
+		Round:       0,
+		BlockHash:   common.HexToHash("0x42"),
+		Sig:         [65]byte{0x11},
+		BlsSig:      [96]byte{0x22},
+	}
+	enc, err := rlp.EncodeToBytes(&valid)
+	assert.NoError(t, err)
+	var back VRankCandidate
+	assert.NoError(t, rlp.DecodeBytes(enc, &back))
+	assert.Equal(t, valid, back)
+
+	// oversized signature bytes fail to decode into the fixed-size fields
+	type wire struct {
+		BlockNumber uint64
+		Round       uint8
+		BlockHash   common.Hash
+		Sig         []byte
+		BlsSig      []byte
+	}
+	oversized, err := rlp.EncodeToBytes(&wire{
+		BlockNumber: 1,
+		Sig:         bytes.Repeat([]byte{0x11}, 1<<20),
+		BlsSig:      bytes.Repeat([]byte{0x22}, 96),
+	})
+	assert.NoError(t, err)
+	assert.Error(t, rlp.DecodeBytes(oversized, new(VRankCandidate)))
 }

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1260,7 +1260,7 @@ func handleVRankCandidateMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	if err := msg.Decode(&data); err != nil {
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
-	if data == nil || len(data.Sig) == 0 || len(data.BlsSig) == 0 {
+	if data == nil {
 		return errResp(ErrDecode, "msg %v: malformed VRankCandidate", msg)
 	}
 


### PR DESCRIPTION
## Proposed changes

`VRankCandidate.Sig`/`BlsSig` and `VRankPreprepare.Sig` were unbounded `[]byte`. A peer could pad them up to the generic 12 MiB protocol limit, and the receiver decoded the whole payload before any length check — a cheap (well-compressing), repeatable allocation load against consensus nodes.

They are now fixed-size `[65]byte` (ECDSA) / `[96]byte` (BLS), so RLP rejects an oversized field at decode — before allocating it — and the peer is dropped on the decode error. The now-redundant non-empty check in `node/cn` is removed.

Wire format is unchanged: RLP encodes `[N]byte` and a same-length `[]byte` identically, so upgraded and non-upgraded nodes still interoperate on valid messages.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

Fixed-size arrays make the signature fields self-validating at RLP decode, so no per-message size limit or explicit length check is needed for these messages.
