### PR TITLE
p2p/discover: set the ID hash on nodes read from the node database

### DIFF
--- a/networks/p2p/discover/database.go
+++ b/networks/p2p/discover/database.go
@@ -396,6 +396,7 @@ func nextNode(db *nodeDB, it iterator.Iterator) *Node {
 			db.deleteNode(id)
 			continue
 		}
+		n.sha = crypto.Keccak256Hash(n.ID[:])
 		return &n
 	}
 	return nil

--- a/networks/p2p/discover/database_test.go
+++ b/networks/p2p/discover/database_test.go
@@ -30,6 +30,10 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var nodeDBKeyTests = []struct {
@@ -296,6 +300,32 @@ func TestNodeDBSeedQuery(t *testing.T) {
 			t.Errorf("missing seed: %v", id)
 		}
 	}
+}
+
+// Without sha the kademlia storage buckets every seed together, capping the table at bucketSize.
+func TestNodeDBSeedQueryBuckets(t *testing.T) {
+	db, _ := newNodeDB("", Version, NodeID{})
+	defer db.close()
+
+	const count = bucketSize * 2
+	for i := 0; i < count; i++ {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		// A distinct /24 each, so the storage IP limits do not interfere.
+		n := NewNode(PubkeyID(&key.PublicKey), net.IPv4(10, byte(i), 1, 1), 30303, 30303, nil, NodeTypeEN)
+		require.NoError(t, db.updateNode(n))
+		require.NoError(t, db.updateBondTime(n.ID, n.IP, time.Now()))
+	}
+
+	seeds := db.querySeeds(count, time.Hour)
+	require.Greater(t, len(seeds), bucketSize, "need more seeds than one bucket holds to be meaningful")
+
+	s := newKademliaStorage(testSelf, newSharedRand())
+	for _, seed := range seeds {
+		assert.Equal(t, crypto.Keccak256Hash(seed.ID[:]), seed.sha)
+		s.add(seed)
+	}
+	assert.Greater(t, s.len(), bucketSize, "seeds piled into a single bucket")
 }
 
 func TestNodeDBPersistency(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

- `nextNode` returns a decoded node without `sha`, so the kademlia storage bucketed every seed from `querySeeds` together and kept only `bucketSize` of them

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
