### PR TITLE
console, api: drop the removed bootnode authorizedNodes references

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -303,29 +303,15 @@ CN filter operations for events and logs
 
 ## Bootnode APIs
 
-### cmd/kbn/api_bootnode.go (BootnodeAPI)
+### networks/p2p/discover/discovery_api.go (DiscoveryAPI)
 
-Bootnode operations
+Discovery table operations
 
-- `bootnode_getAuthorizedNodes`
-
-### cmd/kbn/api_bootnode_registry.go (BootnodeRegistryAPI)
-
-Bootnode registry operations
-
-- `bootnode_createUpdateNodeOnDB`
-- `bootnode_createUpdateNodeOnTable`
-- `bootnode_deleteAuthorizedNodes`
-- `bootnode_deleteNodeFromDB`
-- `bootnode_deleteNodeFromTable`
-- `bootnode_getNodeFromDB`
-- `bootnode_getTableEntries`
-- `bootnode_getTableReplacements`
-- `bootnode_lookup`
-- `bootnode_name`
-- `bootnode_putAuthorizedNodes`
-- `bootnode_readRandomNodes`
-- `bootnode_resolve`
+- `bootnode_refresh`
+- `bootnode_nodes`
+- `bootnode_getNode`
+- `bootnode_putNode`
+- `bootnode_deleteNode`
 
 ## DataSync APIs
 

--- a/console/web3ext/web3ext.go
+++ b/console/web3ext/web3ext.go
@@ -304,21 +304,6 @@ web3._extend({
 			name: 'deleteNode',
 			call: 'bootnode_deleteNode',
 			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'getAuthorizedNodes',
-			call: 'bootnode_getAuthorizedNodes',
-			params: 0
-		}),
-		new web3._extend.Method({
-			name: 'putAuthorizedNodes',
-			call: 'bootnode_putAuthorizedNodes',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'deleteAuthorizedNodes',
-			call: 'bootnode_deleteAuthorizedNodes',
-			params: 1
 		})
 	],
 	properties: []


### PR DESCRIPTION
## Proposed changes

The bootnode `authorizedNodes` handlers were removed in `4879302d5`, but the console still advertises `bootnode_{get,put,delete}AuthorizedNodes` and `api/README.md` still lists them under two `cmd/kbn` files that no longer exist. Drops both, and replaces the README section with `DiscoveryAPI`'s five actual methods.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
