### PR TITLE
kaiax/valset: remove the unused HeaderGovVoters set

### DIFF
--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -153,14 +153,6 @@ func (v *ValsetModule) GetCNPeers(num uint64) ([]common.Address, error) {
 	return cnPeers, nil
 }
 
-// GetHeaderGovVoters returns validators eligible for header governance votes. Pre-fork: council.
-func (v *ValsetModule) GetHeaderGovVoters(num uint64) ([]common.Address, error) {
-	if v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		return v.getHeaderGovVoters(num)
-	}
-	return v.GetCouncil(num)
-}
-
 // GetNodesByState filters NodeMap by state. Empty states means "all".
 // Returns an explicit fork-disabled error pre-fork.
 func (v *ValsetModule) GetNodesByState(num uint64, states []valset.NodeState) (map[common.Address]*valset.Node, error) {

--- a/kaiax/valset/impl/getter_permissionless.go
+++ b/kaiax/valset/impl/getter_permissionless.go
@@ -87,15 +87,6 @@ func (v *ValsetModule) getCNPeers(num uint64) ([]common.Address, error) {
 	return nodes.CNPeers().Addresses(), nil
 }
 
-// getHeaderGovVoters: HeaderGovVoters = {VA} - {Suspended}.
-func (v *ValsetModule) getHeaderGovVoters(num uint64) ([]common.Address, error) {
-	nodes, err := v.getNodes(num)
-	if err != nil {
-		return nil, err
-	}
-	return nodes.HeaderGovVoters().Addresses(), nil
-}
-
 // getNodesByState filters nodes by state. Empty states means "all".
 // Returns a defensive copy so callers can mutate the result freely.
 func (v *ValsetModule) getNodesByState(num uint64, states []valset.NodeState) (valset.NodeMap, error) {

--- a/kaiax/valset/impl/getter_permissionless_test.go
+++ b/kaiax/valset/impl/getter_permissionless_test.go
@@ -53,10 +53,6 @@ func TestPermissionlessPublicGetters(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []common.Address{addr1, addr2, addr3, addr4, addr5, addr6}, cnPeers)
 
-	headerGovVoters, err := v.GetHeaderGovVoters(testGetterBlock)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, []common.Address{addr1}, headerGovVoters)
-
 	demoted, err := v.GetDemotedValidators(testGetterBlock)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []common.Address{addr2, addr3}, demoted)

--- a/kaiax/valset/interface.go
+++ b/kaiax/valset/interface.go
@@ -42,7 +42,6 @@ type ValsetModule interface {
 	// GetCandTesting returns nodes in the CandTesting state at block `num`.
 	GetCandTesting(num uint64) ([]common.Address, error)
 	GetCNPeers(num uint64) ([]common.Address, error)
-	GetHeaderGovVoters(num uint64) ([]common.Address, error)
 	// GetNodesByState returns nodes filtered by state at block `num`.
 	// It returns an error before the permissionless fork.
 	GetNodesByState(num uint64, states []NodeState) (map[common.Address]*Node, error)

--- a/kaiax/valset/mock/module.go
+++ b/kaiax/valset/mock/module.go
@@ -142,21 +142,6 @@ func (mr *MockValsetModuleMockRecorder) GetDemotedValidators(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDemotedValidators", reflect.TypeOf((*MockValsetModule)(nil).GetDemotedValidators), arg0)
 }
 
-// GetHeaderGovVoters mocks base method.
-func (m *MockValsetModule) GetHeaderGovVoters(arg0 uint64) ([]common.Address, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHeaderGovVoters", arg0)
-	ret0, _ := ret[0].([]common.Address)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHeaderGovVoters indicates an expected call of GetHeaderGovVoters.
-func (mr *MockValsetModuleMockRecorder) GetHeaderGovVoters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderGovVoters", reflect.TypeOf((*MockValsetModule)(nil).GetHeaderGovVoters), arg0)
-}
-
 // GetNodesByState mocks base method.
 func (m *MockValsetModule) GetNodesByState(arg0 uint64, arg1 []valset.NodeState) (map[common.Address]*valset.Node, error) {
 	m.ctrl.T.Helper()

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -264,12 +264,6 @@ func (v NodeMap) Committee() NodeMap {
 	return v.FilterByState(ValActive).ExcludeSuspended()
 }
 
-// HeaderGovVoters returns nodes eligible for governance header votes.
-// {ValActive} excluding suspended nodes.
-func (v NodeMap) HeaderGovVoters() NodeMap {
-	return v.FilterByState(ValActive).ExcludeSuspended()
-}
-
 // CNPeers returns nodes that should maintain CN-CN P2P connections.
 // Includes CandReady — P2P must be established before CandTesting promotion.
 func (v NodeMap) CNPeers() NodeMap {


### PR DESCRIPTION
## Proposed changes

`GetHeaderGovVoters`, its private helper, and `NodeMap.HeaderGovVoters` only ever called each other — nothing called in, and it is not on the RPC surface. Header governance already restricts voters through the proposer binding in `headergov`, which admits only the block author and therefore only a committee member.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

KIP-286's derived-set table still lists `HeaderGovVoters`; that row goes in a separate KIP PR.
