### PR TITLE
kaiax/valset: stop answering GetProposer from the block's author

### DIFF
--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -1010,8 +1010,9 @@ func GetConsensusInfo(block *types.Block, mValset valset.ValsetModule, sealer co
 	}
 	sigHash := sealer.SigHash(block.Header())
 
-	// get proposer and committee information from valset module
-	currentProposer, err := mValset.GetProposer(block.NumberU64(), uint64(round))
+	// Proposer is the signer of SigHash, which under a hash lock is the author of the
+	// locked proposal rather than the proposer of the round that committed it.
+	currentProposer, err := sealer.Author(block.Header())
 	if err != nil {
 		return ConsensusInfo{}, err
 	}

--- a/api/api_kaia_blockchain_test.go
+++ b/api/api_kaia_blockchain_test.go
@@ -93,13 +93,17 @@ func TestGetConsensusInfo_UsesOriginalOutputFields(t *testing.T) {
 	require.NoError(t, sealer.WriteValidators(header, validators))
 	sealer.WriteRound(header, 1)
 
+	// The block was sealed at round 1 by `committer`, so Proposer comes from that seal while
+	// OriginProposer still comes from the round-0 schedule.
 	committerSealer := istanbul.NewSealerImpl(committerKey)
+	authorSeal, err := committerSealer.MakeAuthorSeal(header)
+	require.NoError(t, err)
+	require.NoError(t, sealer.WriteAuthorSeal(header, authorSeal))
 	committedSeal, err := committerSealer.MakeCommittedSeal(header)
 	require.NoError(t, err)
 	require.NoError(t, sealer.WriteCommittedSeals(header, [][]byte{committedSeal}))
 
 	valsetModule := mock_valset.NewMockValsetModule(ctrl)
-	valsetModule.EXPECT().GetProposer(uint64(1), uint64(1)).Return(committer, nil)
 	valsetModule.EXPECT().GetCommittee(uint64(1), uint64(1)).Return(validators, nil)
 	valsetModule.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer, nil)
 

--- a/kaiax/valset/impl/getter.go
+++ b/kaiax/valset/impl/getter.go
@@ -100,15 +100,11 @@ func (v *ValsetModule) GetCommittee(num uint64, round uint64) ([]common.Address,
 	return v.getCommitteePermissioned(c, round)
 }
 
+// GetProposer returns the validator scheduled to propose at (num, round). It is not the
+// author of a committed block: under a hash lock the author only proposed an earlier round.
 func (v *ValsetModule) GetProposer(num, round uint64) (common.Address, error) {
 	if num == 0 {
 		return common.Address{}, nil
-	}
-	if header := v.Chain.GetHeaderByNumber(num); header != nil {
-		headerRound, err := v.Chain.Sealer().Round(header)
-		if err == nil && uint64(headerRound) == round {
-			return v.Chain.Sealer().Author(header)
-		}
 	}
 	// TODO-kaiax: Sync blockContext
 	c, err := v.getBlockContext(num)

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -55,6 +55,9 @@ func (v *ValsetModule) getBlockContext(num uint64) (*blockContext, error) {
 		return nil, errNoHeader
 	}
 
+	// The previous block's author, which under a hash lock is not the proposer of the round that
+	// committed it. RoundRobin and Sticky index off this, so redefining it would change the
+	// proposer of already-committed blocks and break resync of an existing chain.
 	prevProposer := qualified.At(0)
 	if num-1 > 0 {
 		prevProposer, err = v.Chain.Sealer().Author(prevHeader)

--- a/kaiax/valset/impl/getter_permissionless_test.go
+++ b/kaiax/valset/impl/getter_permissionless_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/engine"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kaiax/gov"
+	gov_mock "github.com/kaiachain/kaia/kaiax/gov/mock"
 	"github.com/kaiachain/kaia/storage/database"
 	chain_mock "github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
@@ -281,4 +285,65 @@ func TestPermissionlessCommitteeFromHeader(t *testing.T) {
 	qualified, err := v.GetQualifiedValidators(testGetterBlock)
 	require.NoError(t, err)
 	assert.Equal(t, numsToAddrs(1, 2), qualified)
+}
+
+// GetProposer answers "who was scheduled for this round", never "who signed this block". A
+// hash-locked block commits at a later round while still carrying the seal of the validator that
+// built it, so reading the author here would name a node that did not propose the committing round.
+// Re-sealing the same header by a different validator must not move the answer.
+func TestGetProposerIgnoresHeaderAuthor(t *testing.T) {
+	var (
+		ctrl      = gomock.NewController(t)
+		sealer    = engine.NewSealer(nil, nil)
+		mockChain = chain_mock.NewMockBlockChain(ctrl)
+		mockGov   = gov_mock.NewMockGovModule(ctrl)
+		keyA, _   = crypto.GenerateKey()
+		keyB, _   = crypto.GenerateKey()
+		addrA     = crypto.PubkeyToAddress(keyA.PublicKey)
+		addrB     = crypto.PubkeyToAddress(keyB.PublicKey)
+		qualified = []common.Address{addrA, addrB, numToAddr(3), numToAddr(4)}
+	)
+
+	header := &types.Header{Number: big.NewInt(1)}
+	require.NoError(t, sealer.WriteValidators(header, qualified))
+	sealer.WriteRound(header, 2) // committed at round 2
+
+	mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+	mockChain.EXPECT().Sealer().Return(sealer).AnyTimes()
+	mockChain.EXPECT().GetHeaderByNumber(uint64(1)).Return(header).AnyTimes()
+	mockChain.EXPECT().GetHeaderByNumber(uint64(0)).Return(&types.Header{Number: big.NewInt(0)}).AnyTimes()
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		ProposerPolicy: uint64(istanbul.WeightedRandom),
+		MinimumStake:   big.NewInt(0),
+		GovernanceMode: "none",
+	}).AnyTimes()
+
+	v := NewValsetModule()
+	v.Chain = mockChain
+	v.GovModule = mockGov
+
+	// The schedule's answer for round 2, computed without going through GetProposer.
+	c, err := v.getBlockContext(1)
+	require.NoError(t, err)
+	roundProposer, err := v.getProposer(c, 2)
+	require.NoError(t, err)
+
+	// Seal the block as a validator that is NOT the round-2 proposer: that is the hash lock
+	// shape, where the block still carries the seal of the round it was originally built at.
+	authorKey, author := keyA, addrA
+	if roundProposer == addrA {
+		authorKey, author = keyB, addrB
+	}
+	require.NotEqual(t, roundProposer, author)
+	seal, err := istanbul.NewSealerImpl(authorKey).MakeAuthorSeal(header)
+	require.NoError(t, err)
+	require.NoError(t, sealer.WriteAuthorSeal(header, seal))
+	sealed, err := sealer.Author(header)
+	require.NoError(t, err)
+	require.Equal(t, author, sealed, "the header really is sealed by `author`")
+
+	got, err := v.GetProposer(1, 2)
+	require.NoError(t, err)
+	assert.Equal(t, roundProposer, got, "the round's proposer answers")
+	assert.NotEqual(t, author, got, "the header's author does not")
 }

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -289,6 +289,23 @@ func TestSelectReportTarget(t *testing.T) {
 		assert.Equal(t, uint64(11), target)
 	})
 
+	// Under a hash lock the committed block keeps the round-0 proposer's seal, but the candidates
+	// that matter answered the round that committed it. The target belongs to that round's
+	// proposer, so the round-0 proposer must not claim it and report a view nobody asked for.
+	t.Run("hash-locked block belongs to the committing round", func(t *testing.T) {
+		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
+		reproposer := numToAddr(777)
+		cn := newCN(t, withValset(valset), withoutStart(), withHeaders(map[uint64]*types.Header{
+			7: makeHeaderWithRound(7, 2), // proposed here at round 0, committed at round 2
+		}))
+		v := cn.VRankModule
+		v.collector.AddPrepreparedTime(vrank.ViewKey{N: 7, R: 0}, time.Now(), common.Hash{})
+		valset.EXPECT().GetProposer(uint64(7), uint64(2)).Return(reproposer, nil).AnyTimes()
+
+		_, _, ok := v.selectReportTarget(9)
+		assert.False(t, ok, "the round-0 proposer holds no view for the round that committed")
+	})
+
 	t.Run("prior-epoch proposal is not selected", func(t *testing.T) {
 		epoch := uint64(params.DefaultVRankEpoch)
 		v := newCN(t, withoutStart()).VRankModule

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -63,7 +63,7 @@ func (v *VRankModule) pfReport(blockNum uint64) ([]common.Address, error) {
 	if header == nil {
 		return nil, vrank.ErrHeaderNotFound
 	}
-	roundByte, err := v.RoundReader.Round(header)
+	roundByte, err := v.Sealer.Round(header)
 	if err != nil {
 		return nil, err
 	}

--- a/kaiax/vrank/impl/handler.go
+++ b/kaiax/vrank/impl/handler.go
@@ -54,9 +54,10 @@ func (v *VRankModule) HandleIstanbulPreprepare(block *types.Block, view *bft.Vie
 	}
 }
 
-// selectReportTarget returns the most recent block this node produced before number in the same
-// epoch. Rounds it proposed but another validator committed are skipped (committed-header proposer
-// check). ok=false when none exists (first proposal, or a restart cleared the collector).
+// selectReportTarget returns the most recent block this node solicited for before number in the
+// same epoch, and the round that committed it. Rounds it proposed that did not commit are skipped,
+// so a hash-locked block belongs to the round that committed it rather than to its author.
+// ok=false when none exists (first proposal, or a restart cleared the collector).
 func (v *VRankModule) selectReportTarget(number uint64) (targetNum, round uint64, ok bool) {
 	cands := v.collector.PendingEvaluations(calcEpochStart(number, v.vrankEpoch()))
 	slices.Sort(cands)
@@ -83,7 +84,7 @@ func (v *VRankModule) proposerOf(number uint64) (common.Address, uint64, error) 
 	if header == nil {
 		return common.Address{}, 0, vrank.ErrHeaderNotFound
 	}
-	roundByte, err := v.RoundReader.Round(header)
+	roundByte, err := v.Sealer.Round(header)
 	if err != nil {
 		return common.Address{}, 0, err
 	}

--- a/kaiax/vrank/impl/init.go
+++ b/kaiax/vrank/impl/init.go
@@ -54,7 +54,7 @@ var (
 type InitOpts struct {
 	Valset      valset.ValsetModule
 	Randao      vrank.BlsPubkeyGetter
-	RoundReader vrank.RoundReader
+	Sealer      vrank.Sealer
 	NodeKey     *ecdsa.PrivateKey
 	BlsKey      bls.SecretKey
 	ChainConfig *params.ChainConfig
@@ -118,7 +118,7 @@ func (v *VRankModule) scoreCheckpointInterval() uint64 {
 }
 
 func (v *VRankModule) Init(opts *InitOpts) error {
-	if opts == nil || opts.Valset == nil || opts.Randao == nil || opts.RoundReader == nil || opts.NodeKey == nil || opts.BlsKey == nil || opts.ChainConfig == nil || opts.ChainConfig.ChainID == nil || opts.Chain == nil || opts.ChainKv == nil {
+	if opts == nil || opts.Valset == nil || opts.Randao == nil || opts.Sealer == nil || opts.NodeKey == nil || opts.BlsKey == nil || opts.ChainConfig == nil || opts.ChainConfig.ChainID == nil || opts.Chain == nil || opts.ChainKv == nil {
 		return vrank.ErrInitUnexpectedNil
 	}
 	v.InitOpts = *opts

--- a/kaiax/vrank/impl/init_test.go
+++ b/kaiax/vrank/impl/init_test.go
@@ -189,7 +189,7 @@ func newCN(t *testing.T, options ...vrankOpt) *CN {
 		BlsKey:      blsKey,
 		Randao:      opts.randao,
 		Valset:      opts.valset,
-		RoundReader: testIstanbulRoundReader{},
+		Sealer:      testIstanbulSealer{},
 		ChainConfig: params.TestKaiaConfig(opts.hardfork),
 		Chain:       opts.chain,
 		ChainKv:     opts.db,
@@ -240,15 +240,30 @@ func (c *testChain) GetHeaderByNumber(number uint64) *types.Header {
 	return c.headers[number]
 }
 
-// testIstanbulRoundReader implements the vrank.RoundReader interface for tests by reading the
+// testIstanbulSealer implements the vrank.Sealer interface for tests by reading the
 // round byte that makeHeaderWithRound writes into header.Extra.
-type testIstanbulRoundReader struct{}
+type testIstanbulSealer struct{}
 
-func (testIstanbulRoundReader) Round(h *types.Header) (byte, error) {
+func (testIstanbulSealer) Round(h *types.Header) (byte, error) {
 	if len(h.Extra) < istanbul.IstanbulExtraVanity {
 		return 0, errors.New("header extra is too short")
 	}
 	return h.Extra[istanbul.IstanbulExtraVanity-1], nil
+}
+
+// Author returns the address withAuthor stashed in Rewardbase, so tests can make the author
+// differ from the round's proposer the way a hash-locked block does.
+func (testIstanbulSealer) Author(h *types.Header) (common.Address, error) {
+	if len(h.Extra) < istanbul.IstanbulExtraVanity {
+		return common.Address{}, errors.New("header extra is too short")
+	}
+	return h.Rewardbase, nil
+}
+
+// withAuthor sets the header's author for testIstanbulSealer.Author.
+func withAuthor(h *types.Header, author common.Address) *types.Header {
+	h.Rewardbase = author
+	return h
 }
 
 func makeHeaderWithRound(number uint64, round int64) *types.Header {
@@ -287,12 +302,12 @@ func TestInit_CatchUpFromCheckpoint(t *testing.T) {
 	checkpoint := testCheckpointInterval // must be a testCheckpointInterval multiple
 	P1, P2, C1 := numToAddr(1), numToAddr(2), numToAddr(10)
 
-	// The tail block (checkpoint+1) has round=1 and cfReport=[C1]:
+	// The tail block (checkpoint+1) has round=1, author=P2 and cfReport=[C1]:
 	//   - PFS:      pfReport=[P1] (proposer at round 0) → pfs[P1] incremented
-	//   - cpMatrix: reporter=P2   (proposer at round 1) → cpMatrix[C1][P2] incremented
+	//   - cpMatrix: reporter=P2   (the block's author)  → cpMatrix[C1][P2] incremented
 	headers := map[uint64]*types.Header{
 		checkpoint:     makeHeaderWithRound(checkpoint, 0),
-		checkpoint + 1: makeHeaderWithVRank(checkpoint+1, 1, []common.Address{C1}),
+		checkpoint + 1: withAuthor(makeHeaderWithVRank(checkpoint+1, 1, []common.Address{C1}), P2),
 	}
 
 	db := database.NewMemDB()
@@ -383,4 +398,15 @@ func TestVRankModule_RestartAfterStop(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("broadcast did not resume after restart")
 	}
+}
+
+// strictSealer rejects a header with no author stashed, the way IstanbulSealer.Author rejects a
+// header with no author seal. Genesis is the case that matters.
+type strictSealer struct{ testIstanbulSealer }
+
+func (strictSealer) Author(h *types.Header) (common.Address, error) {
+	if h.Rewardbase == (common.Address{}) {
+		return common.Address{}, errors.New("no author seal")
+	}
+	return h.Rewardbase, nil
 }

--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -159,6 +159,9 @@ func (v *VRankModule) applyBlocksForPFS(start, end uint64, seed map[common.Addre
 func (v *VRankModule) applyBlocksForCPMatrix(start, end uint64, seed vrank.CPMatrix) (vrank.CPMatrix, error) {
 	cpMatrix := seed.Clone()
 	for blockNum := start; blockNum <= end; blockNum++ {
+		if blockNum == 0 {
+			continue
+		}
 		header := v.Chain.GetHeaderByNumber(blockNum)
 		if header == nil {
 			return nil, vrank.ErrHeaderNotFound
@@ -169,12 +172,9 @@ func (v *VRankModule) applyBlocksForCPMatrix(start, end uint64, seed vrank.CPMat
 			return nil, err
 		}
 
-		roundByte, err := v.RoundReader.Round(header)
-		if err != nil {
-			return nil, err
-		}
-		round := uint64(roundByte)
-		reporter, err := v.Valset.GetProposer(blockNum, round)
+		// header.VRank was written by whoever built this block. A hash-locked re-proposal
+		// carries it verbatim, so the committing round's proposer is not its reporter.
+		reporter, err := v.Sealer.Author(header)
 		if err != nil {
 			return nil, err
 		}

--- a/kaiax/vrank/impl/scoring_test.go
+++ b/kaiax/vrank/impl/scoring_test.go
@@ -63,7 +63,7 @@ func generateHeadersFromCPMatrix(
 	candidates []common.Address,
 	proposers []common.Address,
 	cpMatrix [][]uint64,
-) (map[uint64]*types.Header, map[uint64]common.Address, uint64, uint64) {
+) (map[uint64]*types.Header, uint64) {
 	t.Helper()
 	require.Len(t, cpMatrix, len(candidates), "cpMatrix row count must equal number of candidates")
 	for i := range cpMatrix {
@@ -85,7 +85,6 @@ func generateHeadersFromCPMatrix(
 	}
 
 	headers := make(map[uint64]*types.Header, int(totalBlocks))
-	blockReporter := make(map[uint64]common.Address, int(totalBlocks))
 
 	nextBlock := start
 	for pi, p := range proposers {
@@ -96,13 +95,12 @@ func generateHeadersFromCPMatrix(
 					report = append(report, c)
 				}
 			}
-			headers[nextBlock] = makeHeaderWithVRank(nextBlock, 0, report)
-			blockReporter[nextBlock] = p
+			headers[nextBlock] = withAuthor(makeHeaderWithVRank(nextBlock, 0, report), p)
 			nextBlock++
 		}
 	}
 
-	return headers, blockReporter, nextBlock - 1, totalBlocks
+	return headers, nextBlock - 1
 }
 
 // # GetPFS
@@ -407,22 +405,16 @@ func TestGetCFS(t *testing.T) {
 		v := b.VRankModule
 		v.Chain = &testChain{
 			headers: map[uint64]*types.Header{
-				epochStart:     makeHeaderWithVRank(epochStart, 0, nil),
-				epochStart + 1: makeHeaderWithVRank(epochStart+1, 0, []common.Address{C1, C2}),
-				epochStart + 2: makeHeaderWithVRank(epochStart+2, 1, []common.Address{C1}),
-				epochStart + 3: makeHeaderWithVRank(epochStart+3, 0, []common.Address{C1, C2, C3}),
-				epochStart + 4: makeHeaderWithVRank(epochStart+4, 0, []common.Address{C1, C2}),
-				epochStart + 5: makeHeaderWithVRank(epochStart+5, 0, []common.Address{C1, C2}),
+				// Per-block authors; can't use withProposer because each block has a different one.
+				epochStart:     withAuthor(makeHeaderWithVRank(epochStart, 0, nil), P1),
+				epochStart + 1: withAuthor(makeHeaderWithVRank(epochStart+1, 0, []common.Address{C1, C2}), P1),
+				epochStart + 2: withAuthor(makeHeaderWithVRank(epochStart+2, 1, []common.Address{C1}), P2),
+				epochStart + 3: withAuthor(makeHeaderWithVRank(epochStart+3, 0, []common.Address{C1, C2, C3}), P3),
+				epochStart + 4: withAuthor(makeHeaderWithVRank(epochStart+4, 0, []common.Address{C1, C2}), P4),
+				epochStart + 5: withAuthor(makeHeaderWithVRank(epochStart+5, 0, []common.Address{C1, C2}), P4),
 			},
 		}
 
-		// Per-block proposer assignments; can't use withProposer because each block has a different one.
-		b.Valset.EXPECT().GetProposer(epochStart, uint64(0)).Return(P1, nil)
-		b.Valset.EXPECT().GetProposer(epochStart+1, uint64(0)).Return(P1, nil)
-		b.Valset.EXPECT().GetProposer(epochStart+2, uint64(1)).Return(P2, nil)
-		b.Valset.EXPECT().GetProposer(epochStart+3, uint64(0)).Return(P3, nil)
-		b.Valset.EXPECT().GetProposer(epochStart+4, uint64(0)).Return(P4, nil)
-		b.Valset.EXPECT().GetProposer(epochStart+5, uint64(0)).Return(P4, nil)
 		cfs, err := v.GetCFS(epochStart + 5)
 		require.NoError(t, err)
 		// ProposerCount = 4, F = 4 - ceil(8/3) = 1. Sorted scores per candidate:
@@ -496,27 +488,28 @@ func TestGetCFS_Errors(t *testing.T) {
 		_, err = v.GetCFS(6)
 		assert.ErrorIs(t, err, vrank.ErrFutureBlock)
 	})
-	t.Run("GetProposer error", func(t *testing.T) {
+	t.Run("author error", func(t *testing.T) {
 		C1 := numToAddr(10)
 		headers := map[uint64]*types.Header{
 			0: makeHeaderWithRound(0, 0),
 			1: makeHeaderWithVRank(1, 0, []common.Address{C1}),
 		}
+		// A header whose author cannot be recovered must surface as an error rather than
+		// silently scoring the report against the zero address.
+		headers[1].Extra = nil
 		cn := newCN(t, withHeaders(headers), withCandidates([]common.Address{C1}))
-		// Block 0 is the first block applied for the [0, 1] range, so its GetProposer is the first call — surface the error there and verify it propagates.
-		cn.Valset.EXPECT().GetProposer(uint64(0), uint64(0)).Return(common.Address{}, assert.AnError).Times(1)
 
 		_, err := cn.VRankModule.GetCFS(1)
-		assert.ErrorIs(t, err, assert.AnError)
+		assert.Error(t, err)
 	})
 	t.Run("missing header error", func(t *testing.T) {
 		C1 := numToAddr(10)
-		// Header exists for block 1 (so CurrentHeader()=1 and ErrFutureBlock is not triggered)
-		// but NOT for block 0, which applyCPMatrix will try to fetch first.
-		headers := map[uint64]*types.Header{1: makeHeaderWithRound(1, 0)}
+		// Header exists for block 2 (so CurrentHeader()=2 and ErrFutureBlock is not triggered)
+		// but NOT for block 1, which applyCPMatrix fetches once it has skipped genesis.
+		headers := map[uint64]*types.Header{2: makeHeaderWithRound(2, 0)}
 		cn := newCN(t, withHeaders(headers), withCandidates([]common.Address{C1}))
 
-		_, err := cn.VRankModule.GetCFS(1)
+		_, err := cn.VRankModule.GetCFS(2)
 		assert.ErrorIs(t, err, vrank.ErrHeaderNotFound)
 	})
 }
@@ -752,19 +745,14 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		v := newCN(t, withValset(valset), withRandao(randao), withGenesis()).VRankModule
 		v.Chain = &testChain{
 			headers: map[uint64]*types.Header{
-				5: makeHeaderWithVRank(5, 0, nil),                          // epoch start, empty
-				6: makeHeaderWithVRank(6, 0, nil),                          // empty report
-				7: makeHeaderWithVRank(7, 0, []common.Address{C1, C2, C3}), // P3 reports all
-				8: makeHeaderWithVRank(8, 0, []common.Address{C1, C2}),     // P4 reports C1,C2
-				9: makeHeaderWithVRank(9, 0, []common.Address{C1, C2}),     // P4 reports C1,C2 again
+				5: withAuthor(makeHeaderWithVRank(5, 0, nil), P1),                          // epoch start, empty
+				6: withAuthor(makeHeaderWithVRank(6, 0, nil), P2),                          // empty report
+				7: withAuthor(makeHeaderWithVRank(7, 0, []common.Address{C1, C2, C3}), P3), // P3 reports all
+				8: withAuthor(makeHeaderWithVRank(8, 0, []common.Address{C1, C2}), P4),     // P4 reports C1,C2
+				9: withAuthor(makeHeaderWithVRank(9, 0, []common.Address{C1, C2}), P4),     // P4 reports C1,C2 again
 			},
 		}
 		valset.EXPECT().GetCandTesting(uint64(5)).Return(candidates, nil)
-		valset.EXPECT().GetProposer(uint64(5), uint64(0)).Return(P1, nil)
-		valset.EXPECT().GetProposer(uint64(6), uint64(0)).Return(P2, nil)
-		valset.EXPECT().GetProposer(uint64(7), uint64(0)).Return(P3, nil)
-		valset.EXPECT().GetProposer(uint64(8), uint64(0)).Return(P4, nil)
-		valset.EXPECT().GetProposer(uint64(9), uint64(0)).Return(P4, nil)
 		cfs, err := computeCFS(v, 5, 9)
 		require.NoError(t, err)
 
@@ -800,7 +788,7 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		}
 
 		start := uint64(1000)
-		headers, blockReporter, end, totalBlocks := generateHeadersFromCPMatrix(t, start, candidates, proposers, cpMatrix)
+		headers, end := generateHeadersFromCPMatrix(t, start, candidates, proposers, cpMatrix)
 
 		ctrl := gomock.NewController(t)
 		valset := mock_valset.NewMockValsetModule(ctrl)
@@ -809,18 +797,6 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		v.Chain = &testChain{headers: headers}
 
 		valset.EXPECT().GetCandTesting(start).Return(candidates, nil).Times(1)
-		valset.EXPECT().GetProposer(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(blockNum, round uint64) (common.Address, error) {
-				if round != 0 {
-					return common.Address{}, assert.AnError
-				}
-				reporter, ok := blockReporter[blockNum]
-				if !ok {
-					return common.Address{}, assert.AnError
-				}
-				return reporter, nil
-			},
-		).Times(int(totalBlocks))
 
 		cfs, err := computeCFS(v, start, end)
 		require.NoError(t, err)
@@ -830,6 +806,62 @@ func TestApplyBlocksForCFS(t *testing.T) {
 		assert.Equal(t, uint64(283), cfs[candidates[2]], "C3")
 		assert.Equal(t, uint64(221), cfs[candidates[3]], "C4")
 		assert.Equal(t, uint64(116), cfs[candidates[4]], "C5")
+	})
+
+	// A hash-locked block is re-proposed verbatim, so header.VRank is still the author's report
+	// even though another validator proposed the round that committed it. The author is the
+	// reporter; crediting the committing round's proposer would attribute a claim it never made.
+	t.Run("hash-locked block credits the author", func(t *testing.T) {
+		author, reproposer := numToAddr(1), numToAddr(2)
+		C1 := numToAddr(10)
+
+		ctrl := gomock.NewController(t)
+		valset := mock_valset.NewMockValsetModule(ctrl)
+		randao := mock_randao.NewMockRandaoModule(ctrl)
+		v := newCN(t, withValset(valset), withRandao(randao), withGenesis()).VRankModule
+		v.Chain = &testChain{
+			headers: map[uint64]*types.Header{
+				0: makeHeaderWithRound(0, 0),
+				1: withAuthor(makeHeaderWithVRank(1, 2, []common.Address{C1}), author),
+			},
+		}
+		valset.EXPECT().GetCandTesting(uint64(0)).Return([]common.Address{C1}, nil)
+		// Present but never consulted: the reporter comes from the header, not the schedule.
+		valset.EXPECT().GetProposer(gomock.Any(), gomock.Any()).Return(reproposer, nil).AnyTimes()
+
+		cpMatrix, err := v.newCPMatrix(0)
+		require.NoError(t, err)
+		cpMatrix, err = v.applyBlocksForCPMatrix(0, 1, cpMatrix)
+		require.NoError(t, err)
+
+		assert.Equal(t, uint64(1), cpMatrix[C1][author], "author wrote the report")
+		assert.Equal(t, uint64(0), cpMatrix[C1][reproposer], "the committing round's proposer did not")
+	})
+
+	// Genesis carries no author seal, so the reporter lookup must not run for it. testIstanbulSealer
+	// is permissive about a missing author; strictSealer is not, matching IstanbulSealer.Author.
+	t.Run("genesis has no author to read", func(t *testing.T) {
+		author := numToAddr(1)
+		C1 := numToAddr(10)
+
+		ctrl := gomock.NewController(t)
+		valset := mock_valset.NewMockValsetModule(ctrl)
+		randao := mock_randao.NewMockRandaoModule(ctrl)
+		v := newCN(t, withValset(valset), withRandao(randao), withGenesis()).VRankModule
+		v.Sealer = strictSealer{}
+		v.Chain = &testChain{
+			headers: map[uint64]*types.Header{
+				0: makeHeaderWithRound(0, 0), // no author, as in a real genesis
+				1: withAuthor(makeHeaderWithVRank(1, 0, []common.Address{C1}), author),
+			},
+		}
+		valset.EXPECT().GetCandTesting(uint64(0)).Return([]common.Address{C1}, nil)
+
+		cpMatrix, err := v.newCPMatrix(0)
+		require.NoError(t, err)
+		cpMatrix, err = v.applyBlocksForCPMatrix(0, 1, cpMatrix)
+		require.NoError(t, err, "genesis must be skipped instead of read")
+		assert.Equal(t, uint64(1), cpMatrix[C1][author])
 	})
 
 	t.Run("epoch_start", func(t *testing.T) {

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -44,10 +44,11 @@ type BlsPubkeyGetter interface {
 	GetBlsPubkey(nodeId common.Address, num *big.Int) (bls.PublicKey, error)
 }
 
-// RoundReader is a narrow interface for reading the round number from a block header.
-// Typically satisfied by consensus.RoundReader via the istanbul backend.
-type RoundReader interface {
+// Sealer is a narrow interface for reading the round and the author from a block header.
+// Typically satisfied by consensus.Sealer via the istanbul backend.
+type Sealer interface {
 	Round(header *types.Header) (byte, error)
+	Author(header *types.Header) (common.Address, error)
 }
 
 type VRankModule interface {

--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -581,7 +581,7 @@ func (s *CN) SetupKaiaxModules(ctx *node.ServiceContext, mValset valset.ValsetMo
 		mVRank.Init(&vrank_impl.InitOpts{
 			Valset:      mValset,
 			Randao:      mRandao,
-			RoundReader: s.blockchain.Sealer(),
+			Sealer:      s.blockchain.Sealer(),
 			NodeKey:     ctx.NodeKey(),
 			BlsKey:      ctx.BlsNodeKey(),
 			ChainConfig: s.chainConfig,


### PR DESCRIPTION
## Proposed changes

Problem

- `GetProposer` short-circuited to the committed header's author when the requested round matched the header's, so it answered "who signed this block" or "who was scheduled for this round" depending on its arguments. The two diverge under a hash lock, where a later round re-proposes the locked block and it commits carrying the original proposer's seal.
- VRank paid for it: the node that solicited at round 0 was picked to report a view it never collected and wrote an empty report, while the node holding the committing round's responses was skipped for not being the author.

Fix

- Drop the short-circuit, and read the author explicitly where the author is what is wanted: the CP matrix reporter (whoever wrote `header.VRank`) and the consensus-info `Proposer` (documented as the signer of SigHash). Every other caller asks about a block that is not canonical yet, so the short-circuit never fired for them.
- Genesis has no proposer, so skip it while accumulating the CP matrix instead of recording the zero address.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

Skipping genesis changes CFS in the first epoch. Every node derives CFS from the headers and it feeds node-state transitions, so this has to land before the fork activates; an already running network would not resync across it.

`prevProposer` in `getBlockContext` stays the previous block's author on purpose — RoundRobin and Sticky index off it, so redefining it would change the proposer of already-committed blocks. The second commit only records that.

`vrank.RoundReader` is renamed to `vrank.Sealer` because it now also reads the author. That rename is mechanical and can be dropped if the diff is easier to review without it.
