### PR TITLE
kaiax/vrank: bound the VRankPreprepare round before truncating it

### DIFF
--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -72,25 +72,31 @@ func (v *VRankModule) HandleVRankPreprepare(msg *vrank.VRankPreprepare) error {
 	if !v.ChainConfig.IsPermissionlessForkEnabled(block.Number()) {
 		return nil
 	}
+	// Out-of-range rounds wrap to a valid proposer in GetProposer while truncating to a
+	// different uint8 round for the signed payload, the replay key and the response.
+	if !view.Round.IsUint64() || view.Round.Uint64() > maxRound {
+		return vrank.ErrRoundOutOfRange
+	}
+	round := uint8(view.Round.Uint64())
 
 	if v.isCandidate(block.NumberU64()) {
-		sender, err := v.recoverVRankPreprepareSender(msg)
+		sender, err := v.recoverVRankPreprepareSender(msg, round)
 		if err != nil {
 			return err
 		}
-		if err := v.verifyVRankPreprepareSender(msg, sender); err != nil {
+		if err := v.verifyVRankPreprepareSender(msg, round, sender); err != nil {
 			return err
 		}
 		v.pruneSeenPreprepare(block.NumberU64())
-		if exactReplay, conflictingView := v.markSeenPreprepare(vrank.ViewKey{N: block.NumberU64(), R: uint8(view.Round.Uint64())}, block.Hash()); exactReplay {
+		if exactReplay, conflictingView := v.markSeenPreprepare(vrank.ViewKey{N: block.NumberU64(), R: round}, block.Hash()); exactReplay {
 			// ignore seen preprepare
 			return nil
 		} else if conflictingView {
-			logger.Warn("Conflicting VRankPreprepare ignored", "blockNum", block.NumberU64(), "round", view.Round.Uint64(), "blockHash", block.Hash().Hex())
+			logger.Warn("Conflicting VRankPreprepare ignored", "blockNum", block.NumberU64(), "round", round, "blockHash", block.Hash().Hex())
 			return nil
 		}
 
-		sigHash := v.vrankCandidateSigHash(block.NumberU64(), uint8(view.Round.Uint64()), block.Hash())
+		sigHash := v.vrankCandidateSigHash(block.NumberU64(), round, block.Hash())
 		sig, err := crypto.Sign(sigHash.Bytes(), v.NodeKey)
 		if err != nil {
 			logger.Error("Sign failed", "blockNum", block.NumberU64(), "blockHash", block.Hash().Hex())
@@ -104,7 +110,7 @@ func (v *VRankModule) HandleVRankPreprepare(msg *vrank.VRankPreprepare) error {
 		}
 		v.BroadcastVRankCandidate(&vrank.VRankCandidate{
 			BlockNumber: block.NumberU64(),
-			Round:       uint8(view.Round.Uint64()),
+			Round:       round,
 			BlockHash:   block.Hash(),
 			Sig:         [crypto.SignatureLength]byte(sig),
 			BlsSig:      [blstypes.SignatureLength]byte(blsSig),
@@ -216,8 +222,8 @@ func (v *VRankModule) vrankPreprepareSigHash(blockNum uint64, round uint8, block
 	return crypto.Keccak256Hash(payload)
 }
 
-func (v *VRankModule) recoverVRankPreprepareSender(msg *vrank.VRankPreprepare) (common.Address, error) {
-	sigHash := v.vrankPreprepareSigHash(msg.Block.NumberU64(), uint8(msg.View.Round.Uint64()), msg.Block.Hash())
+func (v *VRankModule) recoverVRankPreprepareSender(msg *vrank.VRankPreprepare, round uint8) (common.Address, error) {
+	sigHash := v.vrankPreprepareSigHash(msg.Block.NumberU64(), round, msg.Block.Hash())
 	pubkey, err := crypto.SigToPub(sigHash.Bytes(), msg.Sig[:])
 	if err != nil {
 		logger.Debug("SigToPub failed for VRankPreprepare", "err", err, "blockNum", msg.Block.NumberU64())
@@ -226,10 +232,9 @@ func (v *VRankModule) recoverVRankPreprepareSender(msg *vrank.VRankPreprepare) (
 	return crypto.PubkeyToAddress(*pubkey), nil
 }
 
-func (v *VRankModule) verifyVRankPreprepareSender(msg *vrank.VRankPreprepare, sender common.Address) error {
+func (v *VRankModule) verifyVRankPreprepareSender(msg *vrank.VRankPreprepare, round uint8, sender common.Address) error {
 	blockNum := msg.Block.NumberU64()
-	round := msg.View.Round.Uint64()
-	proposer, err := v.Valset.GetProposer(blockNum, round)
+	proposer, err := v.Valset.GetProposer(blockNum, uint64(round))
 	if err != nil {
 		logger.Debug("GetProposer failed", "err", err, "blockNum", blockNum)
 		return err

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -393,6 +393,44 @@ func TestHandleVRankPreprepare(t *testing.T) {
 		mustNotPop(t, candidate.sub)
 	})
 
+	t.Run("out of range round must not claim the truncated round slot", func(t *testing.T) {
+		cns, valset, _ := newCNMulti(t, 3)
+		proposer, attacker, candidate := cns[0], cns[1], cns[2]
+
+		altBlock := types.NewBlockWithHeader(&types.Header{
+			Number:     big.NewInt(1),
+			ParentHash: common.HexToHash("0x01"),
+		})
+
+		valset.EXPECT().GetCandTesting(uint64(1)).Return([]common.Address{candidate.Addr}, nil).AnyTimes()
+		valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer.Addr, nil).AnyTimes()
+		valset.EXPECT().GetCommittee(uint64(1), uint64(0)).Return([]common.Address{proposer.Addr}, nil).Times(1)
+
+		// Round 256 truncates to round 0. GetProposer must never be consulted for it,
+		// so no mock is registered for round 256.
+		aliasSig := signVRankPreprepare(t, attacker.VRankModule, attacker.Key, altBlock.NumberU64(), 0, altBlock.Hash())
+		for _, round := range []*big.Int{
+			big.NewInt(int64(vrank.MaxRound) + 1),
+			big.NewInt(256),
+			new(big.Int).Lsh(big.NewInt(1), 64), // beyond uint64
+		} {
+			err := candidate.VRankModule.HandleVRankPreprepare(&vrank.VRankPreprepare{
+				Block: altBlock,
+				View:  &bft.View{Sequence: big.NewInt(1), Round: round},
+				Sig:   aliasSig,
+			})
+			assert.ErrorIs(t, err, vrank.ErrRoundOutOfRange, "round %s", round)
+			mustNotPop(t, candidate.sub)
+		}
+
+		// round 0 must still be free for the real proposer
+		pppSig := signVRankPreprepare(t, proposer.VRankModule, proposer.Key, block1.NumberU64(), 0, block1.Hash())
+		require.NoError(t, candidate.VRankModule.HandleVRankPreprepare(
+			&vrank.VRankPreprepare{Block: block1, View: view1_0, Sig: pppSig}))
+		req := mustPop(t, candidate.sub)
+		assert.Equal(t, block1.Hash(), req.Msg.(*vrank.VRankCandidate).BlockHash)
+	})
+
 	t.Run("non-proposer signature should be rejected by candidate", func(t *testing.T) {
 		cns, valset, _ := newCNMulti(t, 3)
 		proposer, nonProposer, candidate := cns[0], cns[1], cns[2]


### PR DESCRIPTION
## Proposed changes

`HandleVRankPreprepare` authorized the sender with the full `uint64` round, but truncated it to `uint8` for the signed payload, the replay key and the response. An out-of-range round still resolves to a proposer (`GetProposer` wraps it modulo the committee size), so the proposer of round `256+r` passed authorization while writing into round `r`: it could occupy a candidate's `(N, r)` slot with a made-up block hash, after which the real preprepare is dropped as a conflicting view and the candidate is graded as failed.

The round is now validated once, up front, and that value is passed to signature recovery, proposer lookup, the replay key and the response — the same bound `HandleVRankCandidate` already enforces.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- Please leave any additional comments here. -->
