### PR TITLE
metrics: serve Prometheus /metrics on a private mux

### DIFF
--- a/metrics/utils/metrics.go
+++ b/metrics/utils/metrics.go
@@ -69,12 +69,16 @@ func StartMetricCollectionAndExport(ctx *cli.Context) {
 			pClient := prometheusmetrics.NewPrometheusProvider(metrics.DefaultRegistry, MetricNamespace,
 				"", prometheus.DefaultRegisterer, metricsCollectionInterval)
 			go pClient.UpdatePrometheusMetrics()
-			http.Handle("/metrics", promhttp.Handler())
+
+			// Use a private mux, not http.DefaultServeMux, so net/http/pprof's
+			// globally-registered /debug/pprof/* is not exposed on this port.
+			mux := http.NewServeMux()
+			mux.Handle("/metrics", promhttp.Handler())
 			port := ctx.Int(PrometheusExporterPortFlag)
 
+			server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
 			go func() {
-				err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
-				if err != nil {
+				if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 					logger.Error("PrometheusExporter starting failed:", "port", port, "err", err)
 				}
 			}()

--- a/metrics/utils/metrics.go
+++ b/metrics/utils/metrics.go
@@ -59,6 +59,12 @@ func init() {
 	}
 }
 
+func newPrometheusMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	return mux
+}
+
 // StartMetricCollectionAndExport starts exporting to prometheus and collects process metrics.
 func StartMetricCollectionAndExport(ctx *cli.Context) {
 	metricsCollectionInterval := 3 * time.Second
@@ -70,13 +76,10 @@ func StartMetricCollectionAndExport(ctx *cli.Context) {
 				"", prometheus.DefaultRegisterer, metricsCollectionInterval)
 			go pClient.UpdatePrometheusMetrics()
 
-			// Use a private mux, not http.DefaultServeMux, so net/http/pprof's
-			// globally-registered /debug/pprof/* is not exposed on this port.
-			mux := http.NewServeMux()
-			mux.Handle("/metrics", promhttp.Handler())
 			port := ctx.Int(PrometheusExporterPortFlag)
 
-			server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
+			// Use a private mux so globally registered handlers are not exposed.
+			server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: newPrometheusMux()}
 			go func() {
 				if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 					logger.Error("PrometheusExporter starting failed:", "port", port, "err", err)

--- a/metrics/utils/metrics_test.go
+++ b/metrics/utils/metrics_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package metricutils
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof/* on http.DefaultServeMux, like the node binaries
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// freePort returns an ephemeral TCP port that is free at call time.
+func freePort(t *testing.T) int {
+	t.Helper()
+	var lc net.ListenConfig
+	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// httpGet issues a context-aware GET and returns the response.
+func httpGet(url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
+func newExporterCtx(port int) *cli.Context {
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.Int(PrometheusExporterPortFlag, port, "")
+	return cli.NewContext(cli.NewApp(), set, nil)
+}
+
+// TestPrometheusExporterDoesNotExposePprof checks that the exporter serves
+// /metrics but not net/http/pprof's /debug/pprof/*, guarding against a regression
+// to a nil (DefaultServeMux) handler that would leak them on the Prometheus port.
+func TestPrometheusExporterDoesNotExposePprof(t *testing.T) {
+	// Enabled/EnabledPrometheusExport are normally set by init() from os.Args.
+	prevEnabled, prevExport := Enabled, EnabledPrometheusExport
+	Enabled, EnabledPrometheusExport = true, true
+	t.Cleanup(func() { Enabled, EnabledPrometheusExport = prevEnabled, prevExport })
+
+	port := freePort(t)
+	StartMetricCollectionAndExport(newExporterCtx(port))
+
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// Wait for the listener to come up.
+	require.Eventually(t, func() bool {
+		resp, err := httpGet(base + "/metrics")
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 20*time.Millisecond, "/metrics never became reachable")
+
+	cases := []struct {
+		path string
+		want int
+	}{
+		{"/metrics", http.StatusOK},
+		{"/debug/pprof/", http.StatusNotFound},
+		{"/debug/pprof/cmdline", http.StatusNotFound},
+		{"/debug/pprof/goroutine", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		resp, err := httpGet(base + tc.path)
+		require.NoError(t, err, tc.path)
+		resp.Body.Close()
+		assert.Equal(t, tc.want, resp.StatusCode, "unexpected status for %s", tc.path)
+	}
+}

--- a/metrics/utils/metrics_test.go
+++ b/metrics/utils/metrics_test.go
@@ -17,69 +17,21 @@
 package metricutils
 
 import (
-	"context"
-	"flag"
-	"fmt"
-	"net"
 	"net/http"
+	"net/http/httptest"
 	_ "net/http/pprof" // registers /debug/pprof/* on http.DefaultServeMux, like the node binaries
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v2"
 )
-
-// freePort returns an ephemeral TCP port that is free at call time.
-func freePort(t *testing.T) int {
-	t.Helper()
-	var lc net.ListenConfig
-	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := l.Addr().(*net.TCPAddr).Port
-	require.NoError(t, l.Close())
-	return port
-}
-
-// httpGet issues a context-aware GET and returns the response.
-func httpGet(url string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	return http.DefaultClient.Do(req)
-}
-
-func newExporterCtx(port int) *cli.Context {
-	set := flag.NewFlagSet("test", flag.ContinueOnError)
-	set.Int(PrometheusExporterPortFlag, port, "")
-	return cli.NewContext(cli.NewApp(), set, nil)
-}
 
 // TestPrometheusExporterDoesNotExposePprof checks that the exporter serves
 // /metrics but not net/http/pprof's /debug/pprof/*, guarding against a regression
 // to a nil (DefaultServeMux) handler that would leak them on the Prometheus port.
 func TestPrometheusExporterDoesNotExposePprof(t *testing.T) {
-	// Enabled/EnabledPrometheusExport are normally set by init() from os.Args.
-	prevEnabled, prevExport := Enabled, EnabledPrometheusExport
-	Enabled, EnabledPrometheusExport = true, true
-	t.Cleanup(func() { Enabled, EnabledPrometheusExport = prevEnabled, prevExport })
-
-	port := freePort(t)
-	StartMetricCollectionAndExport(newExporterCtx(port))
-
-	base := fmt.Sprintf("http://127.0.0.1:%d", port)
-
-	// Wait for the listener to come up.
-	require.Eventually(t, func() bool {
-		resp, err := httpGet(base + "/metrics")
-		if err != nil {
-			return false
-		}
-		resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
-	}, 5*time.Second, 20*time.Millisecond, "/metrics never became reachable")
+	server := httptest.NewServer(newPrometheusMux())
+	t.Cleanup(server.Close)
 
 	cases := []struct {
 		path string
@@ -91,7 +43,9 @@ func TestPrometheusExporterDoesNotExposePprof(t *testing.T) {
 		{"/debug/pprof/goroutine", http.StatusNotFound},
 	}
 	for _, tc := range cases {
-		resp, err := httpGet(base + tc.path)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL+tc.path, nil)
+		require.NoError(t, err, tc.path)
+		resp, err := server.Client().Do(req)
 		require.NoError(t, err, tc.path)
 		resp.Body.Close()
 		assert.Equal(t, tc.want, resp.StatusCode, "unexpected status for %s", tc.path)

--- a/metrics/utils/metrics_test.go
+++ b/metrics/utils/metrics_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPrometheusExporterDoesNotExposePprof checks that the exporter serves
-// /metrics but not net/http/pprof's /debug/pprof/*, guarding against a regression
-// to a nil (DefaultServeMux) handler that would leak them on the Prometheus port.
+// TestPrometheusExporterDoesNotExposePprof verifies that newPrometheusMux
+// serves /metrics and does not expose the pprof routes registered on
+// http.DefaultServeMux.
 func TestPrometheusExporterDoesNotExposePprof(t *testing.T) {
 	server := httptest.NewServer(newPrometheusMux())
 	t.Cleanup(server.Close)


### PR DESCRIPTION
## Proposed changes

- Starting the exporter with a `nil` handler served `http.DefaultServeMux`, exposing net/http/pprof's /debug/pprof/* (including cmdline) on the Prometheus port even with `--pprof` off
- Use a private mux; listen address unchanged. Add a regression test.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
