### PR TITLE
p2p: keep a redundant dial from clearing peer state

### DIFF
--- a/networks/p2p/dialsched.go
+++ b/networks/p2p/dialsched.go
@@ -641,8 +641,10 @@ func (ds *DialSched) markDialFailure(id discover.NodeID) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
 
-	ds.connectedAll.remove(id)
-	ds.connectedOutbound.remove(id)
+	// Being connected means this dial was redundant, not that the peer is unreachable.
+	if ds.connectedAll.contains(id) {
+		return
+	}
 
 	if n := ds.static.get(id); n != nil {
 		ds.connFails[id]++

--- a/networks/p2p/dialsched_test.go
+++ b/networks/p2p/dialsched_test.go
@@ -557,6 +557,33 @@ func TestDialSched_Dial_DialFailure(t *testing.T) {
 	assert.False(t, ds.connectedOutbound.contains(staticNode.ID), "static node should not be counted as connected")
 }
 
+// A dial rejected because the peer already reached us inbound must not be counted against it.
+func TestDialSched_Dial_FailureAfterPeerConnected(t *testing.T) {
+	var (
+		staticNode = testNode(302, "10.0.1.32", discover.NodeTypeCN)
+		md         = &mockDialer{dialErr: make(map[discover.NodeID]error)}
+		mb         = &mockSetupBackend{
+			setupErr: map[discover.NodeID]error{
+				staticNode.ID: DiscAlreadyConnected,
+			},
+		}
+		ds = NewDialSched(DialConfig{
+			staticNodes: []*discover.Node{staticNode},
+		}, nil, mb)
+	)
+	ds.dialer = md
+	mb.dialsched = ds
+
+	// The peer reached us inbound while our outbound attempt was still in flight.
+	ds.OnPeerConnected(staticNode.ID, staticNode.NType, true)
+
+	ds.dialOnce(staticNode, staticDialedConn)
+
+	require.Len(t, mb.calls, 1)
+	assert.True(t, ds.connectedAll.contains(staticNode.ID), "the live inbound connection must survive the failure")
+	assert.Zero(t, ds.connFails[staticNode.ID], "a redundant dial is not a connection failure")
+}
+
 // Special feature: Retries dial after upgrading from single-channel to multi-channel.
 func TestDialSched_Dial_RetryOnErrUpdateDial(t *testing.T) {
 	var (


### PR DESCRIPTION
## Proposed changes

Problem

- `markDialFailure` treated any failed attempt as proof the peer is not connected. When a peer reaches us inbound while our outbound attempt is still in flight, that attempt fails with `DiscAlreadyConnected` and erases the connection the Server just admitted.

Fix

- When the peer is already connected, do not clear the connected sets or count a static failure. Connection state is left to `OnPeerConnected`/`OnPeerDisconnected`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
