### PR TITLE
blockchain, node/cn: bound the hash-based header ancestor lookup

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2706,10 +2706,10 @@ func (bc *BlockChain) HasHeader(hash common.Hash, number uint64) bool {
 	return bc.hc.HasHeader(hash, number)
 }
 
-// GetBlockHashesFromHash retrieves a number of block hashes starting at a given
-// hash, fetching towards the genesis block.
-func (bc *BlockChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash {
-	return bc.hc.GetBlockHashesFromHash(hash, max)
+// GetAncestor retrieves the Nth ancestor of a given block, bounding the number of
+// non-canonical blocks checked individually with maxNonCanonical.
+func (bc *BlockChain) GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64) {
+	return bc.hc.GetAncestor(hash, number, ancestor, maxNonCanonical)
 }
 
 // GetHeaderByNumber retrieves a block header from the database by number,

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -269,6 +269,28 @@ func TestGetAncestor(t *testing.T) {
 	assert.Equal(t, uint64(99), budget)
 }
 
+// A branch that is really in the database keeps the walk going, so the budget is what
+// ends it. The branch has to outlast the budget, or the walk reaches the canonical
+// chain and resolves by number instead.
+func TestGetAncestorWalkBudget(t *testing.T) {
+	db, blockchain, err := newCanonical(faker.NewFaker(), 128, false)
+	require.NoError(t, err)
+	defer blockchain.Stop()
+
+	branch := MakeHeaderChain(blockchain.GetHeaderByNumber(10), 20, faker.NewFaker(), db, forkSeed)
+	_, err = blockchain.InsertHeaderChain(branch, 1)
+	require.NoError(t, err)
+
+	head := branch[len(branch)-1]
+	number := head.Number.Uint64()
+	require.NotEqual(t, head.Hash(), blockchain.GetHeaderByNumber(number).Hash(), "the branch became canonical")
+
+	budget := uint64(10)
+	hash, _ := blockchain.GetAncestor(head.Hash(), number, 25, &budget)
+	assert.Equal(t, common.Hash{}, hash)
+	assert.Equal(t, uint64(0), budget, "the walk stopped on a missing header, not on the budget")
+}
+
 // Tests that given a starting canonical chain of a given size, it can be extended
 // with various length chains.
 func TestExtendCanonicalHeaders(t *testing.T) { testExtendCanonical(t, false) }

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -238,6 +238,37 @@ func TestLastBlock(t *testing.T) {
 	}
 }
 
+func TestGetAncestor(t *testing.T) {
+	_, blockchain, err := newCanonical(faker.NewFaker(), 128, false)
+	require.NoError(t, err)
+	defer blockchain.Stop()
+
+	head := blockchain.CurrentHeader()
+	number := head.Number.Uint64()
+
+	// A canonical block resolves its ancestor by number, so the walk budget is
+	// left untouched no matter how far back the ancestor is.
+	for _, ancestor := range []uint64{1, 2, 64, number} {
+		budget := uint64(100)
+		hash, num := blockchain.GetAncestor(head.Hash(), number, ancestor, &budget)
+		assert.Equal(t, number-ancestor, num)
+		assert.Equal(t, blockchain.GetHeaderByNumber(number-ancestor).Hash(), hash)
+		assert.Equal(t, uint64(100), budget, "ancestor=%d spent the walk budget", ancestor)
+	}
+
+	// An ancestor below genesis is rejected without walking.
+	budget := uint64(100)
+	hash, _ := blockchain.GetAncestor(head.Hash(), number, number+1, &budget)
+	assert.Equal(t, common.Hash{}, hash)
+	assert.Equal(t, uint64(100), budget)
+
+	// A non-canonical origin falls back to walking parents, bounded by the budget.
+	budget = uint64(100)
+	hash, _ = blockchain.GetAncestor(common.HexToHash("0xdead"), number, 64, &budget)
+	assert.Equal(t, common.Hash{}, hash)
+	assert.Equal(t, uint64(99), budget)
+}
+
 // Tests that given a starting canonical chain of a given size, it can be extended
 // with various length chains.
 func TestExtendCanonicalHeaders(t *testing.T) { testExtendCanonical(t, false) }

--- a/blockchain/headerchain.go
+++ b/blockchain/headerchain.go
@@ -249,27 +249,43 @@ func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header) (int, error) {
 	return 0, nil
 }
 
-// GetBlockHashesFromHash retrieves a number of block hashes starting at a given
-// hash, fetching towards the genesis block.
-func (hc *HeaderChain) GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash {
-	// Get the origin header from which to fetch
-	header := hc.GetHeaderByHash(hash)
-	if header == nil {
-		return nil
+// GetAncestor retrieves the Nth ancestor of a given block. It assumes that either the given block or
+// a close ancestor of it is canonical. maxNonCanonical points to a downwards counter limiting the
+// number of blocks to be individually checked before we reach the canonical chain.
+//
+// Note: ancestor == 0 returns the same block, 1 returns its parent and so on.
+func (hc *HeaderChain) GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64) {
+	if ancestor > number {
+		return common.Hash{}, 0
 	}
-	// Iterate the headers until enough is collected or the genesis reached
-	chain := make([]common.Hash, 0, max)
-	for range max {
-		next := header.ParentHash
-		if header = hc.GetHeader(next, header.Number.Uint64()-1); header == nil {
-			break
+	if ancestor == 1 {
+		// in this case it is cheaper to just read the header
+		if header := hc.GetHeader(hash, number); header != nil {
+			return header.ParentHash, number - 1
 		}
-		chain = append(chain, next)
-		if header.Number.Sign() == 0 {
-			break
-		}
+		return common.Hash{}, 0
 	}
-	return chain
+	for ancestor != 0 {
+		if hc.chainDB.ReadCanonicalHash(number) == hash {
+			ancestorHash := hc.chainDB.ReadCanonicalHash(number - ancestor)
+			if hc.chainDB.ReadCanonicalHash(number) == hash {
+				number -= ancestor
+				return ancestorHash, number
+			}
+		}
+		if *maxNonCanonical == 0 {
+			return common.Hash{}, 0
+		}
+		*maxNonCanonical--
+		ancestor--
+		header := hc.GetHeader(hash, number)
+		if header == nil {
+			return common.Hash{}, 0
+		}
+		hash = header.ParentHash
+		number--
+	}
+	return hash, number
 }
 
 // GetTd retrieves a block's total blockscore in the canonical chain from the

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -863,9 +863,10 @@ func handleBlockHeadersRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 
 	// Gather headers until the fetch or network limits is reached
 	var (
-		bytes   common.StorageSize
-		headers []*types.Header
-		unknown bool
+		bytes           common.StorageSize
+		headers         []*types.Header
+		unknown         bool
+		maxNonCanonical = uint64(100)
 	)
 	for !unknown && len(headers) < int(query.Amount) && bytes < softResponseLimit && len(headers) < downloader.MaxHeaderFetch {
 		// Retrieve the next header satisfying the query
@@ -878,7 +879,6 @@ func handleBlockHeadersRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 		if origin == nil {
 			break
 		}
-		number := origin.Number.Uint64()
 		headers = append(headers, origin)
 		bytes += estHeaderRlpSize
 
@@ -895,15 +895,8 @@ func handleBlockHeadersRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 				p.GetP2PPeer().Log().Warn("GetBlockHeaders skip underflow attack", "current", current, "skip", query.Skip, "next", next, "attacker", infos)
 				unknown = true
 			} else {
-				for i := 0; i < int(query.Skip)+1; i++ {
-					if header := pm.blockchain.GetHeader(query.Origin.Hash, number); header != nil {
-						query.Origin.Hash = header.ParentHash
-						number--
-					} else {
-						unknown = true
-						break
-					}
-				}
+				query.Origin.Hash, _ = pm.blockchain.GetAncestor(query.Origin.Hash, current, query.Skip+1, &maxNonCanonical)
+				unknown = query.Origin.Hash == common.Hash{}
 			}
 		case query.Origin.Hash != (common.Hash{}) && !query.Reverse:
 			// Hash based traversal towards the leaf block
@@ -917,8 +910,10 @@ func handleBlockHeadersRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 				unknown = true
 			} else {
 				if header := pm.blockchain.GetHeaderByNumber(next); header != nil {
-					if pm.blockchain.GetBlockHashesFromHash(header.Hash(), query.Skip+1)[query.Skip] == query.Origin.Hash {
-						query.Origin.Hash = header.Hash()
+					nextHash := header.Hash()
+					expOldHash, _ := pm.blockchain.GetAncestor(nextHash, next, query.Skip+1, &maxNonCanonical)
+					if expOldHash == query.Origin.Hash {
+						query.Origin.Hash = nextHash
 					} else {
 						unknown = true
 					}

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -257,6 +257,21 @@ func (mr *MockBlockChainMockRecorder) Genesis() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Genesis", reflect.TypeOf((*MockBlockChain)(nil).Genesis))
 }
 
+// GetAncestor mocks base method.
+func (m *MockBlockChain) GetAncestor(arg0 common.Hash, arg1, arg2 uint64, arg3 *uint64) (common.Hash, uint64) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAncestor", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(common.Hash)
+	ret1, _ := ret[1].(uint64)
+	return ret0, ret1
+}
+
+// GetAncestor indicates an expected call of GetAncestor.
+func (mr *MockBlockChainMockRecorder) GetAncestor(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAncestor", reflect.TypeOf((*MockBlockChain)(nil).GetAncestor), arg0, arg1, arg2, arg3)
+}
+
 // GetBlock mocks base method.
 func (m *MockBlockChain) GetBlock(arg0 common.Hash, arg1 uint64) *types.Block {
 	m.ctrl.T.Helper()
@@ -297,20 +312,6 @@ func (m *MockBlockChain) GetBlockByNumber(arg0 uint64) *types.Block {
 func (mr *MockBlockChainMockRecorder) GetBlockByNumber(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByNumber", reflect.TypeOf((*MockBlockChain)(nil).GetBlockByNumber), arg0)
-}
-
-// GetBlockHashesFromHash mocks base method.
-func (m *MockBlockChain) GetBlockHashesFromHash(arg0 common.Hash, arg1 uint64) []common.Hash {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBlockHashesFromHash", arg0, arg1)
-	ret0, _ := ret[0].([]common.Hash)
-	return ret0
-}
-
-// GetBlockHashesFromHash indicates an expected call of GetBlockHashesFromHash.
-func (mr *MockBlockChainMockRecorder) GetBlockHashesFromHash(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockHashesFromHash", reflect.TypeOf((*MockBlockChain)(nil).GetBlockHashesFromHash), arg0, arg1)
 }
 
 // GetBlockReceiptsInCache mocks base method.

--- a/work/work.go
+++ b/work/work.go
@@ -229,7 +229,7 @@ type BlockChain interface {
 	GetBlock(hash common.Hash, number uint64) *types.Block
 	GetBlockByHash(hash common.Hash) *types.Block
 	GetBlockByNumber(number uint64) *types.Block
-	GetBlockHashesFromHash(hash common.Hash, max uint64) []common.Hash
+	GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)
 
 	CurrentHeader() *types.Header
 	HasHeader(hash common.Hash, number uint64) bool


### PR DESCRIPTION
## Proposed changes

The hash-mode advance in the header request handler verified descent by walking `Skip+1` parents and pre-allocating a `Skip`-sized hash slice, so a request whose answer is bounded by `Amount` could cost work proportional to the chain height. This ports go-ethereum's `GetAncestor` ([#16946](https://github.com/ethereum/go-ethereum/pull/16946), released in v1.8.11, after Kaia's fork point): a canonical ancestor is resolved by number, and the non-canonical walk is bounded by a per-request budget. `GetBlockHashesFromHash` had no other caller and is removed, as upstream did.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
