### PR TITLE
fix(consensus): add backpressure to Istanbul message ingress

### DIFF
--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -50,48 +50,61 @@ var (
 
 // HandleMsg implements consensus.Handler.HandleMsg
 func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
+	if msg.Code != consensus.ConsensusMsgCode {
+		return false, nil
+	}
+
+	event, shouldPost, err := sb.prepareConsensusMessageEvent(addr, msg)
+	if err != nil || !shouldPost {
+		return true, err
+	}
+
+	// Post outside coreMu so a stalled event consumer applies backpressure to
+	// this peer without blocking Start or Stop from changing the core lifecycle.
+	return true, sb.istanbulEventMux.Post(event)
+}
+
+// prepareConsensusMessageEvent validates an incoming consensus envelope and
+// records its duplicate-cache state. The event is posted by HandleMsg after
+// coreMu is released, so a slow core cannot turn inbound messages into an
+// unbounded number of blocked goroutines.
+func (sb *backend) prepareConsensusMessageEvent(addr common.Address, msg p2p.Msg) (istanbul.MessageEvent, bool, error) {
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
 
-	if msg.Code == consensus.ConsensusMsgCode {
-		if !sb.coreStarted.Load() {
-			return true, istanbul.ErrStoppedEngine
-		}
-
-		var cmsg bft.ConsensusMsg
-
-		// var data []byte
-		if err := msg.Decode(&cmsg); err != nil {
-			return true, errDecodeFailed
-		}
-		data := cmsg.Payload
-		hash := istanbul.RLPHash(data)
-
-		// Mark peer's message
-		var m *lru.ARCCache
-		ms, ok := sb.recentMessages.Get(addr)
-		if ok {
-			m, _ = ms.(*lru.ARCCache)
-		} else {
-			m, _ = lru.NewARC(inmemoryMessages)
-			sb.recentMessages.Add(addr, m)
-		}
-		m.Add(hash, true)
-
-		// Mark self known message
-		if _, ok := sb.knownMessages.Get(hash); ok {
-			return true, nil
-		}
-		sb.knownMessages.Add(hash, true)
-
-		go sb.istanbulEventMux.Post(istanbul.MessageEvent{
-			Payload: data,
-			Hash:    cmsg.PrevHash,
-		})
-
-		return true, nil
+	if !sb.coreStarted.Load() {
+		return istanbul.MessageEvent{}, false, istanbul.ErrStoppedEngine
 	}
-	return false, nil
+
+	var cmsg bft.ConsensusMsg
+
+	if err := msg.Decode(&cmsg); err != nil {
+		return istanbul.MessageEvent{}, false, errDecodeFailed
+	}
+	data := cmsg.Payload
+	hash := istanbul.RLPHash(data)
+
+	// Mark peer's message
+	var m *lru.ARCCache
+	ms, ok := sb.recentMessages.Get(addr)
+	if ok {
+		m, _ = ms.(*lru.ARCCache)
+	} else {
+		m, _ = lru.NewARC(inmemoryMessages)
+		sb.recentMessages.Add(addr, m)
+	}
+	m.Add(hash, true)
+
+	// Mark self known message
+	if _, ok := sb.knownMessages.Get(hash); ok {
+		return istanbul.MessageEvent{}, false, nil
+	}
+	sb.knownMessages.Add(hash, true)
+
+	return istanbul.MessageEvent{
+		Payload: data,
+		Hash:    cmsg.PrevHash,
+	}, true, nil
 }
 
 func (sb *backend) ValidatePeerType(addr common.Address) error {

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -36,6 +36,7 @@ func TestBackend_HandleMsg(t *testing.T) {
 	_, backend := newBlockChain(t, 1)
 	defer backend.Stop()
 	eventSub := backend.istanbulEventMux.Subscribe(istanbul.MessageEvent{})
+	defer eventSub.Unsubscribe()
 
 	addr := common.StringToAddress("test addr")
 	data := &bft.ConsensusMsg{
@@ -52,12 +53,30 @@ func TestBackend_HandleMsg(t *testing.T) {
 			Size:    uint32(size),
 			Payload: payload,
 		}
-		isHandled, err := backend.HandleMsg(addr, msg)
-		assert.Nil(t, err)
-		assert.True(t, isHandled)
+		type result struct {
+			handled bool
+			err     error
+		}
+		resultCh := make(chan result, 1)
+		go func() {
+			handled, err := backend.HandleMsg(addr, msg)
+			resultCh <- result{handled, err}
+		}()
 
-		if err != nil {
-			t.Fatalf("handle message failed: %v", err)
+		evTimer := time.NewTimer(3 * time.Second)
+		defer evTimer.Stop()
+
+		select {
+		case event := <-eventSub.Chan():
+			switch ev := event.Data.(type) {
+			case istanbul.MessageEvent:
+				assert.Equal(t, data.Payload, ev.Payload)
+				assert.Equal(t, data.PrevHash, ev.Hash)
+			default:
+				t.Fatal("unexpected message type")
+			}
+		case <-evTimer.C:
+			t.Fatal("failed to subscribe istanbul message event")
 		}
 
 		recentMsg, ok := backend.recentMessages.Get(addr)
@@ -74,20 +93,12 @@ func TestBackend_HandleMsg(t *testing.T) {
 		assert.True(t, ok)
 		assert.True(t, value.(bool))
 
-		evTimer := time.NewTimer(3 * time.Second)
-		defer evTimer.Stop()
-
 		select {
-		case event := <-eventSub.Chan():
-			switch ev := event.Data.(type) {
-			case istanbul.MessageEvent:
-				assert.Equal(t, data.Payload, ev.Payload)
-				assert.Equal(t, data.PrevHash, ev.Hash)
-			default:
-				t.Fatal("unexpected message type")
-			}
-		case <-evTimer.C:
-			t.Fatal("failed to subscribe istanbul message event")
+		case result := <-resultCh:
+			assert.NoError(t, result.err)
+			assert.True(t, result.handled)
+		case <-time.After(3 * time.Second):
+			t.Fatal("HandleMsg did not return after event delivery")
 		}
 	}
 
@@ -127,6 +138,69 @@ func TestBackend_HandleMsg(t *testing.T) {
 		isHandled, err := backend.HandleMsg(addr, msg)
 		assert.Equal(t, istanbul.ErrStoppedEngine, err)
 		assert.True(t, isHandled)
+	}
+}
+
+func TestBackend_HandleMsgAppliesBackpressureOutsideCoreMu(t *testing.T) {
+	backend := newTestBackend()
+	backend.coreStarted.Store(true)
+	eventSub := backend.istanbulEventMux.Subscribe(istanbul.MessageEvent{})
+	defer eventSub.Unsubscribe()
+
+	data := &bft.ConsensusMsg{Payload: []byte("backpressure test")}
+	size, payload, err := rlp.EncodeToReader(data)
+	assert.NoError(t, err)
+	hash := istanbul.RLPHash(data.Payload)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := backend.HandleMsg(common.StringToAddress("peer"), p2p.Msg{
+			Code:    consensus.ConsensusMsgCode,
+			Size:    uint32(size),
+			Payload: payload,
+		})
+		done <- err
+	}()
+
+	deadline := time.After(time.Second)
+	for {
+		backend.coreMu.Lock()
+		_, known := backend.knownMessages.Get(hash)
+		backend.coreMu.Unlock()
+		if known {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("HandleMsg did not prepare the consensus event")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	select {
+	case err := <-done:
+		t.Fatalf("HandleMsg returned before the event was received: %v", err)
+	default:
+	}
+
+	locked := make(chan struct{})
+	go func() {
+		backend.coreMu.Lock()
+		backend.coreMu.Unlock()
+		close(locked)
+	}()
+	select {
+	case <-locked:
+	case <-time.After(time.Second):
+		t.Fatal("HandleMsg held coreMu while waiting for event delivery")
+	}
+
+	eventSub.Unsubscribe()
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("HandleMsg did not unblock after event subscription closed")
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Apply backpressure to Istanbul consensus-message ingress.

`HandleMsg` no longer spawns an unbounded goroutine for each `EventMux.Post`. It now posts synchronously after releasing `coreMu`, preventing stalled consumers from retaining an unbounded number of message payloads while preserving backend lifecycle progress.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)
