### PR TITLE
discover: admit only CNPeers members into the CN storage

### DIFF
--- a/networks/p2p/discover/discovery.go
+++ b/networks/p2p/discover/discovery.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"net"
 
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/networks/p2p/netutil"
 	"github.com/kaiachain/kaia/networks/rpc"
 )
@@ -33,6 +34,9 @@ type Discovery2 interface {
 
 	// Serve discovered nodes. Used by p2p.DialSched.
 	RandomNodes(buf []*Node, nType NodeType) int
+
+	// SetCNPeers replaces the allowlist admitting entries into the CN storage.
+	SetCNPeers(addrs []common.Address)
 
 	// APIs returns the RPC APIs for the discovery service.
 	APIs() []rpc.API
@@ -110,4 +114,8 @@ func (d *discovery2) Refresh() {
 
 func (d *discovery2) RandomNodes(buf []*Node, nType NodeType) int {
 	return d.tab.RandomNodes(buf, nType)
+}
+
+func (d *discovery2) SetCNPeers(addrs []common.Address) {
+	d.tab.SetCNPeers(addrs)
 }

--- a/networks/p2p/discover/table_data.go
+++ b/networks/p2p/discover/table_data.go
@@ -18,7 +18,9 @@ package discover
 
 import (
 	"net"
+	"slices"
 
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/crypto"
 )
 
@@ -74,15 +76,68 @@ func (tab *Table2) lenByNodeTypes() map[string]int {
 // If the node is a bootstrap node, it is added to all storages.
 func (tab *Table2) addNode(n *Node) {
 	if n.NType == NodeTypeBN {
-		for _, s := range tab.storages {
+		for nType, s := range tab.storages {
+			if nType == NodeTypeCN && !tab.cnStorageAllowed(n.ID) {
+				continue
+			}
 			s.add(n)
 		}
 		return
 	} else {
+		if n.NType == NodeTypeCN && !tab.cnStorageAllowed(n.ID) {
+			return
+		}
 		if s := tab.storages[n.NType]; s != nil {
 			s.add(n)
 		}
 	}
+}
+
+// SetCNPeers replaces the allowlist admitting entries into the CN storage.
+// nil disables the filter. Entries outside the new list are dropped.
+func (tab *Table2) SetCNPeers(addrs []common.Address) {
+	tab.cnPeerMu.Lock()
+	if addrs == nil {
+		tab.cnPeerAddrs = nil
+		tab.cnPeerMu.Unlock()
+		return
+	}
+	cnPeerAddrs := make(map[common.Address]struct{}, len(addrs))
+	for _, addr := range addrs {
+		cnPeerAddrs[addr] = struct{}{}
+	}
+	tab.cnPeerAddrs = cnPeerAddrs
+	tab.cnPeerMu.Unlock()
+
+	s := tab.storages[NodeTypeCN]
+	if s == nil {
+		return
+	}
+	for _, n := range s.all() {
+		if !tab.cnStorageAllowed(n.ID) {
+			s.delete(n)
+		}
+	}
+}
+
+// cnStorageAllowed reports whether an entry may enter the CN storage. The claimed
+// node type is unauthenticated, so the entry has to be vouched for either on-chain
+// by CNPeers or locally by the configured bootnodes, which seed CN lookups.
+func (tab *Table2) cnStorageAllowed(id NodeID) bool {
+	tab.cnPeerMu.RLock()
+	defer tab.cnPeerMu.RUnlock()
+	if tab.cnPeerAddrs == nil {
+		return true
+	}
+	if slices.ContainsFunc(tab.nursery, func(n *Node) bool { return n.ID == id }) {
+		return true
+	}
+	pub, err := id.Pubkey()
+	if err != nil {
+		return false
+	}
+	_, ok := tab.cnPeerAddrs[crypto.PubkeyToAddress(*pub)]
+	return ok
 }
 
 func (tab *Table2) deleteNode(n *Node) {

--- a/networks/p2p/discover/table_data_test.go
+++ b/networks/p2p/discover/table_data_test.go
@@ -134,6 +134,22 @@ func Test_Table_SetCNPeers_dropsOutsiders(t *testing.T) {
 	assert.Equal(t, 3, tab.storages[NodeTypeCN].len(), "nil allowlist restores the unfiltered behavior")
 }
 
+// An update replaces the previous allowlist rather than adding to it, so a member that
+// leaves goes with it.
+func Test_Table_SetCNPeers_dropsFormerMembers(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	leaving, leavingAddr := newTestNodeWithAddr(t, NodeTypeCN)
+	staying, stayingAddr := newTestNodeWithAddr(t, NodeTypeCN)
+
+	tab.SetCNPeers([]common.Address{leavingAddr, stayingAddr})
+	tab.addNode(leaving)
+	tab.addNode(staying)
+	require.Equal(t, 2, tab.storages[NodeTypeCN].len())
+
+	tab.SetCNPeers([]common.Address{stayingAddr})
+	assert.ElementsMatch(t, []*Node{staying}, tab.storages[NodeTypeCN].all())
+}
+
 func Test_Table_deleteNode_typed(t *testing.T) {
 	tab := newTestTable2(t, nil)
 

--- a/networks/p2p/discover/table_data_test.go
+++ b/networks/p2p/discover/table_data_test.go
@@ -17,8 +17,10 @@
 package discover
 
 import (
+	"net"
 	"testing"
 
+	"github.com/kaiachain/kaia/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,6 +52,86 @@ func Test_Table_addNode_BN(t *testing.T) {
 	assert.Equal(t, 1, tab.storages[NodeTypeEN].len())
 	assert.Equal(t, 1, tab.storages[NodeTypeBN].len())
 	assert.Equal(t, 4, tab.len())
+}
+
+func Test_Table_addNode_CNPeers(t *testing.T) {
+	member, memberAddr := newTestNodeWithAddr(t, NodeTypeCN)
+	outsider, _ := newTestNodeWithAddr(t, NodeTypeCN)
+
+	t.Run("nil allowlist admits any CN claim", func(t *testing.T) {
+		tab := newTestTable2(t, nil)
+		tab.addNode(outsider)
+		assert.Equal(t, 1, tab.storages[NodeTypeCN].len())
+	})
+
+	t.Run("allowlist admits only its members", func(t *testing.T) {
+		tab := newTestTable2(t, nil)
+		tab.SetCNPeers([]common.Address{memberAddr})
+
+		tab.addNode(outsider)
+		assert.Equal(t, 0, tab.storages[NodeTypeCN].len(), "CN outside CNPeers must not take a CN slot")
+
+		tab.addNode(member)
+		assert.Equal(t, 1, tab.storages[NodeTypeCN].len(), "CN inside CNPeers must take a CN slot")
+	})
+
+	t.Run("empty allowlist rejects every CN claim", func(t *testing.T) {
+		tab := newTestTable2(t, nil)
+		tab.SetCNPeers([]common.Address{})
+		tab.addNode(member)
+		assert.Equal(t, 0, tab.storages[NodeTypeCN].len())
+	})
+}
+
+// A node claiming BN reaches every storage, so the CN storage applies the allowlist
+// on that path too. A configured bootnode is exempt: it seeds CN lookups.
+func Test_Table_addNode_BN_CNPeers(t *testing.T) {
+	_, memberAddr := newTestNodeWithAddr(t, NodeTypeCN)
+
+	t.Run("self-declared BN stays out of the CN storage", func(t *testing.T) {
+		tab := newTestTable2(t, nil)
+		tab.SetCNPeers([]common.Address{memberAddr})
+
+		tab.addNode(newTestBootnode(t, net.IP{127, 0, 0, 1}))
+
+		assert.Equal(t, 0, tab.storages[NodeTypeCN].len())
+		assert.Equal(t, 1, tab.storages[NodeTypePN].len())
+		assert.Equal(t, 1, tab.storages[NodeTypeEN].len())
+		assert.Equal(t, 1, tab.storages[NodeTypeBN].len())
+	})
+
+	t.Run("configured bootnode reaches every storage", func(t *testing.T) {
+		tab := newTestTable2(t, nil)
+		bootnode := newTestBootnode(t, net.IP{127, 0, 0, 1})
+		tab.nursery = []*Node{bootnode}
+		tab.SetCNPeers([]common.Address{memberAddr})
+
+		tab.addNode(bootnode)
+
+		assert.Equal(t, 1, tab.storages[NodeTypeCN].len(), "a configured bootnode must keep seeding CN lookups")
+		assert.Equal(t, 4, tab.len())
+	})
+}
+
+func Test_Table_SetCNPeers_dropsOutsiders(t *testing.T) {
+	tab := newTestTable2(t, nil)
+	member, memberAddr := newTestNodeWithAddr(t, NodeTypeCN)
+	outsider, _ := newTestNodeWithAddr(t, NodeTypeCN)
+	bootnode := newTestBootnode(t, net.IP{127, 0, 0, 1})
+	tab.nursery = []*Node{bootnode}
+
+	// Entries admitted before the allowlist was known must not survive it.
+	tab.addNode(member)
+	tab.addNode(outsider)
+	tab.addNode(bootnode)
+	require.Equal(t, 3, tab.storages[NodeTypeCN].len())
+
+	tab.SetCNPeers([]common.Address{memberAddr})
+	assert.ElementsMatch(t, []*Node{member, bootnode}, tab.storages[NodeTypeCN].all())
+
+	tab.SetCNPeers(nil)
+	tab.addNode(outsider)
+	assert.Equal(t, 3, tab.storages[NodeTypeCN].len(), "nil allowlist restores the unfiltered behavior")
 }
 
 func Test_Table_deleteNode_typed(t *testing.T) {

--- a/networks/p2p/discover/table_init.go
+++ b/networks/p2p/discover/table_init.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/kaiachain/kaia/common"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -48,6 +49,10 @@ type Table2 struct {
 	selfID   NodeID
 	nursery  []*Node
 	storages map[NodeType]tableStorage
+
+	// CN storage admission. nil disables the filter.
+	cnPeerMu    sync.RWMutex
+	cnPeerAddrs map[common.Address]struct{}
 
 	// target number of nodes to obtain for each node type.
 	// set discoverTargets[T] = 0 to disable discovery of node type T (i.e. only accept inbound connections).

--- a/networks/p2p/discover/table_lookup_test.go
+++ b/networks/p2p/discover/table_lookup_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaiachain/kaia/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -173,6 +174,32 @@ func Test_Table_lookup_withNursery(t *testing.T) {
 
 	tab.lookup(NodeID{}, NodeTypeEN, false, 10)
 	assert.Greater(t, atomic.LoadInt32(&findCalled), int32(0), "nursery BN should trigger at least one findnode call")
+}
+
+// With the allowlist on, a cold-start CN lookup is seeded by the configured
+// bootnode and keeps only the CNPeers member out of the response.
+func Test_Table_lookup_CNPeers_coldStart(t *testing.T) {
+	member, memberAddr := newTestNodeWithAddr(t, NodeTypeCN)
+	outsider, _ := newTestNodeWithAddr(t, NodeTypeCN)
+	bootnode := newTestBootnode(t, net.IP{127, 0, 0, 1})
+
+	var asked []NodeID
+	udp := newMockTransport()
+	udp.findnodeFn = func(toid NodeID, _ *net.UDPAddr, _ NodeID, _ NodeType, _ int) ([]*Node, error) {
+		asked = append(asked, toid)
+		return []*Node{member, outsider}, nil
+	}
+
+	tab := newTestTable2(t, udp)
+	tab.nursery = []*Node{bootnode}
+	tab.SetCNPeers([]common.Address{memberAddr})
+	tab.addNode(bootnode)
+	require.Equal(t, 1, tab.storages[NodeTypeCN].len())
+
+	tab.lookup(tab.selfID, NodeTypeCN, false, 100)
+
+	require.Equal(t, []NodeID{bootnode.ID}, asked, "the bootnode must seed the CN lookup")
+	assert.ElementsMatch(t, []*Node{bootnode, member}, tab.storages[NodeTypeCN].all())
 }
 
 func Test_Table_lookup_returnsSeedResults(t *testing.T) {

--- a/networks/p2p/discover/test_helpers_test.go
+++ b/networks/p2p/discover/test_helpers_test.go
@@ -88,6 +88,16 @@ func newTestNode(t *testing.T, nType NodeType) *Node {
 	return NewNode(PubkeyID(&key.PublicKey), net.IP{127, 0, 0, 1}, 30303, 30303, nil, nType)
 }
 
+// newTestNodeWithAddr also returns the address derived from the node's NodeID,
+// which is the key CNPeers membership is looked up by.
+func newTestNodeWithAddr(t *testing.T, nType NodeType) (*Node, common.Address) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	n := NewNode(PubkeyID(&key.PublicKey), net.IP{127, 0, 0, 1}, 30303, 30303, nil, nType)
+	return n, crypto.PubkeyToAddress(key.PublicKey)
+}
+
 // newTestTable2 constructs a Table2 backed by an in-memory node database and
 // a no-op UDP transport. tab.Close is registered as a test cleanup, so callers
 // do not have to call it explicitly (though doing so a second time is safe).

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -65,10 +65,10 @@ type BaseServer struct {
 
 	// Relying components
 	logger       log.Logger
-	ntab         discovery       // UDP discovery
-	ourHandshake *protoHandshake // our TCP handshake message
-	listener     net.Listener    // TCP listener
-	peerFeed     event.Feed      // Peer event feed as in peer.go:PeerEventType.
+	ntab         discover.Discovery2 // UDP discovery
+	ourHandshake *protoHandshake     // our TCP handshake message
+	listener     net.Listener        // TCP listener
+	peerFeed     event.Feed          // Peer event feed as in peer.go:PeerEventType.
 
 	// Peer lifecycle state
 	selfID        discover.NodeID // precompulted Self().ID
@@ -709,6 +709,10 @@ func (srv *BaseServer) reportPeerMetric() {
 // SetCNPeers replaces the address-keyed CN admission allowlist.
 // nil disables filtering; an empty list rejects all CN claims.
 func (srv *BaseServer) SetCNPeers(addrs []common.Address) {
+	// Every observer keeps only CN discovery entries it can authenticate.
+	if srv.ntab != nil {
+		srv.ntab.SetCNPeers(addrs)
+	}
 	// Only CNs enforce the validator allowlist. ENs/PNs serve everyone, so they
 	// skip it: leaving cnPeerAddrs nil makes the admit and drop checks no-op.
 	if srv.ConnectionType != common.CONSENSUSNODE {

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kaiachain/kaia/crypto/sha3"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/networks/p2p/rlpx"
+	"github.com/kaiachain/kaia/networks/rpc"
 )
 
 func init() {
@@ -524,16 +525,32 @@ func TestServerCNPeersAdmission(t *testing.T) {
 	}
 }
 
-// Only CNs enforce the CN allowlist. EN/PN must keep serving any peer, so their
-// SetCNPeers is a no-op and admitByCNPeers admits CNs outside any allowlist.
+// fakeDiscovery records the CN allowlist pushed down to discovery.
+type fakeDiscovery struct {
+	cnPeerAddrs []common.Address
+}
+
+func (d *fakeDiscovery) Close()                                              {}
+func (d *fakeDiscovery) Refresh()                                            {}
+func (d *fakeDiscovery) RandomNodes([]*discover.Node, discover.NodeType) int { return 0 }
+func (d *fakeDiscovery) APIs() []rpc.API                                     { return nil }
+func (d *fakeDiscovery) SetCNPeers(addrs []common.Address)                   { d.cnPeerAddrs = addrs }
+
+// Only CNs enforce the CN allowlist on admission: SetCNPeers leaves cnPeerAddrs nil on
+// EN/PN and admitByCNPeers admits CNs outside any allowlist. The discovery filter is
+// installed everywhere, so the allowlist still reaches the table.
 func TestServerENBypassesCNPeerFilter(t *testing.T) {
 	allowed := crypto.PubkeyToAddress(newkey().PublicKey)
 
 	for _, nodeType := range []common.ConnType{common.ENDPOINTNODE, common.PROXYNODE} {
-		srv := &BaseServer{Config: Config{ConnectionType: nodeType}}
-		srv.SetCNPeers([]common.Address{allowed}) // no-op on EN/PN
+		ntab := &fakeDiscovery{}
+		srv := &BaseServer{Config: Config{ConnectionType: nodeType}, ntab: ntab}
+		srv.SetCNPeers([]common.Address{allowed})
 		if srv.cnPeerAddrs != nil {
 			t.Fatalf("%v must not populate cnPeerAddrs", nodeType)
+		}
+		if len(ntab.cnPeerAddrs) != 1 || ntab.cnPeerAddrs[0] != allowed {
+			t.Fatalf("%v must forward the allowlist to discovery, got %v", nodeType, ntab.cnPeerAddrs)
 		}
 		outsider := &conn{conntype: common.CONSENSUSNODE, id: randomID(), flags: inboundConn}
 		if err := srv.admitByCNPeers(outsider); err != nil {


### PR DESCRIPTION
## Proposed changes

The node type in a discovery packet is supplied by the sender and the CN storage is unbounded, so any reachable key pair can fill the list the dial scheduler samples for CN candidates. The CN storage now accepts an entry only when its address is in `CNPeers` or its NodeId is a configured bootnode, bounding the list by an authenticated set instead of a capacity limit. Discovery stays open elsewhere: the filter is off before the hard fork and whenever `CNPeers` is unavailable, bootnodes are exempt so they keep seeding CN lookups, and peer admission is unchanged.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments
