### PR TITLE
p2p: count pending static dials toward the dial demand

### DIFF
--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -332,9 +332,16 @@ func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh b
 	// 2. Add all static nodes, even if they are already connected or in the dialing list. Those will be filtered out later.
 	// Since static nodes are exempt from the connTargets nor peer limits, all static nodes are going to be dialed even if needs[] is zero.
 	candidates = ds.static.all()
+
+	// 3. Subtract the static nodes about to be dialed. They fill the same outbound budget as the dynamic ones.
+	for _, n := range candidates {
+		if _, ok := needs[n.NType]; ok && ds.dialEligible(n) {
+			needs[n.NType]--
+		}
+	}
 	ds.mu.RUnlock()
 
-	// 3. Dynamic nodes — skip when already at total peer capacity.
+	// 4. Dynamic nodes — skip when already at total peer capacity.
 	// Even if we want more outbound peers (needs > 0), the total capacity might be reached (maxPeers) due to inbound peers.
 	// Static dials (added above) bypass this check, mirroring the Server's capacity check.
 	if ds.maxPeers == 0 || ds.connectedAll.len() < ds.maxPeers {
@@ -546,7 +553,11 @@ func (ds *DialSched) markRefreshStart() {
 func (ds *DialSched) shouldDial(n *discover.Node) bool {
 	ds.mu.RLock()
 	defer ds.mu.RUnlock()
+	return ds.dialEligible(n)
+}
 
+// dialEligible is shouldDial without the locking. Callers must hold ds.mu.
+func (ds *DialSched) dialEligible(n *discover.Node) bool {
 	if ds.closed.Load() {
 		return false
 	}

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -224,6 +224,44 @@ func TestDialSched_Candidates_StaticNodes(t *testing.T) {
 	assert.Equal(t, staticNode.ID, cands[0].ID, "static node should be the only candidate")
 }
 
+// Static nodes dialed in the same batch consume the outbound demand of their type.
+func TestDialSched_GetCandidates_StaticNodesConsumeDemand(t *testing.T) {
+	var (
+		staticCNs = []*discover.Node{
+			testNode(61, "10.0.0.61", discover.NodeTypeCN),
+			testNode(62, "10.0.0.62", discover.NodeTypeCN),
+		}
+		dynamicCNs = []*discover.Node{
+			testNode(201, "10.0.0.201", discover.NodeTypeCN),
+			testNode(202, "10.0.0.202", discover.NodeTypeCN),
+		}
+		tab = &mockTable{
+			nodesByType: map[discover.NodeType][]*discover.Node{
+				discover.NodeTypeCN: dynamicCNs,
+			},
+		}
+	)
+
+	filled := NewDialSched(DialConfig{
+		staticNodes: staticCNs,
+		connTarget:  map[discover.NodeType]int{discover.NodeTypeCN: 2},
+	}, tab, nil)
+	cands, _ := filled.getCandidates()
+	assert.Len(t, cands, len(staticCNs), "pending static CNs alone should fill the CN target")
+	for _, dynamic := range dynamicCNs {
+		assert.False(t, hasNodeID(cands, dynamic.ID), "no dynamic CN is needed while statics fill the target")
+	}
+
+	// A connected static is already counted in connectedOutbound, so it must not reserve a second slot.
+	connected := NewDialSched(DialConfig{
+		staticNodes: staticCNs[:1],
+		connTarget:  map[discover.NodeType]int{discover.NodeTypeCN: 2},
+	}, tab, nil)
+	connected.OnPeerConnected(staticCNs[0].ID, staticCNs[0].NType, false)
+	cands, _ = connected.getCandidates()
+	assert.True(t, hasNodeID(cands, dynamicCNs[0].ID), "the demand left by a connected static should pull a dynamic CN")
+}
+
 // Dynamic nodes are candidates if connTarget is not met.
 func TestDialSched_GetCandidates_FromDiscovery(t *testing.T) {
 	var (


### PR DESCRIPTION
## Proposed changes

`getCandidates` computes the dynamic dial demand before appending the static
nodes, so statics dialed in the same batch go uncounted and the outbound count
for their type settles at `target + statics`. The demand now drops by every
static about to be dialed.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Further comments

Only statics passing `dialEligible` are subtracted — connected or dialing ones
already sit in the counts. `shouldDial` was split so that check can run under
the read lock `getCandidates` already holds.
