### PR TITLE
kaiax/valset: break epoch stake ties by higher address

### DIFF
--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -218,7 +218,7 @@ func (ctx *TransitionContext) applyEpochTransition(m valset.NodeMap) valset.Node
 	slices.SortFunc(activeValCompetitors, func(a, b sortableValidator) int {
 		return cmp.Or(
 			cmp.Compare(b.StakingAmount, a.StakingAmount),
-			bytes.Compare(a.addr[:], b.addr[:]), // tie-breaking: address order
+			bytes.Compare(b.addr[:], a.addr[:]), // tie-breaking: higher address first, per KIP-286
 		)
 	})
 	for idx, potentialActiveVal := range activeValCompetitors {

--- a/kaiax/valset/impl/transition_context_test.go
+++ b/kaiax/valset/impl/transition_context_test.go
@@ -245,10 +245,10 @@ func TestApplyEpochTransition_TieBreakingByAddress(t *testing.T) {
 	ctx := epochCtx(t, nil, 2)
 	out := ctx.applyEpochTransition(m)
 
-	// addr1 (0x0001) < addr2 (0x0002) < addr3 (0x0003)
-	assert.Equal(t, ValActive, out[addr1].State)
+	// addr3 (0x0003) > addr2 (0x0002) > addr1 (0x0001)
+	assert.Equal(t, ValActive, out[addr3].State)
 	assert.Equal(t, ValActive, out[addr2].State)
-	assert.Equal(t, ValInactive, out[addr3].State)
+	assert.Equal(t, ValInactive, out[addr1].State)
 }
 
 func TestApplyEpochTransition_DefensiveCopy(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

The epoch tie-break ranked the lower address first, while KIP-286 sorts `(stake, address)` with `reverse=True` — equal stakes rank the higher address first.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
