### PR TITLE
p2p: fix dial scheduler and multichannel dial cleanup

### DIFF
--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -619,9 +619,9 @@ func (ds *DialSched) markDialFailure(id discover.NodeID) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 
-	ds.connectedAll.remove(id)
-	ds.connectedOutbound.remove(id)
-
+	if ds.connectedAll.contains(id) {
+		return
+	}
 	if n := ds.static.get(id); n != nil {
 		ds.connFails[id]++
 		if ds.connFails[id] > dialMaxRetries {

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -320,17 +320,17 @@ func (ds *DialSched) dialLoop() {
 // PN/EN dialing is delayed only if static nodes and CN candidates fill maxConcurrentDials first.
 // But in reality, there are much less static nodes, and even so they will be filtered out by shouldDial() in later iterations quite soon.
 func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh bool) {
-	ds.mu.RLock()
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 
-	// 1. Determine the demand
+	// 1. Determine how many dynamic outbound peers are still needed per node type.
 	needs := make(map[discover.NodeType]int)
 	for targetType := range ds.connTarget {
-		// Note that the needs can be negative because we often over-dial the dynamic nodes in case of failures.
 		needs[targetType] = ds.connTarget[targetType] - ds.connectedOutbound.count(targetType) - ds.dialing.count(targetType)
 	}
 
-	// 2. Add all static nodes, even if they are already connected or in the dialing list. Those will be filtered out later.
-	// Since static nodes are exempt from the connTargets nor peer limits, all static nodes are going to be dialed even if needs[] is zero.
+	// 2. Snapshot static candidates. Static nodes bypass dynamic connTargets and
+	// peer capacity; duplicates or already-connected nodes are filtered later by shouldDial().
 	candidates = ds.static.all()
 
 	// 3. Subtract the static nodes about to be dialed. They fill the same outbound budget as the dynamic ones.
@@ -339,17 +339,50 @@ func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh b
 			needs[n.NType]--
 		}
 	}
-	ds.mu.RUnlock()
 
-	// 4. Dynamic nodes — skip when already at total peer capacity.
-	// Even if we want more outbound peers (needs > 0), the total capacity might be reached (maxPeers) due to inbound peers.
-	// Static dials (added above) bypass this check, mirroring the Server's capacity check.
-	if ds.maxPeers == 0 || ds.connectedAll.len() < ds.maxPeers {
-		for targetType, need := range needs {
-			dynamicNodes, refresh := ds.getDynamicCandidates(targetType, need)
-			candidates = append(candidates, dynamicNodes...)
-			needRefresh = needRefresh || refresh
+	// 4. Stop before dynamic candidates when the total peer capacity is full or discovery is unavailable.
+	// Static candidates collected above are still returned, mirroring the Server's peer-limit bypass for static peers.
+	if (ds.maxPeers != 0 && ds.connectedAll.len() >= ds.maxPeers) || ds.tab == nil {
+		return candidates, needRefresh
+	}
+
+	// 5. Pull dynamic candidates from the per-type queues, refilling from discovery when needed.
+	// CN-to-CN dynamic dialing is additionally constrained by the configured CN peer allowlist.
+	for targetType, need := range needs {
+		if need <= 0 {
+			continue
 		}
+
+		// Refill empty queues from discovery if this type's queue cannot satisfy demand.
+		if len(ds.candidateQueue[targetType]) < need {
+			for refillType := range ds.connTarget {
+				if len(ds.candidateQueue[refillType]) == 0 {
+					buf := make([]*discover.Node, candidateQueueSize)
+					n := ds.tab.RandomNodes(buf, refillType)
+					ds.candidateQueue[refillType] = buf[:n]
+				}
+			}
+		}
+
+		// Discard disallowed CNs so they do not keep occupying the queue.
+		q := ds.candidateQueue[targetType]
+		if ds.selfType == discover.NodeTypeCN && targetType == discover.NodeTypeCN && ds.cnPeerAddrs != nil {
+			q = slices.DeleteFunc(q, func(n *discover.Node) bool {
+				addr, err := addressFromNodeID(n.ID)
+				if err != nil {
+					return true
+				}
+				_, ok := ds.cnPeerAddrs[addr]
+				return !ok
+			})
+		}
+
+		// Pop up to need candidates from the filtered queue.
+		end := min(need, len(q))
+		candidates = append(candidates, q[:end]...)
+		ds.candidateQueue[targetType] = q[end:]
+		// Ask discovery refresh to run if the queue is still short after refill.
+		needRefresh = needRefresh || end < need
 	}
 
 	if len(candidates) > 0 {
@@ -357,29 +390,6 @@ func (ds *DialSched) getCandidates() (candidates []*discover.Node, needRefresh b
 			"connectedOutbound", ds.connectedOutbound.len(), "dialing", ds.dialing.len(), "candidates", len(candidates))
 	}
 	return candidates, needRefresh
-}
-
-func (ds *DialSched) getDynamicCandidates(targetType discover.NodeType, need int) (nodes []*discover.Node, needRefresh bool) {
-	if ds.tab == nil || need <= 0 {
-		return nil, false
-	}
-	// Try to refill from the table if the queue can't satisfy the demand.
-	// The table may already have nodes (e.g. from local nodeDB) without needing a refresh
-	if len(ds.candidateQueue[targetType]) < need {
-		ds.refillCandidates()
-	}
-
-	// Disallowed CNs are discarded so they do not keep occupying the dynamic candidate queue.
-	q := ds.candidateQueue[targetType]
-	q = slices.DeleteFunc(q, func(n *discover.Node) bool {
-		return !ds.dynamicCandidateAllowed(targetType, n)
-	})
-
-	// Pop up to `need` candidates from the filtered queue.
-	end := min(need, len(q))
-	nodes, ds.candidateQueue[targetType] = q[:end], q[end:]
-	// If the queue is short even after a refill, signal the dial loop to run a discovery refresh.
-	return nodes, len(nodes) < need
 }
 
 // #region dial task
@@ -469,38 +479,6 @@ func (ds *DialSched) refreshOnce(refreshResCh chan struct{}) {
 		ds.tab.Refresh()
 		ds.signalResult(refreshResCh)
 	}()
-}
-
-// refillCandidates refills empty per-type candidate queues from the discovery table.
-// Called by dialLoop after a refresh completes, so the table has fresh nodes.
-// Accessed only by the dialLoop goroutine; no mutex required.
-func (ds *DialSched) refillCandidates() {
-	for targetType := range ds.connTarget {
-		if len(ds.candidateQueue[targetType]) == 0 {
-			buf := make([]*discover.Node, candidateQueueSize)
-			n := ds.tab.RandomNodes(buf, targetType)
-			ds.candidateQueue[targetType] = buf[:n]
-		}
-	}
-}
-
-func (ds *DialSched) dynamicCandidateAllowed(targetType discover.NodeType, n *discover.Node) bool {
-	if ds.selfType != discover.NodeTypeCN || targetType != discover.NodeTypeCN {
-		return true
-	}
-
-	ds.mu.RLock()
-	defer ds.mu.RUnlock()
-	if ds.cnPeerAddrs == nil {
-		return true
-	}
-
-	addr, err := addressFromNodeID(n.ID)
-	if err != nil {
-		return false
-	}
-	_, ok := ds.cnPeerAddrs[addr]
-	return ok
 }
 
 // #region internal variable accessors

--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -44,6 +44,13 @@ var (
 // DialBackend is the minimal server-side API dialsched needs for outbound dial execution.
 type DialBackend interface {
 	SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Node) error
+	CleanConn(id discover.NodeID) cleanConnStats
+}
+
+type cleanConnStats struct {
+	expectedChannels         int
+	closedOutboundChannels   int
+	remainingInboundChannels int
 }
 
 // discovery is the minimal table API dialsched needs.
@@ -430,6 +437,9 @@ func (ds *DialSched) dialOnce(n *discover.Node, flags connFlag) {
 	logger.Debug("Dialed node", "id", n.ID, "type", n.NType, "addresses", n.TCPs, "err", err)
 
 	if err != nil {
+		if err == errIncompleteMultiChannelDial {
+			return
+		}
 		ds.markDialFailure(n.ID)
 	}
 	// We don't call markPeerConnected() here. If dial()-SetupConn() succeeds, the Server will call OnPeerConnected()-markPeerConnected().
@@ -450,21 +460,36 @@ func (ds *DialSched) dialMulti(dest *discover.Node, flags connFlag) error {
 		return err
 	}
 
-	var errBackup error
 	for portOrder, fd := range fds {
 		mfd := newMeteredConn(fd, false)
 		destByPort := cloneNode(dest)
 		destByPort.PortOrder = uint16(portOrder)
 		if err := ds.backend.SetupConn(mfd, flags, destByPort); err != nil {
-			errBackup = err
+			closeConns(fds[portOrder+1:])
+			ds.backend.CleanConn(dest.ID)
+			return err
 		}
 	}
-	if errBackup != nil {
-		for _, fd := range fds {
-			fd.Close()
+	ds.mu.RLock()
+	connected := ds.connectedAll.contains(dest.ID)
+	ds.mu.RUnlock()
+	if !connected {
+		stats := ds.backend.CleanConn(dest.ID)
+		logger.Warn("Incomplete multichannel dial", "id", dest.ID, "type", dest.NType,
+			"addresses", dest.TCPs, "expectedChannels", stats.expectedChannels,
+			"dialedChannels", len(fds), "closedOutboundChannels", stats.closedOutboundChannels,
+			"remainingInboundChannels", stats.remainingInboundChannels)
+		return errIncompleteMultiChannelDial
+	}
+	return nil
+}
+
+func closeConns(conns []net.Conn) {
+	for _, conn := range conns {
+		if conn != nil {
+			conn.Close()
 		}
 	}
-	return errBackup
 }
 
 // #region refresh task

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -613,11 +613,13 @@ func TestDialSched_DialMulti(t *testing.T) {
 	var (
 		multiNode = discover.NewNode(testNodeID(401), net.ParseIP("10.0.0.41"), 30303, 30303, []uint16{30304, 30305}, discover.NodeTypeEN)
 		md        = &mockDialer{dialErr: make(map[discover.NodeID]error)}
-		mb        = &mockSetupBackend{setupErr: make(map[discover.NodeID]error)}
+		mb        = &multiDialLifecycleBackend{}
 		ds        = NewDialSched(DialConfig{}, nil, mb)
 	)
-	ds.dialer = md
+	t.Cleanup(mb.Close)
 	mb.dialsched = ds
+	mb.connectOnPort = uint16(len(multiNode.TCPs) - 1)
+	ds.dialer = md
 
 	ds.dialOnce(multiNode, dynDialedConn)
 
@@ -627,6 +629,87 @@ func TestDialSched_DialMulti(t *testing.T) {
 		assert.Equal(t, dynDialedConn, mb.calls[i].flags)
 		assert.Equal(t, uint16(i), mb.calls[i].port, "PortOrder should increment per connection")
 	}
+}
+
+func TestDialSched_DialMultiRollbackOnSetupFailure(t *testing.T) {
+	multiNode := discover.NewNode(testNodeID(402), net.ParseIP("10.0.0.42"), 30303, 30303, []uint16{30304, 30305}, discover.NodeTypeEN)
+	setupErr := errors.New("setup failed")
+	mb := &multiDialLifecycleBackend{
+		setupErrByPort: map[uint16]error{0: setupErr},
+	}
+	t.Cleanup(mb.Close)
+
+	conns := make([]*closeTrackingConn, len(multiNode.TCPs))
+	dialConns := make([]net.Conn, len(multiNode.TCPs))
+	for i := range conns {
+		local, remote := net.Pipe()
+		conns[i] = &closeTrackingConn{Conn: local}
+		dialConns[i] = conns[i]
+		t.Cleanup(func() {
+			_ = local.Close()
+			_ = remote.Close()
+		})
+	}
+	ds := NewDialSched(DialConfig{}, nil, mb)
+	ds.dialer = &fixedMultiDialer{conns: dialConns}
+
+	err := ds.dialMulti(multiNode, dynDialedConn)
+
+	require.ErrorIs(t, err, setupErr)
+	require.Len(t, mb.calls, 1, "SetupConn should stop after the first failure")
+	require.Len(t, mb.cleanups, 1)
+	assert.Equal(t, multiNode.ID, mb.cleanups[0])
+	for i, conn := range conns {
+		assert.True(t, conn.Closed(), "connection %d should be closed", i)
+	}
+}
+
+func TestDialSched_DialMultiCleansIncompleteDial(t *testing.T) {
+	multiNode := discover.NewNode(testNodeID(403), net.ParseIP("10.0.0.43"), 30303, 30303, []uint16{30304, 30305}, discover.NodeTypeEN)
+	mb := &multiDialLifecycleBackend{}
+	t.Cleanup(mb.Close)
+
+	conns := make([]*closeTrackingConn, len(multiNode.TCPs))
+	dialConns := make([]net.Conn, len(multiNode.TCPs))
+	for i := range conns {
+		local, remote := net.Pipe()
+		conns[i] = &closeTrackingConn{Conn: local}
+		dialConns[i] = conns[i]
+		t.Cleanup(func() {
+			_ = local.Close()
+			_ = remote.Close()
+		})
+	}
+	ds := NewDialSched(DialConfig{}, nil, mb)
+	ds.dialer = &fixedMultiDialer{conns: dialConns}
+
+	err := ds.dialMulti(multiNode, dynDialedConn)
+
+	require.ErrorIs(t, err, errIncompleteMultiChannelDial)
+	require.Len(t, mb.calls, len(multiNode.TCPs))
+	require.Len(t, mb.cleanups, 1)
+	assert.Equal(t, multiNode.ID, mb.cleanups[0])
+	for i, conn := range conns {
+		assert.True(t, conn.Closed(), "connection %d should be closed", i)
+	}
+}
+
+func TestDialSched_IncompleteMultiDialDoesNotRemoveStaticPeer(t *testing.T) {
+	multiNode := discover.NewNode(testNodeID(404), net.ParseIP("10.0.0.44"), 30303, 30303, []uint16{30304, 30305}, discover.NodeTypeEN)
+	mb := &multiDialLifecycleBackend{}
+	t.Cleanup(mb.Close)
+
+	ds := NewDialSched(DialConfig{
+		staticNodes: []*discover.Node{multiNode},
+		dialer:      &mockDialer{dialErr: make(map[discover.NodeID]error)},
+	}, nil, mb)
+
+	for i := 0; i < dialMaxRetries+1; i++ {
+		ds.dialOnce(multiNode, staticDialedConn)
+	}
+
+	assert.NotNil(t, ds.static.get(multiNode.ID), "incomplete multichannel dials must not remove static peers")
+	assert.Empty(t, ds.connFails, "incomplete multichannel dials must not count toward static dial failures")
 }
 
 func mustParseNetlist(t *testing.T, s string) *netutil.Netlist {
@@ -732,6 +815,37 @@ type mockDialer struct {
 	dialErr map[discover.NodeID]error // injected errors, discriminated by NodeID.
 }
 
+type fixedMultiDialer struct {
+	conns []net.Conn
+}
+
+func (d *fixedMultiDialer) Dial(*discover.Node) (net.Conn, error) {
+	return nil, errors.New("unexpected single-channel dial")
+}
+
+func (d *fixedMultiDialer) DialMulti(*discover.Node) ([]net.Conn, error) {
+	return append([]net.Conn(nil), d.conns...), nil
+}
+
+type closeTrackingConn struct {
+	net.Conn
+	mu     sync.Mutex
+	closed bool
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+	return c.Conn.Close()
+}
+
+func (c *closeTrackingConn) Closed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}
+
 func (m *mockDialer) Dial(dest *discover.Node) (net.Conn, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -791,6 +905,63 @@ type setupConnArg struct {
 	port  uint16
 }
 
+type multiDialLifecycleBackend struct {
+	mu             sync.Mutex
+	dialsched      *DialSched
+	setupErrByPort map[uint16]error
+	connectOnPort  uint16
+	calls          []setupConnArg
+	cleanups       []discover.NodeID
+	accepted       []net.Conn
+}
+
+func (m *multiDialLifecycleBackend) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Node) error {
+	m.mu.Lock()
+	call := setupConnArg{flags: flags}
+	if dialDest != nil {
+		call.id = dialDest.ID
+		call.port = dialDest.PortOrder
+	}
+	m.calls = append(m.calls, call)
+	err := m.setupErrByPort[call.port]
+	if err == nil && fd != nil {
+		m.accepted = append(m.accepted, fd)
+	}
+	if err == nil && m.dialsched != nil && dialDest != nil && call.port == m.connectOnPort {
+		m.dialsched.markPeerConnected(call.id, dialDest.NType, false)
+	}
+	m.mu.Unlock()
+
+	if err != nil && fd != nil {
+		_ = fd.Close()
+	}
+	return err
+}
+
+func (m *multiDialLifecycleBackend) CleanConn(id discover.NodeID) cleanConnStats {
+	m.mu.Lock()
+	m.cleanups = append(m.cleanups, id)
+	accepted := m.accepted
+	m.accepted = nil
+	m.mu.Unlock()
+
+	for _, fd := range accepted {
+		_ = fd.Close()
+	}
+	return cleanConnStats{closedOutboundChannels: len(accepted)}
+}
+
+func (m *multiDialLifecycleBackend) Close() {
+	m.mu.Lock()
+	accepted := m.accepted
+	m.accepted = nil
+	m.mu.Unlock()
+
+	for _, fd := range accepted {
+		_ = fd.Close()
+	}
+}
+
 type mockSetupBackend struct {
 	mu        sync.Mutex
 	dialsched *DialSched
@@ -819,6 +990,10 @@ func (m *mockSetupBackend) SetupConn(fd net.Conn, flags connFlag, dialDest *disc
 	return nil
 }
 
+func (m *mockSetupBackend) CleanConn(id discover.NodeID) cleanConnStats {
+	return cleanConnStats{}
+}
+
 // rejectBackend always returns an error from SetupConn. Used when the test only
 // cares about the dialing side, not the connection setup side.
 type rejectBackend struct{}
@@ -828,6 +1003,10 @@ func (m *rejectBackend) SetupConn(fd net.Conn, flags connFlag, dialDest *discove
 		fd.Close()
 	}
 	return errors.New("rejectBackend: connection rejected")
+}
+
+func (m *rejectBackend) CleanConn(id discover.NodeID) cleanConnStats {
+	return cleanConnStats{}
 }
 
 // blockingBackend blocks inside SetupConn() until unblockCh is closed.
@@ -847,6 +1026,10 @@ func (m *blockingBackend) SetupConn(fd net.Conn, flags connFlag, dialDest *disco
 	}
 	<-m.unblockCh
 	return errors.New("SetupConn unblocked")
+}
+
+func (m *blockingBackend) CleanConn(id discover.NodeID) cleanConnStats {
+	return cleanConnStats{}
 }
 
 // A SetupConn backend that returns errUpdateDial, telling me (the dialsched) to use different ports.
@@ -880,6 +1063,12 @@ func (m *updateToMultiBackend) SetupConn(fd net.Conn, flags connFlag, dialDest *
 		}
 		return errUpdateDial
 	}
-	m.dialsched.markPeerConnected(dialDest.ID, dialDest.NType, false)
+	if int(dialDest.PortOrder) == len(m.ports)-1 {
+		m.dialsched.markPeerConnected(dialDest.ID, dialDest.NType, false)
+	}
 	return nil
+}
+
+func (m *updateToMultiBackend) CleanConn(id discover.NodeID) cleanConnStats {
+	return cleanConnStats{}
 }

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -557,6 +557,23 @@ func TestDialSched_Dial_DialFailure(t *testing.T) {
 	assert.False(t, ds.connectedOutbound.contains(staticNode.ID), "static node should not be counted as connected")
 }
 
+func TestDialSched_DialFailureDoesNotRemoveConnectedPeer(t *testing.T) {
+	staticNode := testNode(302, "10.0.1.32", discover.NodeTypePN)
+	ds := NewDialSched(DialConfig{
+		staticNodes: []*discover.Node{staticNode},
+	}, nil, nil)
+
+	ds.markPeerConnected(staticNode.ID, staticNode.NType, true)
+	for range dialMaxRetries + 2 {
+		ds.markDialFailure(staticNode.ID)
+	}
+
+	assert.True(t, ds.connectedAll.contains(staticNode.ID), "dial failure must not remove live peer bookkeeping")
+	assert.False(t, ds.connectedOutbound.contains(staticNode.ID), "inbound peer should stay inbound-only")
+	assert.True(t, ds.static.contains(staticNode.ID), "live static peer must not be removed by concurrent dial failures")
+	assert.Zero(t, ds.connFails[staticNode.ID], "live peer should not accumulate static dial failures")
+}
+
 // Special feature: Retries dial after upgrading from single-channel to multi-channel.
 func TestDialSched_Dial_RetryOnErrUpdateDial(t *testing.T) {
 	var (

--- a/networks/p2p/server.go
+++ b/networks/p2p/server.go
@@ -57,8 +57,9 @@ const (
 )
 
 var (
-	errServerStopped = errors.New("server stopped")
-	errUpdateDial    = errors.New("updated to be multichannel peer")
+	errServerStopped              = errors.New("server stopped")
+	errUpdateDial                 = errors.New("updated to be multichannel peer")
+	errIncompleteMultiChannelDial = errors.New("incomplete multichannel dial")
 )
 
 // Config holds Server options.

--- a/networks/p2p/server_base.go
+++ b/networks/p2p/server_base.go
@@ -547,6 +547,12 @@ func (srv *BaseServer) SetupConn(fd net.Conn, flags connFlag, dialDest *discover
 	return err
 }
 
+// CleanConn is a no-op for the single-channel server because it has no pending
+// multichannel candidate bookkeeping.
+func (srv *BaseServer) CleanConn(id discover.NodeID) cleanConnStats {
+	return cleanConnStats{}
+}
+
 func (srv *BaseServer) setupConn(c *conn, flags connFlag, dialDest *discover.Node) error {
 	// Prevent leftover pending conns from entering the handshake.
 	srv.lock.Lock()

--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -246,9 +246,9 @@ func (srv *MultiChannelServer) listenLoop(listener net.Listener) {
 	}
 }
 
-// SetupConn runs the handshakes and attempts to add the connection
-// as a peer. It returns when the connection has been added as a peer
-// or the handshakes have failed.
+// SetupConn runs the handshakes and attempts to add the connection as a peer.
+// For a multichannel peer, nil can also mean that this channel was accepted and
+// is waiting in CandidateConns for the remaining channels.
 func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *discover.Node) error {
 	c := &conn{fd: fd, flags: flags, conntype: common.ConnTypeUndefined, portOrder: PortOrderUndefined}
 
@@ -275,6 +275,40 @@ func (srv *MultiChannelServer) SetupConn(fd net.Conn, flags connFlag, dialDest *
 		srv.logger.Trace("close connection", "id", c.id, "err", err)
 	}
 	return err
+}
+
+func (srv *MultiChannelServer) CleanConn(id discover.NodeID) cleanConnStats {
+	srv.lock.Lock()
+	connSet := srv.CandidateConns[id]
+	var connsToClose []*conn
+	stats := cleanConnStats{expectedChannels: len(srv.ListenAddrs)}
+	if connSet != nil {
+		stats.expectedChannels = len(connSet)
+		remaining := false
+		for portOrder, c := range connSet {
+			if c == nil {
+				continue
+			}
+			if c.Inbound() {
+				stats.remainingInboundChannels++
+				remaining = true
+				continue
+			}
+			connsToClose = append(connsToClose, c)
+			connSet[portOrder] = nil
+		}
+		if !remaining {
+			delete(srv.CandidateConns, id)
+			delete(srv.candidateSince, id)
+		}
+	}
+	srv.lock.Unlock()
+
+	stats.closedOutboundChannels = len(connsToClose)
+	for _, c := range connsToClose {
+		c.close(errIncompleteMultiChannelDial)
+	}
+	return stats
 }
 
 // Overrides BaseServer.setupConn() to preserve multichannel port-order handling

--- a/networks/p2p/server_multi_test.go
+++ b/networks/p2p/server_multi_test.go
@@ -17,6 +17,7 @@
 package p2p
 
 import (
+	"crypto/ecdsa"
 	"net"
 	"testing"
 
@@ -122,6 +123,85 @@ func TestMultiChannelRejectsOutOfRangePortOrder(t *testing.T) {
 	c, _ := newCandidateConn(t, 1, PortOrder(len(srv.ListenAddrs)))
 	assert.ErrorIs(t, srv.handleAddPeerConn(c), DiscUnexpectedIdentity)
 	assert.Empty(t, srv.CandidateConns)
+}
+
+func TestMultiChannelCleanConnClosesOutboundCandidate(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+
+	c, tt := newCandidateConn(t, 1, ConnDefault)
+	c.flags = dynDialedConn
+	require.NoError(t, srv.handleAddPeerConn(c))
+
+	stats := srv.CleanConn(c.id)
+
+	assert.Equal(t, errIncompleteMultiChannelDial, tt.closeErr)
+	assert.Equal(t, cleanConnStats{expectedChannels: 2, closedOutboundChannels: 1}, stats)
+	assert.Empty(t, srv.CandidateConns)
+	assert.Empty(t, srv.candidateSince)
+}
+
+func TestMultiChannelCleanConnKeepsInboundCandidate(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+	srv.ListenAddrs = append(srv.ListenAddrs, ":32325")
+
+	inbound, inboundTransport := newCandidateConn(t, 1, ConnDefault)
+	require.NoError(t, srv.handleAddPeerConn(inbound))
+
+	outbound, outboundTransport := newCandidateConn(t, 1, 1)
+	outbound.flags = dynDialedConn
+	require.NoError(t, srv.handleAddPeerConn(outbound))
+
+	stats := srv.CleanConn(inbound.id)
+
+	assert.Nil(t, inboundTransport.closeErr)
+	assert.Equal(t, errIncompleteMultiChannelDial, outboundTransport.closeErr)
+	assert.Equal(t, cleanConnStats{expectedChannels: 3, closedOutboundChannels: 1, remainingInboundChannels: 1}, stats)
+	require.Contains(t, srv.CandidateConns, inbound.id)
+	assert.Same(t, inbound, srv.CandidateConns[inbound.id][ConnDefault])
+	assert.Nil(t, srv.CandidateConns[inbound.id][1])
+	assert.Contains(t, srv.candidateSince, inbound.id)
+}
+
+func TestMultiChannelSetupConnKeepsIncompleteCandidate(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+	srv.PrivateKey = newkey()
+
+	serverFD, clientFD := net.Pipe()
+	t.Cleanup(func() { serverFD.Close(); clientFD.Close() })
+
+	id := discover.PubkeyID(&newkey().PublicKey)
+	t.Cleanup(func() { srv.CleanConn(id) })
+	tt := newTestTransport(id, serverFD, nil, true).(*testTransport)
+	tt.listenPorts = []uint64{30303, 30304}
+	srv.newTransport = func(net.Conn, *ecdsa.PublicKey) transport { return tt }
+	dialDest := &discover.Node{ID: id, IP: net.ParseIP("10.0.0.1"), TCPs: []uint16{30303, 30304}}
+
+	err := srv.SetupConn(serverFD, dynDialedConn, dialDest)
+
+	require.NoError(t, err)
+	require.Contains(t, srv.CandidateConns, id)
+}
+
+func TestMultiChannelSetupConnKeepsIncompleteFinalCandidate(t *testing.T) {
+	srv := newCandidateTestServer(t, 4)
+	srv.PrivateKey = newkey()
+
+	serverFD, clientFD := net.Pipe()
+	t.Cleanup(func() { serverFD.Close(); clientFD.Close() })
+
+	id := discover.PubkeyID(&newkey().PublicKey)
+	t.Cleanup(func() { srv.CleanConn(id) })
+	tt := newTestTransport(id, serverFD, nil, true).(*testTransport)
+	tt.listenPorts = []uint64{30303, 30304}
+	srv.newTransport = func(net.Conn, *ecdsa.PublicKey) transport { return tt }
+	dialDest := &discover.Node{ID: id, IP: net.ParseIP("10.0.0.1"), TCPs: []uint16{30303, 30304}, PortOrder: 1}
+
+	err := srv.SetupConn(serverFD, dynDialedConn, dialDest)
+
+	require.NoError(t, err)
+	assert.Nil(t, tt.closeErr)
+	require.Contains(t, srv.CandidateConns, id)
+	assert.NotEmpty(t, srv.candidateSince)
 }
 
 func TestMultiChannelStopClosesCandidates(t *testing.T) {

--- a/networks/p2p/server_test.go
+++ b/networks/p2p/server_test.go
@@ -48,6 +48,7 @@ type testTransport struct {
 	id discover.NodeID
 	*rlpxTransport
 	mutichannel bool
+	listenPorts []uint64
 
 	closeErr error
 }
@@ -69,7 +70,7 @@ func (c *testTransport) doEncHandshake(prv *ecdsa.PrivateKey) (*ecdsa.PublicKey,
 }
 
 func (c *testTransport) doProtoHandshake(our *protoHandshake) (*protoHandshake, error) {
-	return &protoHandshake{ID: c.id, Name: "test", Multichannel: c.mutichannel}, nil
+	return &protoHandshake{ID: c.id, Name: "test", Multichannel: c.mutichannel, ListenPort: c.listenPorts}, nil
 }
 
 func (c *testTransport) doConnTypeHandshake(myConnType common.ConnType) (common.ConnType, error) {
@@ -720,22 +721,34 @@ func TestServerSetCNPeersUpdatesDialSched(t *testing.T) {
 	blockedKey := newkey()
 	allowed := discover.NewNode(discover.PubkeyID(&allowedKey.PublicKey), net.ParseIP("10.0.0.1"), 30303, 30303, nil, discover.NodeTypeCN)
 	blocked := discover.NewNode(discover.PubkeyID(&blockedKey.PublicKey), net.ParseIP("10.0.0.2"), 30303, 30303, nil, discover.NodeTypeCN)
-	ds := NewDialSched(DialConfig{selfType: discover.NodeTypeCN}, nil, nil)
+	ds := NewDialSched(DialConfig{selfType: discover.NodeTypeCN}, &mockTable{nodesByType: map[discover.NodeType][]*discover.Node{}}, nil)
 	srv := &BaseServer{
 		dialSched: ds,
 		peers:     make(map[discover.NodeID]*Peer),
 	}
+	hasCandidate := func(nodes []*discover.Node, id discover.NodeID) bool {
+		for _, n := range nodes {
+			if n.ID == id {
+				return true
+			}
+		}
+		return false
+	}
 
 	srv.SetCNPeers([]common.Address{crypto.PubkeyToAddress(allowedKey.PublicKey)})
-	if !ds.dynamicCandidateAllowed(discover.NodeTypeCN, allowed) {
+	ds.candidateQueue[discover.NodeTypeCN] = []*discover.Node{allowed, blocked}
+	candidates, _ := ds.getCandidates()
+	if !hasCandidate(candidates, allowed.ID) {
 		t.Fatal("allowed CN should remain dialable")
 	}
-	if ds.dynamicCandidateAllowed(discover.NodeTypeCN, blocked) {
+	if hasCandidate(candidates, blocked.ID) {
 		t.Fatal("blocked CN should not remain dialable")
 	}
 
 	srv.SetCNPeers(nil)
-	if !ds.dynamicCandidateAllowed(discover.NodeTypeCN, blocked) {
+	ds.candidateQueue[discover.NodeTypeCN] = []*discover.Node{blocked}
+	candidates, _ = ds.getCandidates()
+	if !hasCandidate(candidates, blocked.ID) {
 		t.Fatal("nil CN peer allowlist should disable dynamic dial filtering")
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR addresses p2p dial issues introduced by the DialSched refactor.

It contains three fixes:

063bb7274 p2p: serialize dial candidate collection
- Fixes a dial scheduler race where `getCandidates` read scheduler bookkeeping across inconsistent lock snapshots.
- Keeps candidate demand calculation, static peer snapshot, dynamic queue refill, and CN allowlist filtering under one scheduler lock.
- This makes each dial candidate batch reflect one consistent view of connected/dialing/static/CN peer state.

b0690b2b2 p2p: preserve connected peers on dial failure
- Fixes a simultaneous dial case where outbound dial failure could remove bookkeeping for an already live inbound peer.
- markDialFailure now returns early when the peer is already present in connectedAll.
- This prevents failed outbound attempts from tearing down live peer accounting.

7fb265652 p2p: clean up incomplete multichannel dials
- Fixes partial multichannel dial cleanup when some channels succeed but the full peer is never assembled.
- dialMulti now verifies peer assembly after all channels, cleans only outbound pending candidates, and preserves inbound candidates from simultaneous dials.
- Incomplete multichannel dials no longer remove static peers, and the warning log includes expected/dialed/cleaned channel counts.

One known limitation remains: multichannel candidate assembly is still keyed only by peer ID, so inbound and outbound candidate state can share the same candidate set. This is an existing design limitation rather than a regression introduced by this PR, so it is left out of scope.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
