### PR TITLE
fix(blockchain/types): bound transaction signature lists

### DIFF
--- a/api/api_kaia_transaction.go
+++ b/api/api_kaia_transaction.go
@@ -615,6 +615,8 @@ func (s *KaiaTransactionAPI) RecoverFromTransaction(ctx context.Context, encoded
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Address{}, err
 	}
+	// NOTE: Deliberately not fork-gated because the block number is
+	// caller-supplied, so gating on it would let the caller bypass the limit.
 	if err := tx.ValidateSignatureListLength(); err != nil {
 		return common.Address{}, err
 	}

--- a/api/api_kaia_transaction.go
+++ b/api/api_kaia_transaction.go
@@ -615,6 +615,9 @@ func (s *KaiaTransactionAPI) RecoverFromTransaction(ctx context.Context, encoded
 	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
 		return common.Address{}, err
 	}
+	if err := tx.ValidateSignatureListLength(); err != nil {
+		return common.Address{}, err
+	}
 
 	state, header, err := s.b.StateAndHeaderByNumber(ctx, blockNumber)
 	if err != nil {

--- a/api/api_kaia_transaction_test.go
+++ b/api/api_kaia_transaction_test.go
@@ -12,11 +12,16 @@ import (
 	mock_accounts "github.com/kaiachain/kaia/accounts/mocks"
 	mock_api "github.com/kaiachain/kaia/api/mocks"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/hexutil"
 	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kerrors"
+	"github.com/kaiachain/kaia/networks/rpc"
 	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/rlp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // test tx types and internal data to be supported by APIs in KaiaTransactionAPI.
@@ -156,6 +161,31 @@ func TestTxTypeSupport(t *testing.T) {
 		testTxTypeSupport_noFieldValues(t, api, ctx, args)
 		testTxTypeSupport_unnecessaryFieldValues(t, api, ctx, args)
 	}
+}
+
+func TestRecoverFromTransactionRejectsOversizedSignatureList(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	api := KaiaTransactionAPI{b: mock_api.NewMockBackend(mockCtrl)}
+
+	txData := &types.TxInternalDataFeeDelegatedValueTransfer{
+		Price:     big.NewInt(1),
+		GasLimit:  21000,
+		Amount:    big.NewInt(0),
+		From:      common.Address{1},
+		FeePayer:  common.Address{2},
+		Recipient: common.Address{},
+	}
+	sig := &types.TxSignature{V: big.NewInt(37), R: big.NewInt(1), S: big.NewInt(1)}
+	txData.SetSignature(types.TxSignatures{sig})
+	txData.SetFeePayerSignatures(make(types.TxSignatures, accountkey.MaxNumKeysForMultiSig+1))
+	for i := range txData.GetFeePayerRawSignatureValues() {
+		txData.GetFeePayerRawSignatureValues()[i] = sig
+	}
+
+	encodedTx, err := rlp.EncodeToBytes(types.NewTx(txData))
+	require.NoError(t, err)
+	_, err = api.RecoverFromTransaction(context.Background(), encodedTx, rpc.LatestBlockNumber)
+	require.ErrorIs(t, err, kerrors.ErrMaxKeysExceed)
 }
 
 // testTxTypeSupport_normalCase tests APIs with proper SendTxArgs values.

--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -795,6 +795,10 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction) error {
+	if err := tx.ValidateSignatureListLength(); err != nil {
+		return err
+	}
+
 	// Accept only legacy transactions until EIP-2718/2930 activates.
 	if !pool.rules.IsEthTxType && tx.IsEthTypedTransaction() {
 		return ErrTxTypeNotSupported
@@ -1368,7 +1372,7 @@ func (pool *TxPool) HandleTxMsg(txs types.Transactions) {
 	}
 
 	// TODO-Kaia: Consider removing the next line and move the above logic to `addTx` or `AddRemotes`
-	senderCacher.recover(pool.signer, txs)
+	pool.recoverSenders(txs)
 	pool.txMsgCh <- txs
 }
 
@@ -1542,7 +1546,7 @@ func (pool *TxPool) checkAndAddTxs(txs []*types.Transaction, local bool) []error
 
 // addTx enqueues a single transaction into the pool if it is valid.
 func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
-	senderCacher.recover(pool.signer, []*types.Transaction{tx})
+	pool.recoverSenders([]*types.Transaction{tx})
 
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
@@ -1562,12 +1566,25 @@ func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
 
 // addTxs attempts to queue a batch of transactions if they are valid.
 func (pool *TxPool) addTxs(txs []*types.Transaction, local bool) []error {
-	senderCacher.recover(pool.signer, txs)
+	pool.recoverSenders(txs)
 
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
 	return pool.addTxsLocked(txs, local)
+}
+
+// recoverSenders avoids ecrecover work for transactions that exceed the
+// signature-list limit accepted by the transaction pool. Block processing uses
+// senderCacher directly so historical transactions remain replayable.
+func (pool *TxPool) recoverSenders(txs []*types.Transaction) {
+	validTxs := make([]*types.Transaction, 0, len(txs))
+	for _, tx := range txs {
+		if tx.ValidateSignatureListLength() == nil {
+			validTxs = append(validTxs, tx)
+		}
+	}
+	senderCacher.recover(pool.signer, validTxs)
 }
 
 // addTxsLocked attempts to queue a batch of transactions if they are valid,

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/kaiachain/kaia/blockchain/state"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/types/accountkey"
 	"github.com/kaiachain/kaia/blockchain/vm"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
@@ -49,6 +50,7 @@ import (
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/fork"
 	"github.com/kaiachain/kaia/kaiax/gov"
+	"github.com/kaiachain/kaia/kerrors"
 	"github.com/kaiachain/kaia/params"
 	"github.com/kaiachain/kaia/rlp"
 	"github.com/kaiachain/kaia/storage/database"
@@ -320,6 +322,14 @@ func feeDelegatedWithRatioTx(nonce uint64, gaslimit uint64, gasPrice *big.Int, a
 	return signedTx
 }
 
+func signaturesWithLength(sig *types.TxSignature, length int) types.TxSignatures {
+	sigs := make(types.TxSignatures, length)
+	for i := range sigs {
+		sigs[i] = sig
+	}
+	return sigs
+}
+
 func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 	return setupTxPoolWithConfig(params.TestChainConfig)
 }
@@ -338,6 +348,26 @@ func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateK
 	pool := NewTxPool(testTxPoolConfig, config, blockchain, &dummyGovModule{chainConfig: config})
 
 	return pool, key
+}
+
+func TestTxPoolRejectsOversizedSignatureLists(t *testing.T) {
+	pool, senderKey := setupTxPool()
+	defer pool.Stop()
+
+	feePayerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	maxSignatures := int(accountkey.MaxNumKeysForMultiSig)
+
+	senderTx := feeDelegatedTx(0, 21000, big.NewInt(1), big.NewInt(0), senderKey, feePayerKey)
+	senderTx.SetSignature(signaturesWithLength(senderTx.RawSignatureValues()[0], maxSignatures+1))
+	require.ErrorIs(t, pool.AddRemote(senderTx), kerrors.ErrMaxKeysExceed)
+
+	feePayerTx := feeDelegatedTx(1, 21000, big.NewInt(1), big.NewInt(0), senderKey, feePayerKey)
+	feePayerSignatures, err := feePayerTx.GetFeePayerSignatures()
+	require.NoError(t, err)
+	require.NoError(t, feePayerTx.SetFeePayerSignatures(signaturesWithLength(feePayerSignatures[0], maxSignatures+1)))
+	require.ErrorIs(t, pool.AddRemote(feePayerTx), kerrors.ErrMaxKeysExceed)
+	require.Zero(t, pool.all.Count())
 }
 
 func setupTxPoolWithBlobStorage(t *testing.T) (*TxPool, *testBlockChain, *ecdsa.PrivateKey, string) {

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -236,6 +236,22 @@ func (tx *Transaction) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// sanityCheckTransactionSignatureLists validates the sender signatures and
+// bounds the fee-payer signature list. Fee-payer signature values are validated
+// later because fee-delegated transactions may be decoded before the fee payer
+// signs.
+func sanityCheckTransactionSignatureLists(tx TxInternalData) bool {
+	if !SanityCheckSignatures(tx.RawSignatureValues(), tx.Type()) {
+		return false
+	}
+
+	if feePayerTx, ok := tx.(TxInternalDataFeePayer); ok {
+		return hasValidSignatureListLength(feePayerTx.GetFeePayerRawSignatureValues())
+	}
+
+	return true
+}
+
 // DecodeRLP implements rlp.Decoder
 func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 	serializer := newTxInternalDataSerializer()
@@ -243,7 +259,7 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 
-	if !SanityCheckSignatures(serializer.tx.RawSignatureValues(), serializer.tx.Type()) {
+	if !sanityCheckTransactionSignatureLists(serializer.tx) {
 		return ErrInvalidSig
 	}
 
@@ -280,7 +296,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, serializer); err != nil {
 		return err
 	}
-	if !SanityCheckSignatures(serializer.tx.RawSignatureValues(), serializer.tx.Type()) {
+	if !sanityCheckTransactionSignatureLists(serializer.tx) {
 		return ErrInvalidSig
 	}
 

--- a/blockchain/types/transaction.go
+++ b/blockchain/types/transaction.go
@@ -236,22 +236,6 @@ func (tx *Transaction) MarshalBinary() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-// sanityCheckTransactionSignatureLists validates the sender signatures and
-// bounds the fee-payer signature list. Fee-payer signature values are validated
-// later because fee-delegated transactions may be decoded before the fee payer
-// signs.
-func sanityCheckTransactionSignatureLists(tx TxInternalData) bool {
-	if !SanityCheckSignatures(tx.RawSignatureValues(), tx.Type()) {
-		return false
-	}
-
-	if feePayerTx, ok := tx.(TxInternalDataFeePayer); ok {
-		return hasValidSignatureListLength(feePayerTx.GetFeePayerRawSignatureValues())
-	}
-
-	return true
-}
-
 // DecodeRLP implements rlp.Decoder
 func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 	serializer := newTxInternalDataSerializer()
@@ -259,7 +243,7 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 
-	if !sanityCheckTransactionSignatureLists(serializer.tx) {
+	if !SanityCheckSignatures(serializer.tx.RawSignatureValues(), serializer.tx.Type()) {
 		return ErrInvalidSig
 	}
 
@@ -296,7 +280,7 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	if err := json.Unmarshal(input, serializer); err != nil {
 		return err
 	}
-	if !sanityCheckTransactionSignatureLists(serializer.tx) {
+	if !SanityCheckSignatures(serializer.tx.RawSignatureValues(), serializer.tx.Type()) {
 		return ErrInvalidSig
 	}
 
@@ -902,6 +886,21 @@ func (tx *Transaction) IsMarkedUnexecutable() bool {
 
 func (tx *Transaction) RawSignatureValues() TxSignatures {
 	return tx.data.RawSignatureValues()
+}
+
+// ValidateSignatureListLength checks the signature-list limit applied to
+// untrusted transaction ingress. It must not be used while decoding or
+// executing blocks because pre-Istanbul blocks may contain longer lists.
+func (tx *Transaction) ValidateSignatureListLength() error {
+	if uint64(len(tx.RawSignatureValues())) > accountkey.MaxNumKeysForMultiSig {
+		return kerrors.ErrMaxKeysExceed
+	}
+
+	if feePayerTx, ok := tx.data.(TxInternalDataFeePayer); ok && uint64(len(feePayerTx.GetFeePayerRawSignatureValues())) > accountkey.MaxNumKeysForMultiSig {
+		return kerrors.ErrMaxKeysExceed
+	}
+
+	return nil
 }
 
 func (tx *Transaction) String() string {

--- a/blockchain/types/tx_signatures.go
+++ b/blockchain/types/tx_signatures.go
@@ -38,13 +38,6 @@ var ErrShouldBeSingleSignature = errors.New("the number of signatures should be 
 // TODO-Kaia-Accounts: replace TxSignature with TxSignatures to all newly implemented tx types.
 type TxSignatures []*TxSignature
 
-// hasValidSignatureListLength reports whether the signature list can be
-// satisfied by a supported multisig account. Empty lists are allowed here so
-// callers can decide whether a signature is required in their context.
-func hasValidSignatureListLength(sigs TxSignatures) bool {
-	return uint64(len(sigs)) <= accountkey.MaxNumKeysForMultiSig
-}
-
 func NewTxSignatures() TxSignatures {
 	return TxSignatures{NewTxSignature()}
 }
@@ -139,10 +132,6 @@ func (t TxSignatures) RecoverAddress(txhash common.Hash, homestead bool, vfunc f
 }
 
 func (t TxSignatures) RecoverPubkey(txhash common.Hash, homestead bool, vfunc func(*big.Int) *big.Int) ([]*ecdsa.PublicKey, error) {
-	if !hasValidSignatureListLength(t) {
-		return nil, kerrors.ErrMaxKeysExceed
-	}
-
 	var err error
 
 	pubkeys := make([]*ecdsa.PublicKey, len(t))
@@ -188,7 +177,7 @@ func (t TxSignaturesJSON) ToTxSignatures() TxSignatures {
 // SanityCheckSignatures validates whether the signature values are valid.
 // It checks the signatures from the given TxSignatures.
 func SanityCheckSignatures(sigs TxSignatures, txType TxType) bool {
-	if len(sigs) == 0 || !hasValidSignatureListLength(sigs) {
+	if len(sigs) == 0 {
 		return false
 	}
 

--- a/blockchain/types/tx_signatures.go
+++ b/blockchain/types/tx_signatures.go
@@ -38,6 +38,13 @@ var ErrShouldBeSingleSignature = errors.New("the number of signatures should be 
 // TODO-Kaia-Accounts: replace TxSignature with TxSignatures to all newly implemented tx types.
 type TxSignatures []*TxSignature
 
+// hasValidSignatureListLength reports whether the signature list can be
+// satisfied by a supported multisig account. Empty lists are allowed here so
+// callers can decide whether a signature is required in their context.
+func hasValidSignatureListLength(sigs TxSignatures) bool {
+	return uint64(len(sigs)) <= accountkey.MaxNumKeysForMultiSig
+}
+
 func NewTxSignatures() TxSignatures {
 	return TxSignatures{NewTxSignature()}
 }
@@ -132,6 +139,10 @@ func (t TxSignatures) RecoverAddress(txhash common.Hash, homestead bool, vfunc f
 }
 
 func (t TxSignatures) RecoverPubkey(txhash common.Hash, homestead bool, vfunc func(*big.Int) *big.Int) ([]*ecdsa.PublicKey, error) {
+	if !hasValidSignatureListLength(t) {
+		return nil, kerrors.ErrMaxKeysExceed
+	}
+
 	var err error
 
 	pubkeys := make([]*ecdsa.PublicKey, len(t))
@@ -177,7 +188,7 @@ func (t TxSignaturesJSON) ToTxSignatures() TxSignatures {
 // SanityCheckSignatures validates whether the signature values are valid.
 // It checks the signatures from the given TxSignatures.
 func SanityCheckSignatures(sigs TxSignatures, txType TxType) bool {
-	if len(sigs) == 0 {
+	if len(sigs) == 0 || !hasValidSignatureListLength(sigs) {
 		return false
 	}
 

--- a/blockchain/types/tx_signatures_test.go
+++ b/blockchain/types/tx_signatures_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/kaiachain/kaia/blockchain/types/accountkey"
-	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kerrors"
 	"github.com/kaiachain/kaia/rlp"
 	"github.com/stretchr/testify/require"
@@ -49,65 +48,65 @@ func TestSanityCheckSignaturesLength(t *testing.T) {
 	require.False(t, SanityCheckSignatures(nil, TxTypeValueTransfer))
 	require.True(t, SanityCheckSignatures(validTestSignatures(1), TxTypeValueTransfer))
 	require.True(t, SanityCheckSignatures(validTestSignatures(maxSignatures), TxTypeValueTransfer))
-	require.False(t, SanityCheckSignatures(validTestSignatures(maxSignatures+1), TxTypeValueTransfer))
+	require.True(t, SanityCheckSignatures(validTestSignatures(maxSignatures+1), TxTypeValueTransfer))
 }
 
-func TestRecoverPubkeyRejectsTooManySignatures(t *testing.T) {
-	tooManySignatures := validTestSignatures(int(accountkey.MaxNumKeysForMultiSig) + 1)
-	vfuncCalled := false
+func TestTransactionSignatureListLength(t *testing.T) {
+	maxSignatures := int(accountkey.MaxNumKeysForMultiSig)
 
-	_, err := tooManySignatures.RecoverPubkey(common.Hash{}, true, func(v *big.Int) *big.Int {
-		vfuncCalled = true
-		return v
-	})
+	senderTx := NewTx(newTxInternalDataValueTransfer())
+	senderTx.SetSignature(validTestSignatures(maxSignatures))
+	require.NoError(t, senderTx.ValidateSignatureListLength())
+	senderTx.SetSignature(validTestSignatures(maxSignatures + 1))
+	require.ErrorIs(t, senderTx.ValidateSignatureListLength(), kerrors.ErrMaxKeysExceed)
 
-	require.ErrorIs(t, err, kerrors.ErrMaxKeysExceed)
-	require.False(t, vfuncCalled)
+	feePayerTxData := newTxInternalDataFeeDelegatedValueTransfer()
+	feePayerTxData.SetSignature(validTestSignatures(1))
+	feePayerTxData.SetFeePayerSignatures(validTestSignatures(maxSignatures))
+	feePayerTx := NewTx(feePayerTxData)
+	require.NoError(t, feePayerTx.ValidateSignatureListLength())
+	feePayerTxData.SetFeePayerSignatures(validTestSignatures(maxSignatures + 1))
+	require.ErrorIs(t, feePayerTx.ValidateSignatureListLength(), kerrors.ErrMaxKeysExceed)
 }
 
-func TestTransactionDecodeChecksFeePayerSignatureLength(t *testing.T) {
+func TestTransactionDecodeAllowsOversizedSignatureLists(t *testing.T) {
+	maxSignatures := int(accountkey.MaxNumKeysForMultiSig)
 	tests := []struct {
-		name    string
-		numSigs int
-		wantErr bool
+		name string
+		tx   *Transaction
 	}{
 		{
-			name:    "at limit",
-			numSigs: int(accountkey.MaxNumKeysForMultiSig),
+			name: "sender signatures",
+			tx: func() *Transaction {
+				txData := newTxInternalDataValueTransfer()
+				txData.SetSignature(validTestSignatures(maxSignatures + 1))
+				return NewTx(txData)
+			}(),
 		},
 		{
-			name:    "over limit",
-			numSigs: int(accountkey.MaxNumKeysForMultiSig) + 1,
-			wantErr: true,
+			name: "fee payer signatures",
+			tx: func() *Transaction {
+				txData := newTxInternalDataFeeDelegatedValueTransfer()
+				txData.SetSignature(validTestSignatures(1))
+				txData.SetFeePayerSignatures(validTestSignatures(maxSignatures + 1))
+				return NewTx(txData)
+			}(),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			txData := newTxInternalDataFeeDelegatedValueTransfer()
-			txData.SetSignature(validTestSignatures(1))
-			txData.SetFeePayerSignatures(validTestSignatures(test.numSigs))
-			tx := NewTx(txData)
-
-			rawRLP, err := rlp.EncodeToBytes(tx)
+			rawRLP, err := rlp.EncodeToBytes(test.tx)
 			require.NoError(t, err)
 			var decodedRLP Transaction
-			err = rlp.DecodeBytes(rawRLP, &decodedRLP)
-			if test.wantErr {
-				require.ErrorIs(t, err, ErrInvalidSig)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, rlp.DecodeBytes(rawRLP, &decodedRLP))
+			require.ErrorIs(t, decodedRLP.ValidateSignatureListLength(), kerrors.ErrMaxKeysExceed)
 
-			rawJSON, err := json.Marshal(tx)
+			rawJSON, err := json.Marshal(test.tx)
 			require.NoError(t, err)
 			var decodedJSON Transaction
-			err = json.Unmarshal(rawJSON, &decodedJSON)
-			if test.wantErr {
-				require.ErrorIs(t, err, ErrInvalidSig)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, json.Unmarshal(rawJSON, &decodedJSON))
+			require.ErrorIs(t, decodedJSON.ValidateSignatureListLength(), kerrors.ErrMaxKeysExceed)
 		})
 	}
 }

--- a/blockchain/types/tx_signatures_test.go
+++ b/blockchain/types/tx_signatures_test.go
@@ -1,0 +1,113 @@
+// Modifications Copyright 2026 The Kaia Authors
+// Copyright 2019 The klaytn Authors
+// This file is part of the klaytn library.
+//
+// The klaytn library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The klaytn library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the klaytn library. If not, see <http://www.gnu.org/licenses/>.
+// Modified and improved for the Kaia development.
+
+package types
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types/accountkey"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kerrors"
+	"github.com/kaiachain/kaia/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+func validTestSignatures(n int) TxSignatures {
+	sig := &TxSignature{
+		V: big.NewInt(37),
+		R: big.NewInt(1),
+		S: big.NewInt(1),
+	}
+	sigs := make(TxSignatures, n)
+	for i := range sigs {
+		sigs[i] = sig
+	}
+	return sigs
+}
+
+func TestSanityCheckSignaturesLength(t *testing.T) {
+	maxSignatures := int(accountkey.MaxNumKeysForMultiSig)
+
+	require.False(t, SanityCheckSignatures(nil, TxTypeValueTransfer))
+	require.True(t, SanityCheckSignatures(validTestSignatures(1), TxTypeValueTransfer))
+	require.True(t, SanityCheckSignatures(validTestSignatures(maxSignatures), TxTypeValueTransfer))
+	require.False(t, SanityCheckSignatures(validTestSignatures(maxSignatures+1), TxTypeValueTransfer))
+}
+
+func TestRecoverPubkeyRejectsTooManySignatures(t *testing.T) {
+	tooManySignatures := validTestSignatures(int(accountkey.MaxNumKeysForMultiSig) + 1)
+	vfuncCalled := false
+
+	_, err := tooManySignatures.RecoverPubkey(common.Hash{}, true, func(v *big.Int) *big.Int {
+		vfuncCalled = true
+		return v
+	})
+
+	require.ErrorIs(t, err, kerrors.ErrMaxKeysExceed)
+	require.False(t, vfuncCalled)
+}
+
+func TestTransactionDecodeChecksFeePayerSignatureLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		numSigs int
+		wantErr bool
+	}{
+		{
+			name:    "at limit",
+			numSigs: int(accountkey.MaxNumKeysForMultiSig),
+		},
+		{
+			name:    "over limit",
+			numSigs: int(accountkey.MaxNumKeysForMultiSig) + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			txData := newTxInternalDataFeeDelegatedValueTransfer()
+			txData.SetSignature(validTestSignatures(1))
+			txData.SetFeePayerSignatures(validTestSignatures(test.numSigs))
+			tx := NewTx(txData)
+
+			rawRLP, err := rlp.EncodeToBytes(tx)
+			require.NoError(t, err)
+			var decodedRLP Transaction
+			err = rlp.DecodeBytes(rawRLP, &decodedRLP)
+			if test.wantErr {
+				require.ErrorIs(t, err, ErrInvalidSig)
+			} else {
+				require.NoError(t, err)
+			}
+
+			rawJSON, err := json.Marshal(tx)
+			require.NoError(t, err)
+			var decodedJSON Transaction
+			err = json.Unmarshal(rawJSON, &decodedJSON)
+			if test.wantErr {
+				require.ErrorIs(t, err, ErrInvalidSig)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/blockchain/types/tx_signatures_test.go
+++ b/blockchain/types/tx_signatures_test.go
@@ -48,6 +48,7 @@ func TestSanityCheckSignaturesLength(t *testing.T) {
 	require.False(t, SanityCheckSignatures(nil, TxTypeValueTransfer))
 	require.True(t, SanityCheckSignatures(validTestSignatures(1), TxTypeValueTransfer))
 	require.True(t, SanityCheckSignatures(validTestSignatures(maxSignatures), TxTypeValueTransfer))
+	// no cap here by design: DecodeRLP must keep accepting pre-Istanbul blocks; the cap is enforced at ingress
 	require.True(t, SanityCheckSignatures(validTestSignatures(maxSignatures+1), TxTypeValueTransfer))
 }
 


### PR DESCRIPTION
## Proposed changes

- Limit sender and fee-payer signature lists to `accountkey.MaxNumKeysForMultiSig`.
- Reject oversized lists before signature validation or public-key recovery.
- Add boundary tests for RLP and JSON decoding.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Further comments

Tested with:

```sh
go test ./blockchain/types -count=1
```