### PR TITLE
p2p: expire multichannel peers that never complete their channels

### DIFF
--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -71,10 +71,11 @@ func (srv *MultiChannelServer) Stop() {
 	}
 
 	// Peers under assembly have no read loop to notice the shutdown.
+	var candidates []*conn
 	for id, connSet := range srv.CandidateConns {
 		for _, c := range connSet {
 			if c != nil {
-				c.close(DiscQuitting)
+				candidates = append(candidates, c)
 			}
 		}
 		delete(srv.CandidateConns, id)
@@ -85,6 +86,10 @@ func (srv *MultiChannelServer) Stop() {
 
 	// Unlock here to allow Server loops and dialsched loop to finish their remaining jobs, dialsched to finish its dial goroutines.
 	srv.lock.Unlock()
+
+	for _, c := range candidates {
+		c.close(DiscQuitting)
+	}
 
 	if srv.dialSched != nil {
 		srv.dialSched.Close() // Wait for dial attempts to finish.
@@ -348,13 +353,28 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 // Override BaseServer.handleAddPeerConn because multichannel peer admission
 // waits for the full candidate connection set and updates outbound metrics.
 func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
+	// close writes a disconnect reason under a write deadline, so it must not run under srv.lock.
+	// Registered before the unlock below to run after it.
+	var (
+		expired  []*conn
+		replaced *conn
+	)
+	defer func() {
+		for _, ec := range expired {
+			ec.close(DiscUselessPeer)
+		}
+		if replaced != nil {
+			replaced.close(DiscAlreadyConnected)
+		}
+	}()
+
 	srv.lock.Lock()
 	defer srv.lock.Unlock()
 
 	if !srv.running {
 		return errServerStopped
 	}
-	srv.expireCandidates(mclock.Now())
+	expired = srv.expireCandidates(mclock.Now())
 	err := srv.protoHandshakeChecks(srv.peers, c)
 	if err != nil {
 		return err
@@ -374,9 +394,7 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 			srv.candidateSince[c.id] = mclock.Now()
 		}
 
-		if old := connSet[c.portOrder]; old != nil {
-			old.close(DiscAlreadyConnected)
-		}
+		replaced = connSet[c.portOrder]
 		connSet[c.portOrder] = c
 
 		pending := len(connSet)
@@ -416,23 +434,25 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 	return nil
 }
 
-// expireCandidates drops multichannel peers whose remaining channels never arrived.
-// Nothing else does: CandidateConns is cleared only once every channel is present.
-// Caller must hold srv.lock.
-func (srv *MultiChannelServer) expireCandidates(now mclock.AbsTime) {
+// expireCandidates drops multichannel peers whose remaining channels never arrived and returns
+// their connections for the caller to close. Nothing else does: CandidateConns is cleared only
+// once every channel is present. Caller must hold srv.lock.
+func (srv *MultiChannelServer) expireCandidates(now mclock.AbsTime) []*conn {
+	var expired []*conn
 	for id, connSet := range srv.CandidateConns {
 		if now-srv.candidateSince[id] < mclock.AbsTime(candidateAssemblyTimeout) {
 			continue
 		}
 		for _, c := range connSet {
 			if c != nil {
-				c.close(DiscUselessPeer)
+				expired = append(expired, c)
 			}
 		}
 		delete(srv.CandidateConns, id)
 		delete(srv.candidateSince, id)
 		srv.logger.Debug("Dropped incomplete multichannel peer", "id", id)
 	}
+	return expired
 }
 
 // Overrides BaseServer.runPeer() because multichannel peers run all socket

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -36,14 +36,18 @@ import (
 	"github.com/kaiachain/kaia/networks/p2p/nat"
 )
 
+// A peer dials all of its channels at once, so a set still incomplete after this is not coming.
+const candidateAssemblyTimeout = 10 * time.Second
+
 // MultiChannelServer is a server that uses a multi channel.
 // It inherits BaseServer. This file only contains overriding methods.
 // There must be a reason to override BaseServer methods.
 type MultiChannelServer struct {
 	*BaseServer
-	listeners      []net.Listener              // Extended TCP listener
-	ListenAddrs    []string                    // Extended TCP listen addresses
-	CandidateConns map[discover.NodeID][]*conn // Subset of connections towards a premature peer
+	listeners      []net.Listener                     // Extended TCP listener
+	ListenAddrs    []string                           // Extended TCP listen addresses
+	CandidateConns map[discover.NodeID][]*conn        // Subset of connections towards a premature peer
+	candidateSince map[discover.NodeID]mclock.AbsTime // Open time of each CandidateConns entry
 }
 
 // Stop terminates the server and all active peer connections.
@@ -64,6 +68,17 @@ func (srv *MultiChannelServer) Stop() {
 	}
 	for _, listener := range srv.listeners {
 		listener.Close()
+	}
+
+	// Peers under assembly have no read loop to notice the shutdown.
+	for id, connSet := range srv.CandidateConns {
+		for _, c := range connSet {
+			if c != nil {
+				c.close(DiscQuitting)
+			}
+		}
+		delete(srv.CandidateConns, id)
+		delete(srv.candidateSince, id)
 	}
 
 	close(srv.quit) // Ask loops to terminate
@@ -148,6 +163,7 @@ func (srv *MultiChannelServer) initialize() error {
 	srv.ListenAddrs = append(srv.ListenAddrs, srv.ListenAddr)
 	srv.ListenAddrs = append(srv.ListenAddrs, srv.SubListenAddr...)
 	srv.CandidateConns = make(map[discover.NodeID][]*conn)
+	srv.candidateSince = make(map[discover.NodeID]mclock.AbsTime)
 	return nil
 }
 
@@ -338,6 +354,7 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 	if !srv.running {
 		return errServerStopped
 	}
+	srv.expireCandidates(mclock.Now())
 	err := srv.protoHandshakeChecks(srv.peers, c)
 	if err != nil {
 		return err
@@ -345,15 +362,22 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 
 	var p *Peer
 	if c.multiChannel {
+		// Out of range fills no slot; falling through would drop c unstored and unclosed.
+		if int(c.portOrder) < 0 || int(c.portOrder) >= len(srv.ListenAddrs) {
+			return DiscUnexpectedIdentity
+		}
+
 		connSet := srv.CandidateConns[c.id]
 		if connSet == nil {
 			connSet = make([]*conn, len(srv.ListenAddrs))
 			srv.CandidateConns[c.id] = connSet
+			srv.candidateSince[c.id] = mclock.Now()
 		}
 
-		if int(c.portOrder) < len(connSet) {
-			connSet[c.portOrder] = c
+		if old := connSet[c.portOrder]; old != nil {
+			old.close(DiscAlreadyConnected)
 		}
+		connSet[c.portOrder] = c
 
 		pending := len(connSet)
 		for _, conn := range connSet {
@@ -367,6 +391,7 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 
 		p, err = newPeer(connSet, srv.Protocols, srv.Config.RWTimerConfig)
 		delete(srv.CandidateConns, c.id)
+		delete(srv.candidateSince, c.id)
 	} else {
 		p, err = newPeer([]*conn{c}, srv.Protocols, srv.Config.RWTimerConfig)
 	}
@@ -389,6 +414,25 @@ func (srv *MultiChannelServer) handleAddPeerConn(c *conn) error {
 	srv.peerWG.Add(1)
 	go srv.runPeer(p)
 	return nil
+}
+
+// expireCandidates drops multichannel peers whose remaining channels never arrived.
+// Nothing else does: CandidateConns is cleared only once every channel is present.
+// Caller must hold srv.lock.
+func (srv *MultiChannelServer) expireCandidates(now mclock.AbsTime) {
+	for id, connSet := range srv.CandidateConns {
+		if now-srv.candidateSince[id] < mclock.AbsTime(candidateAssemblyTimeout) {
+			continue
+		}
+		for _, c := range connSet {
+			if c != nil {
+				c.close(DiscUselessPeer)
+			}
+		}
+		delete(srv.CandidateConns, id)
+		delete(srv.candidateSince, id)
+		srv.logger.Debug("Dropped incomplete multichannel peer", "id", id)
+	}
 }
 
 // Overrides BaseServer.runPeer() because multichannel peers run all socket

--- a/networks/p2p/server_multi_test.go
+++ b/networks/p2p/server_multi_test.go
@@ -64,10 +64,28 @@ func newCandidateConn(t *testing.T, n int, portOrder PortOrder) (*conn, *testTra
 	}, tt
 }
 
+// lockProbeTransport records whether srv.lock was free while close ran. close writes a disconnect
+// reason under a 1s deadline, so a sweep holding the lock across it stalls the whole server.
+type lockProbeTransport struct {
+	transport
+	srv      *MultiChannelServer
+	lockFree bool
+}
+
+func (t *lockProbeTransport) close(err error) {
+	if t.srv.lock.TryLock() {
+		t.lockFree = true
+		t.srv.lock.Unlock()
+	}
+	t.transport.close(err)
+}
+
 func TestMultiChannelCandidatesExpire(t *testing.T) {
 	srv := newCandidateTestServer(t, 4)
 
 	stale, staleTransport := newCandidateConn(t, 1, ConnDefault)
+	probe := &lockProbeTransport{transport: stale.transport, srv: srv}
+	stale.transport = probe
 	require.NoError(t, srv.handleAddPeerConn(stale))
 	require.Len(t, srv.CandidateConns, 1)
 	require.Empty(t, srv.peers, "half-assembled peers must not be registered")
@@ -78,6 +96,7 @@ func TestMultiChannelCandidatesExpire(t *testing.T) {
 	require.NoError(t, srv.handleAddPeerConn(fresh))
 
 	assert.Equal(t, DiscUselessPeer, staleTransport.closeErr, "the expired candidate must be closed")
+	assert.True(t, probe.lockFree, "the sweep must not close connections under srv.lock")
 	require.Len(t, srv.CandidateConns, 1)
 	assert.NotContains(t, srv.CandidateConns, stale.id)
 	assert.Contains(t, srv.CandidateConns, fresh.id)

--- a/networks/p2p/server_multi_test.go
+++ b/networks/p2p/server_multi_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"net"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/mclock"
+	"github.com/kaiachain/kaia/log"
+	"github.com/kaiachain/kaia/networks/p2p/discover"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCandidateTestServer builds a two-channel server holding no peers yet.
+func newCandidateTestServer(t *testing.T, maxPeers int) *MultiChannelServer {
+	t.Helper()
+	return &MultiChannelServer{
+		BaseServer: &BaseServer{
+			Config:  Config{ConnectionType: common.CONSENSUSNODE, MaxPhysicalConnections: maxPeers},
+			running: true,
+			peers:   make(map[discover.NodeID]*Peer),
+			logger:  log.NewModuleLogger(log.NetworksP2P),
+		},
+		ListenAddrs:    []string{":32323", ":32324"},
+		CandidateConns: make(map[discover.NodeID][]*conn),
+		candidateSince: make(map[discover.NodeID]mclock.AbsTime),
+	}
+}
+
+// newCandidateConn builds an inbound multichannel connection for node `n` on one channel.
+func newCandidateConn(t *testing.T, n int, portOrder PortOrder) (*conn, *testTransport) {
+	t.Helper()
+	serverFD, clientFD := net.Pipe()
+	t.Cleanup(func() { serverFD.Close(); clientFD.Close() })
+
+	var id discover.NodeID
+	id[0] = byte(n)
+	tt := newTestTransport(id, serverFD, nil, true).(*testTransport)
+	return &conn{
+		fd:           serverFD,
+		transport:    tt,
+		flags:        inboundConn,
+		conntype:     common.ENDPOINTNODE,
+		id:           id,
+		portOrder:    portOrder,
+		multiChannel: true,
+	}, tt
+}
+
+func TestMultiChannelCandidatesExpire(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+
+	stale, staleTransport := newCandidateConn(t, 1, ConnDefault)
+	require.NoError(t, srv.handleAddPeerConn(stale))
+	require.Len(t, srv.CandidateConns, 1)
+	require.Empty(t, srv.peers, "half-assembled peers must not be registered")
+
+	srv.candidateSince[stale.id] = mclock.Now() - mclock.AbsTime(candidateAssemblyTimeout) - 1
+
+	fresh, _ := newCandidateConn(t, 2, ConnDefault)
+	require.NoError(t, srv.handleAddPeerConn(fresh))
+
+	assert.Equal(t, DiscUselessPeer, staleTransport.closeErr, "the expired candidate must be closed")
+	require.Len(t, srv.CandidateConns, 1)
+	assert.NotContains(t, srv.CandidateConns, stale.id)
+	assert.Contains(t, srv.CandidateConns, fresh.id)
+}
+
+func TestMultiChannelDuplicateChannelClosesPrevious(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+
+	first, firstTransport := newCandidateConn(t, 1, ConnDefault)
+	require.NoError(t, srv.handleAddPeerConn(first))
+
+	second, _ := newCandidateConn(t, 1, ConnDefault) // same node, same channel
+	require.NoError(t, srv.handleAddPeerConn(second))
+
+	assert.Equal(t, DiscAlreadyConnected, firstTransport.closeErr)
+	require.Len(t, srv.CandidateConns, 1)
+	assert.Same(t, second, srv.CandidateConns[second.id][ConnDefault])
+}
+
+func TestMultiChannelRejectsOutOfRangePortOrder(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+
+	c, _ := newCandidateConn(t, 1, PortOrder(len(srv.ListenAddrs)))
+	assert.ErrorIs(t, srv.handleAddPeerConn(c), DiscUnexpectedIdentity)
+	assert.Empty(t, srv.CandidateConns)
+}
+
+func TestMultiChannelStopClosesCandidates(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+	srv.quit = make(chan struct{})
+
+	c, tt := newCandidateConn(t, 1, ConnDefault)
+	require.NoError(t, srv.handleAddPeerConn(c))
+
+	srv.Stop()
+
+	assert.Equal(t, DiscQuitting, tt.closeErr)
+	assert.Empty(t, srv.CandidateConns)
+}


### PR DESCRIPTION
## Proposed changes

A multichannel peer becomes a `Peer` only once every channel arrives. Until then its first connection sits in `CandidateConns`:

- absent from `srv.peers`, so it escapes `MaxPhysicalConnections`, the inbound limit and `peerTargets`
- no read loop, never closed, and still reachable from the server, so the GC cannot reclaim its socket
- released only on successful assembly — no deadline, no eviction

So a peer that opens one channel, declares `Multichannel` and never sends the rest holds a file descriptor for the lifetime of the process, and can repeat with fresh node keys until the node can no longer accept or dial.

Fix:

- candidates carry an open time and are dropped, sockets and all, past the assembly deadline
- a channel replacing an occupied slot closes the one it replaces
- a `portOrder` outside our listener set is rejected instead of silently dropped
- shutdown closes whatever is still under assembly

Expiry runs at the start of `handleAddPeerConn`, not on a timer: p2p has no periodic loop, and the call that needs the room is the one that reclaims it.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- Please leave any additional comments here. -->
