### PR TITLE
blockchain: fix the author check in verifySeals

### DIFF
--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -248,12 +248,12 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	if err != nil {
 		return err
 	}
-	if len(committers) == 0 {
-		return istanbul.ErrEmptyCommittedSeals
-	}
 
 	// Skip module-dependent seal validation when gov/valset modules are not registered.
 	if v.mValset == nil || v.mGov == nil {
+		if len(committers) == 0 {
+			return istanbul.ErrEmptyCommittedSeals
+		}
 		return nil
 	}
 
@@ -319,6 +319,10 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 }
 
 func countValidCommittedSeals(committers []common.Address, signerSet *valset.AddressSet) (int, error) {
+	// A proposal has no committed seals, so authorize the author before this gate, not after.
+	if len(committers) == 0 {
+		return 0, istanbul.ErrEmptyCommittedSeals
+	}
 	validSeal := 0
 	for _, addr := range committers {
 		if !signerSet.Remove(addr) {

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -262,16 +262,6 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		if err != nil {
 			return err
 		}
-		proposer, err := v.mValset.GetProposer(blockNum, uint64(round))
-		if err != nil {
-			return err
-		}
-		// author == proposer implies the author is the committee-selected proposer,
-		// so a separate qualified-membership check is redundant here.
-		if author != proposer {
-			return consensus.ErrUnauthorized
-		}
-
 		// Count committed seals only from the round's committee, matching the set the
 		// live consensus commits against (handleCommit rejects non-committee senders),
 		// rather than the broader qualified/council set.
@@ -280,6 +270,9 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 			return err
 		}
 		committeeSet := valset.NewAddressSet(committee)
+		if !committeeSet.Contains(author) {
+			return consensus.ErrUnauthorized
+		}
 		validSeal, err := countValidCommittedSeals(committers, committeeSet)
 		if err != nil {
 			return err

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -273,6 +273,55 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeAuthor(t *testing.T) {
 	assert.ErrorIs(t, validator.verifySeals(header), consensus.ErrUnauthorized)
 }
 
+// TestVerifySealsAuthorizesAuthorWithoutSeals checks that the author is authorized on a
+// header that carries no committed seals. Live consensus verifies proposals, which never
+// carry seals, so a check reachable only once seals exist would let a proposal be prepared
+// and hash-locked before any node refuses it.
+func TestVerifySealsAuthorizesAuthorWithoutSeals(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		other    = common.HexToAddress("0x0002")
+		blockNum = uint64(7)
+	)
+
+	testcases := []struct {
+		name        string
+		beforeFork  bool
+		signers     []common.Address
+		expectedErr error
+	}{
+		{"rejects non-committee author", false, []common.Address{other}, consensus.ErrUnauthorized},
+		{"committee author awaits seals", false, []common.Address{author}, istanbul.ErrEmptyCommittedSeals},
+		{"before fork rejects unqualified author", true, []common.Address{other}, consensus.ErrUnauthorized},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			config := params.TestKaiaConfig("permissionless").Copy()
+			mValset := mock_valset.NewMockValsetModule(ctrl)
+			if tc.beforeFork {
+				config.PermissionlessCompatibleBlock = big.NewInt(10)
+				mValset.EXPECT().GetQualifiedValidators(blockNum).Return(tc.signers, nil)
+			} else {
+				mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(tc.signers, nil)
+			}
+
+			validator := &BlockValidator{
+				config:  config,
+				sealer:  &verifySealsTestSealer{Sealer: faker.NewFaker(), author: author},
+				mGov:    mock_gov.NewMockGovModule(ctrl),
+				mValset: mValset,
+			}
+
+			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+			assert.ErrorIs(t, validator.verifySeals(header), tc.expectedErr)
+		})
+	}
+}
+
 func TestVerifySealsBeforePermissionlessUsesQualifiedSet(t *testing.T) {
 	var (
 		author   = common.HexToAddress("0x0001")

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -239,13 +239,21 @@ func TestValidateHeader(t *testing.T) {
 	}
 }
 
-func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
+// TestVerifySealsPermissionlessRejectsNonCommitteeAuthor checks that an author outside the
+// round's committee is rejected even when every committed seal is valid.
+func TestVerifySealsPermissionlessRejectsNonCommitteeAuthor(t *testing.T) {
 	var (
-		author        = common.HexToAddress("0x0001")
-		otherProposer = common.HexToAddress("0x0002")
-		blockNum      = uint64(7)
-		header        = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
-		sealer        = faker.NewFakerWithFixedSealer(author)
+		author    = common.HexToAddress("0x0001")
+		b         = common.HexToAddress("0x0002")
+		c         = common.HexToAddress("0x0003")
+		blockNum  = uint64(7)
+		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		committee = []common.Address{b, c}
+		sealer    = &verifySealsTestSealer{
+			Sealer:     faker.NewFaker(),
+			author:     author,
+			committers: []common.Address{b, c},
+		}
 	)
 
 	ctrl := gomock.NewController(t)
@@ -253,7 +261,7 @@ func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(otherProposer, nil)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
 		config:  params.TestKaiaConfig("permissionless"),
@@ -265,7 +273,7 @@ func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
 	assert.ErrorIs(t, validator.verifySeals(header), consensus.ErrUnauthorized)
 }
 
-func TestVerifySealsSkipsProposerAuthorCheckBeforePermissionless(t *testing.T) {
+func TestVerifySealsBeforePermissionlessUsesQualifiedSet(t *testing.T) {
 	var (
 		author   = common.HexToAddress("0x0001")
 		blockNum = uint64(7)
@@ -294,7 +302,7 @@ func TestVerifySealsSkipsProposerAuthorCheckBeforePermissionless(t *testing.T) {
 	assert.NoError(t, validator.verifySeals(header))
 }
 
-func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
+func TestVerifySealsPermissionlessAcceptsCommitteeAuthor(t *testing.T) {
 	var (
 		author   = common.HexToAddress("0x0001")
 		blockNum = uint64(7)
@@ -307,7 +315,6 @@ func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{author}, nil)
 
 	validator := &BlockValidator{
@@ -346,7 +353,6 @@ func TestVerifySealsPermissionlessUsesSealerQuorum(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
@@ -386,7 +392,6 @@ func TestVerifySealsPermissionlessRejectsBelowQuorum(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
@@ -424,7 +429,6 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
@@ -488,7 +492,6 @@ func TestVerifySealsPermissionlessRejectsMutatedRound(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, gomock.Any()).Return(addrs[0], nil).AnyTimes()
 	mValset.EXPECT().GetCommittee(blockNum, gomock.Any()).Return(addrs, nil).AnyTimes()
 
 	validator := &BlockValidator{config: config, sealer: sealer, mGov: mGov, mValset: mValset}
@@ -497,6 +500,59 @@ func TestVerifySealsPermissionlessRejectsMutatedRound(t *testing.T) {
 
 	sealer.WriteRound(header, round+1)
 	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+}
+
+// TestVerifySealsPermissionlessAcceptsHashLockedAuthor covers the block a round change
+// produces: the locked proposal is re-proposed in a later round, so the header carries the
+// final round with the original author's seal. Such a block is valid, and deciding it must
+// not depend on who was scheduled to propose the final round.
+func TestVerifySealsPermissionlessAcceptsHashLockedAuthor(t *testing.T) {
+	const round = int64(3)
+	var (
+		blockNum = uint64(7)
+		keys     = make([]*ecdsa.PrivateKey, 4) // Quorum(4, 4) == 3, so 4 valid seals pass
+		addrs    = make([]common.Address, 4)
+	)
+	for i := range keys {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		keys[i], addrs[i] = key, crypto.PubkeyToAddress(key.PublicKey)
+	}
+
+	sealer := &roundBoundSealer{istanbul.NewSealerImpl(keys[0])} // keys[0] sealed an earlier round
+
+	header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+	require.NoError(t, sealer.WriteValidators(header, addrs))
+	sealer.WriteRound(header, round)
+	authorSeal, err := sealer.MakeAuthorSeal(header)
+	require.NoError(t, err)
+	require.NoError(t, sealer.WriteAuthorSeal(header, authorSeal))
+
+	seals := make([][]byte, len(keys))
+	for i, key := range keys {
+		preimage := istanbul.PrepareCommittedSealWithRound(sealer.HeaderHash(header), byte(round))
+		seals[i], err = crypto.Sign(crypto.Keccak256(preimage), key)
+		require.NoError(t, err)
+	}
+	require.NoError(t, sealer.WriteCommittedSeals(header, seals))
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(round)).Return(addrs, nil)
+	// The final round is another validator's turn, and the block must be valid regardless.
+	mValset.EXPECT().GetProposer(blockNum, uint64(round)).Return(addrs[1], nil).AnyTimes()
+
+	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	require.NoError(t, validator.verifySeals(header))
 }
 
 func TestVerifyBlockBody(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

`verifySeals` demanded `author == GetProposer(N, R)` post-permissionless, which a re-proposed locked block never satisfies: the header pairs the final round with the original proposer's seal, so such a block is refused on import. The check also sat below the empty-committed-seal report, which every proposal reaches because a proposal carries no seals — so live consensus never ran it at all, and a header author outside the committee survived PREPARE and COMMIT and was hash-locked before the importer could refuse it.

Check committee membership instead of proposer equality, and move the empty-seal report into `countValidCommittedSeals` so the author is authorized first. `header.Round` integrity already comes from the round-bound committed seal, and a header that carries seals gets the same verdict as before.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
