### PR TITLE
node/cn: derive the CN peer allowlist from the canonical head

### DIFF
--- a/kaiax/valset/impl/error.go
+++ b/kaiax/valset/impl/error.go
@@ -31,6 +31,7 @@ var (
 	errNoVoteBlockNums        = errors.New("no validator vote block nums")
 	errMismatchedValidators   = errors.New("header extra validators do not match qualified validators")
 	errPermissionlessDisabled = errors.New("permissionless fork is not enabled")
+	errVRankModuleNotSet      = errors.New("VRankModule is not set")
 
 	// rpc related errors
 	errPendingNotAllowed       = errors.New("pending is not allowed")

--- a/kaiax/valset/impl/transition.go
+++ b/kaiax/valset/impl/transition.go
@@ -119,16 +119,22 @@ func (v *ValsetModule) applyTransition(header *types.Header, statedb *state.Stat
 	}
 	abv2result.Nodes.MarkSuspended(abv2result.SuspendedValidators)
 
-	ctx := v.newTransitionContext(header, abv2result)
+	ctx, err := v.newTransitionContext(header, abv2result)
+	if err != nil {
+		return nil, err
+	}
 	return ctx.ApplyAllTransitions(abv2result.Nodes), nil
 }
 
-func (v *ValsetModule) newTransitionContext(header *types.Header, abv2result *system.ABv2Snapshot) *TransitionContext {
+func (v *ValsetModule) newTransitionContext(header *types.Header, abv2result *system.ABv2Snapshot) (*TransitionContext, error) {
 	headNum := header.Number.Uint64()
 	nextNum := headNum + 1
 
 	pset := v.GovModule.GetParamSet(nextNum)
-	cfs, pfs, pfReport := v.fetchVRankCtx(headNum)
+	cfs, pfs, pfReport, err := v.fetchVRankCtx(headNum)
+	if err != nil {
+		return nil, err
+	}
 
 	ctx := NewTransitionContext()
 	ctx.SetBlockCtx(header, v.isVrankEpoch(nextNum))
@@ -136,44 +142,37 @@ func (v *ValsetModule) newTransitionContext(header *types.Header, abv2result *sy
 	ctx.SetABv2TransitionParam(abv2result.TransitionParam())
 	ctx.SetSlotsCtx(slotLimitsFor(abv2result.EpochVACount))
 	ctx.SetVRankCtx(cfs, pfs, pfReport)
-	return ctx
+	return ctx, nil
 }
 
 // fetchVRankCtx pulls the three vrank scores transitions need at block num.
-// Errors are swallowed here so the orchestrator stays robust to transient vrank failures.
-func (v *ValsetModule) fetchVRankCtx(num uint64) (cfs, pfs map[common.Address]uint64, pfReport []common.Address) {
-	if v.VRankModule == nil {
-		logger.Error("VRankModule is nil")
-		return nil, nil, nil
-	}
+// Read failures are returned, never absorbed into an empty context: transition
+// results are cached (getTransitionResult) and consumed by the consensus write
+// path (writeTransitionToABv2), so a result computed with missing vrank
+// evidence must fail instead of being produced as a valid result.
+func (v *ValsetModule) fetchVRankCtx(num uint64) (cfs, pfs map[common.Address]uint64, pfReport []common.Address, err error) {
 	// Pre-HF blocks have no VRank evidence. Keep applyTr(HF-1) as a no-op
 	// for VRank-dependent transitions by returning an empty VRank context.
 	if !v.Chain.Config().IsPermissionlessForkEnabled(new(big.Int).SetUint64(num)) {
-		return nil, nil, nil
+		return nil, nil, nil, nil
+	}
+	if v.VRankModule == nil {
+		return nil, nil, nil, errVRankModuleNotSet
 	}
 	if nextNum := num + 1; v.isVrankEpoch(nextNum) {
-		c, err := v.VRankModule.GetCFS(num)
-		if err != nil {
-			logger.Error("fetchVRankCtx: GetCFS failed", "num", num, "err", err)
-		} else {
-			cfs = c
+		if cfs, err = v.VRankModule.GetCFS(num); err != nil {
+			return nil, nil, nil, fmt.Errorf("GetCFS(%d) failed: %w", num, err)
 		}
 	}
-	r, err := v.VRankModule.GetPfReport(num)
-	if err != nil {
-		logger.Error("fetchVRankCtx: GetPfReport failed", "num", num, "err", err)
-	} else {
-		pfReport = r
+	if pfReport, err = v.VRankModule.GetPfReport(num); err != nil {
+		return nil, nil, nil, fmt.Errorf("GetPfReport(%d) failed: %w", num, err)
 	}
 	if len(pfReport) > 0 {
-		p, err := v.VRankModule.GetPFS(num)
-		if err != nil {
-			logger.Error("fetchVRankCtx: GetPFS failed", "num", num, "err", err)
-		} else {
-			pfs = p
+		if pfs, err = v.VRankModule.GetPFS(num); err != nil {
+			return nil, nil, nil, fmt.Errorf("GetPFS(%d) failed: %w", num, err)
 		}
 	}
-	return cfs, pfs, pfReport
+	return cfs, pfs, pfReport, nil
 }
 
 func (v *ValsetModule) isVrankEpoch(num uint64) bool {

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -306,42 +306,41 @@ func TestFetchVRankCtx(t *testing.T) {
 		assert.Nil(t, gotPfReport)
 	})
 
-	t.Run("CFS read failure propagates", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
+	t.Run("read failure propagates", func(t *testing.T) {
 		vrankErr := errors.New("vrank unavailable")
+		// num 9 is the epoch boundary (10) minus one, so only it reads CFS.
+		testcases := []struct {
+			name   string
+			num    uint64
+			expect func(*vrank_mock.MockVRankModule)
+		}{
+			{"CFS", 9, func(m *vrank_mock.MockVRankModule) {
+				m.EXPECT().GetCFS(uint64(9)).Return(nil, vrankErr)
+			}},
+			{"pfReport", 8, func(m *vrank_mock.MockVRankModule) {
+				m.EXPECT().GetPfReport(uint64(8)).Return(nil, vrankErr)
+			}},
+			{"PFS", 8, func(m *vrank_mock.MockVRankModule) {
+				m.EXPECT().GetPfReport(uint64(8)).Return([]common.Address{addr1}, nil)
+				m.EXPECT().GetPFS(uint64(8)).Return(nil, vrankErr)
+			}},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				mockChain := chain_mock.NewMockBlockChain(ctrl)
+				mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+				mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+				tc.expect(mockVRank)
 
-		mockChain := chain_mock.NewMockBlockChain(ctrl)
-		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+				v := NewValsetModule()
+				v.Chain = mockChain
+				v.VRankModule = mockVRank
 
-		mockVRank := vrank_mock.NewMockVRankModule(ctrl)
-		mockVRank.EXPECT().GetCFS(uint64(9)).Return(nil, vrankErr)
-
-		v := NewValsetModule()
-		v.Chain = mockChain
-		v.VRankModule = mockVRank
-
-		_, _, _, err := v.fetchVRankCtx(9)
-		require.ErrorIs(t, err, vrankErr)
-	})
-
-	t.Run("PFS read failure propagates", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		pfReport := []common.Address{addr1}
-		vrankErr := errors.New("vrank unavailable")
-
-		mockChain := chain_mock.NewMockBlockChain(ctrl)
-		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
-
-		mockVRank := vrank_mock.NewMockVRankModule(ctrl)
-		mockVRank.EXPECT().GetPfReport(uint64(8)).Return(pfReport, nil)
-		mockVRank.EXPECT().GetPFS(uint64(8)).Return(nil, vrankErr)
-
-		v := NewValsetModule()
-		v.Chain = mockChain
-		v.VRankModule = mockVRank
-
-		_, _, _, err := v.fetchVRankCtx(8)
-		require.ErrorIs(t, err, vrankErr)
+				_, _, _, err := v.fetchVRankCtx(tc.num)
+				require.ErrorIs(t, err, vrankErr)
+			})
+		}
 	})
 
 	t.Run("post-fork without VRankModule is an error", func(t *testing.T) {

--- a/kaiax/valset/impl/transition_test.go
+++ b/kaiax/valset/impl/transition_test.go
@@ -204,6 +204,39 @@ func TestGetNodesParentReadErrors(t *testing.T) {
 	})
 }
 
+// The transition result cache is shared with the consensus write path
+// (writeTransitionToABv2), so a transition computed from a failed vrank read
+// must fail without leaving a cache entry; a later call must recompute.
+func TestGetNodesVRankFailureIsNotCached(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := newABv2Harness(t)
+
+	mockGov := gov_mock.NewMockGovModule(ctrl)
+	mockGov.EXPECT().GetParamSet(gomock.Any()).Return(gov.ParamSet{
+		MinimumStake: common.Big0,
+	}).AnyTimes()
+
+	vrankErr := errors.New("vrank unavailable")
+	mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+	gomock.InOrder(
+		mockVRank.EXPECT().GetPfReport(gomock.Any()).Return(nil, vrankErr),
+		mockVRank.EXPECT().GetPfReport(gomock.Any()).Return(nil, nil),
+	)
+
+	v := h.Valset
+	v.GovModule = mockGov
+	v.VRankModule = mockVRank
+
+	_, err := v.getNodes(1)
+	require.ErrorIs(t, err, vrankErr)
+	_, inCache := v.transitionResultCache.Get(uint64(1))
+	require.False(t, inCache, "a transition computed from a failed vrank read must not be cached")
+
+	nodes, err := v.getNodes(1)
+	require.NoError(t, err)
+	require.NotEmpty(t, nodes)
+}
+
 func TestWriteTransitionToABv2PreForkNoOp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockChain := chain_mock.NewMockBlockChain(ctrl)
@@ -247,7 +280,8 @@ func TestFetchVRankCtx(t *testing.T) {
 		v.Chain = mockChain
 		v.VRankModule = mockVRank
 
-		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(9)
+		gotCFS, gotPFS, gotPfReport, err := v.fetchVRankCtx(9)
+		require.NoError(t, err)
 		assert.Equal(t, cfs, gotCFS)
 		assert.Equal(t, pfs, gotPFS)
 		assert.Equal(t, pfReport, gotPfReport)
@@ -265,13 +299,32 @@ func TestFetchVRankCtx(t *testing.T) {
 		v.Chain = mockChain
 		v.VRankModule = mockVRank
 
-		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(8)
+		gotCFS, gotPFS, gotPfReport, err := v.fetchVRankCtx(8)
+		require.NoError(t, err)
 		assert.Nil(t, gotCFS)
 		assert.Nil(t, gotPFS)
 		assert.Nil(t, gotPfReport)
 	})
 
-	t.Run("errors fail open", func(t *testing.T) {
+	t.Run("CFS read failure propagates", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		vrankErr := errors.New("vrank unavailable")
+
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+
+		mockVRank := vrank_mock.NewMockVRankModule(ctrl)
+		mockVRank.EXPECT().GetCFS(uint64(9)).Return(nil, vrankErr)
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+		v.VRankModule = mockVRank
+
+		_, _, _, err := v.fetchVRankCtx(9)
+		require.ErrorIs(t, err, vrankErr)
+	})
+
+	t.Run("PFS read failure propagates", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		pfReport := []common.Address{addr1}
 		vrankErr := errors.New("vrank unavailable")
@@ -280,18 +333,27 @@ func TestFetchVRankCtx(t *testing.T) {
 		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
 
 		mockVRank := vrank_mock.NewMockVRankModule(ctrl)
-		mockVRank.EXPECT().GetCFS(uint64(9)).Return(nil, vrankErr)
-		mockVRank.EXPECT().GetPfReport(uint64(9)).Return(pfReport, nil)
-		mockVRank.EXPECT().GetPFS(uint64(9)).Return(nil, vrankErr)
+		mockVRank.EXPECT().GetPfReport(uint64(8)).Return(pfReport, nil)
+		mockVRank.EXPECT().GetPFS(uint64(8)).Return(nil, vrankErr)
 
 		v := NewValsetModule()
 		v.Chain = mockChain
 		v.VRankModule = mockVRank
 
-		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(9)
-		assert.Nil(t, gotCFS)
-		assert.Nil(t, gotPFS)
-		assert.Equal(t, pfReport, gotPfReport)
+		_, _, _, err := v.fetchVRankCtx(8)
+		require.ErrorIs(t, err, vrankErr)
+	})
+
+	t.Run("post-fork without VRankModule is an error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockChain := chain_mock.NewMockBlockChain(ctrl)
+		mockChain.EXPECT().Config().Return(testPermissionlessConfig(0, 10)).AnyTimes()
+
+		v := NewValsetModule()
+		v.Chain = mockChain
+
+		_, _, _, err := v.fetchVRankCtx(8)
+		require.ErrorIs(t, err, errVRankModuleNotSet)
 	})
 
 	t.Run("pre-fork block returns empty context without vrank reads", func(t *testing.T) {
@@ -303,7 +365,8 @@ func TestFetchVRankCtx(t *testing.T) {
 		v.Chain = mockChain
 		v.VRankModule = vrank_mock.NewMockVRankModule(ctrl)
 
-		gotCFS, gotPFS, gotPfReport := v.fetchVRankCtx(29)
+		gotCFS, gotPFS, gotPfReport, err := v.fetchVRankCtx(29)
+		require.NoError(t, err)
 		assert.Nil(t, gotCFS)
 		assert.Nil(t, gotPFS)
 		assert.Nil(t, gotPfReport)

--- a/node/cn/cnpeers.go
+++ b/node/cn/cnpeers.go
@@ -145,8 +145,8 @@ func (s *CN) cnPeerSyncLoop(ch <-chan blockchain.ChainHeadEvent, sub event.Subsc
 
 	for {
 		select {
-		case ev := <-ch:
-			s.cnPeerUpdater.syncHead(ev.Block)
+		case <-ch:
+			s.cnPeerUpdater.syncHead(s.blockchain.CurrentBlock())
 		case err, ok := <-sub.Err():
 			if ok && err != nil {
 				logger.Warn("CN peer sync stopped", "err", err)

--- a/node/cn/cnpeers_test.go
+++ b/node/cn/cnpeers_test.go
@@ -21,9 +21,13 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/work/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -196,6 +200,33 @@ func TestCNPeerUpdaterFailureKeepsLastAllowlist(t *testing.T) {
 			assert.Equal(t, cnTestAddrs(1), cn.sink.calls[0])
 		})
 	}
+}
+
+// ChainHeadEvents are posted outside the chain lock, so one can arrive after a newer
+// one. The loop must read the canonical head rather than the block in the event.
+func TestCNPeerSyncLoopReadsCanonicalHead(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	head := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(100)})
+	chain := mocks.NewMockBlockChain(ctrl)
+	chain.EXPECT().CurrentBlock().Return(head).AnyTimes()
+
+	cn := newCNPeerUpdaterTest(t)
+	s := &CN{blockchain: chain, cnPeerUpdater: cn.updater}
+
+	var feed event.Feed
+	ch := make(chan blockchain.ChainHeadEvent) // unbuffered, so Send returns once the loop has taken it
+	sub := feed.Subscribe(ch)
+	s.cnPeerSyncWg.Add(1)
+	go s.cnPeerSyncLoop(ch, sub)
+
+	// A stale event for a block far below the canonical head.
+	feed.Send(blockchain.ChainHeadEvent{Block: types.NewBlockWithHeader(&types.Header{Number: big.NewInt(50)})})
+	sub.Unsubscribe()
+	s.cnPeerSyncWg.Wait() // the loop finished the event before exiting
+
+	assert.Equal(t, []uint64{101}, cn.reader.calls, "must look up the head's next block, not the event's")
 }
 
 func cnTestAddrs(n ...int) []common.Address {


### PR DESCRIPTION
## Proposed changes

Problem

- The sync loop derived the allowlist from the block in the `ChainHeadEvent`. Those events are posted after the insertion lock is released, so an older one can arrive after a newer one and overwrite the current allowlist with a stale one.

Fix

- Read the canonical head instead. The event is only a signal that the head moved.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
