### PR TITLE
blockchain/system: memoize BLS proof-of-possession verification

### DIFF
--- a/blockchain/system/kip113.go
+++ b/blockchain/system/kip113.go
@@ -26,9 +26,11 @@ import (
 	"sort"
 	"strings"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/accounts/abi/bind"
 	"github.com/kaiachain/kaia/common"
 	contracts "github.com/kaiachain/kaia/contracts/bindings/kip113"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/crypto/bls"
 )
 
@@ -38,12 +40,31 @@ type BlsPublicKeyInfo struct {
 	VerifyErr error // Nil if valid. Must check before use.
 }
 
+// Has to hold AddressBookV2's whole node set at once, or every read evicts what the
+// next one needs. maxNodeCount is configurable, so this is a ceiling, not a bound.
+const blsPopCacheSize = 1024
+
+// Memoizes verifyBlsPublicKeyInfo, whose inputs stay put while the AddressBookV2
+// storage root moves, so an unrelated write does not re-verify the whole set.
+var blsPopCache, _ = lru.NewARC(blsPopCacheSize)
+
 func newBlsPublicKeyInfo(publicKey []byte, pop []byte) BlsPublicKeyInfo {
 	return BlsPublicKeyInfo{
 		PublicKey: publicKey,
 		Pop:       pop,
-		VerifyErr: verifyBlsPublicKeyInfo(publicKey, pop),
+		VerifyErr: verifyBlsPublicKeyInfoCached(publicKey, pop),
 	}
+}
+
+func verifyBlsPublicKeyInfoCached(publicKey []byte, pop []byte) error {
+	cacheKey := string(crypto.Keccak256(publicKey, pop))
+	if cached, ok := blsPopCache.Get(cacheKey); ok {
+		err, _ := cached.(error) // a nil error is stored as a nil interface
+		return err
+	}
+	err := verifyBlsPublicKeyInfo(publicKey, pop)
+	blsPopCache.Add(cacheKey, err)
+	return err
 }
 
 func verifyBlsPublicKeyInfo(publicKey []byte, pop []byte) error {

--- a/blockchain/system/kip113_test.go
+++ b/blockchain/system/kip113_test.go
@@ -138,6 +138,47 @@ func TestAllocKip113(t *testing.T) {
 	compareStorage(t, backend, kip113Addr, allocLogicStorage)
 }
 
+// The verification result is memoized per key, so an AddressBookV2 write unrelated to
+// BLS does not re-verify the whole validator set.
+func TestVerifyBlsPublicKeyInfoCached(t *testing.T) {
+	_, pub, pop := makeBlsKey()
+
+	t.Run("populates", func(t *testing.T) {
+		blsPopCache.Purge()
+		assert.NoError(t, newBlsPublicKeyInfo(pub, pop).VerifyErr)
+		assert.Equal(t, 1, blsPopCache.Len())
+		assert.NoError(t, newBlsPublicKeyInfo(pub, pop).VerifyErr)
+		assert.Equal(t, 1, blsPopCache.Len())
+	})
+
+	// A poisoned entry must win over the real verification of a valid pair.
+	t.Run("is consulted", func(t *testing.T) {
+		blsPopCache.Purge()
+		blsPopCache.Add(string(crypto.Keccak256(pub, pop)), assert.AnError)
+		assert.ErrorIs(t, newBlsPublicKeyInfo(pub, pop).VerifyErr, assert.AnError)
+	})
+
+	// Distinct keys must not share an entry, whatever their results are.
+	t.Run("keys are isolated", func(t *testing.T) {
+		blsPopCache.Purge()
+		_, pub2, pop2 := makeBlsKey()
+		for range 2 { // twice, so the second pass is served from the cache
+			assert.NoError(t, newBlsPublicKeyInfo(pub, pop).VerifyErr)
+			assert.NoError(t, newBlsPublicKeyInfo(pub2, pop2).VerifyErr)
+			assert.ErrorIs(t, newBlsPublicKeyInfo(pub, pop2).VerifyErr, ErrKip113BadPop)
+		}
+		assert.Equal(t, 3, blsPopCache.Len())
+	})
+
+	t.Run("caches failure", func(t *testing.T) {
+		blsPopCache.Purge()
+		_, _, otherPop := makeBlsKey()
+		assert.ErrorIs(t, newBlsPublicKeyInfo(pub, otherPop).VerifyErr, ErrKip113BadPop)
+		assert.Equal(t, 1, blsPopCache.Len())
+		assert.ErrorIs(t, newBlsPublicKeyInfo(pub, otherPop).VerifyErr, ErrKip113BadPop)
+	})
+}
+
 func deployKip113Mock(t *testing.T, sender *bind.TransactOpts, backend *backends.SimulatedBackend, params ...interface{}) (*testcontracts.KIP113MockTransactor, common.Address) {
 	// Prepare input data for ERC1967Proxy constructor
 	abi, err := testcontracts.KIP113MockMetaData.GetAbi()


### PR DESCRIPTION
## Proposed changes

Problem

- Reading the validator BLS set re-verifies every proof of possession, and the result is cached under the AddressBookV2 storage root, so any write to that account — a reward address, a voter address, metadata — drops a still-valid entry and pays for the whole set again.

Fix

- Verification is a pure function of the public key and the proof, both immutable for a node's lifetime, so memoize it keyed by the two. A re-read then costs the contract call alone; the storage root cache is unchanged.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

A BLS revision counter in AddressBookV2 would let the set cache hit outright, but it needs a system contract upgrade. Keying on the key material is the best a client can do on its own: the storage root is a Merkle-Patricia trie over `keccak(slot)`, so there is no BLS-only subtree root to read.
