### PR TITLE
vrank: read epoch candidates from the header when state is gone

### DIFF
--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -65,7 +65,7 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 	}
 	// Failures score against the reporter's own byzantine-filterable column regardless of content,
 	// so only the failed list is checked (CandTesting is epoch-stable within the epoch).
-	candidates, err := v.Valset.GetCandTesting(number - 1)
+	candidates, err := v.Valset.GetCandTesting(number)
 	if err != nil {
 		return err
 	}

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -151,14 +151,14 @@ func TestVerifyHeader(t *testing.T) {
 	t.Run("candidate membership is checked against the reporting block's epoch", func(t *testing.T) {
 		cn := newCN(t, withoutStart())
 		// The target is an earlier block of the same epoch, and CandTesting is epoch-stable.
-		cn.Valset.EXPECT().GetCandTesting(num-1).Return(candidates, nil).Times(1)
+		cn.Valset.EXPECT().GetCandTesting(num).Return(candidates, nil).Times(1)
 
 		assert.NoError(t, cn.VRankModule.VerifyHeader(makeSelfReportHeader(t, num, []common.Address{C1}), nil))
 	})
 
 	t.Run("candidate lookup failure is returned", func(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
-		valset.EXPECT().GetCandTesting(num-1).Return(nil, assert.AnError).AnyTimes()
+		valset.EXPECT().GetCandTesting(num).Return(nil, assert.AnError).AnyTimes()
 		v := newCN(t, withValset(valset), withoutStart()).VRankModule
 		assert.ErrorIs(t, v.VerifyHeader(makeSelfReportHeader(t, num, []common.Address{C1}), nil), assert.AnError)
 	})

--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -132,12 +132,27 @@ func (v *VRankModule) lookupCFSSeed(blockNum uint64) (start uint64, seed vrank.C
 }
 
 func (v *VRankModule) newCPMatrix(blockNum uint64) (vrank.CPMatrix, error) {
-	candidates, err := v.Valset.GetCandTesting(blockNum)
+	candidates, err := v.epochCandidates(blockNum)
 	if err != nil {
 		return nil, err
 	}
 
 	return vrank.NewCPMatrix(candidates), nil
+}
+
+// epochCandidates returns the epoch's CandTesting, from the epoch-start header that carries it
+// when the state GetCandTesting needs is not on this node.
+func (v *VRankModule) epochCandidates(blockNum uint64) ([]common.Address, error) {
+	candidates, err := v.Valset.GetCandTesting(blockNum)
+	if err == nil {
+		return candidates, nil
+	}
+	header := v.Chain.GetHeaderByNumber(calcEpochStart(blockNum, v.vrankEpoch()))
+	if header == nil {
+		return nil, err
+	}
+	logger.Warn("CandTesting unavailable from state, reading the epoch-start header", "num", blockNum, "err", err)
+	return vrank.DecodeReport(header.VRank)
 }
 
 // applyBlocksForPFS accumulates the pfReport for blocks in [start, end].

--- a/kaiax/vrank/impl/scoring_test.go
+++ b/kaiax/vrank/impl/scoring_test.go
@@ -775,6 +775,32 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		assert.True(t, hasC3, "C3 should appear in CFS map")
 	})
 
+	t.Run("epoch-start header supplies candidates when state is unavailable", func(t *testing.T) {
+		epochStart := params.DefaultVRankEpoch
+		P1, P2 := numToAddr(10), numToAddr(11)
+		C1, C2 := numToAddr(20), numToAddr(21)
+
+		ctrl := gomock.NewController(t)
+		valset := mock_valset.NewMockValsetModule(ctrl)
+		randao := mock_randao.NewMockRandaoModule(ctrl)
+		v := newCN(t, withValset(valset), withRandao(randao), withGenesis()).VRankModule
+		v.Chain = &testChain{
+			headers: map[uint64]*types.Header{
+				epochStart:     makeHeaderWithVRank(epochStart, 0, []common.Address{C1, C2}), // CandTesting
+				epochStart + 1: makeHeaderWithVRank(epochStart+1, 0, []common.Address{C1}),   // P2 reports C1
+			},
+		}
+		valset.EXPECT().GetCandTesting(epochStart).Return(nil, assert.AnError)
+		valset.EXPECT().GetProposer(epochStart, uint64(0)).Return(P1, nil)
+		valset.EXPECT().GetProposer(epochStart+1, uint64(0)).Return(P2, nil)
+
+		cfs, err := computeCFS(v, epochStart, epochStart+1)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), cfs[C1], "C1 was reported once")
+		_, hasC2 := cfs[C2]
+		assert.True(t, hasC2, "C2 comes from the header list, so it must be scored too")
+	})
+
 	t.Run("KIP227_Example2", func(t *testing.T) {
 		// Reproduces KIP-227 Example 2 through the chain-reading path.
 		// Raw per-candidate/per-reporter totals are materialized as per-block cfReports.


### PR DESCRIPTION
## Proposed changes

`newCPMatrix` seeded the CP matrix from `GetCandTesting`, which reads node states
one block below its argument — so an epoch block's transition needed the state two
blocks below it, which a node that synced the range without executing it does not
have. The epoch-start header carries the same candidate list and is now used when
the state read fails.

## Types of changes

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
