### PR TITLE
datasync/fetcher: bound the memory held by the block import queue

### DIFF
--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -51,6 +51,10 @@ const (
 var (
 	errTerminated = errors.New("terminated")
 	logger        = log.NewModuleLogger(log.DatasyncFetcher)
+
+	// queuedBytesLimit caps the encoded size of the blocks held in the import queue,
+	// matching the downloader's blockCacheMemory. blockLimit alone bounds the count.
+	queuedBytesLimit uint64 = 64 * 1024 * 1024
 )
 
 // blockRetrievalFn is a callback type for retrieving a block from the local chain.
@@ -111,8 +115,9 @@ type bodyFilterTask struct {
 
 // inject represents a schedules import operation.
 type inject struct {
-	origin string
-	block  *types.Block
+	origin  string
+	block   *types.Block
+	trusted bool // locally produced by consensus; exempt from the queue byte budget
 }
 
 // Fetcher is responsible for accumulating block announcements from various peers
@@ -126,8 +131,9 @@ type Fetcher struct {
 	headerFilter chan chan *headerFilterTask
 	bodyFilter   chan chan *bodyFilterTask
 
-	done chan common.Hash
-	quit chan struct{}
+	done       chan common.Hash
+	forgetPeer chan string
+	quit       chan struct{}
 
 	// Announce states
 	announces  map[string]int              // Per peer announce counts to prevent memory exhaustion
@@ -137,9 +143,10 @@ type Fetcher struct {
 	completing map[common.Hash]*announce   // Blocks with headers, currently body-completing
 
 	// Block cache
-	queue  *prque.Prque            // Queue containing the import operations (block number sorted)
-	queues map[string]int          // Per peer block counts to prevent memory exhaustion
-	queued map[common.Hash]*inject // Set of already queued blocks (to dedupe imports)
+	queue       *prque.Prque            // Queue containing the import operations (block number sorted)
+	queues      map[string]int          // Per peer block counts to prevent memory exhaustion
+	queued      map[common.Hash]*inject // Set of already queued blocks (to dedupe imports)
+	queuedBytes uint64                  // Encoded size of the queued blocks
 
 	// Callbacks
 	getBlock           blockRetrievalFn       // Retrieves a block from the local chain
@@ -169,6 +176,7 @@ func New(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBloc
 		headerFilter:       make(chan chan *headerFilterTask),
 		bodyFilter:         make(chan chan *bodyFilterTask),
 		done:               make(chan common.Hash, numInsertTasks),
+		forgetPeer:         make(chan string),
 		quit:               make(chan struct{}),
 		announces:          make(map[string]int),
 		announced:          make(map[common.Hash][]*announce),
@@ -228,16 +236,29 @@ func (f *Fetcher) Notify(peer string, hash common.Hash, number uint64, time time
 
 // Enqueue tries to fill gaps the fetcher's future import queue.
 func (f *Fetcher) Enqueue(peer string, block *types.Block) error {
-	op := &inject{
-		origin: peer,
-		block:  block,
-	}
+	return f.enqueueOp(&inject{origin: peer, block: block})
+}
 
+// EnqueueTrusted schedules a block this node produced or committed itself, which is
+// exempt from the queue byte budget so a peer cannot crowd out the consensus import path.
+func (f *Fetcher) EnqueueTrusted(peer string, block *types.Block) error {
+	return f.enqueueOp(&inject{origin: peer, block: block, trusted: true})
+}
+
+func (f *Fetcher) enqueueOp(op *inject) error {
 	select {
 	case f.inject <- op:
 		return nil
 	case <-f.quit:
 		return errTerminated
+	}
+}
+
+// ForgetPeer releases the blocks a disconnected peer left in the import queue.
+func (f *Fetcher) ForgetPeer(peer string) {
+	select {
+	case f.forgetPeer <- peer:
+	case <-f.quit:
 	}
 }
 
@@ -315,6 +336,9 @@ func (f *Fetcher) loop() {
 		height := f.chainHeight()
 		for !f.queue.Empty() {
 			op := f.queue.PopItem().(*inject)
+			if op.block == nil { // released when its source peer disconnected
+				continue
+			}
 			if f.queueChangeHook != nil {
 				f.queueChangeHook(op.block.Hash(), false)
 			}
@@ -391,7 +415,20 @@ func (f *Fetcher) loop() {
 		case op := <-f.inject:
 			// A direct block insertion was requested, try and fill any pending gaps
 			propBroadcastInMeter.Mark(1)
-			f.enqueue(op.origin, op.block)
+			f.enqueue(op.origin, op.block, op.trusted)
+
+		case peer := <-f.forgetPeer:
+			// The peer is gone; release what it queued instead of holding it until
+			// the chain reaches those heights.
+			for hash, op := range f.queued {
+				if op.origin == peer {
+					f.forgetBlock(hash)
+					op.block = nil // the queue entry itself is dropped when popped
+					if f.queueChangeHook != nil {
+						f.queueChangeHook(hash, false)
+					}
+				}
+			}
 
 		case hash := <-f.done:
 			// A pending import finished, remove all traces of the notification
@@ -539,7 +576,7 @@ func (f *Fetcher) loop() {
 			// Schedule the header-only blocks for import
 			for _, block := range complete {
 				if announce := f.completing[block.Hash()]; announce != nil {
-					f.enqueue(announce.origin, block)
+					f.enqueue(announce.origin, block, false)
 				}
 			}
 
@@ -604,7 +641,7 @@ func (f *Fetcher) loop() {
 			// Schedule the retrieved blocks for ordered import
 			for _, block := range blocks {
 				if announce := f.completing[block.Hash()]; announce != nil {
-					f.enqueue(announce.origin, block)
+					f.enqueue(announce.origin, block, false)
 				}
 			}
 		}
@@ -645,7 +682,7 @@ func (f *Fetcher) rescheduleComplete(complete *time.Timer) {
 
 // enqueue schedules a new future import operation, if the block to be imported
 // has not yet been seen.
-func (f *Fetcher) enqueue(peer string, block *types.Block) {
+func (f *Fetcher) enqueue(peer string, block *types.Block, trusted bool) {
 	hash := block.Hash()
 
 	// Ensure the peer isn't DOSing us
@@ -663,14 +700,25 @@ func (f *Fetcher) enqueue(peer string, block *types.Block) {
 		f.forgetHash(hash)
 		return
 	}
+	// Bound the memory the queue holds. Blocks this node committed itself are exempt:
+	// they are the consensus import path and must not be crowded out by a peer.
+	size := uint64(block.Size())
+	if !trusted && f.queuedBytes+size > queuedBytesLimit {
+		logger.Debug("Discarded propagated block, exceeded byte allowance", "peer", peer, "number", block.Number(), "hash", hash, "limit", queuedBytesLimit)
+		propBroadcastDOSMeter.Mark(1)
+		f.forgetHash(hash)
+		return
+	}
 	// Schedule the block for future importing
 	if _, ok := f.queued[hash]; !ok {
 		op := &inject{
-			origin: peer,
-			block:  block,
+			origin:  peer,
+			block:   block,
+			trusted: trusted,
 		}
 		f.queues[peer] = count
 		f.queued[hash] = op
+		f.queuedBytes += size
 		f.queue.Push(op, -int64(block.NumberU64()))
 		if f.queueChangeHook != nil {
 			f.queueChangeHook(op.block.Hash(), true)
@@ -793,6 +841,7 @@ func (f *Fetcher) forgetBlock(hash common.Hash) {
 		if f.queues[insert.origin] == 0 {
 			delete(f.queues, insert.origin)
 		}
+		f.queuedBytes -= uint64(insert.block.Size())
 		delete(f.queued, hash)
 	}
 }

--- a/datasync/fetcher/fetcher.go
+++ b/datasync/fetcher/fetcher.go
@@ -117,7 +117,7 @@ type bodyFilterTask struct {
 type inject struct {
 	origin  string
 	block   *types.Block
-	trusted bool // locally produced by consensus; exempt from the queue byte budget
+	trusted bool // locally produced by consensus; exempt from the byte budget and from ForgetPeer
 }
 
 // Fetcher is responsible for accumulating block announcements from various peers
@@ -421,7 +421,7 @@ func (f *Fetcher) loop() {
 			// The peer is gone; release what it queued instead of holding it until
 			// the chain reaches those heights.
 			for hash, op := range f.queued {
-				if op.origin == peer {
+				if op.origin == peer && !op.trusted {
 					f.forgetBlock(hash)
 					op.block = nil // the queue entry itself is dropped when popped
 					if f.queueChangeHook != nil {
@@ -710,21 +710,24 @@ func (f *Fetcher) enqueue(peer string, block *types.Block, trusted bool) {
 		return
 	}
 	// Schedule the block for future importing
-	if _, ok := f.queued[hash]; !ok {
-		op := &inject{
-			origin:  peer,
-			block:   block,
-			trusted: trusted,
-		}
-		f.queues[peer] = count
-		f.queued[hash] = op
-		f.queuedBytes += size
-		f.queue.Push(op, -int64(block.NumberU64()))
-		if f.queueChangeHook != nil {
-			f.queueChangeHook(op.block.Hash(), true)
-		}
-		logger.Debug("Queued propagated block", "peer", peer, "number", block.Number(), "hash", hash, "queued", f.queue.Size())
+	if queued, ok := f.queued[hash]; ok {
+		// Carry the commit mark over, so a peer that announced it first cannot take it away.
+		queued.trusted = queued.trusted || trusted
+		return
 	}
+	op := &inject{
+		origin:  peer,
+		block:   block,
+		trusted: trusted,
+	}
+	f.queues[peer] = count
+	f.queued[hash] = op
+	f.queuedBytes += size
+	f.queue.Push(op, -int64(block.NumberU64()))
+	if f.queueChangeHook != nil {
+		f.queueChangeHook(op.block.Hash(), true)
+	}
+	logger.Debug("Queued propagated block", "peer", peer, "number", block.Number(), "hash", hash, "queued", f.queue.Size())
 }
 
 type insertTask struct {

--- a/datasync/fetcher/fetcher_fake.go
+++ b/datasync/fetcher/fetcher_fake.go
@@ -32,7 +32,9 @@ func NewFakeFetcher() *FakeFetcher {
 	return &FakeFetcher{}
 }
 
-func (*FakeFetcher) Enqueue(peer string, block *types.Block) error { return nil }
+func (*FakeFetcher) Enqueue(peer string, block *types.Block) error        { return nil }
+func (*FakeFetcher) EnqueueTrusted(peer string, block *types.Block) error { return nil }
+func (*FakeFetcher) ForgetPeer(peer string)                               {}
 func (*FakeFetcher) FilterBodies(peer string, transactions [][]*types.Transaction, time time.Time) [][]*types.Transaction {
 	return nil
 }

--- a/datasync/fetcher/fetcher_test.go
+++ b/datasync/fetcher/fetcher_test.go
@@ -864,8 +864,8 @@ func TestQueuedBytesLimit(t *testing.T) {
 }
 
 // TestForgetPeerReleasesQueue checks that a disconnected peer's blocks are released
-// instead of held until the chain reaches their height, and that the byte budget they
-// held is returned.
+// instead of held until the chain reaches their height, that the byte budget they held
+// is returned, and that a block this node committed is not released with them.
 func TestForgetPeerReleasesQueue(t *testing.T) {
 	tester := newTester()
 
@@ -902,6 +902,14 @@ func TestForgetPeerReleasesQueue(t *testing.T) {
 
 	// The released budget is available again.
 	tester.fetcher.Enqueue("valid", queueable[4])
+	time.Sleep(100 * time.Millisecond)
+	if queued := atomic.LoadInt32(&enqueued); queued != 1 {
+		t.Fatalf("queued block count mismatch: have %d, want %d", queued, 1)
+	}
+
+	// Committing the block a peer already queued keeps it across that peer's disconnect.
+	tester.fetcher.EnqueueTrusted("istanbul", queueable[4])
+	tester.fetcher.ForgetPeer("valid")
 	time.Sleep(100 * time.Millisecond)
 	if queued := atomic.LoadInt32(&enqueued); queued != 1 {
 		t.Fatalf("queued block count mismatch: have %d, want %d", queued, 1)

--- a/datasync/fetcher/fetcher_test.go
+++ b/datasync/fetcher/fetcher_test.go
@@ -817,3 +817,93 @@ func TestBlockMemoryExhaustionAttack(t *testing.T) {
 	}
 	verifyImportDone(t, imported)
 }
+
+// queueableBlocks returns n blocks above head+1, which therefore stay in the import
+// queue instead of being handed to the importer.
+func queueableBlocks(n int) []*types.Block {
+	hashes, blocks := makeChain(n+1, 1, unknownBlock)
+	queueable := make([]*types.Block, n)
+	for i := range queueable {
+		queueable[i] = blocks[hashes[i]]
+	}
+	return queueable
+}
+
+// TestQueuedBytesLimit checks that the import queue admits propagated blocks only
+// while its byte budget lasts, and that a block the consensus engine committed is
+// admitted regardless.
+func TestQueuedBytesLimit(t *testing.T) {
+	tester := newTester()
+
+	enqueued := int32(0)
+	tester.fetcher.queueChangeHook = func(hash common.Hash, added bool) {
+		if added {
+			atomic.AddInt32(&enqueued, 1)
+		} else {
+			atomic.AddInt32(&enqueued, -1)
+		}
+	}
+	queueable := queueableBlocks(4)
+
+	defer func(limit uint64) { queuedBytesLimit = limit }(queuedBytesLimit)
+	queuedBytesLimit = uint64(queueable[0].Size()) + uint64(queueable[1].Size())
+
+	for _, block := range queueable {
+		tester.fetcher.Enqueue("attacker", block)
+	}
+	time.Sleep(200 * time.Millisecond)
+	if queued := atomic.LoadInt32(&enqueued); queued != 2 {
+		t.Fatalf("queued block count mismatch: have %d, want %d", queued, 2)
+	}
+
+	tester.fetcher.EnqueueTrusted("istanbul", queueable[3])
+	time.Sleep(100 * time.Millisecond)
+	if queued := atomic.LoadInt32(&enqueued); queued != 3 {
+		t.Fatalf("queued block count mismatch: have %d, want %d", queued, 3)
+	}
+}
+
+// TestForgetPeerReleasesQueue checks that a disconnected peer's blocks are released
+// instead of held until the chain reaches their height, and that the byte budget they
+// held is returned.
+func TestForgetPeerReleasesQueue(t *testing.T) {
+	tester := newTester()
+
+	enqueued := int32(0)
+	tester.fetcher.queueChangeHook = func(hash common.Hash, added bool) {
+		if added {
+			atomic.AddInt32(&enqueued, 1)
+		} else {
+			atomic.AddInt32(&enqueued, -1)
+		}
+	}
+	queueable := queueableBlocks(5)
+
+	defer func(limit uint64) { queuedBytesLimit = limit }(queuedBytesLimit)
+	queuedBytesLimit = 0
+	for _, block := range queueable[:4] {
+		queuedBytesLimit += uint64(block.Size())
+	}
+
+	for _, block := range queueable[:4] {
+		tester.fetcher.Enqueue("attacker", block)
+	}
+	tester.fetcher.Enqueue("attacker", queueable[4]) // budget spent, discarded
+	time.Sleep(200 * time.Millisecond)
+	if queued := atomic.LoadInt32(&enqueued); queued != 4 {
+		t.Fatalf("queued block count mismatch: have %d, want %d", queued, 4)
+	}
+
+	tester.fetcher.ForgetPeer("attacker")
+	time.Sleep(100 * time.Millisecond)
+	if queued := atomic.LoadInt32(&enqueued); queued != 0 {
+		t.Fatalf("queued block count mismatch: have %d, want %d", queued, 0)
+	}
+
+	// The released budget is available again.
+	tester.fetcher.Enqueue("valid", queueable[4])
+	time.Sleep(100 * time.Millisecond)
+	if queued := atomic.LoadInt32(&enqueued); queued != 1 {
+		t.Fatalf("queued block count mismatch: have %d, want %d", queued, 1)
+	}
+}

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -62,6 +62,10 @@ const (
 	softResponseLimit = 2 * 1024 * 1024 // Target maximum size of returned blocks, headers or node data.
 	estHeaderRlpSize  = 500             // Approximate size of an RLP encoded block header
 
+	// maxPropagatedTDBits bounds the total blockscore a propagated block may claim.
+	// The peer keeps the value after the message is handled, so it must be bounded.
+	maxPropagatedTDBits = 100
+
 	// txChanSize is the size of channel listening to NewTxsEvent.
 	// The number is referenced from the size of tx pool.
 	txChanSize = 4096
@@ -1509,6 +1513,9 @@ func handleNewBlockMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	var request newBlockData
 	if err := msg.Decode(&request); err != nil {
 		return errResp(ErrDecode, "%v: %v", msg, err)
+	}
+	if request.TD.BitLen() > maxPropagatedTDBits {
+		return errResp(ErrDecode, "too large total blockscore: bitlen %d", request.TD.BitLen())
 	}
 	request.Block.ReceivedAt = msg.ReceivedAt
 	request.Block.ReceivedFrom = p

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -404,7 +404,8 @@ func (pm *ProtocolManager) removePeer(id string) {
 		pm.downloader.GetSnapSyncer().Unregister(id)
 	}
 
-	// Unregister the peer from the downloader and peer set
+	// Unregister the peer from the fetcher, the downloader and the peer set
+	pm.fetcher.ForgetPeer(id)
 	pm.downloader.UnregisterPeer(id)
 	if err := pm.peers.Unregister(id); err != nil {
 		logger.Error("Peer removal failed", "peer", id, "err", err)
@@ -1914,8 +1915,10 @@ func (pm *ProtocolManager) NodeInfo() *NodeInfo {
 
 // Below functions are used in Istanbul BFT consensus.
 // Enqueue wraps fetcher's Enqueue function to insert the given block.
+// Enqueue schedules a block the consensus engine committed. Its only caller is the
+// engine, so the block bypasses the fetcher's peer-facing byte budget.
 func (pm *ProtocolManager) Enqueue(id string, block *types.Block) {
-	pm.fetcher.Enqueue(id, block)
+	pm.fetcher.EnqueueTrusted(id, block)
 }
 
 func (pm *ProtocolManager) FindPeers(targets map[common.Address]bool) map[common.Address]consensus.Peer {

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -240,6 +240,19 @@ func TestHandleNewBlockMsg_LargeLocalPeerBlockScore(t *testing.T) {
 	assert.NoError(t, handleNewBlockMsg(pm, mockPeer, msg))
 }
 
+// TestHandleNewBlockMsg_RejectsOversizedTD checks that an absurd total blockscore is
+// refused before the peer retains it.
+func TestHandleNewBlockMsg_RejectsOversizedTD(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	td := new(big.Int).Lsh(big.NewInt(1), maxPropagatedTDBits+1)
+	msg := generateMsg(t, NewBlockMsg, newBlockData{Block: newBlock(blockNum1), TD: td})
+
+	err := handleNewBlockMsg(&ProtocolManager{}, NewMockPeer(mockCtrl), msg)
+	assert.ErrorContains(t, err, "total blockscore")
+}
+
 func TestHandleNewBlockMsg_SmallLocalPeerBlockScore_NoSynchronise(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -230,6 +230,10 @@ func TestProtocolManager_removePeer(t *testing.T) {
 		mockDownloader.EXPECT().UnregisterPeer(peerID).Times(1)
 		pm.downloader = mockDownloader
 
+		mockFetcher := mocks.NewMockProtocolManagerFetcher(mockCtrl)
+		mockFetcher.EXPECT().ForgetPeer(peerID).Times(1)
+		pm.fetcher = mockFetcher
+
 		// Return
 		mockPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
 
@@ -255,6 +259,10 @@ func TestProtocolManager_removePeer(t *testing.T) {
 		mockDownloader := mocks.NewMockProtocolManagerDownloader(mockCtrl)
 		mockDownloader.EXPECT().UnregisterPeer(peerID).Times(1)
 		pm.downloader = mockDownloader
+
+		mockFetcher := mocks.NewMockProtocolManagerFetcher(mockCtrl)
+		mockFetcher.EXPECT().ForgetPeer(peerID).Times(1)
+		pm.fetcher = mockFetcher
 
 		// Return
 		mockPeer.EXPECT().ExistSnapExtension().Return(false).Times(1)
@@ -966,7 +974,8 @@ func TestEnqueue(t *testing.T) {
 	block := newBlock(blockNum1)
 	id := nodeids[0].String()
 
-	fetcherMock.EXPECT().Enqueue(id, block).Times(1)
+	// The consensus engine is the only caller, so its blocks bypass the byte budget.
+	fetcherMock.EXPECT().EnqueueTrusted(id, block).Times(1)
 	pm.Enqueue(id, block)
 }
 

--- a/node/cn/mocks/fetcher_mock.go
+++ b/node/cn/mocks/fetcher_mock.go
@@ -51,6 +51,20 @@ func (mr *MockProtocolManagerFetcherMockRecorder) Enqueue(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enqueue", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).Enqueue), arg0, arg1)
 }
 
+// EnqueueTrusted mocks base method.
+func (m *MockProtocolManagerFetcher) EnqueueTrusted(arg0 string, arg1 *types.Block) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnqueueTrusted", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnqueueTrusted indicates an expected call of EnqueueTrusted.
+func (mr *MockProtocolManagerFetcherMockRecorder) EnqueueTrusted(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueTrusted", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).EnqueueTrusted), arg0, arg1)
+}
+
 // FilterBodies mocks base method.
 func (m *MockProtocolManagerFetcher) FilterBodies(arg0 string, arg1 [][]*types.Transaction, arg2 time.Time) [][]*types.Transaction {
 	m.ctrl.T.Helper()
@@ -77,6 +91,18 @@ func (m *MockProtocolManagerFetcher) FilterHeaders(arg0 string, arg1 []*types.He
 func (mr *MockProtocolManagerFetcherMockRecorder) FilterHeaders(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterHeaders", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).FilterHeaders), arg0, arg1, arg2)
+}
+
+// ForgetPeer mocks base method.
+func (m *MockProtocolManagerFetcher) ForgetPeer(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ForgetPeer", arg0)
+}
+
+// ForgetPeer indicates an expected call of ForgetPeer.
+func (mr *MockProtocolManagerFetcherMockRecorder) ForgetPeer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForgetPeer", reflect.TypeOf((*MockProtocolManagerFetcher)(nil).ForgetPeer), arg0)
 }
 
 // Notify mocks base method.

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -181,6 +181,8 @@ type ProtocolManagerDownloader interface {
 //go:generate mockgen -destination=./mocks/fetcher_mock.go -package=mocks github.com/kaiachain/kaia/node/cn ProtocolManagerFetcher
 type ProtocolManagerFetcher interface {
 	Enqueue(peer string, block *types.Block) error
+	EnqueueTrusted(peer string, block *types.Block) error
+	ForgetPeer(peer string)
 	FilterBodies(peer string, transactions [][]*types.Transaction, time time.Time) [][]*types.Transaction
 	FilterHeaders(peer string, headers []*types.Header, time time.Time) []*types.Header
 	Notify(peer string, hash common.Hash, number uint64, time time.Time, headerFetcher fetcher.HeaderRequesterFn, bodyFetcher fetcher.BodyRequesterFn) error


### PR DESCRIPTION
## Proposed changes

Problem

- `handleNewBlockMsg` queues a decoded block before its header, parent, body or size is checked.
- The queue admits on counts only — `blockLimit` per peer, `maxQueueDist` ahead — with no bound on the bytes they hold.
- Entries are not released when the peer disconnects, so a new identity gets a fresh allowance while the old blocks stay.

Fix

- Track the encoded size of the queued blocks and refuse propagated ones once it exceeds 64 MiB, the budget the downloader already uses for block caching.
- Release a peer's entries when it disconnects.
- Exempt blocks the consensus engine committed: a validator that did not propose imports its own committed block through this queue.
- Bound `newBlockData.TD`, an unbounded `big.Int` that `SetHead` keeps on the peer (second commit).

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
