### PR TITLE
api, kaiax/valset: fix typo in error variable name (Larget -> Larger)

### DIFF
--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -55,7 +55,7 @@ var (
 	errPendingNotAllowed       = errors.New("pending is not allowed")
 	errRangeNil                = errors.New("range values should not be nil")
 	errStartNotPositive        = errors.New("start block number should be positive")
-	errEndLargetThanLatest     = errors.New("end block number should be smaller than the latest block number")
+	errEndLargerThanLatest     = errors.New("end block number should be smaller than the latest block number")
 	errStartLargerThanEnd      = errors.New("start should be smaller than end")
 	errRequestedBlocksTooLarge = errors.New("number of requested blocks should be smaller than 50")
 	errNoCypressCreditContract = errors.New("no mainnet credit contract")
@@ -318,7 +318,7 @@ func (s *KaiaBlockChainAPI) GetBlockWithConsensusInfoByNumberRange(ctx context.C
 	eChain := s.b.CurrentBlock().Number().Int64()
 	if endNum > eChain {
 		logger.Trace("end should be smaller than the latest block number", "end", end, "eChain", eChain)
-		return nil, errEndLargetThanLatest
+		return nil, errEndLargerThanLatest
 	}
 
 	if startNum > endNum {

--- a/kaiax/valset/impl/error.go
+++ b/kaiax/valset/impl/error.go
@@ -36,7 +36,7 @@ var (
 	errPendingNotAllowed       = errors.New("pending is not allowed")
 	errInternalError           = errors.New("internal error")
 	errStartNotPositive        = errors.New("start block number should be positive")
-	errEndLargetThanLatest     = errors.New("end block number should be smaller than the latest block number")
+	errEndLargerThanLatest     = errors.New("end block number should be smaller than the latest block number")
 	errStartLargerThanEnd      = errors.New("start should be smaller than end")
 	errRequestedBlocksTooLarge = errors.New("number of requested blocks should be smaller than 50")
 	errRangeNil                = errors.New("range values should not be nil")


### PR DESCRIPTION
## Proposed changes

`errEndLargetThanLatest` is a misspelling of `errEndLargerThanLatest`.

Two pieces of evidence that this is a typo rather than intentional naming:

- The adjacent `errStartLargerThanEnd`, declared in the same `var` block and
  following the same `err<X>LargerThan<Y>` pattern, already uses the correct
  "Larger" spelling.
- The error is returned when the requested `end` block number is larger than
  the latest block number (`api/api_kaia_blockchain.go`, `if endNum > eChain`),
  so "Larger" is also the semantically correct word.

The misspelling dates back to the initial commit and was later copied into
`kaiax/valset/impl/error.go`. Both occurrences are updated.

The identifier is unexported and has no string-based references, so this
rename is purely cosmetic with no functional or API impact.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

N/A

## Further comments

Verified locally:

- `make test` — all packages pass (0 failures)
- `go run build/ci.go lint -v --new-from-rev=dev` — 0 issues

Note that `kaiax/valset/impl/error.go` currently duplicates several error
variables from `api/api_kaia_blockchain.go` that are unused in that package
(including this one). Happy to remove them instead in a follow-up if
maintainers prefer that over renaming.
