### PR TITLE
Update/cnbn bootnode urls

### DIFF
--- a/cmd/kbn/main.go
+++ b/cmd/kbn/main.go
@@ -137,6 +137,22 @@ func bootnode(ctx *cli.Context) error {
 		}
 	}
 
+	// KIP-311 requires a BN to rate limit discovery pings from unknown NodeIds.
+	// Reject a negative rate outright, and warn when the limiter is disabled or
+	// set so low that legitimate NAT'd nodes would be throttled.
+	pingRateLimit := ctx.Int(utils.BNPingRateLimitFlag.Name)
+	if pingRateLimit < 0 {
+		log.Fatalf("Invalid --%s %d: must not be negative (0 disables the limiter)",
+			utils.BNPingRateLimitFlag.Name, pingRateLimit)
+	}
+	if pingRateLimit == 0 {
+		logger.Warn("Discovery ping rate limiting is disabled; KIP-311 requires a bootstrap node to rate limit pings from unknown NodeIds",
+			"flag", utils.BNPingRateLimitFlag.Name)
+	} else if pingRateLimit < 2 {
+		logger.Warn("Discovery ping rate limit is very low; nodes sharing one public IP via NAT may be throttled",
+			"flag", utils.BNPingRateLimitFlag.Name, "value", pingRateLimit)
+	}
+
 	cfg := discover.Config{
 		NetworkID:     bcfg.networkID,
 		PrivateKey:    bcfg.nodeKey,
@@ -147,7 +163,7 @@ func bootnode(ctx *cli.Context) error {
 		Id:            discover.PubkeyID(&bcfg.nodeKey.PublicKey),
 		NodeType:      p2p.ConvertNodeType(common.BOOTNODE),
 		DiscoverTypes: discover.DiscoverTypesConfig{CN: true, PN: true, EN: true},
-		PingRateLimit: float64(ctx.Int(utils.BNPingRateLimitFlag.Name)),
+		PingRateLimit: float64(pingRateLimit),
 		PingBurst:     ctx.Int(utils.BNPingBurstFlag.Name),
 	}
 

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -374,22 +374,26 @@ func convertNodeType(nodetype string) common.ConnType {
 func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 	var urls []string
 	switch {
+	// An explicitly empty value is honored as "no bootnodes" rather than falling
+	// back to the network defaults, so a test or private deployment can start a
+	// node with no seed. Note this also applies to an empty
+	// KLAYTN_BOOTNODES/KAIA_BOOTNODES, which cli reports as set.
 	case ctx.IsSet(BootnodesFlag.Name):
 		logger.Info("Customized bootnodes are set")
 		urls = strings.Split(ctx.String(BootnodesFlag.Name), ",")
 	case ctx.Bool(MainnetFlag.Name):
 		logger.Info("Mainnet bootnodes are set")
-		urls = params.MainnetBootnodes[cfg.ConnectionType].Addrs
+		urls = params.MainnetBootnodes
 	case ctx.Bool(KairosFlag.Name):
 		logger.Info("Kairos bootnodes are set")
 		// set pre-configured bootnodes when 'kairos' option was enabled
-		urls = params.KairosBootnodes[cfg.ConnectionType].Addrs
+		urls = params.KairosBootnodes
 	case cfg.BootstrapNodes != nil:
 		return // already set, don't apply defaults.
 	case !ctx.IsSet(NetworkIdFlag.Name):
 		if NodeTypeFlag.Value != "scn" && NodeTypeFlag.Value != "spn" && NodeTypeFlag.Value != "sen" {
 			logger.Info("Mainnet bootnodes are set")
-			urls = params.MainnetBootnodes[cfg.ConnectionType].Addrs
+			urls = params.MainnetBootnodes
 		}
 	}
 
@@ -406,6 +410,13 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		}
 		logger.Info("Bootnode - Add Seed", "Node", node)
 		cfg.BootstrapNodes = append(cfg.BootstrapNodes, node)
+	}
+
+	// Discovery cannot bootstrap without a seed, so make the condition explicit
+	// instead of leaving it to be inferred from the absence of "Add Seed" lines.
+	if len(cfg.BootstrapNodes) == 0 && !ctx.Bool(NoDiscoverFlag.Name) {
+		logger.Warn("No bootstrap nodes configured; this node may fail to discover peers",
+			"requestedURLs", len(urls))
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -47,6 +47,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// defaultBNPingRateLimit is the default per-source-IP discovery ping rate, in
+// pings/sec, enforced by a bootstrap node. KIP-311 requires BNs to rate limit
+// discovery pings, so the limiter is on by default.
+const defaultBNPingRateLimit = 5
+
 func init() {
 	cli.FlagStringer = FlagString
 }
@@ -1307,9 +1312,14 @@ var (
 		EnvVars: []string{"KLAYTN_BNADDR", "KAIA_BNADDR"},
 	}
 	BNPingRateLimitFlag = &cli.IntFlag{
-		Name:     "bn.ping-ratelimit",
+		Name: "bn.ping-ratelimit",
+		// KIP-311 requires a BN to rate limit discovery pings from unknown NodeIds,
+		// so this defaults to a positive value. A node pings a bootnode at roughly
+		// 1/s and several nodes can share one public IP via NAT, so the default
+		// leaves headroom for a small NAT'd cluster while still cutting a
+		// single-source flood by orders of magnitude.
 		Usage:    "Per-source-IP discovery ping rate limit in pings/sec on a bootstrap node. 0 disables it; LAN/loopback sources are always exempt",
-		Value:    0,
+		Value:    defaultBNPingRateLimit,
 		EnvVars:  []string{"KLAYTN_BN_PING_RATELIMIT", "KAIA_BN_PING_RATELIMIT"},
 		Category: "MISC",
 	}

--- a/networks/p2p/discover/discovery_test.go
+++ b/networks/p2p/discover/discovery_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/params"
@@ -38,8 +37,8 @@ func TestDiscovery_MainnetBootnodes(t *testing.T) {
 	}
 	log.EnableLogForTest(log.LvlCrit, log.LvlDebug)
 
-	// Load mainnet bootnodes for EN users
-	urls := params.MainnetBootnodes[common.ENDPOINTNODE].Addrs
+	// Load mainnet bootnodes. KIP-311 BNs are shared by all node types.
+	urls := params.MainnetBootnodes
 	oldLookupIPFunc := lookupIPFunc
 	lookupIPFunc = net.LookupIP
 	defer func() {

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -22,30 +22,18 @@
 
 package params
 
-import (
-	"github.com/kaiachain/kaia/common"
-)
-
-type bootnodesByTypes struct {
-	Addrs []string
-}
+// KIP-311 defines BN as the single bootstrap role for all node types, replacing
+// the pre-fork role-specific bootstrap nodes. These lists are therefore shared by
+// CN, PN and EN; do not reintroduce a per-node-type split.
 
 // MainnetBootnodes are the URLs of bootnodes running on the Kaia main network.
-var MainnetBootnodes = map[common.ConnType]bootnodesByTypes{
-	common.CONSENSUSNODE: {
-		[]string{
-			"kni://b286e4140aea469992146c299f8915e34d59a014c29a045de41e578014761114176f42dece34a54ce1e37f92ab981fe1bb14e54fe23576e1182778c40e6272a2@ston146.node.kaia.io:32323?ntype=bn",
-			"kni://a6b61ee786952e3f8b681867d2535485622e80d0b9b7b89f26b2c631e59a4246b5f879487fbde7c324c3308ece0cdb1d7738430bdffce4f7f8c4f5a09eef80a3@ston738.node.kaia.io:32323?ntype=bn",
-			"kni://b25838727eb6b4631c8f8910b4f6376fe28041f251ee21129078a61d18d62d0dc2601be5a97eab8bdb5772309f861fddb7192935483813ef20e5716a34266f16@ston903.node.kaia.io:32323?ntype=bn",
-		},
-	},
+var MainnetBootnodes = []string{
+	"kni://b286e4140aea469992146c299f8915e34d59a014c29a045de41e578014761114176f42dece34a54ce1e37f92ab981fe1bb14e54fe23576e1182778c40e6272a2@ston146.node.kaia.io:32323?ntype=bn",
+	"kni://a6b61ee786952e3f8b681867d2535485622e80d0b9b7b89f26b2c631e59a4246b5f879487fbde7c324c3308ece0cdb1d7738430bdffce4f7f8c4f5a09eef80a3@ston738.node.kaia.io:32323?ntype=bn",
+	"kni://b25838727eb6b4631c8f8910b4f6376fe28041f251ee21129078a61d18d62d0dc2601be5a97eab8bdb5772309f861fddb7192935483813ef20e5716a34266f16@ston903.node.kaia.io:32323?ntype=bn",
 }
 
 // KairosBootnodes are the URLs of bootnodes running on the Kairos network.
-var KairosBootnodes = map[common.ConnType]bootnodesByTypes{
-	common.CONSENSUSNODE: {
-		[]string{
-			"kni://979159c738bb0c8c60b36267c56d2b4d4a995326be666460c3d612856caab522ebe6f81ea5cdbb605051f12cbf8f787ce0f172256545a5b3400c751afbdcd0c8@ston36-kairos.node.kaia.io:32323?discport=32323&ntype=bn",
-		},
-	},
+var KairosBootnodes = []string{
+	"kni://979159c738bb0c8c60b36267c56d2b4d4a995326be666460c3d612856caab522ebe6f81ea5cdbb605051f12cbf8f787ce0f172256545a5b3400c751afbdcd0c8@ston36-kairos.node.kaia.io:32323?discport=32323&ntype=bn",
 }

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -33,7 +33,11 @@ type bootnodesByTypes struct {
 // MainnetBootnodes are the URLs of bootnodes running on the Kaia main network.
 var MainnetBootnodes = map[common.ConnType]bootnodesByTypes{
 	common.CONSENSUSNODE: {
-		[]string{},
+		[]string{
+			"kni://b286e4140aea469992146c299f8915e34d59a014c29a045de41e578014761114176f42dece34a54ce1e37f92ab981fe1bb14e54fe23576e1182778c40e6272a2@ston146.node.kaia.io:32323?ntype=bn",
+			"kni://a6b61ee786952e3f8b681867d2535485622e80d0b9b7b89f26b2c631e59a4246b5f879487fbde7c324c3308ece0cdb1d7738430bdffce4f7f8c4f5a09eef80a3@ston738.node.kaia.io:32323?ntype=bn",
+			"kni://b25838727eb6b4631c8f8910b4f6376fe28041f251ee21129078a61d18d62d0dc2601be5a97eab8bdb5772309f861fddb7192935483813ef20e5716a34266f16@ston903.node.kaia.io:32323?ntype=bn",
+		},
 	},
 	common.PROXYNODE: {
 		[]string{
@@ -54,7 +58,9 @@ var MainnetBootnodes = map[common.ConnType]bootnodesByTypes{
 // KairosBootnodes are the URLs of bootnodes running on the Kairos network.
 var KairosBootnodes = map[common.ConnType]bootnodesByTypes{
 	common.CONSENSUSNODE: {
-		[]string{},
+		[]string{
+			"kni://979159c738bb0c8c60b36267c56d2b4d4a995326be666460c3d612856caab522ebe6f81ea5cdbb605051f12cbf8f787ce0f172256545a5b3400c751afbdcd0c8@ston36-kairos.node.kaia.io:32323?discport=32323&ntype=bn",
+		},
 	},
 	common.PROXYNODE: {
 		[]string{

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -39,20 +39,6 @@ var MainnetBootnodes = map[common.ConnType]bootnodesByTypes{
 			"kni://b25838727eb6b4631c8f8910b4f6376fe28041f251ee21129078a61d18d62d0dc2601be5a97eab8bdb5772309f861fddb7192935483813ef20e5716a34266f16@ston903.node.kaia.io:32323?ntype=bn",
 		},
 	},
-	common.PROXYNODE: {
-		[]string{
-			"kni://18b36118cce093673499fc6e9aa196f047fe17a0de35b6f2a76a4557802f6abf9f89aa5e7330e93c9014b714b9df6378393611efe39aec9d3d831d6aa9d617ae@ston65.node.kaia.io:32323?ntype=bn",
-			"kni://63f1c96874da85140ecca3ce24875cb5ef28fa228bc3572e16f690db4a48fc8067502d2f6e8f0c66fb558276a5ada1e4906852c7ae42b0003e9f9f25d1e123b1@ston873.node.kaia.io:32323?ntype=bn",
-			"kni://94cc15e2014b86584908707de55800c0a2ea8a24dc5550dcb507043e4cf18ff04f21dc86ed17757dc63b1fa85bb418b901e5e24e4197ad4bbb0d96cd9389ed98@ston106.node.kaia.io:32323?ntype=bn",
-		},
-	},
-	common.ENDPOINTNODE: {
-		[]string{
-			"kni://18b36118cce093673499fc6e9aa196f047fe17a0de35b6f2a76a4557802f6abf9f89aa5e7330e93c9014b714b9df6378393611efe39aec9d3d831d6aa9d617ae@ston65.node.kaia.io:32323?ntype=bn",
-			"kni://63f1c96874da85140ecca3ce24875cb5ef28fa228bc3572e16f690db4a48fc8067502d2f6e8f0c66fb558276a5ada1e4906852c7ae42b0003e9f9f25d1e123b1@ston873.node.kaia.io:32323?ntype=bn",
-			"kni://94cc15e2014b86584908707de55800c0a2ea8a24dc5550dcb507043e4cf18ff04f21dc86ed17757dc63b1fa85bb418b901e5e24e4197ad4bbb0d96cd9389ed98@ston106.node.kaia.io:32323?ntype=bn",
-		},
-	},
 }
 
 // KairosBootnodes are the URLs of bootnodes running on the Kairos network.
@@ -60,16 +46,6 @@ var KairosBootnodes = map[common.ConnType]bootnodesByTypes{
 	common.CONSENSUSNODE: {
 		[]string{
 			"kni://979159c738bb0c8c60b36267c56d2b4d4a995326be666460c3d612856caab522ebe6f81ea5cdbb605051f12cbf8f787ce0f172256545a5b3400c751afbdcd0c8@ston36-kairos.node.kaia.io:32323?discport=32323&ntype=bn",
-		},
-	},
-	common.PROXYNODE: {
-		[]string{
-			"kni://779d766628247ebda5f3e108e9303bd8efdb8eba9fd8d6c529e2614aec7207ebf6614fe7e61d0d99b75e8b23dd3a679b112fd0de7e4e71a7008f0718710da48f@ston45-kairos.node.kaia.io:32323?ntype=bn",
-		},
-	},
-	common.ENDPOINTNODE: {
-		[]string{
-			"kni://779d766628247ebda5f3e108e9303bd8efdb8eba9fd8d6c529e2614aec7207ebf6614fe7e61d0d99b75e8b23dd3a679b112fd0de7e4e71a7008f0718710da48f@ston45-kairos.node.kaia.io:32323?ntype=bn",
 		},
 	},
 }


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<details>

<summary>CNBN test</summary>

This test should succeed after setting up the CNBNs.

```go
func TestCNBNLiveCheck(t *testing.T) {
	if os.Getenv("P2P_CNBN_LIVE_CHECK") == "" {
		t.Skip("skipping CNBN live check")
	}
	log.EnableLogForTest(log.LvlCrit, log.LvlError)

	oldLookupIPFunc := lookupIPFunc
	lookupIPFunc = net.LookupIP
	defer func() { lookupIPFunc = oldLookupIPFunc }()

	cases := []struct {
		name      string
		networkID uint64
		urls      []string
	}{
		{
			name:      "control-old-mainnet-bn",
			networkID: params.MainnetNetworkId,
			urls: []string{
				"kni://18b36118cce093673499fc6e9aa196f047fe17a0de35b6f2a76a4557802f6abf9f89aa5e7330e93c9014b714b9df6378393611efe39aec9d3d831d6aa9d617ae@ston65.node.kaia.io:32323?ntype=bn",
				"kni://63f1c96874da85140ecca3ce24875cb5ef28fa228bc3572e16f690db4a48fc8067502d2f6e8f0c66fb558276a5ada1e4906852c7ae42b0003e9f9f25d1e123b1@ston873.node.kaia.io:32323?ntype=bn",
				"kni://94cc15e2014b86584908707de55800c0a2ea8a24dc5550dcb507043e4cf18ff04f21dc86ed17757dc63b1fa85bb418b901e5e24e4197ad4bbb0d96cd9389ed98@ston106.node.kaia.io:32323?ntype=bn",
			},
		},
		{
			name:      "control-old-kairos-bn",
			networkID: params.KairosNetworkId,
			urls: []string{
				"kni://779d766628247ebda5f3e108e9303bd8efdb8eba9fd8d6c529e2614aec7207ebf6614fe7e61d0d99b75e8b23dd3a679b112fd0de7e4e71a7008f0718710da48f@ston45-kairos.node.kaia.io:32323?ntype=bn",
			},
		},
		{
			name:      "mainnet",
			networkID: params.MainnetNetworkId,
			urls: []string{
				"kni://b286e4140aea469992146c299f8915e34d59a014c29a045de41e578014761114176f42dece34a54ce1e37f92ab981fe1bb14e54fe23576e1182778c40e6272a2@ston146.node.kaia.io:32323?ntype=bn",
				"kni://a6b61ee786952e3f8b681867d2535485622e80d0b9b7b89f26b2c631e59a4246b5f879487fbde7c324c3308ece0cdb1d7738430bdffce4f7f8c4f5a09eef80a3@ston738.node.kaia.io:32323?ntype=bn",
				"kni://b25838727eb6b4631c8f8910b4f6376fe28041f251ee21129078a61d18d62d0dc2601be5a97eab8bdb5772309f861fddb7192935483813ef20e5716a34266f16@ston903.node.kaia.io:32323?ntype=bn",
			},
		},
		{
			name:      "kairos",
			networkID: params.KairosNetworkId,
			urls: []string{
				"kni://979159c738bb0c8c60b36267c56d2b4d4a995326be666460c3d612856caab522ebe6f81ea5cdbb605051f12cbf8f787ce0f172256545a5b3400c751afbdcd0c8@ston36-kairos.node.kaia.io:32323?discport=32323&ntype=bn",
			},
		},
	}

	for _, tc := range cases {
		t.Run(tc.name, func(t *testing.T) {
			nodes := make([]*Node, 0, len(tc.urls))
			for _, u := range tc.urls {
				n, err := ParseNode(u)
				require.NoError(t, err, "parse %s", u)
				nodes = append(nodes, n)
			}

			key, err := crypto.GenerateKey()
			require.NoError(t, err)
			udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
			require.NoError(t, err)
			defer udpConn.Close()

			cfg := &Config{
				NetworkID:  tc.networkID,
				PrivateKey: key,
				Bootnodes:  nodes,
				Id:         PubkeyID(&key.PublicKey),
				Addr:       udpConn.LocalAddr().(*net.UDPAddr),
				Conn:       udpConn,
				NodeType:   NodeTypeCN,
				DiscoverTypes: DiscoverTypesConfig{
					CN: true,
				},
			}
			disc, err := NewDiscovery2(cfg)
			require.NoError(t, err)
			defer disc.Close()
			d := disc.(*discovery2)

			for _, n := range nodes {
				host := fmt.Sprintf("%s:%d", n.IP, n.UDP)

				// 1. TCP reachability of the p2p port
				tcpConn, tcpErr := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", n.IP, n.TCP), 5*time.Second)
				if tcpErr == nil {
					tcpConn.Close()
				}

				// 2. Discovery PING -> PONG (validates node ID, since pending replies are keyed by ID)
				start := time.Now()
				pingErr := d.udp.ping(n.ID, n.addr())
				pingDur := time.Since(start)

				// 3. Full 4-way bond
				bondErr := d.tab.Bond(false, n)

				t.Logf("%s %x@%s tcp=%v ping=%v (%v) bond=%v",
					tc.name, n.ID[:8], host, errStr(tcpErr), errStr(pingErr), pingDur.Round(time.Millisecond), errStr(bondErr))
			}
		})
	}
}
```

</details>