### PR TITLE
p2p: size the inbound throttle to one peer's connections

### DIFF
--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -407,26 +407,22 @@ func (srv *BaseServer) maxDialedConns() int {
 	}
 }
 
-// checkInboundConn decides whether an inbound connection from remoteIP should
-// be accepted. It rejects connections that do not match NetRestrict, and
-// throttles repeated attempts from the same non-LAN IP within
-// inboundThrottleTime to bound connection-flood attempts. now is passed in so
-// the throttle window is deterministic and testable.
-func (srv *BaseServer) checkInboundConn(remoteIP net.IP, now mclock.AbsTime) error {
+// checkInboundConn reports whether an inbound connection from remoteIP may proceed to
+// the handshake at time now.
+func (srv *BaseServer) checkInboundConn(remoteIP net.IP, allowance int, now mclock.AbsTime) error {
 	if remoteIP == nil {
 		// No usable remote IP (e.g. in-process test pipes); nothing to throttle.
 		return nil
 	}
-	// Reject connections that do not match NetRestrict.
 	if srv.NetRestrict != nil && !srv.NetRestrict.Contains(remoteIP) {
 		return errNotWhitelisted
 	}
-	// Reject peers that try to connect too frequently. LAN addresses are
-	// exempt so co-located/internal nodes are never throttled.
+
 	srv.inboundHistoryMu.Lock()
 	defer srv.inboundHistoryMu.Unlock()
 	srv.inboundHistory.expire(now, nil)
-	if !netutil.IsLAN(remoteIP) && srv.inboundHistory.contains(remoteIP.String()) {
+	// LAN addresses are exempt so co-located/internal nodes are never throttled.
+	if !netutil.IsLAN(remoteIP) && srv.inboundHistory.count(remoteIP.String()) >= allowance {
 		return errTooManyInboundAttempts
 	}
 	srv.inboundHistory.add(remoteIP.String(), now+mclock.AbsTime(inboundThrottleTime))
@@ -455,6 +451,13 @@ func (srv *BaseServer) acceptWithBackoff(listener net.Listener, lastLog *time.Ti
 	}
 }
 
+// inboundAllowance is how many inbound connections one remote IP may open within
+// inboundThrottleTime. A single-channel node advertises one port, so one peer opens
+// one connection.
+func (srv *BaseServer) inboundAllowance() int {
+	return 1
+}
+
 // acceptInbound returns the next inbound connection worth handshaking. It wraps
 // acceptWithBackoff and applies the inbound checks (NetRestrict + per-IP
 // throttle), silently dropping rejected connections. It returns nil when the
@@ -463,13 +466,13 @@ func (srv *BaseServer) acceptWithBackoff(listener net.Listener, lastLog *time.Ti
 // The handshake slot is held across rejects: listenLoop is the sole receiver of
 // its slots channel (SetupConn goroutines only send), so releasing and
 // re-acquiring a token on each reject would be a no-op.
-func (srv *BaseServer) acceptInbound(listener net.Listener, lastLog *time.Time) net.Conn {
+func (srv *BaseServer) acceptInbound(listener net.Listener, allowance int, lastLog *time.Time) net.Conn {
 	for {
 		fd := srv.acceptWithBackoff(listener, lastLog)
 		if fd == nil {
 			return nil
 		}
-		if err := srv.checkInboundConn(tcpAddrIP(fd.RemoteAddr()), mclock.Now()); err != nil {
+		if err := srv.checkInboundConn(tcpAddrIP(fd.RemoteAddr()), allowance, mclock.Now()); err != nil {
 			srv.logger.Debug("Rejected inbound connection", "addr", fd.RemoteAddr(), "err", err)
 			fd.Close()
 			continue
@@ -498,7 +501,7 @@ func (srv *BaseServer) listenLoop() {
 		// Wait for a handshake slot before accepting.
 		<-slots
 
-		fd := srv.acceptInbound(srv.listener, &lastLog)
+		fd := srv.acceptInbound(srv.listener, srv.inboundAllowance(), &lastLog)
 		if fd == nil {
 			return
 		}

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -213,6 +213,13 @@ func (srv *MultiChannelServer) startListening() error {
 	return nil
 }
 
+// Overrides BaseServer.inboundAllowance(): a peer opens one connection per listener,
+// plus the single-channel dial it made before the handshake told it that this node is
+// multichannel.
+func (srv *MultiChannelServer) inboundAllowance() int {
+	return len(srv.ListenAddrs) + 1
+}
+
 // listenLoop waits for an external connection and connects it.
 func (srv *MultiChannelServer) listenLoop(listener net.Listener) {
 	defer srv.loopWG.Done()
@@ -232,7 +239,7 @@ func (srv *MultiChannelServer) listenLoop(listener net.Listener) {
 		// Wait for a handshake slot before accepting.
 		<-slots
 
-		fd := srv.acceptInbound(listener, &lastLog)
+		fd := srv.acceptInbound(listener, srv.inboundAllowance(), &lastLog)
 		if fd == nil {
 			return
 		}

--- a/networks/p2p/server_multi_test.go
+++ b/networks/p2p/server_multi_test.go
@@ -124,6 +124,25 @@ func TestMultiChannelRejectsOutOfRangePortOrder(t *testing.T) {
 	assert.Empty(t, srv.CandidateConns)
 }
 
+// One multichannel peer opens a single-channel dial that ends in errUpdateDial, then
+// one connection per listener, all from the same IP within microseconds. The per-IP
+// inbound throttle has to fit them all, since handleAddPeerConn only builds a Peer
+// once every channel has arrived.
+func TestMultiChannelInboundThrottleFitsOnePeer(t *testing.T) {
+	srv := newCandidateTestServer(t, 10)
+	allowance := srv.inboundAllowance()
+	require.Equal(t, 3, allowance, "a two-channel node must fit one dial per listener plus the single-channel dial")
+
+	// TEST-NET-3 is public, so netutil.IsLAN does not exempt it the way loopback does.
+	ip := net.ParseIP("203.0.113.7")
+	now := mclock.AbsTime(0)
+
+	for i := 0; i < allowance; i++ {
+		require.NoError(t, srv.checkInboundConn(ip, allowance, now), "connection %d of one peer was rejected", i)
+	}
+	require.Error(t, srv.checkInboundConn(ip, allowance, now), "the throttle must still bound connections beyond one peer")
+}
+
 func TestMultiChannelStopClosesCandidates(t *testing.T) {
 	srv := newCandidateTestServer(t, 4)
 	srv.quit = make(chan struct{})

--- a/networks/p2p/util.go
+++ b/networks/p2p/util.go
@@ -46,14 +46,15 @@ func (h *expHeap) add(item string, exp mclock.AbsTime) {
 	heap.Push(h, expItem{item, exp})
 }
 
-// contains checks whether an item is present.
-func (h expHeap) contains(item string) bool {
+// count returns how many unexpired entries an item holds.
+func (h expHeap) count(item string) int {
+	n := 0
 	for _, v := range h {
 		if v.item == item {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
 }
 
 // expire removes items with expiry time before 'now'.

--- a/networks/p2p/util_test.go
+++ b/networks/p2p/util_test.go
@@ -45,7 +45,7 @@ func TestExpHeap(t *testing.T) {
 	if h.nextExpiry() != exptimeA {
 		t.Fatal("wrong nextExpiry")
 	}
-	if !h.contains("a") || !h.contains("b") || !h.contains("c") {
+	if h.count("a") != 1 || h.count("b") != 1 || h.count("c") != 1 {
 		t.Fatal("heap doesn't contain all live items")
 	}
 
@@ -53,10 +53,10 @@ func TestExpHeap(t *testing.T) {
 	if h.nextExpiry() != exptimeB {
 		t.Fatal("wrong nextExpiry")
 	}
-	if h.contains("a") {
+	if h.count("a") != 0 {
 		t.Fatal("heap contains a even though it has already expired")
 	}
-	if !h.contains("b") || !h.contains("c") {
+	if h.count("b") != 1 || h.count("c") != 1 {
 		t.Fatal("heap doesn't contain all live items")
 	}
 }
@@ -69,13 +69,13 @@ func TestCheckInboundConnThrottle(t *testing.T) {
 	ip := net.ParseIP("203.0.113.7") // TEST-NET-3, treated as a public (non-LAN) IP
 	now := mclock.AbsTime(0)
 
-	if err := srv.checkInboundConn(ip, now); err != nil {
+	if err := srv.checkInboundConn(ip, 1, now); err != nil {
 		t.Fatalf("first attempt should be accepted, got %v", err)
 	}
-	if err := srv.checkInboundConn(ip, now+mclock.AbsTime(inboundThrottleTime/2)); err != errTooManyInboundAttempts {
+	if err := srv.checkInboundConn(ip, 1, now+mclock.AbsTime(inboundThrottleTime/2)); err != errTooManyInboundAttempts {
 		t.Fatalf("attempt within throttle window should be rejected, got %v", err)
 	}
-	if err := srv.checkInboundConn(ip, now+mclock.AbsTime(inboundThrottleTime)+1); err != nil {
+	if err := srv.checkInboundConn(ip, 1, now+mclock.AbsTime(inboundThrottleTime)+1); err != nil {
 		t.Fatalf("attempt after throttle window should be accepted, got %v", err)
 	}
 }
@@ -86,7 +86,7 @@ func TestCheckInboundConnLANExempt(t *testing.T) {
 	srv := &BaseServer{}
 	ip := net.ParseIP("127.0.0.1")
 	for i := 0; i < 5; i++ {
-		if err := srv.checkInboundConn(ip, mclock.AbsTime(0)); err != nil {
+		if err := srv.checkInboundConn(ip, 1, mclock.AbsTime(0)); err != nil {
 			t.Fatalf("LAN IP should never be throttled, got %v on attempt %d", err, i)
 		}
 	}
@@ -102,10 +102,10 @@ func TestCheckInboundConnNetRestrict(t *testing.T) {
 	srv := &BaseServer{}
 	srv.NetRestrict = list
 
-	if err := srv.checkInboundConn(net.ParseIP("203.0.113.7"), 0); err != errNotWhitelisted {
+	if err := srv.checkInboundConn(net.ParseIP("203.0.113.7"), 1, 0); err != errNotWhitelisted {
 		t.Fatalf("IP outside NetRestrict should be rejected, got %v", err)
 	}
-	if err := srv.checkInboundConn(net.ParseIP("192.0.2.5"), 0); err != nil {
+	if err := srv.checkInboundConn(net.ParseIP("192.0.2.5"), 1, 0); err != nil {
 		t.Fatalf("IP within NetRestrict should be accepted, got %v", err)
 	}
 }


### PR DESCRIPTION
## Proposed changes

The inbound throttle is keyed on the remote IP and allowed one connection per 30s
window, but a multichannel peer opens one connection to every listen port from that
same IP. Every channel after the first was closed before its handshake, and a peer is
only complete once all of them arrive, so multichannel peering could not form at all
between public IPs — LAN is exempt, which is why loopback tests never showed it. The
throttle now allows one peer's worth of connections: `len(ListenAddrs) + 1` for a
multichannel node — one per listener, plus the single-channel dial a peer makes before
the handshake tells it there are more ports — and 1 for a single-channel node.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

Regression from #926, present in `v3.0.0-rc.1`.

## Further comments

Giving each listener its own throttle history does not work: the initial
single-channel dial and its retry both land on the main port, so that listener still
sees the same IP twice. Two nodes behind one public IP still share an allowance, as
upstream.
