### PR TITLE
kaiax/vrank: drop duplicate VRankCandidate before verifying it

### DIFF
--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -173,6 +173,9 @@ func (v *VRankModule) HandleVRankCandidate(msg *vrank.VRankCandidate) error {
 	if err != nil {
 		return err
 	}
+	if v.collector.HasCandMsg(vk, sender) {
+		return nil
+	}
 	blsNum := big.NewInt(0).Add(v.Chain.CurrentHeader().Number, big.NewInt(1)) // head + 1
 	blsPub, err := v.Randao.GetBlsPubkey(sender, blsNum)
 	if err != nil {
@@ -181,9 +184,6 @@ func (v *VRankModule) HandleVRankCandidate(msg *vrank.VRankCandidate) error {
 	ok, err := bls.VerifySignature(msg.BlsSig[:], sigHash, blsPub)
 	if err != nil || !ok {
 		return vrank.ErrInvalidCandidateBlsSig
-	}
-	if v.collector.HasCandMsg(vk, sender) {
-		return nil
 	}
 	v.collector.AddCandMsg(vk, sender, receivedAt, msg)
 	return nil

--- a/kaiax/vrank/impl/handler_test.go
+++ b/kaiax/vrank/impl/handler_test.go
@@ -557,6 +557,13 @@ func TestHandleVRankCandidate(t *testing.T) {
 				assert.Equal(t, receivedAt, cm.ReceivedAt, "ReceivedAt should not change on duplicate")
 			}
 		}
+
+		// This replay carries a BLS signature from the wrong key. Dropping it without an error
+		// means the duplicate check ran before the verification.
+		_, wrongBlsSig := signVRankCandidate(t, val.VRankModule, val.Key, val.BlsKey, msg.BlockNumber, msg.Round, msg.BlockHash)
+		replay := msg
+		replay.BlsSig = wrongBlsSig
+		assert.NoError(t, val.VRankModule.HandleVRankCandidate(&replay))
 	})
 
 	t.Run("stale messages should be discarded", func(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

The duplicate check for `VRankCandidate` sat after the BLS verification, so every replay paid for a pairing before being discarded — and a valid duplicate returns nil, so the peer is never dropped and can keep sending. It now runs right after the ECDSA recovery that produces the sender.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- Please leave any additional comments here. -->
