### PR TITLE
p2p: read dial scheduler bookkeeping under the lock

### DIFF
--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -339,12 +339,15 @@ func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh b
 			needs[n.NType]--
 		}
 	}
+
+	numConnectedAll, numStatic := ds.connectedAll.len(), ds.static.len()
+	numOutbound, numDialing := ds.connectedOutbound.len(), ds.dialing.len()
 	ds.mu.RUnlock()
 
 	// 4. Dynamic nodes — skip when already at total peer capacity.
 	// Even if we want more outbound peers (needs > 0), the total capacity might be reached (maxPeers) due to inbound peers.
 	// Static dials (added above) bypass this check, mirroring the Server's capacity check.
-	if ds.maxPeers == 0 || ds.connectedAll.len() < ds.maxPeers {
+	if ds.maxPeers == 0 || numConnectedAll < ds.maxPeers {
 		for targetType, need := range needs {
 			dynamicNodes, refresh := ds.getDynamicCandidates(targetType, need)
 			candidates = append(candidates, dynamicNodes...)
@@ -353,8 +356,8 @@ func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh b
 	}
 
 	if len(candidates) > 0 {
-		logger.Debug("Dialing candidates", "needs", needs, "static", ds.static.len(),
-			"connectedOutbound", ds.connectedOutbound.len(), "dialing", ds.dialing.len(), "candidates", len(candidates))
+		logger.Debug("Dialing candidates", "needs", needs, "static", numStatic,
+			"connectedOutbound", numOutbound, "dialing", numDialing, "candidates", len(candidates))
 	}
 	return candidates, needRefresh
 }


### PR DESCRIPTION
## Proposed changes

Problem

- `getCandidates` releases `ds.mu` after copying the static nodes, then keeps reading `connectedAll`, `static`, `connectedOutbound` and `dialing`, which are written from the handshake, peer and dial goroutines.

Fix

- Take those counts while the lock is still held. The lock is not extended over the rest of the function, because the dynamic candidate path acquires it again.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
