### PR TITLE
blockchain: isolate tx cache during prefetch

### DIFF
--- a/blockchain/state_prefetcher.go
+++ b/blockchain/state_prefetcher.go
@@ -58,6 +58,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, stateDB *state.StateDB, c
 		}
 		// Block precaching permitted to continue, execute the transaction
 		stateDB.SetTxContext(tx.Hash(), block.Hash(), i)
+		tx = copyTxForPrefetch(tx)
 		if err := precacheTransaction(p.chain, nil, stateDB, header, tx, cfg); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}
@@ -81,9 +82,16 @@ func (p *statePrefetcher) PrefetchTx(block *types.Block, ti int, stateDB *state.
 
 	// Block precaching permitted to continue, execute the transaction
 	stateDB.SetTxContext(tx.Hash(), block.Hash(), ti)
+	tx = copyTxForPrefetch(tx)
 	if err := precacheTransaction(p.chain, nil, stateDB, header, tx, cfg); err != nil {
 		return // Ugh, something went horribly wrong, bail out
 	}
+}
+
+// Prefetch runs against speculative state, so it must not overwrite the
+// state-dependent execution caches on the transaction imported by the block.
+func copyTxForPrefetch(tx *types.Transaction) *types.Transaction {
+	return types.NewTx(tx.GetTxInternalData())
 }
 
 // precacheTransaction attempts to apply a transaction to the given state database

--- a/blockchain/state_prefetcher_test.go
+++ b/blockchain/state_prefetcher_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package blockchain
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/blockchain/types/accountkey"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/fork"
+	"github.com/kaiachain/kaia/params"
+	"github.com/stretchr/testify/require"
+)
+
+type prefetchTestKeyPicker map[common.Address]accountkey.AccountKey
+
+func (p prefetchTestKeyPicker) GetKey(addr common.Address) accountkey.AccountKey {
+	return p[addr]
+}
+
+func (p prefetchTestKeyPicker) Exist(addr common.Address) bool {
+	return p[addr] != nil
+}
+
+// TestCopyTxForPrefetchDoesNotOverwriteOriginalValidatedGas verifies that
+// prefetch cannot overwrite state-dependent validatedGas cached on the original
+// block transaction.
+func TestCopyTxForPrefetchDoesNotOverwriteOriginalValidatedGas(t *testing.T) {
+	require.NoError(t, fork.SetHardForkBlockNumberConfig(&params.ChainConfig{
+		IstanbulCompatibleBlock: big.NewInt(100),
+	}))
+
+	const blockNumber = uint64(0)
+	signer := types.LatestSignerForChainID(big.NewInt(1))
+	senderKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	extraKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	from := crypto.PubkeyToAddress(senderKey.PublicKey)
+	to := common.HexToAddress("0x0000000000000000000000000000000000000100")
+	txData, err := types.NewTxInternalDataWithMap(types.TxTypeValueTransfer, map[types.TxValueKeyType]interface{}{
+		types.TxValueKeyNonce:    uint64(0),
+		types.TxValueKeyTo:       to,
+		types.TxValueKeyAmount:   big.NewInt(1),
+		types.TxValueKeyGasLimit: uint64(100000),
+		types.TxValueKeyGasPrice: big.NewInt(1),
+		types.TxValueKeyFrom:     from,
+	})
+	require.NoError(t, err)
+
+	tx := types.NewTx(txData)
+	require.NoError(t, tx.SignWithKeys(signer, []*ecdsa.PrivateKey{senderKey}))
+
+	stalePicker := prefetchTestKeyPicker{
+		from: accountkey.NewAccountKeyPublicWithValue(&senderKey.PublicKey),
+	}
+	currentPicker := prefetchTestKeyPicker{
+		from: accountkey.NewAccountKeyWeightedMultiSigWithValues(1, accountkey.WeightedPublicKeys{
+			accountkey.NewWeightedPublicKey(1, (*accountkey.PublicKeySerializable)(&senderKey.PublicKey)),
+			accountkey.NewWeightedPublicKey(1, (*accountkey.PublicKeySerializable)(&extraKey.PublicKey)),
+		}),
+	}
+
+	_, err = tx.AsMessageWithAccountKeyPicker(signer, currentPicker, blockNumber)
+	require.NoError(t, err)
+	originalGas := tx.ValidatedGas().IntrinsicGas
+
+	prefetchTx := copyTxForPrefetch(tx)
+	_, err = prefetchTx.AsMessageWithAccountKeyPicker(signer, stalePicker, blockNumber)
+	require.NoError(t, err)
+
+	require.Equal(t, params.TxValidationGasPerKey, originalGas-prefetchTx.ValidatedGas().IntrinsicGas)
+	require.Equal(t, originalGas, tx.ValidatedGas().IntrinsicGas)
+}


### PR DESCRIPTION
## Summary

- During mainnet sync, one block was rejected once and later imported successfully.
- GasUsed mismatch was `15000` (`134249803` remote vs `134234803` local).
- The delta matches one Kaia signature-validation key.
- The peer was v2.2.2, so logs/code-version differences made the symptom hard to isolate.

## Cause

- EVM-based prefetch calls `tx.AsMessageWithAccountKeyPicker(...)`.
- That method mutates tx wrapper caches, including `validatedGas`.
- Prefetch used the original block tx pointer.
- Speculative prefetch state could overwrite caches later used by real `insertChain` execution.
- The added unit test reproduces the `15000` gas cache pollution case.

## Fix

- Use a fresh transaction wrapper before prefetch execution:

```go
types.NewTx(tx.GetTxInternalData())
```

- This keeps original block transaction caches untouched.
- It does not deep-copy tx data, signatures, or payload.

## History

- [`5e25a0f71`](https://github.com/kaiachain/kaia/commit/5e25a0f71): added copied tx prefetching.
- [`c57ec37bd`](https://github.com/kaiachain/kaia/commit/c57ec37bd): removed copied tx logic.
- Later locks prevent data races, but not logical cache pollution from speculative prefetch.
- `kaiabft` avoids this differently via [`d4671fa8a`](https://github.com/kaiachain/kaia/commit/d4671fa8a), but that is a larger behavior/performance change, so this PR keeps the fix minimal for `dev`.

## Scope

- Affected:
  - block import/sync through `insertChain` prefetch paths
- Not affected:
  - proposer block creation path
  - proposer path does not use `statePrefetcher`, `Prefetch`, or `PrefetchTx`

## Test

- Before the fix, the regression test fails because prefetch overwrites the original tx gas cache.
- After the fix, the same regression test passes and the full blockchain package test passes.

```sh
# Before the fix: copyTxForPrefetch returns the original tx.
$ go test ./blockchain -run TestCopyTxForPrefetchDoesNotOverwriteOriginalValidatedGas -count=1
INFO[08/06,17:37:04 +08] [5] InitDeriveSha                             initial=0 withGov=false
--- FAIL: TestCopyTxForPrefetchDoesNotOverwriteOriginalValidatedGas (0.00s)
    state_prefetcher_test.go:92:
        Error Trace:    /Users/yumiel/.codex/worktrees/6174/kaia/blockchain/state_prefetcher_test.go:92
        Error:          Not equal:
                        expected: 0x8ca0
                        actual  : 0x5208
        Test:           TestCopyTxForPrefetchDoesNotOverwriteOriginalValidatedGas
FAIL
FAIL    github.com/kaiachain/kaia/blockchain    0.549s
FAIL

# After the fix.
$ go test ./blockchain -run TestCopyTxForPrefetchDoesNotOverwriteOriginalValidatedGas -count=1
ok      github.com/kaiachain/kaia/blockchain    0.547s

$ go test ./blockchain -count=1
ok      github.com/kaiachain/kaia/blockchain    20.236s
```
