### PR TITLE
node/cn: reject consensus messages from non-CN peers

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -720,6 +720,9 @@ func (pm *ProtocolManager) handleMsg(p Peer, addr common.Address, msg p2p.Msg) e
 	//}
 	//addr := crypto.PubkeyToAddress(*pubKey)
 	if msg.Code == consensus.ConsensusMsgCode {
+		if p.ConnType() != common.CONSENSUSNODE {
+			return errResp(ErrInvalidMsgCode, "consensus message from a non-CN peer: conntype %d", p.ConnType())
+		}
 		if pm.handler == nil {
 			return nil
 		}

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
+	"github.com/kaiachain/kaia/consensus"
+	"github.com/kaiachain/kaia/consensus/bft"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/kzg4844"
@@ -77,6 +79,47 @@ func prepareTestHandleNewBlockMsg(t *testing.T, mockCtrl *gomock.Controller, blo
 	mockFetcher.EXPECT().Enqueue(nodeids[0].String(), newBlock).Times(1)
 
 	return newBlock, msg, mockPeer, mockFetcher
+}
+
+// countingConsensusHandler records how many messages reached the consensus engine.
+type countingConsensusHandler struct{ calls int }
+
+func (h *countingConsensusHandler) NewChainHead() error                  { return nil }
+func (h *countingConsensusHandler) SetBroadcaster(consensus.Broadcaster) {}
+
+func (h *countingConsensusHandler) HandleMsg(common.Address, p2p.Msg) (bool, error) {
+	h.calls++
+	return true, nil
+}
+
+func TestHandleConsensusMsgFromNonCNPeer(t *testing.T) {
+	tcs := []struct {
+		name      string
+		connType  common.ConnType
+		wantErr   bool
+		wantCalls int
+	}{
+		{"cn", common.CONSENSUSNODE, false, 1},
+		{"en", common.ENDPOINTNODE, true, 0},
+		{"pn", common.PROXYNODE, true, 0},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockPeer := NewMockPeer(mockCtrl)
+			mockPeer.EXPECT().ConnType().Return(tc.connType).AnyTimes()
+
+			handler := &countingConsensusHandler{}
+			pm := &ProtocolManager{handler: handler}
+			msg := generateMsg(t, consensus.ConsensusMsgCode, &bft.ConsensusMsg{})
+
+			err := pm.handleMsg(mockPeer, addrs[0], msg)
+			assert.Equal(t, tc.wantErr, err != nil, "err: %v", err)
+			assert.Equal(t, tc.wantCalls, handler.calls)
+		})
+	}
 }
 
 func prepareDownloader(t *testing.T) (*gomock.Controller, *mocks2.MockProtocolManagerDownloader, *MockPeer, *ProtocolManager) {

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -1367,7 +1367,7 @@ func (p *multiChannelPeer) Handle(pm *ProtocolManager) error {
 	var consensusChannel chan p2p.Msg
 	isCN := false
 
-	if pm.handler != nil && pm.nodetype == common.CONSENSUSNODE {
+	if pm.handler != nil && pm.nodetype == common.CONSENSUSNODE && p.ConnType() == common.CONSENSUSNODE {
 		consensusChannel = make(chan p2p.Msg, channelSizePerPeer)
 		defer close(consensusChannel)
 		if err := p.RegisterConsensusMsgCode(consensus.ConsensusMsgCode); err != nil {


### PR DESCRIPTION
## Proposed changes

A peer declaring `ConnType` EN or PN skips the `CNPeers` check, but both message routers still forwarded `ConsensusMsgCode` to the Istanbul backend, which detaches the payload with `go Post` and returns success. Both routers now require the remote peer to be a CN.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
