### PR TITLE
valset: keep an active validator across the epoch transition

### DIFF
--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -179,6 +179,8 @@ func (ctx *TransitionContext) applyEpochTransition(m valset.NodeMap) valset.Node
 	var (
 		newValidators        = m.Copy()
 		activeValCompetitors []sortableValidator
+		// Captured before the loop mutates states.
+		prevActive = newValidators.FilterByState(valset.ValActive).Addresses()
 	)
 
 	// T3a/T3b: compete for top-N or demote to ValInactive.
@@ -234,6 +236,16 @@ func (ctx *TransitionContext) applyEpochTransition(m valset.NodeMap) valset.Node
 			}
 			potentialActiveVal.State = valset.ValInactive // T3b
 		}
+	}
+	// An empty active set halts the chain, so nobody is demoted when the epoch leaves none.
+	if newValidators.CountByState(valset.ValActive) == 0 {
+		for _, addr := range prevActive {
+			val := newValidators[addr]
+			val.State = valset.ValActive
+			val.IdleTimeout = time.Time{}
+			val.PausedTimeout = time.Time{}
+		}
+		logger.Warn("epoch transition would leave no active validator, retaining the previous set", "count", len(prevActive))
 	}
 	return newValidators
 }

--- a/kaiax/valset/impl/transition_context_test.go
+++ b/kaiax/valset/impl/transition_context_test.go
@@ -175,7 +175,7 @@ func TestApplyEpochTransition_StateTransitions(t *testing.T) {
 		{"ValReady + stake above → ValActive", ValReady, aboveMinStake, ValActive, false},
 		{"ValActive + stake above → ValActive (preserved)", ValActive, aboveMinStake, ValActive, false},
 		{"ValPaused + stake above → ValPaused (preserved)", ValPaused, aboveMinStake, ValPaused, false},
-		{"T3b: ValActive + stake below → ValInactive", ValActive, belowMinStake, ValInactive, true},
+		{"ValActive + stake below → ValActive (last active retained)", ValActive, belowMinStake, ValActive, false},
 		{"T3b: ValReady + stake below → ValInactive", ValReady, belowMinStake, ValInactive, false},
 		{"T3b: ValPaused + stake below → ValInactive", ValPaused, belowMinStake, ValInactive, true},
 	}
@@ -249,6 +249,37 @@ func TestApplyEpochTransition_TieBreakingByAddress(t *testing.T) {
 	assert.Equal(t, ValActive, out[addr1].State)
 	assert.Equal(t, ValActive, out[addr2].State)
 	assert.Equal(t, ValInactive, out[addr3].State)
+}
+
+// An empty active set has no in-band recovery, so an epoch that would demote every
+// active validator retains the previous set instead.
+func TestApplyEpochTransition_RetainsLastActiveSet(t *testing.T) {
+	m := NodeMap{
+		addr1: {State: ValActive, StakingAmount: belowMinStake},
+		addr2: {State: ValActive, StakingAmount: belowMinStake},
+		addr3: {State: ValReady, StakingAmount: belowMinStake},
+	}
+	ctx := epochCtx(t, nil, testMaxValCount)
+	out := ctx.applyEpochTransition(m)
+
+	assert.Equal(t, ValActive, out[addr1].State)
+	assert.Equal(t, ValActive, out[addr2].State)
+	assert.True(t, out[addr1].IdleTimeout.IsZero(), "a retained validator carries no idle deadline")
+	assert.Equal(t, ValInactive, out[addr3].State, "only the previously active set is retained")
+}
+
+// A top-N slot filled by a ValPaused competitor yields no active validator, so the
+// retention must key on the resulting ValActive count, not on an empty competitor pool.
+func TestApplyEpochTransition_RetainsWhenOnlyPausedCompetes(t *testing.T) {
+	m := NodeMap{
+		addr1: {State: ValActive, StakingAmount: belowMinStake},
+		addr2: {State: ValPaused, StakingAmount: aboveMinStake},
+	}
+	ctx := epochCtx(t, nil, testMaxValCount)
+	out := ctx.applyEpochTransition(m)
+
+	assert.Equal(t, ValPaused, out[addr2].State, "a paused competitor stays paused")
+	assert.Equal(t, ValActive, out[addr1].State)
 }
 
 func TestApplyEpochTransition_DefensiveCopy(t *testing.T) {
@@ -830,6 +861,22 @@ func TestApplyAllTransitions(t *testing.T) {
 			assert.Equal(t, tc.expectedEpochVACount, result.epochVACountForWrite)
 		})
 	}
+}
+
+// The violation and timeout passes run after the epoch one, so a set retained by the
+// epoch pass has to survive them.
+func TestApplyAllTransitions_RetainedActiveSetSurvives(t *testing.T) {
+	m := NodeMap{
+		addr1: {State: ValActive, StakingAmount: belowMinStake},
+		addr2: {State: ValActive, StakingAmount: belowMinStake},
+	}
+	ctx := epochCtx(t, nil, testMaxValCount)
+	ctx.IsEpoch = true
+
+	result := ctx.ApplyAllTransitions(m)
+
+	assert.Equal(t, uint64(2), result.Nodes.CountByState(ValActive))
+	assert.Equal(t, uint64(2), result.epochVACountForWrite)
 }
 
 //#endregion


### PR DESCRIPTION
## Proposed changes

The epoch transition demotes every below-`MinStake` node straight to `ValInactive` without the `minActiveCount` floor that the violation transition applies. A boundary where no node clears `MinStake` therefore leaves an empty active set, and nothing recovers from it — the qualified set and its suspension fallback are both empty, no block can be produced, so no transaction restoring stake can be included either. The epoch pass now retains the previous active set when it would otherwise leave none, matching what the permissioned path already does by demoting nobody.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

The retention keys on the resulting `ValActive` count rather than an empty competitor pool: a top-N slot taken by a `ValPaused` competitor yields no active validator. Only the previously active set is retained, so a `ValReady` or `ValPaused` node is never promoted as a side effect. KIP-286 T3b currently prescribes the demotion without a slot check, so this needs matching KIP wording.
