### PR TITLE
blockchain/system: build the permissionless genesis at block 0

### DIFF
--- a/blockchain/system/permissionless.go
+++ b/blockchain/system/permissionless.go
@@ -140,13 +140,11 @@ func allocPermissionless(config *AllocPermissionlessConfig, installABv2 bool) (m
 		return nil, nil, err
 	}
 
-	// The registry entries are initially registered at activation=1, so the
-	// initialization calls can resolve them while running against the genesis
-	// staging state. The activation slots are patched back to zero below.
-	if installABv2 {
-		// Advance block number so getActiveAddr finds records with activation=1
-		cfg.BlockNumber = big.NewInt(1)
+	// Patch all Registry activation slots to 0 so contracts are active from genesis.
+	// Must precede the calls below, which resolve these records at block 0.
+	patchRegistryActivations(statedb, "CnStakingFactory", "ABv2DataContract")
 
+	if installABv2 {
 		// Step 5: Install ABv2 at 0x400 and call initialize()
 		if err := installAndInitABv2(cfg, statedb, result.abv2Impl); err != nil {
 			return nil, nil, err
@@ -159,9 +157,6 @@ func allocPermissionless(config *AllocPermissionlessConfig, installABv2 bool) (m
 			return nil, nil, err
 		}
 	}
-
-	// Patch all Registry activation slots to 0 so contracts are active from genesis
-	patchRegistryActivations(statedb, "CnStakingFactory", "ABv2DataContract")
 
 	// Clean up balances for all managers
 	for _, info := range config.NodeInfos {

--- a/blockchain/system/permissionless_test.go
+++ b/blockchain/system/permissionless_test.go
@@ -213,6 +213,34 @@ func TestAllocPermissionless_SingleValidator(t *testing.T) {
 	verifyPermissionlessAlloc(t, config, alloc)
 }
 
+// A genesis with non-ValActive initial states must record the post-override active count
+// in epochVACount, not the count ABv2.initialize() saw.
+func TestAllocPermissionless_InitialStateOverrideUpdatesEpochVACount(t *testing.T) {
+	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
+	config := makeTestPermissionlessConfig(9)
+	config.NodeInfos[8].State = valset.CandReady.ToUint8()
+
+	alloc, err := AllocPermissionless(config)
+	require.NoError(t, err)
+
+	backend := backends.NewSimulatedBackend(blockchain.GenesisAlloc(alloc))
+	caller, err := addressbookv2contract.NewAddressBookV2Caller(AddressBookAddr, backend)
+	require.NoError(t, err)
+
+	active, err := caller.GetStateCount(&bind.CallOpts{}, valset.ValActive.ToUint8())
+	require.NoError(t, err)
+	require.Equal(t, uint64(8), active.Uint64(), "one of nine nodes starts as CandReady")
+
+	epochVACount, err := caller.GetEpochVACount(&bind.CallOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, active.Uint64(), epochVACount.Uint64(), "epochVACount must match the active count")
+
+	// (8/3+1)/2 = 1; the pre-override count 9 would allow 2.
+	limits, err := caller.GetSlotLimits(&bind.CallOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), limits.MaxSlotAvailable.Uint64())
+}
+
 func TestAllocPermissionlessPrerequisites(t *testing.T) {
 	log.EnableLogForTest(log.LvlCrit, log.LvlWarn)
 	config := makeTestPermissionlessConfig(4)


### PR DESCRIPTION
## Proposed changes

Problem

- The allocator advanced the temporary EVM to block 1 to resolve its `activation=1` Registry records and never moved back, so `applyInitialNodeStateOverrides` ran there too. ABv2 only records `epochVACount` on an epoch block, so the count it was handed was discarded and a genesis with any non-ValActive initial state started with more pause and exiting slots than its active set allows.

Fix

- Patch the Registry activation slots before the initialization calls, so the records resolve at block 0 and the block number never has to move. The generated alloc for an all-ValActive genesis is unchanged.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
