### PR TITLE
consensus/istanbul: apply the import body rules in backend.Verify

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -24,6 +24,8 @@ package backend
 
 import (
 	"crypto/ecdsa"
+	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -374,12 +376,27 @@ func (sb *backend) Verify(proposal bft.Proposal) (time.Duration, error) {
 		return 0, blockchain.ErrBlacklistedHash
 	}
 
+	// The checks below mirror BlockValidator.ValidateBody, so a bad proposal is rejected
+	// here instead of being PREPARE/COMMIT-ed and then refused on the import path.
+
+	// check EIP-7934 RLP-encoded block size cap
+	if sb.chain.Config().IsOsakaForkEnabled(block.Number()) && block.Size() > params.MaxBlockSize {
+		return 0, blockchain.ErrBlockOversized
+	}
+
 	// check block body
+	header := block.Header()
 	txnHash := types.DeriveTransactionsRoot(block.Transactions(), block.Number())
-	if txnHash != block.Header().TxHash {
+	if txnHash != header.TxHash {
 		return 0, istanbul.ErrMismatchTxhashes
 	}
+	baseFee := header.BaseFee
+	var blobs int
 	for _, tx := range block.Transactions() {
+		if baseFee != nil && baseFee.Cmp(tx.GasPrice()) > 0 {
+			return 0, fmt.Errorf("invalid GasPrice: txHash %x, GasPrice %d, BaseFee %d", tx.Hash(), tx.GasPrice(), baseFee)
+		}
+		blobs += len(tx.BlobHashes())
 		if tx.Type() == types.TxTypeEthereumBlob {
 			sidecar := tx.BlobTxSidecar()
 			if sidecar == nil {
@@ -392,12 +409,12 @@ func (sb *backend) Verify(proposal bft.Proposal) (time.Duration, error) {
 			}
 		}
 	}
-
-	// check EIP-7934 RLP-encoded block size cap, mirroring BlockValidator.ValidateBody
-	// so an oversized proposal is rejected here instead of being PREPARE/COMMIT-ed and
-	// then refused on the import path.
-	if sb.chain.Config().IsOsakaForkEnabled(block.Number()) && block.Size() > params.MaxBlockSize {
-		return 0, blockchain.ErrBlockOversized
+	if header.BlobGasUsed != nil {
+		if want := *header.BlobGasUsed / params.BlobTxBlobGasPerBlob; uint64(blobs) != want {
+			return 0, fmt.Errorf("blob gas used mismatch (header %v, calculated %v)", *header.BlobGasUsed, blobs*params.BlobTxBlobGasPerBlob)
+		}
+	} else if blobs > 0 {
+		return 0, errors.New("data blobs present in block body")
 	}
 
 	// verify the header of proposed block

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -229,10 +229,9 @@ func TestCommit(t *testing.T) {
 	}
 }
 
-// buildOversizedBlock returns a sealed block whose RLP-encoded size exceeds
-// params.MaxBlockSize, built on top of the chain's current head. Verify does not
-// execute transactions, so the injected tx only needs to inflate the encoded size.
-func buildOversizedBlock(t *testing.T, chain *blockchain.BlockChain, engine *backend) *types.Block {
+// buildBlockWithTx returns a sealed block carrying the given tx, built on top of the
+// chain's current head.
+func buildBlockWithTx(t *testing.T, chain *blockchain.BlockChain, engine *backend, txdata *types.TxInternalDataLegacy) *types.Block {
 	t.Helper()
 	parent := chain.CurrentBlock()
 	header := makeHeader(parent, chain.Config())
@@ -248,27 +247,32 @@ func buildOversizedBlock(t *testing.T, chain *blockchain.BlockChain, engine *bac
 		t.Fatal(err)
 	}
 
-	recipient := common.Address{}
-	tx := types.NewTx(&types.TxInternalDataLegacy{
-		AccountNonce: 0,
-		Price:        big.NewInt(1),
-		GasLimit:     1,
-		Recipient:    &recipient,
-		Amount:       big.NewInt(0),
-		Payload:      make([]byte, params.MaxBlockSize), // pushes the whole block past the cap
-	})
 	key, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(chain.Config().ChainID), key)
+	signedTx, err := types.SignTx(types.NewTx(txdata), types.LatestSignerForChainID(chain.Config().ChainID), key)
 	if err != nil {
 		t.Fatal(err)
 	}
+	// NewBlock recomputes the header TxHash from the supplied tx, so Verify's tx-root
+	// check still passes.
+	return sealBlock(engine, types.NewBlock(emptyBlock.Header(), []*types.Transaction{signedTx}, nil))
+}
 
-	// NewBlock recomputes the header TxHash from the supplied txs, so Verify's
-	// tx-root check still passes and the test isolates the size cap.
-	block := sealBlock(engine, types.NewBlock(emptyBlock.Header(), []*types.Transaction{signedTx}, nil))
+// buildOversizedBlock returns a sealed block whose RLP-encoded size exceeds
+// params.MaxBlockSize. Verify does not execute transactions, so the injected tx only
+// needs to inflate the encoded size.
+func buildOversizedBlock(t *testing.T, chain *blockchain.BlockChain, engine *backend) *types.Block {
+	t.Helper()
+	recipient := common.Address{}
+	block := buildBlockWithTx(t, chain, engine, &types.TxInternalDataLegacy{
+		Price:     big.NewInt(1),
+		GasLimit:  1,
+		Recipient: &recipient,
+		Amount:    big.NewInt(0),
+		Payload:   make([]byte, params.MaxBlockSize), // pushes the whole block past the cap
+	})
 	if block.Size() <= params.MaxBlockSize {
 		t.Fatalf("test setup: block is not oversized (size=%d, cap=%d)", uint64(block.Size()), params.MaxBlockSize)
 	}
@@ -307,5 +311,62 @@ func TestBackend_VerifyEnforcesBlockSizeCap(t *testing.T) {
 		oversized := buildOversizedBlock(t, chain, engine)
 		_, err := engine.Verify(oversized)
 		assert.NotErrorIs(t, err, blockchain.ErrBlockOversized)
+	})
+}
+
+// TestBackend_VerifyEnforcesBodyRules checks that backend.Verify applies the body rules
+// ValidateBody enforces on import, running both paths on the same block.
+func TestBackend_VerifyEnforcesBodyRules(t *testing.T) {
+	t.Run("gasPrice", func(t *testing.T) {
+		const baseFeeGkei = 30
+		chain, engine := newBlockChain(t, 1,
+			LondonCompatibleBlock(big.NewInt(0)),
+			EthTxTypeCompatibleBlock(big.NewInt(0)),
+			magmaCompatibleBlock(big.NewInt(0)),
+			lowerBoundBaseFee(baseFeeGkei*params.Gkei),
+			upperBoundBaseFee(baseFeeGkei*params.Gkei),
+		)
+		defer chain.Stop()
+		defer engine.Stop()
+
+		recipient := common.Address{}
+		build := func(gasPrice uint64) *types.Block {
+			return buildBlockWithTx(t, chain, engine, &types.TxInternalDataLegacy{
+				Price:     new(big.Int).SetUint64(gasPrice),
+				GasLimit:  21000,
+				Recipient: &recipient,
+				Amount:    big.NewInt(0),
+			})
+		}
+
+		priced := build(baseFeeGkei * params.Gkei)
+		_, err := engine.Verify(priced)
+		assert.NoError(t, err)
+		assert.NoError(t, chain.Validator().ValidateBody(priced))
+
+		underpriced := build(baseFeeGkei*params.Gkei - 1)
+		_, err = engine.Verify(underpriced)
+		assert.ErrorContains(t, err, "invalid GasPrice")
+		assert.ErrorContains(t, chain.Validator().ValidateBody(underpriced), "invalid GasPrice")
+	})
+
+	// ValidateHeader cannot catch this: it never sees the body.
+	t.Run("blobGasUsed", func(t *testing.T) {
+		chain, engine := newBlockChain(t, 1, osakaCompatibleBlock(big.NewInt(0)))
+		defer chain.Stop()
+		defer engine.Stop()
+
+		normal := makeBlockWithSeal(chain, engine, chain.CurrentBlock())
+		_, err := engine.Verify(normal)
+		assert.NoError(t, err)
+
+		header := normal.Header()
+		claimed := uint64(params.BlobTxBlobGasPerBlob)
+		header.BlobGasUsed = &claimed
+		lying := sealBlock(engine, types.NewBlock(header, nil, nil))
+
+		_, err = engine.Verify(lying)
+		assert.ErrorContains(t, err, "blob gas used mismatch")
+		assert.ErrorContains(t, chain.Validator().ValidateBody(lying), "blob gas used mismatch")
 	})
 }


### PR DESCRIPTION
## Proposed changes

Problem

- `backend.Verify` checked the tx root but not two body rules `ValidateBody` enforces on import: that every tx is priced at or above the header's base fee, and that the header's `blobGasUsed` agrees with the body. The tx root only commits to the list the proposer chose, and `ValidateHeader` never sees the body.
- A proposal breaking either rule is PREPARE/COMMIT-ed by honest validators and only refused later on import.

Fix

- Apply both rules in `Verify`, as the EIP-7934 size cap already is. That cap now runs before the transaction loop so a block breaking several rules reports the same error the import path would.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
