### PR TITLE
node/cn: keep the last CN peer allowlist when a read yields none

### DIFF
--- a/node/cn/cnpeers.go
+++ b/node/cn/cnpeers.go
@@ -44,8 +44,7 @@ type cnPeerUpdater struct {
 	sink        cnPeerSink
 	chainConfig *params.ChainConfig
 
-	lastHash  *common.Hash // Last hashed SetCNPeers input; nil means never pushed.
-	filtering bool         // Whether the last pushed allowlist was non-nil, i.e. CN filtering is on.
+	lastHash *common.Hash // Last hashed SetCNPeers input; nil means never pushed.
 }
 
 type cnPeerInput struct {
@@ -93,7 +92,8 @@ func (u *cnPeerUpdater) sync(num uint64) {
 	if addrs == nil {
 		// The read produced no allowlist. Pushing nil would turn CN filtering off
 		// entirely, so keep the last one instead.
-		if u.filtering {
+		isLastPushNonNil := u.lastHash != nil && *u.lastHash != hashCNPeerInput(nil)
+		if isLastPushNonNil {
 			logger.Warn("syncCNPeers: keeping the last CN peer allowlist", "num", num, "err", err)
 			return
 		}
@@ -108,7 +108,6 @@ func (u *cnPeerUpdater) setCNPeersIfChanged(addrs []common.Address) {
 		return
 	}
 	u.lastHash = &hash
-	u.filtering = addrs != nil
 	u.sink.SetCNPeers(addrs)
 }
 

--- a/node/cn/cnpeers.go
+++ b/node/cn/cnpeers.go
@@ -44,7 +44,8 @@ type cnPeerUpdater struct {
 	sink        cnPeerSink
 	chainConfig *params.ChainConfig
 
-	lastHash *common.Hash // Last hashed SetCNPeers input; nil means never pushed.
+	lastHash  *common.Hash // Last hashed SetCNPeers input; nil means never pushed.
+	filtering bool         // Whether the last pushed allowlist was non-nil, i.e. CN filtering is on.
 }
 
 type cnPeerInput struct {
@@ -87,9 +88,16 @@ func (u *cnPeerUpdater) sync(num uint64) {
 	}
 	addrs, err := u.reader.GetCNPeers(num)
 	if err != nil {
-		logger.Warn("syncCNPeers: disabling CN peer filter after initial GetCNPeers failed", "num", num, "err", err)
-		u.setCNPeersIfChanged(nil)
-		return
+		addrs = nil
+	}
+	if addrs == nil {
+		// The read produced no allowlist. Pushing nil would turn CN filtering off
+		// entirely, so keep the last one instead.
+		if u.filtering {
+			logger.Warn("syncCNPeers: keeping the last CN peer allowlist", "num", num, "err", err)
+			return
+		}
+		logger.Warn("syncCNPeers: leaving the CN peer filter disabled", "num", num, "err", err)
 	}
 	u.setCNPeersIfChanged(addrs)
 }
@@ -100,6 +108,7 @@ func (u *cnPeerUpdater) setCNPeersIfChanged(addrs []common.Address) {
 		return
 	}
 	u.lastHash = &hash
+	u.filtering = addrs != nil
 	u.sink.SetCNPeers(addrs)
 }
 

--- a/node/cn/cnpeers_test.go
+++ b/node/cn/cnpeers_test.go
@@ -174,18 +174,28 @@ func TestCNPeerUpdaterFailureDisablesBeforeFirstPush(t *testing.T) {
 	assert.Nil(t, cn.sink.calls[0])
 }
 
-func TestCNPeerUpdaterFailureDisablesFilteringAfterPreviousPush(t *testing.T) {
-	cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(
-		cnPeerReadResult{addrs: cnTestAddrs(1)},
-		cnPeerReadResult{err: errors.New("temporary read failure")},
-	))
+func TestCNPeerUpdaterFailureKeepsLastAllowlist(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		failedRead cnPeerReadResult
+	}{
+		{"read failure", cnPeerReadResult{err: errors.New("temporary read failure")}},
+		// GetCNPeers reports a failed read as a nil list, not as an error.
+		{"no addresses", cnPeerReadResult{addrs: nil}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cn := newCNPeerUpdaterTest(t, withCNPeerReadResults(
+				cnPeerReadResult{addrs: cnTestAddrs(1)},
+				tc.failedRead,
+			))
 
-	cn.updater.sync(11)
-	cn.updater.sync(12)
+			cn.updater.sync(11)
+			cn.updater.sync(12)
 
-	require.Len(t, cn.sink.calls, 2)
-	assert.Equal(t, cnTestAddrs(1), cn.sink.calls[0])
-	assert.Nil(t, cn.sink.calls[1])
+			require.Len(t, cn.sink.calls, 1)
+			assert.Equal(t, cnTestAddrs(1), cn.sink.calls[0])
+		})
+	}
 }
 
 func cnTestAddrs(n ...int) []common.Address {


### PR DESCRIPTION
## Proposed changes

`GetCNPeers` reports a failed post-fork read as a nil list, and both `admitByCNPeers` and the dial scheduler read nil as "CN filtering disabled". A single transient read therefore replaced a working allowlist with nil, opening CN admission to any peer claiming `CONSENSUSNODE` until the next successful read.

The updater now keeps the allowlist it last pushed when a read yields nothing. Only `syncHead`'s pre-fork path still disables filtering, which is a policy decision rather than a failed read.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- Please leave any additional comments here. -->
