### PR TITLE
p2p: reserve a cross-type slot for a dialed peer

### DIFF
--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -326,7 +326,20 @@ func (srv *BaseServer) exceedsPeerTarget(peers map[discover.NodeID]*Peer, c *con
 	peersByType := slices.DeleteFunc(slices.Collect(maps.Values(peers)), func(p *Peer) bool {
 		return EffectiveConnType(p.ConnType()) != peerType
 	})
-	return len(peersByType) >= target
+	if len(peersByType) >= target {
+		return true
+	}
+	// Inbound peers don't count toward dialTargets, so reserve one slot for a dialed peer.
+	if c.Inbound() && selfType == common.CONSENSUSNODE && selfType != peerType {
+		inbound := 0
+		for _, p := range peersByType {
+			if p.Inbound() {
+				inbound++
+			}
+		}
+		return inbound >= target-crossTypeDialReserve(selfType, peerType, target)
+	}
+	return false
 }
 
 // admissiblePeerType reports whether the server accepts a peer of this type.

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -450,6 +450,55 @@ func TestServerPeerTargets(t *testing.T) {
 	}
 }
 
+// A CN keeps one of its cross-type slots for an EN it dials itself, so inbound
+// EN/PN peers alone cannot make dialTargets[CN][EN] unsatisfiable.
+func TestServerCrossTypeDialReserve(t *testing.T) {
+	newPeer := func(connType common.ConnType, flags connFlag) *Peer {
+		return &Peer{rws: []*conn{{conntype: connType, flags: flags}}}
+	}
+	peersOf := func(ps ...*Peer) map[discover.NodeID]*Peer {
+		peers := make(map[discover.NodeID]*Peer, len(ps))
+		for _, p := range ps {
+			peers[randomID()] = p
+		}
+		return peers
+	}
+
+	// defaultCNReservedSlots = 3 and dialTargets[CN][EN] = 1, so a CN takes at
+	// most two inbound EN-equivalent peers.
+	cnSrv := &BaseServer{Config: Config{ConnectionType: common.CONSENSUSNODE, MaxPhysicalConnections: 10}}
+	inboundEN := &conn{conntype: common.ENDPOINTNODE, flags: inboundConn}
+	dialedEN := &conn{conntype: common.ENDPOINTNODE, flags: dynDialedConn}
+
+	oneInbound := peersOf(newPeer(common.ENDPOINTNODE, inboundConn))
+	if cnSrv.exceedsPeerTarget(oneInbound, inboundEN) {
+		t.Fatal("a second inbound EN should be accepted")
+	}
+
+	twoInbound := peersOf(
+		newPeer(common.ENDPOINTNODE, inboundConn),
+		newPeer(common.PROXYNODE, inboundConn),
+	)
+	if !cnSrv.exceedsPeerTarget(twoInbound, inboundEN) {
+		t.Fatal("a third inbound EN-equivalent should not take the slot reserved for a dialed peer")
+	}
+	if cnSrv.exceedsPeerTarget(twoInbound, dialedEN) {
+		t.Fatal("the dialed EN should still be admitted into the reserved slot")
+	}
+	if cnSrv.exceedsPeerTarget(twoInbound, &conn{conntype: common.ENDPOINTNODE, flags: inboundConn | trustedConn}) {
+		t.Fatal("trusted peers should stay exempt from the inbound sub-cap")
+	}
+
+	// The sub-cap counts inbound peers only, so the bucket can still fill to the cap.
+	withDialed := peersOf(
+		newPeer(common.ENDPOINTNODE, dynDialedConn),
+		newPeer(common.ENDPOINTNODE, inboundConn),
+	)
+	if cnSrv.exceedsPeerTarget(withDialed, inboundEN) {
+		t.Fatal("an inbound EN should fill the last slot once a dialed EN holds the reservation")
+	}
+}
+
 // CN/EN servers reject untrusted non-CN/EN peers (which would escape the
 // per-type cap); trusted/static and non-CN/EN servers accept any type.
 func TestAdmissiblePeerType(t *testing.T) {

--- a/networks/p2p/server_util.go
+++ b/networks/p2p/server_util.go
@@ -74,6 +74,12 @@ func peerTargetFor(selfType, peerType common.ConnType, maxPhys, reservedCrossTyp
 	return reservedCrossTypeSlots, true // cross-type CN<->EN
 }
 
+// crossTypeDialReserve is the part of the cross-type cap held for dialed peers,
+// clamped so at least one inbound slot remains.
+func crossTypeDialReserve(selfType, peerType common.ConnType, target int) int {
+	return min(dialTargets[ConvertNodeType(selfType)][ConvertNodeType(peerType)], target-1)
+}
+
 // MaxPhysicalConnectionsLowerBound is the minimum valid MaxPhysicalConnections for
 // cfg's node type: below it the own-mesh cap (maxconnections minus the reservation)
 // would be 0, leaving no room to mesh with its own type.


### PR DESCRIPTION
## Proposed changes

A CN's cross-type cap counts inbound and outbound peers together, but its dial target counts only outbound. Inbound EN peers alone can therefore fill the cap and block the EN a CN needs to dial, even with most of its capacity free — the link a CN outside `CNPeers` depends on for block sync. A CN now keeps one of those slots for an EN it dials itself.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

Only CN observers apply this: an EN's cap equals its dial target, so it has no slot to spare, and shrinking its inbound CN slots would block the CN dial this protects.
