### PR TITLE
blockchain/vm: fix `onlyTopCall` discarding the top frame's logs

### DIFF
--- a/blockchain/vm/call_tracer.go
+++ b/blockchain/vm/call_tracer.go
@@ -251,7 +251,8 @@ func (t *CallTracer) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost, ccL
 	if err != nil || !t.config.WithLog || t.interrupt.Load() {
 		return
 	}
-	if t.config.OnlyTopCall && depth > 0 {
+	// depth counts active frames, so top frame == 1 (geth's OnEnter depth is a 0-based index).
+	if t.config.OnlyTopCall && depth > 1 {
 		return
 	}
 	if op < LOG0 || op > LOG4 || len(t.callstack) == 0 {


### PR DESCRIPTION
## Proposed changes

- callTracer with `withLog && onlyTopCall` returned no logs at all, including the top frame's own
- `depth` is the opcode depth, which counts active frames and therefore reads 1 while the top frame executes, not 0
- replace `> 0` to `> 1` accordingly

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

Before refactoring, [geth](/ethereum/go-ethereum/pull/29068) had the same issue.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
