### PR TITLE
node/cn: bound the length of decoded response lists

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -949,12 +949,35 @@ func handleBlockHeadersRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 	return p.SendBlockHeaders(headers)
 }
 
+// decodeResponseList decodes a response list one element at a time, refusing a list
+// longer than limit. Decoding the whole list at once lets a peer turn a message-sized
+// packet into an arbitrarily larger object graph, and we never request more than limit.
+func decodeResponseList[T any](msg p2p.Msg, limit int) ([]T, error) {
+	stream := rlp.NewStream(msg.Payload, uint64(msg.Size))
+	if _, err := stream.List(); err != nil {
+		return nil, errResp(ErrDecode, "msg %v: %v", msg, err)
+	}
+	var items []T
+	for {
+		var item T
+		if err := stream.Decode(&item); err == rlp.EOL {
+			return items, nil
+		} else if err != nil {
+			return nil, errResp(ErrDecode, "msg %v: %v", msg, err)
+		}
+		if len(items) >= limit {
+			return nil, errResp(ErrTooManyItems, "msg %v: limit %d", msg, limit)
+		}
+		items = append(items, item)
+	}
+}
+
 // handleBlockHeadersMsg handles block header response message.
 func handleBlockHeadersMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of headers arrived to one of our previous requests
-	var headers []*types.Header
-	if err := msg.Decode(&headers); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	headers, err := decodeResponseList[*types.Header](msg, downloader.MaxHeaderFetch)
+	if err != nil {
+		return err
 	}
 	if err := pm.downloader.DeliverHeaders(p.GetID(), headers); err != nil {
 		logger.Debug("Failed to deliver headers", "err", err)
@@ -1009,9 +1032,9 @@ func handleBlockBodiesRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 // handleGetBlockBodiesMsg handles block body response message.
 func handleBlockBodiesMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of block bodies arrived to one of our previous requests
-	var request blockBodiesData
-	if err := msg.Decode(&request); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	request, err := decodeResponseList[*blockBody](msg, downloader.MaxBlockFetch)
+	if err != nil {
+		return err
 	}
 	// Deliver them all to the downloader for queuing
 	transactions := make([][]*types.Transaction, len(request))
@@ -1020,8 +1043,7 @@ func handleBlockBodiesMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		transactions[i] = body.Transactions
 	}
 
-	err := pm.downloader.DeliverBodies(p.GetID(), transactions)
-	if err != nil {
+	if err := pm.downloader.DeliverBodies(p.GetID(), transactions); err != nil {
 		logger.Debug("Failed to deliver bodies", "err", err)
 	}
 
@@ -1069,9 +1091,9 @@ func handleNodeDataRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 // handleNodeDataMsg handles node data response message.
 func handleNodeDataMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of node state data arrived to one of our previous requests
-	var data [][]byte
-	if err := msg.Decode(&data); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	data, err := decodeResponseList[[]byte](msg, downloader.MaxStateFetch)
+	if err != nil {
+		return err
 	}
 	// Deliver all to the downloader
 	if err := pm.downloader.DeliverNodeData(p.GetID(), data); err != nil {
@@ -1124,9 +1146,9 @@ func handleReceiptsRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 // handleReceiptsMsg handles receipt response message.
 func handleReceiptsMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of receipts arrived to one of our previous requests
-	var receipts [][]*types.Receipt
-	if err := msg.Decode(&receipts); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	receipts, err := decodeResponseList[[]*types.Receipt](msg, downloader.MaxReceiptFetch)
+	if err != nil {
+		return err
 	}
 	// Deliver all to the downloader
 	if err := pm.downloader.DeliverReceipts(p.GetID(), receipts); err != nil {
@@ -1202,9 +1224,9 @@ func handleStakingInfoMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	}
 
 	// A batch of stakingInfos arrived to one of our previous requests
-	var stakingInfos []*staking.P2PStakingInfo
-	if err := msg.Decode(&stakingInfos); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	stakingInfos, err := decodeResponseList[*staking.P2PStakingInfo](msg, downloader.MaxStakingInfoFetch)
+	if err != nil {
+		return err
 	}
 	// Deliver all to the downloader
 	if err := pm.downloader.DeliverStakingInfos(p.GetID(), stakingInfos); err != nil {
@@ -1483,9 +1505,9 @@ func handleBlockBodiesFetchRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) 
 // handleBlockBodiesFetchResponseMsg handles block bodies fetch response message.
 func handleBlockBodiesFetchResponseMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of block bodies arrived to one of our previous requests
-	var request blockBodiesData
-	if err := msg.Decode(&request); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	request, err := decodeResponseList[*blockBody](msg, downloader.MaxBlockFetch)
+	if err != nil {
+		return err
 	}
 	// Deliver them all to the downloader for queuing
 	transactions := make([][]*types.Transaction, len(request))

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1356,9 +1356,9 @@ func handleBlobSidecarsMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		return errors.New("blob sidecar request manager is not initialized")
 	}
 
-	var sidecars []*blobSidecarsData
-	if err := msg.Decode(&sidecars); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	sidecars, err := decodeResponseList[*blobSidecarsData](msg, downloader.MaxBlobSidecarsFetch)
+	if err != nil {
+		return err
 	}
 
 	for _, sidecar := range sidecars {

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -1167,3 +1167,95 @@ func generateTestSidecar(hash common.Hash) *types.BlobTxSidecar {
 		Proofs:      []kzg4844.Proof{proof},
 	}
 }
+
+// TestHandleResponseMsg_ListLimit checks each response handler against the number of
+// items we may request: that many is delivered, one more is refused.
+func TestHandleResponseMsg_ListLimit(t *testing.T) {
+	headers := func(n int) interface{} {
+		out := make([]*types.Header, n)
+		for i := range out {
+			out[i] = &types.Header{}
+		}
+		return out
+	}
+	bodies := func(n int) interface{} {
+		out := make(blockBodiesData, n)
+		for i := range out {
+			out[i] = &blockBody{}
+		}
+		return out
+	}
+	stakingInfos := func(n int) interface{} {
+		out := make([]*staking.P2PStakingInfo, n)
+		for i := range out {
+			out[i] = &staking.P2PStakingInfo{}
+		}
+		return out
+	}
+	nodeData := func(n int) interface{} { return make([][]byte, n) }
+	receipts := func(n int) interface{} { return make([][]*types.Receipt, n) }
+
+	testcases := []struct {
+		name    string
+		code    uint64
+		limit   int
+		payload func(n int) interface{}
+		deliver func(*mocks2.MockProtocolManagerDownloader, *mocks2.MockProtocolManagerFetcher)
+	}{
+		{"BlockHeadersMsg", BlockHeadersMsg, downloader.MaxHeaderFetch, headers, func(d *mocks2.MockProtocolManagerDownloader, _ *mocks2.MockProtocolManagerFetcher) {
+			d.EXPECT().DeliverHeaders(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		}},
+		{"BlockBodiesMsg", BlockBodiesMsg, downloader.MaxBlockFetch, bodies, func(d *mocks2.MockProtocolManagerDownloader, _ *mocks2.MockProtocolManagerFetcher) {
+			d.EXPECT().DeliverBodies(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		}},
+		{"BlockBodiesFetchResponseMsg", BlockBodiesFetchResponseMsg, downloader.MaxBlockFetch, bodies, func(_ *mocks2.MockProtocolManagerDownloader, f *mocks2.MockProtocolManagerFetcher) {
+			f.EXPECT().FilterBodies(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		}},
+		{"NodeDataMsg", NodeDataMsg, downloader.MaxStateFetch, nodeData, func(d *mocks2.MockProtocolManagerDownloader, _ *mocks2.MockProtocolManagerFetcher) {
+			d.EXPECT().DeliverNodeData(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		}},
+		{"ReceiptsMsg", ReceiptsMsg, downloader.MaxReceiptFetch, receipts, func(d *mocks2.MockProtocolManagerDownloader, _ *mocks2.MockProtocolManagerFetcher) {
+			d.EXPECT().DeliverReceipts(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		}},
+		{"StakingInfoMsg", StakingInfoMsg, downloader.MaxStakingInfoFetch, stakingInfos, func(d *mocks2.MockProtocolManagerDownloader, _ *mocks2.MockProtocolManagerFetcher) {
+			d.EXPECT().DeliverStakingInfos(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		}},
+	}
+	for _, tc := range testcases {
+		newPM := func(mockCtrl *gomock.Controller) (*ProtocolManager, *MockPeer, *mocks2.MockProtocolManagerDownloader, *mocks2.MockProtocolManagerFetcher) {
+			mockPeer := NewMockPeer(mockCtrl)
+			mockPeer.EXPECT().GetVersion().Return(kaia68).AnyTimes()
+			mockPeer.EXPECT().GetID().Return(nodeids[0].String()).AnyTimes()
+
+			chainConfig := params.TestChainConfig.Copy()
+			chainConfig.Istanbul = params.GetDefaultIstanbulConfig()
+			chainConfig.Istanbul.ProposerPolicy = uint64(istanbul.WeightedRandom)
+
+			mockDownloader := mocks2.NewMockProtocolManagerDownloader(mockCtrl)
+			mockFetcher := mocks2.NewMockProtocolManagerFetcher(mockCtrl)
+			return &ProtocolManager{downloader: mockDownloader, fetcher: mockFetcher, chainconfig: chainConfig}, mockPeer, mockDownloader, mockFetcher
+		}
+
+		t.Run(tc.name+"/at limit", func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			pm, mockPeer, mockDownloader, mockFetcher := newPM(mockCtrl)
+			tc.deliver(mockDownloader, mockFetcher)
+
+			msg := generateMsg(t, tc.code, tc.payload(tc.limit))
+			assert.NoError(t, pm.handleMsg(mockPeer, addrs[0], msg))
+		})
+
+		// The delivery mocks carry no expectations here, so reaching them fails the test.
+		t.Run(tc.name+"/over limit", func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			pm, mockPeer, _, _ := newPM(mockCtrl)
+
+			msg := generateMsg(t, tc.code, tc.payload(tc.limit+1))
+			assert.ErrorContains(t, pm.handleMsg(mockPeer, addrs[0], msg), "Too many items")
+		})
+	}
+}

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -1192,6 +1192,14 @@ func TestHandleResponseMsg_ListLimit(t *testing.T) {
 		}
 		return out
 	}
+	blobSidecars := func(n int) interface{} {
+		sidecar := generateTestSidecar(common.HexToHash("0x1"))
+		out := make([]*blobSidecarsData, n)
+		for i := range out {
+			out[i] = &blobSidecarsData{Sidecar: sidecar}
+		}
+		return out
+	}
 	nodeData := func(n int) interface{} { return make([][]byte, n) }
 	receipts := func(n int) interface{} { return make([][]*types.Receipt, n) }
 
@@ -1220,6 +1228,9 @@ func TestHandleResponseMsg_ListLimit(t *testing.T) {
 		{"StakingInfoMsg", StakingInfoMsg, downloader.MaxStakingInfoFetch, stakingInfos, func(d *mocks2.MockProtocolManagerDownloader, _ *mocks2.MockProtocolManagerFetcher) {
 			d.EXPECT().DeliverStakingInfos(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 		}},
+		// Sidecars are delivered through the txpool, not through these two, and they
+		// carry no pending request, so the handler drops them before reaching it.
+		{"BlobSidecarsMsg", BlobSidecarsMsg, downloader.MaxBlobSidecarsFetch, blobSidecars, nil},
 	}
 	for _, tc := range testcases {
 		newPM := func(mockCtrl *gomock.Controller) (*ProtocolManager, *MockPeer, *mocks2.MockProtocolManagerDownloader, *mocks2.MockProtocolManagerFetcher) {
@@ -1233,7 +1244,12 @@ func TestHandleResponseMsg_ListLimit(t *testing.T) {
 
 			mockDownloader := mocks2.NewMockProtocolManagerDownloader(mockCtrl)
 			mockFetcher := mocks2.NewMockProtocolManagerFetcher(mockCtrl)
-			return &ProtocolManager{downloader: mockDownloader, fetcher: mockFetcher, chainconfig: chainConfig}, mockPeer, mockDownloader, mockFetcher
+			return &ProtocolManager{
+				downloader:            mockDownloader,
+				fetcher:               mockFetcher,
+				chainconfig:           chainConfig,
+				blobSidecarReqManager: &sidecarReqManager{list: map[common.Hash]*sidecarReq{}},
+			}, mockPeer, mockDownloader, mockFetcher
 		}
 
 		t.Run(tc.name+"/at limit", func(t *testing.T) {
@@ -1241,7 +1257,9 @@ func TestHandleResponseMsg_ListLimit(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			pm, mockPeer, mockDownloader, mockFetcher := newPM(mockCtrl)
-			tc.deliver(mockDownloader, mockFetcher)
+			if tc.deliver != nil {
+				tc.deliver(mockDownloader, mockFetcher)
+			}
 
 			msg := generateMsg(t, tc.code, tc.payload(tc.limit))
 			assert.NoError(t, pm.handleMsg(mockPeer, addrs[0], msg))

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -128,6 +128,7 @@ const (
 	ErrUnexpectedTxType
 	ErrFailedToGetStateDB
 	ErrUnsupportedEnginePolicy
+	ErrTooManyItems
 )
 
 func (e errCode) String() string {
@@ -149,6 +150,7 @@ var errorToString = map[int]string{
 	ErrUnexpectedTxType:        "Unexpected tx type",
 	ErrFailedToGetStateDB:      "Failed to get stateDB",
 	ErrUnsupportedEnginePolicy: "Unsupported engine or policy",
+	ErrTooManyItems:            "Too many items",
 }
 
 // ProtocolManagerDownloader is an interface of downloader.Downloader used by ProtocolManager.


### PR DESCRIPTION
## Proposed changes

Problem

- The synchronisation response handlers decoded a peer's list in full before asking whether it answered anything.
- The message cap bounds the encoded packet, not the object graph reflection builds from it: a 12 MiB `NodeDataMsg` of one-byte elements decodes to 12.5 million slice headers.
- A delivery that finds no pending request is only logged, so the packet can be repeated on the same connection.

Fix

- Decode these lists one element at a time and refuse one longer than the number we could have requested, reusing the limit each message already applies when it is requested and when it is served.
- A longer list cannot come from an implementation of this protocol, so the handler returns an error and the peer is dropped by the existing path.
- Deliveries that find no pending request keep being logged: without request IDs a late but well-formed response is indistinguishable from an unsolicited one.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
