### PR TITLE
kaiax/vrank: move the score APIs to the governance namespace

### DIFF
--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -363,6 +363,18 @@ web3._extend({
 			call: 'governance_getRewardsAccumulated',
 			params: 2,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getPFS',
+			call: 'governance_getPFS',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getCFS',
+			call: 'governance_getCFS',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		})
 	],
 	properties: [
@@ -1177,18 +1189,6 @@ var klayMethods = [
 	new web3._extend.Method({
 		name: 'isConsoleLogEnabled',
 		call: 'klay_isConsoleLogEnabled',
-	}),
-	new web3._extend.Method({
-		name: 'getPFS',
-		call: 'kaia_getPFS',
-		params: 1,
-		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
-	}),
-	new web3._extend.Method({
-		name: 'getCFS',
-		call: 'kaia_getCFS',
-		params: 1,
-		inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter],
 	}),
 ];
 `

--- a/kaiax/vrank/impl/api.go
+++ b/kaiax/vrank/impl/api.go
@@ -24,32 +24,32 @@ import (
 func (v *VRankModule) APIs() []rpc.API {
 	return []rpc.API{
 		{
-			Namespace: "kaia",
+			Namespace: "governance",
 			Version:   "1.0",
-			Service:   &VRankKaiaAPI{v: v},
+			Service:   &VRankGovernanceAPI{v: v},
 			Public:    true,
 		},
 	}
 }
 
-// VRankKaiaAPI defines the kaia namespace APIs for VRank scores.
-type VRankKaiaAPI struct {
+// VRankGovernanceAPI defines the governance namespace APIs for VRank scores.
+type VRankGovernanceAPI struct {
 	v *VRankModule
 }
 
 // GetPFS returns the Proposal Failure Scores for all validators at the given block number.
-func (api *VRankKaiaAPI) GetPFS(num *rpc.BlockNumber) (map[common.Address]uint64, error) {
+func (api *VRankGovernanceAPI) GetPFS(num *rpc.BlockNumber) (map[common.Address]uint64, error) {
 	blockNum := api.resolveBlockNum(num)
 	return api.v.GetPFS(blockNum)
 }
 
 // GetCFS returns the Consensus Failure Scores for all validators at the given block number.
-func (api *VRankKaiaAPI) GetCFS(num *rpc.BlockNumber) (map[common.Address]uint64, error) {
+func (api *VRankGovernanceAPI) GetCFS(num *rpc.BlockNumber) (map[common.Address]uint64, error) {
 	blockNum := api.resolveBlockNum(num)
 	return api.v.GetCFS(blockNum)
 }
 
-func (api *VRankKaiaAPI) resolveBlockNum(num *rpc.BlockNumber) uint64 {
+func (api *VRankGovernanceAPI) resolveBlockNum(num *rpc.BlockNumber) uint64 {
 	if num == nil || *num == rpc.LatestBlockNumber || *num == rpc.PendingBlockNumber {
 		return api.v.Chain.CurrentHeader().Number.Uint64()
 	}

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -622,7 +622,7 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 		}
 	}
 
-	// VRank exposes the kaia_getCFS / kaia_getPFS JSON-RPC APIs on all node types.
+	// VRank exposes the governance_getCFS / governance_getPFS JSON-RPC APIs on all node types.
 	mJsonRpc = append(mJsonRpc, mVRank)
 
 	// Register modules to respective components


### PR DESCRIPTION
## Proposed changes

- `getPFS`/`getCFS` move from the `kaia` namespace to `governance`, console bindings with them.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
