### PR TITLE
params: reject chain config missing blobSchedule when Osaka is enabled

### DIFF
--- a/params/blob_config.go
+++ b/params/blob_config.go
@@ -53,6 +53,21 @@ func (bcfg *BlobConfig) MaxBlobGas() uint64 {
 	return uint64(bcfg.Max) * BlobTxBlobGasPerBlob
 }
 
+// validate checks that a blob config from a chain configuration is sane.
+// UpdateFraction must be non-zero because it is used as a division denominator.
+func (bcfg *BlobConfig) validate() error {
+	if bcfg.Max < 0 {
+		return errors.New("max < 0")
+	}
+	if bcfg.Target < 0 {
+		return errors.New("target < 0")
+	}
+	if bcfg.UpdateFraction == 0 {
+		return errors.New("update fraction must be defined and non-zero")
+	}
+	return nil
+}
+
 // blobPriceEIP4844 returns the price for EIP-4844 of one blob in Wei.
 func (bcfg *BlobConfig) BlobPriceEIP4844(excessBlobGas uint64) *big.Int {
 	f := bcfg.BlobBaseFeeEIP4844(excessBlobGas)

--- a/params/config.go
+++ b/params/config.go
@@ -449,7 +449,7 @@ func (c *ChainConfig) Copy() *ChainConfig {
 
 // BlobConfig returns the blob config associated with the provided fork.
 func (c *ChainConfig) BlobConfig(head *big.Int) *BlobConfig {
-	if c.IsOsakaForkEnabled(head) {
+	if c.IsOsakaForkEnabled(head) && c.BlobScheduleConfig != nil {
 		return c.BlobScheduleConfig.Osaka
 	}
 	return nil
@@ -648,6 +648,19 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		if cur.block != nil {
 			lastFork = cur
 		}
+	}
+
+	// Check that the fork enabling blobs explicitly defines a valid blob schedule.
+	var osakaBlobConfig *BlobConfig
+	if c.BlobScheduleConfig != nil {
+		osakaBlobConfig = c.BlobScheduleConfig.Osaka
+	}
+	if osakaBlobConfig != nil {
+		if err := osakaBlobConfig.validate(); err != nil {
+			return fmt.Errorf("invalid chain configuration in blobSchedule for fork %q: %v", "osaka", err)
+		}
+	} else if c.OsakaCompatibleBlock != nil {
+		return fmt.Errorf("invalid chain configuration: missing entry for fork %q in blobSchedule", "osaka")
 	}
 	return nil
 }


### PR DESCRIPTION
A hand-written genesis that enables Osaka without a blobSchedule nil-dereferenced in ChainConfig.BlobConfig, killing an EN on a single eth_feeHistory call and panicking a CN at block-1 validation.

CheckConfigForkOrder now requires a valid Osaka blob schedule (with non-zero baseFeeUpdateFraction, which is a division denominator) so such a config is rejected at load, and BlobConfig is nil-safe as a second layer.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
