### PR TITLE
valset: use unsigned modular arithmetic for proposer selection

### DIFF
--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -45,12 +45,12 @@ func (c *core) checkMessage(msgCode uint64, view *bft.View) error {
 		return bft.ErrInvalidMessage
 	}
 
+	// The round is consumed as a uint64 (View.Round.Uint64()); reject out-of-range values.
+	if !view.Round.IsUint64() {
+		return bft.ErrInvalidMessage
+	}
+
 	if msgCode == bft.MsgRoundChange {
-		// Round-change buckets are keyed by uint64 round in roundChangeSet.
-		// Reject out-of-range round values early to avoid truncation collisions.
-		if !view.Round.IsUint64() {
-			return bft.ErrInvalidMessage
-		}
 		if view.Sequence.Cmp(c.currentView().Sequence) > 0 {
 			return errFutureMessage
 		} else if view.Cmp(c.currentView()) < 0 {

--- a/kaiax/valset/address_set.go
+++ b/kaiax/valset/address_set.go
@@ -121,7 +121,13 @@ func (as *AddressSet) Len() int {
 func (as *AddressSet) At(i int) common.Address {
 	as.mu.RLock()
 	defer as.mu.RUnlock()
-	return as.list[i%len(as.list)]
+	// Normalize into [0, len) so a negative i cannot index out of range.
+	n := len(as.list)
+	idx := i % n
+	if idx < 0 {
+		idx += n
+	}
+	return as.list[idx]
 }
 
 func (as *AddressSet) IndexOf(addr common.Address) int {

--- a/kaiax/valset/impl/getter_context.go
+++ b/kaiax/valset/impl/getter_context.go
@@ -202,18 +202,22 @@ func (v *ValsetModule) getProposer(c *blockContext, round uint64) (common.Addres
 
 func selectRoundRobinProposer(qualified *valset.AddressSet, prevProposer common.Address, round uint64) common.Address {
 	prevIdx := max(qualified.IndexOf(prevProposer), 0)
-	return qualified.At((prevIdx + int(round) + 1) % qualified.Len())
+	// Unsigned modular arithmetic keeps the index in range for any round.
+	n := uint64(qualified.Len())
+	return qualified.At(int((uint64(prevIdx) + 1 + round%n) % n))
 }
 
 func selectStickyProposer(qualified *valset.AddressSet, prevProposer common.Address, round uint64) common.Address {
 	prevIdx := max(qualified.IndexOf(prevProposer), 0)
-	return qualified.At((prevIdx + int(round)) % qualified.Len())
+	n := uint64(qualified.Len())
+	return qualified.At(int((uint64(prevIdx) + round%n) % n))
 }
 
 // listSourceNum is the block number at which the list is generated. The caller must ensure that `len(list) > 0` and `listSourceNum <= num - 1`
 func selectWeightedRandomProposer(list []common.Address, listSourceNum, num uint64, round uint64) common.Address {
+	// Unsigned modulo, matching selectRandaoProposer.
 	idx := num + round - listSourceNum - 1
-	return list[int(idx)%len(list)]
+	return list[idx%uint64(len(list))]
 }
 
 func selectRandaoProposer(committee []common.Address, round uint64) common.Address {

--- a/kaiax/valset/impl/getter_context_test.go
+++ b/kaiax/valset/impl/getter_context_test.go
@@ -17,6 +17,7 @@
 package impl
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -405,6 +406,70 @@ func TestCollectStakingAmounts(t *testing.T) {
 		stakingAmounts := collectStakingAmounts(tc.validators, tc.stakingInfo)
 		for idx, nodeId := range tc.validators {
 			assert.Equal(t, stakingAmounts[nodeId], tc.expectedStakingAmounts[idx])
+		}
+	}
+}
+
+// The selectors must return an in-set proposer for any round value.
+func TestSelectorLargeRoundStaysInSet(t *testing.T) {
+	qualified := valset.NewAddressSet([]common.Address{
+		common.HexToAddress("0x1"), common.HexToAddress("0x2"),
+		common.HexToAddress("0x3"), common.HexToAddress("0x4"),
+	})
+	prev := common.HexToAddress("0x1")
+	list := qualified.List()
+
+	inSet := func(a common.Address) bool {
+		for _, x := range list {
+			if x == a {
+				return true
+			}
+		}
+		return false
+	}
+
+	rounds := []uint64{
+		0, 1, 2, 3, 4, 5,
+		uint64(math.MaxInt64),
+		uint64(math.MaxInt64) + 1,
+		uint64(math.MaxInt64) + 2,
+		uint64(math.MaxInt64) + 3,
+		math.MaxUint64 - 1,
+		math.MaxUint64,
+	}
+	for _, r := range rounds {
+		if a := selectRoundRobinProposer(qualified, prev, r); !inSet(a) {
+			t.Fatalf("round_robin round=%d returned out-of-set %s", r, a.Hex())
+		}
+		if a := selectStickyProposer(qualified, prev, r); !inSet(a) {
+			t.Fatalf("sticky round=%d returned out-of-set %s", r, a.Hex())
+		}
+		if a := selectWeightedRandomProposer(list, 0, 1, r); !inSet(a) {
+			t.Fatalf("weighted round=%d returned out-of-set %s", r, a.Hex())
+		}
+	}
+}
+
+// For the small rounds seen in normal operation the selectors are unchanged.
+func TestSelectorSmallRoundEquivalence(t *testing.T) {
+	qualified := valset.NewAddressSet([]common.Address{
+		common.HexToAddress("0x1"), common.HexToAddress("0x2"),
+		common.HexToAddress("0x3"), common.HexToAddress("0x4"),
+	})
+	list := qualified.List()
+	n := qualified.Len()
+	for _, prev := range list {
+		pi := qualified.IndexOf(prev)
+		for round := uint64(0); round < 1000; round++ {
+			if got, want := selectRoundRobinProposer(qualified, prev, round), qualified.At((pi+int(round)+1)%n); got != want {
+				t.Fatalf("round_robin mismatch prev=%s round=%d: got %s want %s", prev.Hex(), round, got.Hex(), want.Hex())
+			}
+			if got, want := selectStickyProposer(qualified, prev, round), qualified.At((pi+int(round))%n); got != want {
+				t.Fatalf("sticky mismatch prev=%s round=%d: got %s want %s", prev.Hex(), round, got.Hex(), want.Hex())
+			}
+			if got, want := selectWeightedRandomProposer(list, 0, 1, round), list[int(round)%len(list)]; got != want {
+				t.Fatalf("weighted mismatch round=%d: got %s want %s", round, got.Hex(), want.Hex())
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

- Compute proposer indices in `uint64`
- bound the consensus round to `uint64` in `checkMessage`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
