### PR TITLE
vrank: decode an absent report as an empty one

### DIFF
--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -55,13 +55,12 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 	}
 
 	// Non-epoch-start block
-	if len(header.VRank) == 0 {
-		return nil
-	}
-
 	report, err := vrank.DecodeReport(header.VRank)
 	if err != nil {
 		return vrank.ErrInvalidVRankFormat
+	}
+	if len(report) == 0 {
+		return nil
 	}
 	// Failures score against the reporter's own byzantine-filterable column regardless of content,
 	// so only the failed list is checked (CandTesting is epoch-stable within the epoch).

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -40,9 +40,6 @@ func (v *VRankModule) cfReport(blockNum uint64) ([]common.Address, error) {
 	if header == nil {
 		return nil, vrank.ErrHeaderNotFound
 	}
-	if len(header.VRank) == 0 {
-		return []common.Address{}, nil
-	}
 	return vrank.DecodeReport(header.VRank)
 }
 

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -108,6 +108,10 @@ func EncodeAddressList(addrs []common.Address) ([]byte, error) {
 }
 
 func DecodeReport(data []byte) ([]common.Address, error) {
+	if len(data) == 0 {
+		return []common.Address{}, nil
+	}
+
 	var report []common.Address
 	if err := rlp.DecodeBytes(data, &report); err != nil {
 		return nil, err

--- a/kaiax/vrank/types_test.go
+++ b/kaiax/vrank/types_test.go
@@ -50,10 +50,10 @@ func TestEncodeDecodeReport(t *testing.T) {
 			enc, err := EncodeReport(tc.report)
 			assert.NoError(t, err)
 			if len(tc.report) == 0 {
-				assert.Nil(t, enc)
-				return
+				assert.Nil(t, enc, "an empty report is encoded as absent bytes")
+			} else {
+				assert.NotEmpty(t, enc)
 			}
-			assert.NotEmpty(t, enc)
 			gotReport, err := DecodeReport(enc)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.report, gotReport)


### PR DESCRIPTION
## Proposed changes

`EncodeReport` emits no bytes for an empty report while `DecodeReport` required a valid RLP list, so the pair did not round-trip and callers had to test the raw header field first. `DecodeReport` now accepts absent bytes, and both pre-checks are gone.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

An empty report stays encoded as absent bytes, which an epoch-start header needs to distinguish a present-but-empty candidate list from absence.
