### PR TITLE
chore: update test chainconfig to permissionless

### DIFF
--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -565,6 +565,7 @@ func TestVerifyBlockBodyForOsakaFork(t *testing.T) {
 	config.KaiaCompatibleBlock = common.Big1
 	config.PragueCompatibleBlock = common.Big1
 	config.OsakaCompatibleBlock = common.Big1
+	config.PermissionlessCompatibleBlock = common.Big1
 	var (
 		testdb  = database.NewMemoryDBManager()
 		gspec   = &Genesis{Config: config}

--- a/blockchain/system/permissionless_config.go
+++ b/blockchain/system/permissionless_config.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package system
+
+import (
+	"math/big"
+
+	"github.com/kaiachain/kaia/common"
+	abv2data "github.com/kaiachain/kaia/contracts/bindings/abv2data"
+	addressbookv2contract "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/kaiachain/kaia/params"
+)
+
+// defaultGenesisStake is staked per validator by MakeABv2AllocConfig.
+var defaultGenesisStake = new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(params.KAIA))
+
+// ABv2NodeSpec is what a caller supplies per genesis validator. Everything else in
+// NodeInfo is derived by makeABv2NodeInfos.
+type ABv2NodeSpec struct {
+	NodeID  common.Address
+	BlsInfo addressbookv2contract.BlsPublicKeyInfo
+}
+
+// MakeABv2AllocConfig fills an AllocPermissionlessConfig with the genesis defaults for the
+// given validators, staking defaultGenesisStake each. Callers that expose any of these as
+// flags or governance (homi) overwrite those fields on the returned config.
+func MakeABv2AllocConfig(owner common.Address, specs []ABv2NodeSpec) *AllocPermissionlessConfig {
+	nodeIds, nodeInfos := makeABv2NodeInfos(specs)
+
+	stakeAmts := make([]*big.Int, len(specs))
+	for i := range stakeAmts {
+		stakeAmts[i] = new(big.Int).Set(defaultGenesisStake)
+	}
+
+	return &AllocPermissionlessConfig{
+		Owner:     owner,
+		NodeIds:   nodeIds,
+		NodeInfos: nodeInfos,
+		StakeAmts: stakeAmts,
+		DataConfig: abv2data.IABv2DataContractInitData{
+			InitialOwner:            owner,
+			InitialSuspender:        owner,
+			InitialConfigurator:     owner,
+			PfsThreshold:            big.NewInt(valset.DefaultPfsThreshold),
+			CfsThreshold:            big.NewInt(valset.DefaultCfsThreshold),
+			PauseTimeout:            big.NewInt(int64(valset.DefaultValPausedTimeout.Seconds())),
+			IdleTimeout:             big.NewInt(int64(valset.DefaultValIdleTimeout.Seconds())),
+			MaxNodeCount:            big.NewInt(valset.DefaultMaxNodeCount),
+			MaxValActivePausedCount: big.NewInt(valset.DefaultMaxValActivePausedCount),
+			MaxCandReadyCount:       big.NewInt(valset.DefaultMaxCandReadyCount),
+			KefAddress:              owner,
+			KifAddress:              owner,
+			KpfAddress:              owner,
+		},
+	}
+}
+
+// makeABv2NodeInfos builds the genesis validator list for AllocPermissionlessConfig.
+// RewardAddress is derived rather than reused: the ABv2DataContract constructor rejects
+// a reward address equal to the node address.
+func makeABv2NodeInfos(specs []ABv2NodeSpec) ([]common.Address, []addressbookv2contract.NodeInfo) {
+	nodeIds := make([]common.Address, len(specs))
+	infos := make([]addressbookv2contract.NodeInfo, len(specs))
+	for i, spec := range specs {
+		nodeIds[i] = spec.NodeID
+		infos[i] = addressbookv2contract.NodeInfo{
+			Manager:       spec.NodeID,
+			RewardAddress: common.BytesToAddress(crypto.Keccak256(spec.NodeID.Bytes())),
+			VoterAddress:  spec.NodeID,
+			TimeoutAt:     new(big.Int),
+			GcId:          big.NewInt(int64(i + 1)),
+			BlsInfo:       spec.BlsInfo,
+			State:         valset.ValActive.ToUint8(),
+		}
+	}
+	return nodeIds, infos
+}

--- a/blockchain/system/permissionless_test.go
+++ b/blockchain/system/permissionless_test.go
@@ -17,7 +17,6 @@
 package system
 
 import (
-	"crypto/ecdsa"
 	"math/big"
 	"testing"
 
@@ -25,81 +24,31 @@ import (
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/common"
-	abv2data "github.com/kaiachain/kaia/contracts/bindings/abv2data"
 	addressbookv2contract "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/bls"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/log"
-	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// makeTestPermissionlessConfig delegates to the exported MakeTestPermissionlessConfig.
+// makeTestPermissionlessConfig creates an AllocPermissionlessConfig with n validators.
 func makeTestPermissionlessConfig(n int) *AllocPermissionlessConfig {
-	config, _ := MakeTestPermissionlessConfig(n)
-	return config
-}
-
-// MakeTestPermissionlessConfig creates a test AllocPermissionlessConfig with n validators.
-func MakeTestPermissionlessConfig(n int) (*AllocPermissionlessConfig, []*ecdsa.PrivateKey) {
 	ownerKey, _ := crypto.GenerateKey()
-	owner := crypto.PubkeyToAddress(ownerKey.PublicKey)
-
-	nodeKeys := make([]*ecdsa.PrivateKey, n)
-	nodeIds := make([]common.Address, n)
-	nodeInfos := make([]addressbookv2contract.NodeInfo, n)
-	stakeAmts := make([]*big.Int, n)
-	stakeAmt := new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(params.KAIA))
-
-	for i := 0; i < n; i++ {
+	specs := make([]ABv2NodeSpec, n)
+	for i := range specs {
 		key, _ := crypto.GenerateKey()
-		addr := crypto.PubkeyToAddress(key.PublicKey)
-		nodeKeys[i] = key
-		blsSk, _ := bls.DeriveFromECDSA(key)
-		blsPk := blsSk.PublicKey()
-		blsPop := bls.PopProve(blsSk)
-		pub := blsPk.Marshal()
-		pop := blsPop.Marshal()
-
-		nodeIds[i] = addr
-		stakeAmts[i] = new(big.Int).Set(stakeAmt)
-		nodeInfos[i] = addressbookv2contract.NodeInfo{
-			Manager:       addr,
-			RewardAddress: common.BytesToAddress(crypto.Keccak256(addr.Bytes())),
-			VoterAddress:  addr,
-			TimeoutAt:     new(big.Int),
-			GcId:          big.NewInt(int64(i + 1)),
+		blsKey, _ := bls.DeriveFromECDSA(key)
+		specs[i] = ABv2NodeSpec{
+			NodeID: crypto.PubkeyToAddress(key.PublicKey),
 			BlsInfo: addressbookv2contract.BlsPublicKeyInfo{
-				PublicKey: pub,
-				Pop:       pop,
+				PublicKey: blsKey.PublicKey().Marshal(),
+				Pop:       bls.PopProve(blsKey).Marshal(),
 			},
-			State: valset.ValActive.ToUint8(),
 		}
 	}
-
-	return &AllocPermissionlessConfig{
-		Owner:     owner,
-		NodeIds:   nodeIds,
-		NodeInfos: nodeInfos,
-		StakeAmts: stakeAmts,
-		DataConfig: abv2data.IABv2DataContractInitData{
-			InitialOwner:            owner,
-			InitialSuspender:        owner,
-			InitialConfigurator:     owner,
-			PfsThreshold:            big.NewInt(2),
-			CfsThreshold:            big.NewInt(300),
-			PauseTimeout:            big.NewInt(8 * 3600),   // 8h
-			IdleTimeout:             big.NewInt(30 * 86400), // 30d
-			MaxNodeCount:            big.NewInt(100),
-			MaxValActivePausedCount: big.NewInt(50),
-			MaxCandReadyCount:       big.NewInt(3),
-			KefAddress:              common.HexToAddress("0x1111"),
-			KifAddress:              common.HexToAddress("0x2222"),
-			KpfAddress:              common.HexToAddress("0x3333"),
-		},
-	}, nodeKeys
+	return MakeABv2AllocConfig(crypto.PubkeyToAddress(ownerKey.PublicKey), specs)
 }
 
 // verifyPermissionlessAlloc checks alloc-level properties and ABv2 contract state.

--- a/cmd/homi/setup/cmd.go
+++ b/cmd/homi/setup/cmd.go
@@ -41,13 +41,11 @@ import (
 	"github.com/kaiachain/kaia/cmd/homi/docker/service"
 	"github.com/kaiachain/kaia/cmd/homi/genesis"
 	"github.com/kaiachain/kaia/common"
-	abv2data "github.com/kaiachain/kaia/contracts/bindings/abv2data"
 	addressbookv2contract "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/kaiax/auction"
 	"github.com/kaiachain/kaia/kaiax/gasless"
 	"github.com/kaiachain/kaia/kaiax/valset"
-	valsetimpl "github.com/kaiachain/kaia/kaiax/valset/impl"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/params"
@@ -67,9 +65,8 @@ type GrafanaFile struct {
 }
 
 const (
-	defaultMaxReadyCandidateCount        = 3
-	defaultPfsThreshold                  = 2
-	defaultCfsThreshold                  = 300
+	defaultPfsThreshold                  = valset.DefaultPfsThreshold
+	defaultCfsThreshold                  = valset.DefaultCfsThreshold
 	defaultPermissionlessGenesisDeployer = "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead"
 )
 
@@ -591,55 +588,25 @@ func makePermissionlessConfig(ctx *cli.Context, validatorAddrs []common.Address,
 	if !common.IsHexAddress(deployerStr) {
 		log.Fatalf("'%s' is not a valid permissionless genesis deployer address", deployerStr)
 	}
-	deployer := common.HexToAddress(deployerStr)
-	numValidators := len(validatorAddrs)
-	stakeAmt := new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(params.KAIA))
-
-	nodeInfos := make([]addressbookv2contract.NodeInfo, numValidators)
+	specs := make([]system.ABv2NodeSpec, len(validatorAddrs))
 	for i, addr := range validatorAddrs {
 		blsInfo := kip113Init.Infos[addr]
-		nodeInfos[i] = addressbookv2contract.NodeInfo{
-			Manager:       addr,
-			RewardAddress: common.BytesToAddress(crypto.Keccak256(addr.Bytes())),
-			VoterAddress:  addr,
-			TimeoutAt:     new(big.Int),
-			GcId:          big.NewInt(int64(i + 1)),
+		specs[i] = system.ABv2NodeSpec{
+			NodeID: addr,
 			BlsInfo: addressbookv2contract.BlsPublicKeyInfo{
 				PublicKey: blsInfo.PublicKey,
 				Pop:       blsInfo.Pop,
 			},
-			State: valset.ValActive.ToUint8(),
 		}
 	}
 
-	stakeAmts := make([]*big.Int, numValidators)
-	for i := range stakeAmts {
-		stakeAmts[i] = new(big.Int).Set(stakeAmt)
-	}
-
-	return &system.AllocPermissionlessConfig{
-		Owner:              owner,
-		Deployer:           deployer,
-		NodeIds:            validatorAddrs,
-		NodeInfos:          nodeInfos,
-		StakeAmts:          stakeAmts,
-		EpochBlockInterval: int64(ctx.Uint64(vrankEpochFlag.Name)),
-		DataConfig: abv2data.IABv2DataContractInitData{
-			InitialOwner:            owner,
-			InitialSuspender:        owner,
-			InitialConfigurator:     owner,
-			PfsThreshold:            big.NewInt(ctx.Int64(pfsThresholdFlag.Name)),
-			CfsThreshold:            big.NewInt(ctx.Int64(cfsThresholdFlag.Name)),
-			PauseTimeout:            big.NewInt(int64(valsetimpl.DefaultValPausedTimeout.Seconds())),
-			IdleTimeout:             big.NewInt(int64(valsetimpl.DefaultValIdleTimeout.Seconds())),
-			MaxNodeCount:            big.NewInt(int64(valsetimpl.DefaultMaxNodeCount)),
-			MaxValActivePausedCount: big.NewInt(int64(valsetimpl.DefaultMaxValActivePausedCount)),
-			MaxCandReadyCount:       big.NewInt(defaultMaxReadyCandidateCount),
-			KefAddress:              owner,
-			KifAddress:              owner,
-			KpfAddress:              owner,
-		},
-	}
+	// Start from the genesis defaults and overwrite what this command exposes as flags.
+	config := system.MakeABv2AllocConfig(owner, specs)
+	config.Deployer = common.HexToAddress(deployerStr)
+	config.EpochBlockInterval = int64(ctx.Uint64(vrankEpochFlag.Name))
+	config.DataConfig.PfsThreshold = big.NewInt(ctx.Int64(pfsThresholdFlag.Name))
+	config.DataConfig.CfsThreshold = big.NewInt(ctx.Int64(cfsThresholdFlag.Name))
+	return config
 }
 
 func allocateRegistry(ctx *cli.Context, genesisJson *blockchain.Genesis, owner common.Address, records map[string]common.Address) {

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -69,6 +69,7 @@ func TestBackend_GetTargetReceivers(t *testing.T) {
 	configItems = append(configItems, kaiaCompatibleBlock(nil))
 	configItems = append(configItems, pragueCompatibleBlock(nil))
 	configItems = append(configItems, osakaCompatibleBlock(nil))
+	configItems = append(configItems, permissionlessCompatibleBlock(nil))
 	configItems = append(configItems, blockPeriod(0)) // set block period to 0 to prevent creating future block
 	configItems = append(configItems, mStaking)
 
@@ -300,7 +301,7 @@ func TestBackend_VerifyEnforcesBlockSizeCap(t *testing.T) {
 
 	// Pre-Osaka: the cap is gated on IsOsakaForkEnabled, so it must not apply.
 	t.Run("pre-osaka", func(t *testing.T) {
-		chain, engine := newBlockChain(t, 1, osakaCompatibleBlock(nil))
+		chain, engine := newBlockChain(t, 1, osakaCompatibleBlock(nil), permissionlessCompatibleBlock(nil))
 		defer chain.Stop()
 		defer engine.Stop()
 

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/istanbul"
-	abv2data "github.com/kaiachain/kaia/contracts/bindings/abv2data"
 	addressbookv2contract "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/bls"
@@ -143,56 +142,24 @@ func setNodeKeys(n int, governingNode *ecdsa.PrivateKey) ([]*ecdsa.PrivateKey, [
 	return nodeKeys, addrs
 }
 
-// permissionlessGenesisConfig describes the test validators for AllocPermissionless.
-// Each node's BLS key is derived from its consensus key, so the keys ABv2 publishes are
-// the ones the nodes actually sign with.
-func permissionlessGenesisConfig(keys []*ecdsa.PrivateKey, nodes []common.Address) *system.AllocPermissionlessConfig {
-	owner := common.HexToAddress("0xffff")
-	stakeAmt := new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(params.KAIA))
-
-	nodeInfos := make([]addressbookv2contract.NodeInfo, len(nodes))
-	stakeAmts := make([]*big.Int, len(nodes))
-	for i, addr := range nodes {
-		blsKey, err := bls.DeriveFromECDSA(keys[i])
+// abv2SpecsFromKeys derives one ABv2 spec per validator, taking each BLS key from the
+// node's consensus key so ABv2 publishes the keys the nodes actually sign with.
+func abv2SpecsFromKeys(keys []*ecdsa.PrivateKey) []system.ABv2NodeSpec {
+	specs := make([]system.ABv2NodeSpec, len(keys))
+	for i, key := range keys {
+		blsKey, err := bls.DeriveFromECDSA(key)
 		if err != nil {
 			panic(err)
 		}
-		nodeInfos[i] = addressbookv2contract.NodeInfo{
-			Manager:       addr,
-			RewardAddress: common.BytesToAddress(crypto.Keccak256(addr.Bytes())),
-			VoterAddress:  addr,
-			TimeoutAt:     new(big.Int),
-			GcId:          big.NewInt(int64(i + 1)),
+		specs[i] = system.ABv2NodeSpec{
+			NodeID: crypto.PubkeyToAddress(key.PublicKey),
 			BlsInfo: addressbookv2contract.BlsPublicKeyInfo{
 				PublicKey: blsKey.PublicKey().Marshal(),
 				Pop:       bls.PopProve(blsKey).Marshal(),
 			},
-			State: valset.ValActive.ToUint8(),
 		}
-		stakeAmts[i] = new(big.Int).Set(stakeAmt)
 	}
-
-	return &system.AllocPermissionlessConfig{
-		Owner:     owner,
-		NodeIds:   append([]common.Address(nil), nodes...),
-		NodeInfos: nodeInfos,
-		StakeAmts: stakeAmts,
-		DataConfig: abv2data.IABv2DataContractInitData{
-			InitialOwner:            owner,
-			InitialSuspender:        owner,
-			InitialConfigurator:     owner,
-			PfsThreshold:            big.NewInt(2),
-			CfsThreshold:            big.NewInt(300),
-			PauseTimeout:            big.NewInt(8 * 3600),
-			IdleTimeout:             big.NewInt(30 * 86400),
-			MaxNodeCount:            big.NewInt(100),
-			MaxValActivePausedCount: big.NewInt(50),
-			MaxCandReadyCount:       big.NewInt(3),
-			KefAddress:              common.HexToAddress("0x1111"),
-			KifAddress:              common.HexToAddress("0x2222"),
-			KpfAddress:              common.HexToAddress("0x3333"),
-		},
-	}
+	return specs
 }
 
 // in this test, we can set n to 1, and it means we can process Istanbul and commit a
@@ -299,7 +266,8 @@ func newBlockChain(t *testing.T, n int, items ...interface{}) (*blockchain.Block
 	case genesis.Config.IsPermissionlessForkEnabled(common.Big0):
 		// Post-fork BLS keys come from ABv2, not KIP113 (randao.readBlsPermissionless), so the
 		// randao branch is dead here and its Registry must not overwrite this one.
-		alloc, err := system.AllocPermissionless(permissionlessGenesisConfig(nodeKeys, addrs))
+		specs := abv2SpecsFromKeys(nodeKeys)
+		alloc, err := system.AllocPermissionless(system.MakeABv2AllocConfig(common.HexToAddress("0xffff"), specs))
 		if err != nil {
 			panic(err)
 		}

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/istanbul"
+	abv2data "github.com/kaiachain/kaia/contracts/bindings/abv2data"
+	addressbookv2contract "github.com/kaiachain/kaia/contracts/bindings/addressbookv2"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/bls"
 	"github.com/kaiachain/kaia/datasync/downloader"
@@ -86,6 +88,8 @@ type (
 	kaiaCompatibleBlock      *big.Int
 	pragueCompatibleBlock    *big.Int
 	osakaCompatibleBlock     *big.Int
+
+	permissionlessCompatibleBlock *big.Int
 )
 
 type (
@@ -139,6 +143,58 @@ func setNodeKeys(n int, governingNode *ecdsa.PrivateKey) ([]*ecdsa.PrivateKey, [
 	return nodeKeys, addrs
 }
 
+// permissionlessGenesisConfig describes the test validators for AllocPermissionless.
+// Each node's BLS key is derived from its consensus key, so the keys ABv2 publishes are
+// the ones the nodes actually sign with.
+func permissionlessGenesisConfig(keys []*ecdsa.PrivateKey, nodes []common.Address) *system.AllocPermissionlessConfig {
+	owner := common.HexToAddress("0xffff")
+	stakeAmt := new(big.Int).Mul(big.NewInt(5_000_000), big.NewInt(params.KAIA))
+
+	nodeInfos := make([]addressbookv2contract.NodeInfo, len(nodes))
+	stakeAmts := make([]*big.Int, len(nodes))
+	for i, addr := range nodes {
+		blsKey, err := bls.DeriveFromECDSA(keys[i])
+		if err != nil {
+			panic(err)
+		}
+		nodeInfos[i] = addressbookv2contract.NodeInfo{
+			Manager:       addr,
+			RewardAddress: common.BytesToAddress(crypto.Keccak256(addr.Bytes())),
+			VoterAddress:  addr,
+			TimeoutAt:     new(big.Int),
+			GcId:          big.NewInt(int64(i + 1)),
+			BlsInfo: addressbookv2contract.BlsPublicKeyInfo{
+				PublicKey: blsKey.PublicKey().Marshal(),
+				Pop:       bls.PopProve(blsKey).Marshal(),
+			},
+			State: valset.ValActive.ToUint8(),
+		}
+		stakeAmts[i] = new(big.Int).Set(stakeAmt)
+	}
+
+	return &system.AllocPermissionlessConfig{
+		Owner:     owner,
+		NodeIds:   append([]common.Address(nil), nodes...),
+		NodeInfos: nodeInfos,
+		StakeAmts: stakeAmts,
+		DataConfig: abv2data.IABv2DataContractInitData{
+			InitialOwner:            owner,
+			InitialSuspender:        owner,
+			InitialConfigurator:     owner,
+			PfsThreshold:            big.NewInt(2),
+			CfsThreshold:            big.NewInt(300),
+			PauseTimeout:            big.NewInt(8 * 3600),
+			IdleTimeout:             big.NewInt(30 * 86400),
+			MaxNodeCount:            big.NewInt(100),
+			MaxValActivePausedCount: big.NewInt(50),
+			MaxCandReadyCount:       big.NewInt(3),
+			KefAddress:              common.HexToAddress("0x1111"),
+			KifAddress:              common.HexToAddress("0x2222"),
+			KpfAddress:              common.HexToAddress("0x3333"),
+		},
+	}
+}
+
 // in this test, we can set n to 1, and it means we can process Istanbul and commit a
 // block by one node. Otherwise, if n is larger than 1, we have to generate
 // other fake events to process Istanbul.
@@ -183,6 +239,8 @@ func newBlockChain(t *testing.T, n int, items ...interface{}) (*blockchain.Block
 			genesis.Config.PragueCompatibleBlock = v
 		case osakaCompatibleBlock:
 			genesis.Config.OsakaCompatibleBlock = v
+		case permissionlessCompatibleBlock:
+			genesis.Config.PermissionlessCompatibleBlock = v
 		case proposerPolicy:
 			genesis.Config.Istanbul.ProposerPolicy = uint64(v)
 		case epoch:
@@ -237,8 +295,23 @@ func newBlockChain(t *testing.T, n int, items ...interface{}) (*blockchain.Block
 	}
 	genesis.ExtraData = append([]byte(nil), genesisHeader.Extra...)
 
+	switch {
+	case genesis.Config.IsPermissionlessForkEnabled(common.Big0):
+		// Post-fork BLS keys come from ABv2, not KIP113 (randao.readBlsPermissionless), so the
+		// randao branch is dead here and its Registry must not overwrite this one.
+		alloc, err := system.AllocPermissionless(permissionlessGenesisConfig(nodeKeys, addrs))
+		if err != nil {
+			panic(err)
+		}
+		if genesis.Alloc == nil {
+			genesis.Alloc = make(blockchain.GenesisAlloc)
+		}
+		for addr, account := range alloc {
+			genesis.Alloc[addr] = account
+		}
+
 	// Set up Registry and KIP113 contracts for Randao fork if RandaoCompatibleBlock is set
-	if genesis.Config.RandaoCompatibleBlock != nil {
+	case genesis.Config.RandaoCompatibleBlock != nil:
 		// Generate BLS keys for all nodes
 		nodeBlsKeys := make([]bls.SecretKey, n)
 		for i := range n {

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -19,7 +19,6 @@ package impl
 import (
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"
@@ -29,13 +28,6 @@ import (
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/valset"
-)
-
-const (
-	DefaultValPausedTimeout        = time.Hour * 8
-	DefaultValIdleTimeout          = 30 * 24 * time.Hour
-	DefaultMaxNodeCount            = 100
-	DefaultMaxValActivePausedCount = 50
 )
 
 // #region getter

--- a/kaiax/valset/types.go
+++ b/kaiax/valset/types.go
@@ -27,6 +27,18 @@ import (
 	"github.com/kaiachain/kaia/common"
 )
 
+// Genesis defaults for the ABv2 parameters. Chains may configure other values; these are
+// what homi writes and what tests build their genesis from.
+const (
+	DefaultValPausedTimeout        = time.Hour * 8
+	DefaultValIdleTimeout          = 30 * 24 * time.Hour
+	DefaultMaxNodeCount            = 100
+	DefaultMaxValActivePausedCount = 50
+	DefaultMaxCandReadyCount       = 3
+	DefaultPfsThreshold            = 2
+	DefaultCfsThreshold            = 300
+)
+
 type NodeState uint8
 
 const (

--- a/params/config.go
+++ b/params/config.go
@@ -146,7 +146,7 @@ var (
 		UnitPrice: 25000000000,
 	}
 
-	TestChainConfig = TestKaiaConfig("osaka")
+	TestChainConfig = TestKaiaConfig("permissionless")
 )
 
 func TestKaiaConfig(maxHardfork string) *ChainConfig {


### PR DESCRIPTION
## Proposed changes

- chore: update test chainconfig to permissionless
- blockchain/system: share the permissionless genesis alloc defaults

## Types of changes

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
