### PR TITLE
blockchain: separate proposal and finalized header validation

### DIFF
--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -101,8 +101,17 @@ func (v *BlockValidator) ValsetModule() valset.ValsetModule {
 	return v.mValset
 }
 
+// ValidateHeader validates a finalized header: every rule, including the presence and
+// quorum of the committed seals.
 func (v *BlockValidator) ValidateHeader(header *types.Header) error {
-	return v.validateHeader(header, nil)
+	return v.validateHeader(header, nil, true)
+}
+
+// ValidateProposalHeader validates a consensus proposal, which carries no committed seals
+// yet. Every rule applies except the committed-seal ones. Consensus path only: it leaves
+// the committed seals unchecked.
+func (v *BlockValidator) ValidateProposalHeader(header *types.Header) error {
+	return v.validateHeader(header, nil, false)
 }
 
 func (v *BlockValidator) Preprocess(headers []*types.Header) (chan<- struct{}, <-chan error) {
@@ -144,7 +153,9 @@ func (v *BlockValidator) Preprocess(headers []*types.Header) (chan<- struct{}, <
 	return abort, results
 }
 
-func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Header) error {
+// validateHeader runs every header rule. withSeals selects whether the committed-seal
+// rules apply; every other rule runs either way.
+func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Header, withSeals bool) error {
 	// Don't waste time checking blocks from the future
 	if header.Time.Cmp(big.NewInt(time.Now().Add(time.Duration(params.DefaultBlockGenerationInterval)*time.Second).Unix())) > 0 {
 		return consensus.ErrFutureBlock
@@ -220,14 +231,17 @@ func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Head
 	}
 
 	// Verify the header's seal and consensus-specific fields.
-	if err := v.verifySeals(header); err != nil {
+	if err := v.verifySeals(header, withSeals); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (v *BlockValidator) verifySeals(header *types.Header) error {
+// verifySeals authorizes the header author, and verifies the committed seals when
+// withSeals is set. The author is recoverable from header.Extra alone, so it is checked
+// either way; only the seal presence and quorum need a committed header.
+func (v *BlockValidator) verifySeals(header *types.Header, withSeals bool) error {
 	if header.Number.Uint64() == 0 {
 		return nil
 	}
@@ -243,6 +257,25 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		rules = v.config.Rules(new(big.Int).SetUint64(blockNum))
 	}
 
+	// Skip module-dependent validation when gov/valset modules are not registered.
+	modulesReady := v.mValset != nil && v.mGov != nil
+
+	var (
+		signerSet    *valset.AddressSet
+		qualifiedLen int
+	)
+	if modulesReady {
+		// Also yields the set the committed seals are counted against, so both use the same one.
+		signerSet, qualifiedLen, err = v.authorizeAuthor(header, author, blockNum, rules)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !withSeals {
+		return nil
+	}
+
 	// Committers is fork-aware: post-permissionless it recovers with the round-bound preimage.
 	committers, err := v.sealer.Committers(header)
 	if err != nil {
@@ -251,61 +284,24 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 	if len(committers) == 0 {
 		return istanbul.ErrEmptyCommittedSeals
 	}
-
-	// Skip module-dependent seal validation when gov/valset modules are not registered.
-	if v.mValset == nil || v.mGov == nil {
+	if !modulesReady {
 		return nil
 	}
 
-	if rules.IsPermissionless {
-		round, err := v.sealer.Round(header)
-		if err != nil {
-			return err
-		}
-		// Count committed seals only from the round's committee, matching the set the
-		// live consensus commits against (handleCommit rejects non-committee senders),
-		// rather than the broader qualified/council set.
-		committee, err := v.mValset.GetCommittee(blockNum, uint64(round))
-		if err != nil {
-			return err
-		}
-		committeeSet := valset.NewAddressSet(committee)
-		if !committeeSet.Contains(author) {
-			return consensus.ErrUnauthorized
-		}
-		validSeal, err := countValidCommittedSeals(committers, committeeSet)
-		if err != nil {
-			return err
-		}
-		// Require the quorum over the committee. Post-permissionless the committee
-		// equals the qualified set, so pass its size for both arguments.
-		if validSeal < v.sealer.Quorum(blockNum, len(committee), len(committee)) {
-			return istanbul.ErrInvalidCommittedSeals
-		}
-		return nil
-	}
-
-	qualified, err := v.mValset.GetQualifiedValidators(blockNum)
-	if err != nil {
-		return err
-	}
-	qualifiedSet := valset.NewAddressSet(qualified)
-	if !qualifiedSet.Contains(author) {
-		return consensus.ErrUnauthorized
-	}
-
-	// Reached only pre-permissionless (post-fork returns above); count seals against the council.
-	council, err := v.mValset.GetCouncil(blockNum)
-	if err != nil {
-		return err
-	}
-	signerSet := valset.NewAddressSet(council).Copy()
 	validSeal, err := countValidCommittedSeals(committers, signerSet)
 	if err != nil {
 		return err
 	}
 
-	qualifiedLen := len(qualified)
+	if rules.IsPermissionless {
+		// Require the quorum over the committee. Post-permissionless the committee
+		// equals the qualified set, so pass its size for both arguments.
+		if validSeal < v.sealer.Quorum(blockNum, qualifiedLen, qualifiedLen) {
+			return istanbul.ErrInvalidCommittedSeals
+		}
+		return nil
+	}
+
 	committeeSize := qualifiedLen
 	if !gov.DeprecatedAt(gov.IstanbulCommitteeSize, rules) {
 		committeeSize = int(v.mGov.GetParamSet(blockNum).CommitteeSize)
@@ -316,6 +312,49 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		return istanbul.ErrInvalidCommittedSeals
 	}
 	return nil
+}
+
+// authorizeAuthor checks that the header's recovered author may produce this block, and
+// returns the set the committed seals are counted against plus the size the quorum is
+// derived from. It reads only header.Extra and the validator set, so it is valid on a
+// proposal as well as a finalized header.
+func (v *BlockValidator) authorizeAuthor(header *types.Header, author common.Address, blockNum uint64, rules params.Rules) (*valset.AddressSet, int, error) {
+	if rules.IsPermissionless {
+		round, err := v.sealer.Round(header)
+		if err != nil {
+			return nil, 0, err
+		}
+		// Membership, not "author == this round's proposer": a hash-locked proposal is
+		// re-proposed verbatim while the header's round advances. The committee is not
+		// round-subselected here, so membership holds across those rounds.
+		committee, err := v.mValset.GetCommittee(blockNum, uint64(round))
+		if err != nil {
+			return nil, 0, err
+		}
+		committeeSet := valset.NewAddressSet(committee)
+		if !committeeSet.Contains(author) {
+			return nil, 0, consensus.ErrUnauthorized
+		}
+		// Count committed seals only from the round's committee, matching the set the
+		// live consensus commits against (handleCommit rejects non-committee senders),
+		// rather than the broader qualified/council set.
+		return committeeSet, len(committee), nil
+	}
+
+	qualified, err := v.mValset.GetQualifiedValidators(blockNum)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !valset.NewAddressSet(qualified).Contains(author) {
+		return nil, 0, consensus.ErrUnauthorized
+	}
+	// Pre-permissionless counts committed seals against the council, which is broader
+	// than the qualified set.
+	council, err := v.mValset.GetCouncil(blockNum)
+	if err != nil {
+		return nil, 0, err
+	}
+	return valset.NewAddressSet(council), len(qualified), nil
 }
 
 func countValidCommittedSeals(committers []common.Address, signerSet *valset.AddressSet) (int, error) {

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -262,16 +262,6 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		if err != nil {
 			return err
 		}
-		proposer, err := v.mValset.GetProposer(blockNum, uint64(round))
-		if err != nil {
-			return err
-		}
-		// author == proposer implies the author is the committee-selected proposer,
-		// so a separate qualified-membership check is redundant here.
-		if author != proposer {
-			return consensus.ErrUnauthorized
-		}
-
 		// Count committed seals only from the round's committee, matching the set the
 		// live consensus commits against (handleCommit rejects non-committee senders),
 		// rather than the broader qualified/council set.
@@ -280,6 +270,9 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 			return err
 		}
 		committeeSet := valset.NewAddressSet(committee)
+		if !committeeSet.Contains(author) {
+			return consensus.ErrUnauthorized
+		}
 		validSeal, err := countValidCommittedSeals(committers, committeeSet)
 		if err != nil {
 			return err

--- a/blockchain/block_validator.go
+++ b/blockchain/block_validator.go
@@ -101,8 +101,17 @@ func (v *BlockValidator) ValsetModule() valset.ValsetModule {
 	return v.mValset
 }
 
+// ValidateHeader validates a finalized header: every rule, including the presence and
+// quorum of the committed seals.
 func (v *BlockValidator) ValidateHeader(header *types.Header) error {
-	return v.validateHeader(header, nil)
+	return v.validateHeader(header, nil, true)
+}
+
+// ValidateProposalHeader validates a consensus proposal, which carries no committed seals
+// yet. Every rule applies except the committed-seal ones. Consensus path only: it leaves
+// the committed seals unchecked.
+func (v *BlockValidator) ValidateProposalHeader(header *types.Header) error {
+	return v.validateHeader(header, nil, false)
 }
 
 func (v *BlockValidator) Preprocess(headers []*types.Header) (chan<- struct{}, <-chan error) {
@@ -144,7 +153,9 @@ func (v *BlockValidator) Preprocess(headers []*types.Header) (chan<- struct{}, <
 	return abort, results
 }
 
-func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Header) error {
+// validateHeader runs every header rule. withSeals selects whether the committed-seal
+// rules apply; every other rule runs either way.
+func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Header, withSeals bool) error {
 	// Don't waste time checking blocks from the future
 	if header.Time.Cmp(big.NewInt(time.Now().Add(time.Duration(params.DefaultBlockGenerationInterval)*time.Second).Unix())) > 0 {
 		return consensus.ErrFutureBlock
@@ -220,14 +231,17 @@ func (v *BlockValidator) validateHeader(header *types.Header, parent *types.Head
 	}
 
 	// Verify the header's seal and consensus-specific fields.
-	if err := v.verifySeals(header); err != nil {
+	if err := v.verifySeals(header, withSeals); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (v *BlockValidator) verifySeals(header *types.Header) error {
+// verifySeals authorizes the header author, and verifies the committed seals when
+// withSeals is set. The author is recoverable from header.Extra alone, so it is checked
+// either way; only the seal presence and quorum need a committed header.
+func (v *BlockValidator) verifySeals(header *types.Header, withSeals bool) error {
 	if header.Number.Uint64() == 0 {
 		return nil
 	}
@@ -243,69 +257,51 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		rules = v.config.Rules(new(big.Int).SetUint64(blockNum))
 	}
 
+	// Skip module-dependent validation when gov/valset modules are not registered.
+	modulesReady := v.mValset != nil && v.mGov != nil
+
+	var (
+		signerSet    *valset.AddressSet
+		qualifiedLen int
+	)
+	if modulesReady {
+		// Also yields the set the committed seals are counted against, so both use the same one.
+		signerSet, qualifiedLen, err = v.authorizeAuthor(header, author, blockNum, rules)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !withSeals {
+		return nil
+	}
+
 	// Committers is fork-aware: post-permissionless it recovers with the round-bound preimage.
 	committers, err := v.sealer.Committers(header)
 	if err != nil {
 		return err
 	}
-
-	// Skip module-dependent seal validation when gov/valset modules are not registered.
-	if v.mValset == nil || v.mGov == nil {
-		if len(committers) == 0 {
-			return istanbul.ErrEmptyCommittedSeals
-		}
+	if len(committers) == 0 {
+		return istanbul.ErrEmptyCommittedSeals
+	}
+	if !modulesReady {
 		return nil
 	}
 
-	if rules.IsPermissionless {
-		round, err := v.sealer.Round(header)
-		if err != nil {
-			return err
-		}
-		// Count committed seals only from the round's committee, matching the set the
-		// live consensus commits against (handleCommit rejects non-committee senders),
-		// rather than the broader qualified/council set.
-		committee, err := v.mValset.GetCommittee(blockNum, uint64(round))
-		if err != nil {
-			return err
-		}
-		committeeSet := valset.NewAddressSet(committee)
-		if !committeeSet.Contains(author) {
-			return consensus.ErrUnauthorized
-		}
-		validSeal, err := countValidCommittedSeals(committers, committeeSet)
-		if err != nil {
-			return err
-		}
-		// Require the quorum over the committee. Post-permissionless the committee
-		// equals the qualified set, so pass its size for both arguments.
-		if validSeal < v.sealer.Quorum(blockNum, len(committee), len(committee)) {
-			return istanbul.ErrInvalidCommittedSeals
-		}
-		return nil
-	}
-
-	qualified, err := v.mValset.GetQualifiedValidators(blockNum)
-	if err != nil {
-		return err
-	}
-	qualifiedSet := valset.NewAddressSet(qualified)
-	if !qualifiedSet.Contains(author) {
-		return consensus.ErrUnauthorized
-	}
-
-	// Reached only pre-permissionless (post-fork returns above); count seals against the council.
-	council, err := v.mValset.GetCouncil(blockNum)
-	if err != nil {
-		return err
-	}
-	signerSet := valset.NewAddressSet(council).Copy()
 	validSeal, err := countValidCommittedSeals(committers, signerSet)
 	if err != nil {
 		return err
 	}
 
-	qualifiedLen := len(qualified)
+	if rules.IsPermissionless {
+		// Require the quorum over the committee. Post-permissionless the committee
+		// equals the qualified set, so pass its size for both arguments.
+		if validSeal < v.sealer.Quorum(blockNum, qualifiedLen, qualifiedLen) {
+			return istanbul.ErrInvalidCommittedSeals
+		}
+		return nil
+	}
+
 	committeeSize := qualifiedLen
 	if !gov.DeprecatedAt(gov.IstanbulCommitteeSize, rules) {
 		committeeSize = int(v.mGov.GetParamSet(blockNum).CommitteeSize)
@@ -316,6 +312,49 @@ func (v *BlockValidator) verifySeals(header *types.Header) error {
 		return istanbul.ErrInvalidCommittedSeals
 	}
 	return nil
+}
+
+// authorizeAuthor checks that the header's recovered author may produce this block, and
+// returns the set the committed seals are counted against plus the size the quorum is
+// derived from. It reads only header.Extra and the validator set, so it is valid on a
+// proposal as well as a finalized header.
+func (v *BlockValidator) authorizeAuthor(header *types.Header, author common.Address, blockNum uint64, rules params.Rules) (*valset.AddressSet, int, error) {
+	if rules.IsPermissionless {
+		round, err := v.sealer.Round(header)
+		if err != nil {
+			return nil, 0, err
+		}
+		// Membership, not "author == this round's proposer": a hash-locked proposal is
+		// re-proposed verbatim while the header's round advances. The committee is not
+		// round-subselected here, so membership holds across those rounds.
+		committee, err := v.mValset.GetCommittee(blockNum, uint64(round))
+		if err != nil {
+			return nil, 0, err
+		}
+		committeeSet := valset.NewAddressSet(committee)
+		if !committeeSet.Contains(author) {
+			return nil, 0, consensus.ErrUnauthorized
+		}
+		// Count committed seals only from the round's committee, matching the set the
+		// live consensus commits against (handleCommit rejects non-committee senders),
+		// rather than the broader qualified/council set.
+		return committeeSet, len(committee), nil
+	}
+
+	qualified, err := v.mValset.GetQualifiedValidators(blockNum)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !valset.NewAddressSet(qualified).Contains(author) {
+		return nil, 0, consensus.ErrUnauthorized
+	}
+	// Pre-permissionless counts committed seals against the council, which is broader
+	// than the qualified set.
+	council, err := v.mValset.GetCouncil(blockNum)
+	if err != nil {
+		return nil, 0, err
+	}
+	return valset.NewAddressSet(council), len(qualified), nil
 }
 
 func countValidCommittedSeals(committers []common.Address, signerSet *valset.AddressSet) (int, error) {

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -239,13 +239,21 @@ func TestValidateHeader(t *testing.T) {
 	}
 }
 
-func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
+// TestVerifySealsPermissionlessRejectsNonCommitteeAuthor checks that an author outside the
+// round's committee is rejected even when every committed seal is valid.
+func TestVerifySealsPermissionlessRejectsNonCommitteeAuthor(t *testing.T) {
 	var (
-		author        = common.HexToAddress("0x0001")
-		otherProposer = common.HexToAddress("0x0002")
-		blockNum      = uint64(7)
-		header        = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
-		sealer        = faker.NewFakerWithFixedSealer(author)
+		author    = common.HexToAddress("0x0001")
+		b         = common.HexToAddress("0x0002")
+		c         = common.HexToAddress("0x0003")
+		blockNum  = uint64(7)
+		header    = &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+		committee = []common.Address{b, c}
+		sealer    = &verifySealsTestSealer{
+			Sealer:     faker.NewFaker(),
+			author:     author,
+			committers: []common.Address{b, c},
+		}
 	)
 
 	ctrl := gomock.NewController(t)
@@ -253,7 +261,7 @@ func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(otherProposer, nil)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
 		config:  params.TestKaiaConfig("permissionless"),
@@ -265,7 +273,7 @@ func TestVerifySealsChecksAuthorMatchesProposer(t *testing.T) {
 	assert.ErrorIs(t, validator.verifySeals(header), consensus.ErrUnauthorized)
 }
 
-func TestVerifySealsSkipsProposerAuthorCheckBeforePermissionless(t *testing.T) {
+func TestVerifySealsBeforePermissionlessUsesQualifiedSet(t *testing.T) {
 	var (
 		author   = common.HexToAddress("0x0001")
 		blockNum = uint64(7)
@@ -294,7 +302,7 @@ func TestVerifySealsSkipsProposerAuthorCheckBeforePermissionless(t *testing.T) {
 	assert.NoError(t, validator.verifySeals(header))
 }
 
-func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
+func TestVerifySealsPermissionlessAcceptsCommitteeAuthor(t *testing.T) {
 	var (
 		author   = common.HexToAddress("0x0001")
 		blockNum = uint64(7)
@@ -307,7 +315,6 @@ func TestVerifySealsAcceptsExpectedProposer(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{author}, nil)
 
 	validator := &BlockValidator{
@@ -346,7 +353,6 @@ func TestVerifySealsPermissionlessUsesSealerQuorum(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
@@ -386,7 +392,6 @@ func TestVerifySealsPermissionlessRejectsBelowQuorum(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
@@ -424,7 +429,6 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, uint64(0)).Return(author, nil)
 	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return(committee, nil)
 
 	validator := &BlockValidator{
@@ -488,7 +492,6 @@ func TestVerifySealsPermissionlessRejectsMutatedRound(t *testing.T) {
 
 	mGov := mock_gov.NewMockGovModule(ctrl)
 	mValset := mock_valset.NewMockValsetModule(ctrl)
-	mValset.EXPECT().GetProposer(blockNum, gomock.Any()).Return(addrs[0], nil).AnyTimes()
 	mValset.EXPECT().GetCommittee(blockNum, gomock.Any()).Return(addrs, nil).AnyTimes()
 
 	validator := &BlockValidator{config: config, sealer: sealer, mGov: mGov, mValset: mValset}
@@ -497,6 +500,59 @@ func TestVerifySealsPermissionlessRejectsMutatedRound(t *testing.T) {
 
 	sealer.WriteRound(header, round+1)
 	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+}
+
+// TestVerifySealsPermissionlessAcceptsHashLockedAuthor covers the block a round change
+// produces: the locked proposal is re-proposed in a later round, so the header carries the
+// final round with the original author's seal. Such a block is valid, and deciding it must
+// not depend on who was scheduled to propose the final round.
+func TestVerifySealsPermissionlessAcceptsHashLockedAuthor(t *testing.T) {
+	const round = int64(3)
+	var (
+		blockNum = uint64(7)
+		keys     = make([]*ecdsa.PrivateKey, 4) // Quorum(4, 4) == 3, so 4 valid seals pass
+		addrs    = make([]common.Address, 4)
+	)
+	for i := range keys {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		keys[i], addrs[i] = key, crypto.PubkeyToAddress(key.PublicKey)
+	}
+
+	sealer := &roundBoundSealer{istanbul.NewSealerImpl(keys[0])} // keys[0] sealed an earlier round
+
+	header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+	require.NoError(t, sealer.WriteValidators(header, addrs))
+	sealer.WriteRound(header, round)
+	authorSeal, err := sealer.MakeAuthorSeal(header)
+	require.NoError(t, err)
+	require.NoError(t, sealer.WriteAuthorSeal(header, authorSeal))
+
+	seals := make([][]byte, len(keys))
+	for i, key := range keys {
+		preimage := istanbul.PrepareCommittedSealWithRound(sealer.HeaderHash(header), byte(round))
+		seals[i], err = crypto.Sign(crypto.Keccak256(preimage), key)
+		require.NoError(t, err)
+	}
+	require.NoError(t, sealer.WriteCommittedSeals(header, seals))
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(round)).Return(addrs, nil)
+	// The final round is another validator's turn, and the block must be valid regardless.
+	mValset.EXPECT().GetProposer(blockNum, uint64(round)).Return(addrs[1], nil).AnyTimes()
+
+	validator := &BlockValidator{
+		config:  params.TestKaiaConfig("permissionless"),
+		sealer:  sealer,
+		mGov:    mGov,
+		mValset: mValset,
+	}
+
+	require.NoError(t, validator.verifySeals(header))
 }
 
 func TestVerifyBlockBody(t *testing.T) {

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -270,7 +270,7 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeAuthor(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.ErrorIs(t, validator.verifySeals(header), consensus.ErrUnauthorized)
+	assert.ErrorIs(t, validator.verifySeals(header, true), consensus.ErrUnauthorized)
 }
 
 func TestVerifySealsBeforePermissionlessUsesQualifiedSet(t *testing.T) {
@@ -299,7 +299,7 @@ func TestVerifySealsBeforePermissionlessUsesQualifiedSet(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.NoError(t, validator.verifySeals(header))
+	assert.NoError(t, validator.verifySeals(header, true))
 }
 
 func TestVerifySealsPermissionlessAcceptsCommitteeAuthor(t *testing.T) {
@@ -324,7 +324,7 @@ func TestVerifySealsPermissionlessAcceptsCommitteeAuthor(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.NoError(t, validator.verifySeals(header))
+	assert.NoError(t, validator.verifySeals(header, true))
 }
 
 // TestVerifySealsPermissionlessUsesSealerQuorum checks that post-permissionless, the
@@ -362,7 +362,7 @@ func TestVerifySealsPermissionlessUsesSealerQuorum(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.NoError(t, validator.verifySeals(header))
+	assert.NoError(t, validator.verifySeals(header, true))
 	// Quorum is computed over the committee size, passed as both arguments.
 	assert.Equal(t, len(committee), sealer.qualifiedLen)
 	assert.Equal(t, len(committee), sealer.committeeSize)
@@ -401,7 +401,7 @@ func TestVerifySealsPermissionlessRejectsBelowQuorum(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+	assert.ErrorIs(t, validator.verifySeals(header, true), istanbul.ErrInvalidCommittedSeals)
 }
 
 // TestVerifySealsPermissionlessRejectsNonCommitteeCommitter checks that a committed
@@ -438,7 +438,7 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+	assert.ErrorIs(t, validator.verifySeals(header, true), istanbul.ErrInvalidCommittedSeals)
 }
 
 // roundBoundSealer stands in for the post-permissionless dynamicSealer: it always recovers
@@ -496,10 +496,10 @@ func TestVerifySealsPermissionlessRejectsMutatedRound(t *testing.T) {
 
 	validator := &BlockValidator{config: config, sealer: sealer, mGov: mGov, mValset: mValset}
 
-	require.NoError(t, validator.verifySeals(header))
+	require.NoError(t, validator.verifySeals(header, true))
 
 	sealer.WriteRound(header, round+1)
-	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+	assert.ErrorIs(t, validator.verifySeals(header, true), istanbul.ErrInvalidCommittedSeals)
 }
 
 // TestVerifySealsPermissionlessAcceptsHashLockedAuthor covers the block a round change
@@ -552,7 +552,7 @@ func TestVerifySealsPermissionlessAcceptsHashLockedAuthor(t *testing.T) {
 		mValset: mValset,
 	}
 
-	require.NoError(t, validator.verifySeals(header))
+	require.NoError(t, validator.verifySeals(header, true))
 }
 
 func TestVerifyBlockBody(t *testing.T) {
@@ -797,4 +797,157 @@ func TestValidateHeaderRejectsOutOfUint64Number(t *testing.T) {
 		BlockScore: params.DefaultBlockScore,
 	}
 	assert.ErrorIs(t, v.ValidateHeader(h), ErrInvalidBlockNumber)
+}
+
+type roundShiftSealer struct {
+	*verifySealsTestSealer
+	round byte
+}
+
+func (s *roundShiftSealer) Round(*types.Header) (byte, error) { return s.round, nil }
+
+func permissionlessConfig(t *testing.T, on bool, blockNum uint64) *params.ChainConfig {
+	t.Helper()
+	config := params.TestKaiaConfig("permissionless").Copy()
+	if !on {
+		config.PermissionlessCompatibleBlock = big.NewInt(int64(blockNum + 100))
+	}
+	return config
+}
+
+// A proposal has no committed seals, but its author must still be authorized.
+func TestProposalHeaderRejectsUnauthorizedAuthor(t *testing.T) {
+	var (
+		outsider = common.HexToAddress("0x00ff")
+		a        = common.HexToAddress("0x0001")
+		b        = common.HexToAddress("0x0002")
+		blockNum = uint64(7)
+	)
+
+	for _, permissionless := range []bool{false, true} {
+		name := "pre-permissionless"
+		if permissionless {
+			name = "post-permissionless"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			sealer := &verifySealsTestSealer{author: outsider, committers: nil}
+			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+			mGov := mock_gov.NewMockGovModule(ctrl)
+			mValset := mock_valset.NewMockValsetModule(ctrl)
+			if permissionless {
+				mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{a, b}, nil)
+			} else {
+				mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{a, b}, nil)
+			}
+
+			v := &BlockValidator{
+				config: permissionlessConfig(t, permissionless, blockNum),
+				sealer: sealer, mGov: mGov, mValset: mValset,
+			}
+			assert.ErrorIs(t, v.verifySeals(header, false), consensus.ErrUnauthorized)
+		})
+	}
+}
+
+// On the proposal path, absent committed seals are expected and must not raise an error.
+func TestProposalHeaderAcceptsAuthorizedAuthorWithoutSeals(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		b        = common.HexToAddress("0x0002")
+		blockNum = uint64(7)
+	)
+
+	for _, permissionless := range []bool{false, true} {
+		name := "pre-permissionless"
+		if permissionless {
+			name = "post-permissionless"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			sealer := &verifySealsTestSealer{author: author, committers: nil}
+			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+			mGov := mock_gov.NewMockGovModule(ctrl)
+			mValset := mock_valset.NewMockValsetModule(ctrl)
+			if permissionless {
+				mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{author, b}, nil)
+			} else {
+				mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author, b}, nil)
+				mValset.EXPECT().GetCouncil(blockNum).Return([]common.Address{author, b}, nil)
+			}
+
+			v := &BlockValidator{
+				config: permissionlessConfig(t, permissionless, blockNum),
+				sealer: sealer, mGov: mGov, mValset: mValset,
+			}
+			assert.NoError(t, v.verifySeals(header, false))
+		})
+	}
+}
+
+// The import path still requires committed seals.
+func TestImportPathStillRequiresCommittedSeals(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		b        = common.HexToAddress("0x0002")
+		blockNum = uint64(7)
+	)
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	sealer := &verifySealsTestSealer{author: author, committers: nil}
+	header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{author, b}, nil)
+
+	v := &BlockValidator{
+		config: permissionlessConfig(t, true, blockNum),
+		sealer: sealer, mGov: mGov, mValset: mValset,
+	}
+	assert.ErrorIs(t, v.verifySeals(header, true), istanbul.ErrEmptyCommittedSeals)
+}
+
+// A hash-locked proposal keeps its original author's seal while the header's round
+// advances. It must stay valid on both paths.
+func TestRoundShiftedLockedProposalStaysValid(t *testing.T) {
+	var (
+		round0Proposer = common.HexToAddress("0x0001")
+		round1Proposer = common.HexToAddress("0x0002")
+		third          = common.HexToAddress("0x0003")
+		blockNum       = uint64(7)
+		committee      = []common.Address{round0Proposer, round1Proposer, third}
+	)
+
+	for _, withSeals := range []bool{false, true} {
+		name := "proposal path"
+		if withSeals {
+			name = "import path"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			base := &verifySealsTestSealer{author: round0Proposer, committers: committee, quorum: 3}
+			sealer := &roundShiftSealer{verifySealsTestSealer: base, round: 1}
+			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+			mGov := mock_gov.NewMockGovModule(ctrl)
+			mValset := mock_valset.NewMockValsetModule(ctrl)
+			mValset.EXPECT().GetCommittee(blockNum, uint64(1)).Return(committee, nil)
+
+			v := &BlockValidator{
+				config: params.TestKaiaConfig("permissionless"),
+				sealer: sealer, mGov: mGov, mValset: mValset,
+			}
+			assert.NoError(t, v.verifySeals(header, withSeals))
+		})
+	}
 }

--- a/blockchain/block_validator_test.go
+++ b/blockchain/block_validator_test.go
@@ -270,7 +270,7 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeAuthor(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.ErrorIs(t, validator.verifySeals(header), consensus.ErrUnauthorized)
+	assert.ErrorIs(t, validator.verifySeals(header, true), consensus.ErrUnauthorized)
 }
 
 // TestVerifySealsAuthorizesAuthorWithoutSeals checks that the author is authorized on a
@@ -317,7 +317,7 @@ func TestVerifySealsAuthorizesAuthorWithoutSeals(t *testing.T) {
 			}
 
 			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
-			assert.ErrorIs(t, validator.verifySeals(header), tc.expectedErr)
+			assert.ErrorIs(t, validator.verifySeals(header, true), tc.expectedErr)
 		})
 	}
 }
@@ -348,7 +348,7 @@ func TestVerifySealsBeforePermissionlessUsesQualifiedSet(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.NoError(t, validator.verifySeals(header))
+	assert.NoError(t, validator.verifySeals(header, true))
 }
 
 func TestVerifySealsPermissionlessAcceptsCommitteeAuthor(t *testing.T) {
@@ -373,7 +373,7 @@ func TestVerifySealsPermissionlessAcceptsCommitteeAuthor(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.NoError(t, validator.verifySeals(header))
+	assert.NoError(t, validator.verifySeals(header, true))
 }
 
 // TestVerifySealsPermissionlessUsesSealerQuorum checks that post-permissionless, the
@@ -411,7 +411,7 @@ func TestVerifySealsPermissionlessUsesSealerQuorum(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.NoError(t, validator.verifySeals(header))
+	assert.NoError(t, validator.verifySeals(header, true))
 	// Quorum is computed over the committee size, passed as both arguments.
 	assert.Equal(t, len(committee), sealer.qualifiedLen)
 	assert.Equal(t, len(committee), sealer.committeeSize)
@@ -450,7 +450,7 @@ func TestVerifySealsPermissionlessRejectsBelowQuorum(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+	assert.ErrorIs(t, validator.verifySeals(header, true), istanbul.ErrInvalidCommittedSeals)
 }
 
 // TestVerifySealsPermissionlessRejectsNonCommitteeCommitter checks that a committed
@@ -487,7 +487,7 @@ func TestVerifySealsPermissionlessRejectsNonCommitteeCommitter(t *testing.T) {
 		mValset: mValset,
 	}
 
-	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+	assert.ErrorIs(t, validator.verifySeals(header, true), istanbul.ErrInvalidCommittedSeals)
 }
 
 // roundBoundSealer stands in for the post-permissionless dynamicSealer: it always recovers
@@ -545,10 +545,10 @@ func TestVerifySealsPermissionlessRejectsMutatedRound(t *testing.T) {
 
 	validator := &BlockValidator{config: config, sealer: sealer, mGov: mGov, mValset: mValset}
 
-	require.NoError(t, validator.verifySeals(header))
+	require.NoError(t, validator.verifySeals(header, true))
 
 	sealer.WriteRound(header, round+1)
-	assert.ErrorIs(t, validator.verifySeals(header), istanbul.ErrInvalidCommittedSeals)
+	assert.ErrorIs(t, validator.verifySeals(header, true), istanbul.ErrInvalidCommittedSeals)
 }
 
 // TestVerifySealsPermissionlessAcceptsHashLockedAuthor covers the block a round change
@@ -601,7 +601,7 @@ func TestVerifySealsPermissionlessAcceptsHashLockedAuthor(t *testing.T) {
 		mValset: mValset,
 	}
 
-	require.NoError(t, validator.verifySeals(header))
+	require.NoError(t, validator.verifySeals(header, true))
 }
 
 func TestVerifyBlockBody(t *testing.T) {
@@ -846,4 +846,157 @@ func TestValidateHeaderRejectsOutOfUint64Number(t *testing.T) {
 		BlockScore: params.DefaultBlockScore,
 	}
 	assert.ErrorIs(t, v.ValidateHeader(h), ErrInvalidBlockNumber)
+}
+
+type roundShiftSealer struct {
+	*verifySealsTestSealer
+	round byte
+}
+
+func (s *roundShiftSealer) Round(*types.Header) (byte, error) { return s.round, nil }
+
+func permissionlessConfig(t *testing.T, on bool, blockNum uint64) *params.ChainConfig {
+	t.Helper()
+	config := params.TestKaiaConfig("permissionless").Copy()
+	if !on {
+		config.PermissionlessCompatibleBlock = big.NewInt(int64(blockNum + 100))
+	}
+	return config
+}
+
+// A proposal has no committed seals, but its author must still be authorized.
+func TestProposalHeaderRejectsUnauthorizedAuthor(t *testing.T) {
+	var (
+		outsider = common.HexToAddress("0x00ff")
+		a        = common.HexToAddress("0x0001")
+		b        = common.HexToAddress("0x0002")
+		blockNum = uint64(7)
+	)
+
+	for _, permissionless := range []bool{false, true} {
+		name := "pre-permissionless"
+		if permissionless {
+			name = "post-permissionless"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			sealer := &verifySealsTestSealer{author: outsider, committers: nil}
+			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+			mGov := mock_gov.NewMockGovModule(ctrl)
+			mValset := mock_valset.NewMockValsetModule(ctrl)
+			if permissionless {
+				mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{a, b}, nil)
+			} else {
+				mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{a, b}, nil)
+			}
+
+			v := &BlockValidator{
+				config: permissionlessConfig(t, permissionless, blockNum),
+				sealer: sealer, mGov: mGov, mValset: mValset,
+			}
+			assert.ErrorIs(t, v.verifySeals(header, false), consensus.ErrUnauthorized)
+		})
+	}
+}
+
+// On the proposal path, absent committed seals are expected and must not raise an error.
+func TestProposalHeaderAcceptsAuthorizedAuthorWithoutSeals(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		b        = common.HexToAddress("0x0002")
+		blockNum = uint64(7)
+	)
+
+	for _, permissionless := range []bool{false, true} {
+		name := "pre-permissionless"
+		if permissionless {
+			name = "post-permissionless"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			sealer := &verifySealsTestSealer{author: author, committers: nil}
+			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+			mGov := mock_gov.NewMockGovModule(ctrl)
+			mValset := mock_valset.NewMockValsetModule(ctrl)
+			if permissionless {
+				mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{author, b}, nil)
+			} else {
+				mValset.EXPECT().GetQualifiedValidators(blockNum).Return([]common.Address{author, b}, nil)
+				mValset.EXPECT().GetCouncil(blockNum).Return([]common.Address{author, b}, nil)
+			}
+
+			v := &BlockValidator{
+				config: permissionlessConfig(t, permissionless, blockNum),
+				sealer: sealer, mGov: mGov, mValset: mValset,
+			}
+			assert.NoError(t, v.verifySeals(header, false))
+		})
+	}
+}
+
+// The import path still requires committed seals.
+func TestImportPathStillRequiresCommittedSeals(t *testing.T) {
+	var (
+		author   = common.HexToAddress("0x0001")
+		b        = common.HexToAddress("0x0002")
+		blockNum = uint64(7)
+	)
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	sealer := &verifySealsTestSealer{author: author, committers: nil}
+	header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+	mGov := mock_gov.NewMockGovModule(ctrl)
+	mValset := mock_valset.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetCommittee(blockNum, uint64(0)).Return([]common.Address{author, b}, nil)
+
+	v := &BlockValidator{
+		config: permissionlessConfig(t, true, blockNum),
+		sealer: sealer, mGov: mGov, mValset: mValset,
+	}
+	assert.ErrorIs(t, v.verifySeals(header, true), istanbul.ErrEmptyCommittedSeals)
+}
+
+// A hash-locked proposal keeps its original author's seal while the header's round
+// advances. It must stay valid on both paths.
+func TestRoundShiftedLockedProposalStaysValid(t *testing.T) {
+	var (
+		round0Proposer = common.HexToAddress("0x0001")
+		round1Proposer = common.HexToAddress("0x0002")
+		third          = common.HexToAddress("0x0003")
+		blockNum       = uint64(7)
+		committee      = []common.Address{round0Proposer, round1Proposer, third}
+	)
+
+	for _, withSeals := range []bool{false, true} {
+		name := "proposal path"
+		if withSeals {
+			name = "import path"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+
+			base := &verifySealsTestSealer{author: round0Proposer, committers: committee, quorum: 3}
+			sealer := &roundShiftSealer{verifySealsTestSealer: base, round: 1}
+			header := &types.Header{Number: new(big.Int).SetUint64(blockNum)}
+
+			mGov := mock_gov.NewMockGovModule(ctrl)
+			mValset := mock_valset.NewMockValsetModule(ctrl)
+			mValset.EXPECT().GetCommittee(blockNum, uint64(1)).Return(committee, nil)
+
+			v := &BlockValidator{
+				config: params.TestKaiaConfig("permissionless"),
+				sealer: sealer, mGov: mGov, mValset: mValset,
+			}
+			assert.NoError(t, v.verifySeals(header, withSeals))
+		})
+	}
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -2729,6 +2729,11 @@ func (bc *BlockChain) ValidateHeader(header *types.Header) error {
 	return bc.validator.ValidateHeader(header)
 }
 
+// ValidateProposalHeader validates a consensus proposal. See BlockValidator.
+func (bc *BlockChain) ValidateProposalHeader(header *types.Header) error {
+	return bc.validator.ValidateProposalHeader(header)
+}
+
 // Snapshots returns the blockchain snapshot tree.
 func (bc *BlockChain) Snapshots() *snapshot.Tree {
 	return bc.snaps

--- a/blockchain/types.go
+++ b/blockchain/types.go
@@ -47,6 +47,9 @@ type Validator interface {
 	// ValidateHeader validates or preprocesses the given header.
 	ValidateHeader(header *types.Header) error
 
+	// ValidateProposalHeader validates a consensus proposal. Consensus path only.
+	ValidateProposalHeader(header *types.Header) error
+
 	// ValidateBody validates the given block's content.
 	ValidateBody(block *types.Block) error
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -51,6 +51,10 @@ type ChainReader interface {
 	// ValidateHeader validates a header according to chain rules.
 	ValidateHeader(header *types.Header) error
 
+	// ValidateProposalHeader validates a consensus proposal according to chain rules,
+	// skipping only the committed-seal rules.
+	ValidateProposalHeader(header *types.Header) error
+
 	// GetHeader retrieves a block header from the database by hash and number.
 	GetHeader(hash common.Hash, number uint64) *types.Header
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -400,10 +400,11 @@ func (sb *backend) Verify(proposal bft.Proposal) (time.Duration, error) {
 		return 0, blockchain.ErrBlockOversized
 	}
 
-	// verify the header of proposed block
-	err := sb.chain.ValidateHeader(block.Header())
-	// ignore errEmptyCommittedSeals error because we don't have the committed seals yet
-	if err == nil || err == istanbul.ErrEmptyCommittedSeals {
+	// Verify the header of the proposed block. The proposal entry point skips the
+	// committed-seal rules by construction, so every other rule is enforced here and any
+	// failure rejects the proposal.
+	err := sb.chain.ValidateProposalHeader(block.Header())
+	if err == nil {
 		return 0, nil
 	} else if err == consensus.ErrFutureBlock {
 		return time.Unix(block.Header().Time.Int64(), 0).Sub(time.Now()), consensus.ErrFutureBlock

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -417,10 +417,11 @@ func (sb *backend) Verify(proposal bft.Proposal) (time.Duration, error) {
 		return 0, errors.New("data blobs present in block body")
 	}
 
-	// verify the header of proposed block
-	err := sb.chain.ValidateHeader(block.Header())
-	// ignore errEmptyCommittedSeals error because we don't have the committed seals yet
-	if err == nil || err == istanbul.ErrEmptyCommittedSeals {
+	// Verify the header of the proposed block. The proposal entry point skips the
+	// committed-seal rules by construction, so every other rule is enforced here and any
+	// failure rejects the proposal.
+	err := sb.chain.ValidateProposalHeader(block.Header())
+	if err == nil {
 		return 0, nil
 	} else if err == consensus.ErrFutureBlock {
 		return time.Unix(block.Header().Time.Int64(), 0).Sub(time.Now()), consensus.ErrFutureBlock

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -29,16 +29,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/bls"
 	"github.com/kaiachain/kaia/kaiax"
+	staking_mock "github.com/kaiachain/kaia/kaiax/staking/mock"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -308,4 +312,113 @@ func TestBackend_VerifyEnforcesBlockSizeCap(t *testing.T) {
 		_, err := engine.Verify(oversized)
 		assert.NotErrorIs(t, err, blockchain.ErrBlockOversized)
 	})
+}
+
+// A proposal sealed by an address outside the validator set must be rejected at
+// proposal-verification time, before it can reach a committed-seal quorum.
+//
+// The author here is BLS-registered, so the Randao header check resolves its public key,
+// but has no staking entry and is therefore demoted out of the qualified set.
+func TestVerifyRejectsUnauthorizedProposalAuthor(t *testing.T) {
+	const (
+		validatorCount = 5
+		outsiderIndex  = validatorCount - 1
+		minStake       = uint64(5_000_000)
+	)
+
+	setNodeKeys(validatorCount, nil)
+	stakingInfo := makeTestStakingInfo([]uint64{minStake, minStake, minStake, minStake, 0}, 0)
+	stakingInfo.NodeIds = stakingInfo.NodeIds[:outsiderIndex]
+	stakingInfo.StakingContracts = stakingInfo.StakingContracts[:outsiderIndex]
+	stakingInfo.RewardAddrs = stakingInfo.RewardAddrs[:outsiderIndex]
+	stakingInfo.StakingAmounts = stakingInfo.StakingAmounts[:outsiderIndex]
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mStaking := staking_mock.NewMockStakingModule(ctrl)
+	mStaking.EXPECT().GetStakingInfo(gomock.Any()).Return(stakingInfo, nil).AnyTimes()
+
+	config := testRandaoConfig.Copy()
+	config.IstanbulCompatibleBlock = common.Big0
+	config.PermissionlessCompatibleBlock = nil
+	config.Istanbul.ProposerPolicy = params.WeightedRandom
+	config.Governance.Reward.MinimumStake = new(big.Int).SetUint64(minStake)
+	config.Governance.Reward.StakingUpdateInterval = 1
+	config.Governance.Reward.ProposerUpdateInterval = 1
+
+	chain, engine := newBlockChain(t, validatorCount, config, mStaking, blockPeriod(0))
+	defer chain.Stop()
+	defer engine.Stop()
+
+	outsiderKey, outsiderAddr := nodeKeys[outsiderIndex], addrs[outsiderIndex]
+	outsiderBlsKey, err := bls.DeriveFromECDSA(outsiderKey)
+	require.NoError(t, err)
+
+	proposal := sealProposalWithForeignAuthor(t, chain, outsiderKey, outsiderBlsKey)
+
+	qualified, err := engine.valsetModule.GetQualifiedValidators(proposal.NumberU64())
+	require.NoError(t, err)
+	require.NotContains(t, qualified, outsiderAddr, "author must be outside the qualified set")
+
+	author, err := engine.sealer.Author(proposal.Header())
+	require.NoError(t, err)
+	require.Equal(t, outsiderAddr, author)
+
+	require.ErrorIs(t, chain.ValidateProposalHeader(proposal.Header()), consensus.ErrUnauthorized)
+
+	_, err = engine.Verify(proposal)
+	require.ErrorIs(t, err, consensus.ErrUnauthorized,
+		"backend.Verify must reject a proposal sealed by an unauthorized author")
+}
+
+// A well-formed proposal must still be accepted, its absent committed seals raising no error.
+func TestVerifyAcceptsWellFormedProposal(t *testing.T) {
+	chain, engine := newBlockChain(t, 1)
+	defer chain.Stop()
+	defer engine.Stop()
+
+	block := makeBlockWithoutSeal(chain, engine, chain.Genesis())
+	proposal, err := engine.updateBlock(block)
+	require.NoError(t, err)
+
+	require.NoError(t, chain.ValidateProposalHeader(proposal.Header()))
+	_, err = engine.Verify(proposal)
+	require.NoError(t, err)
+}
+
+func sealProposalWithForeignAuthor(t *testing.T, chain *blockchain.BlockChain, authorKey *ecdsa.PrivateKey, authorBlsKey bls.SecretKey) *types.Block {
+	t.Helper()
+
+	parent := chain.CurrentBlock()
+	header := makeHeader(parent, chain.Config())
+	require.NoError(t, chain.PrepareHeader(header))
+
+	// Re-derive the Randao fields under the other author's BLS key so the Randao header
+	// module resolves that author's registered public key.
+	msg := common.BytesToHash(header.Number.Bytes())
+	header.RandomReveal = bls.Sign(authorBlsKey, msg.Bytes()).Marshal()
+	var prevMixHash []byte
+	if chain.Config().IsRandaoForkBlockParent(parent.Number()) {
+		prevMixHash = append([]byte(nil), params.ZeroMixHash...)
+	} else {
+		prevMixHash = append([]byte(nil), parent.Header().MixHash...)
+	}
+	require.Len(t, prevMixHash, 32)
+	revealHash := crypto.Keccak256(header.RandomReveal)
+	header.MixHash = make([]byte, 32)
+	for i := range 32 {
+		header.MixHash[i] = prevMixHash[i] ^ revealHash[i]
+	}
+
+	state, err := chain.StateAt(parent.Root())
+	require.NoError(t, err)
+	block, err := chain.Processor().FinalizeState(header, state, nil, nil)
+	require.NoError(t, err)
+
+	sealed := block.Header()
+	s := istanbul.NewSealerImpl(authorKey)
+	seal, err := s.MakeAuthorSeal(sealed)
+	require.NoError(t, err)
+	require.NoError(t, s.WriteAuthorSeal(sealed, seal))
+	return block.WithSeal(sealed)
 }

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -29,16 +29,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus"
 	"github.com/kaiachain/kaia/consensus/istanbul"
 	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/crypto/bls"
 	"github.com/kaiachain/kaia/kaiax"
+	staking_mock "github.com/kaiachain/kaia/kaiax/staking/mock"
 	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/params"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -369,4 +373,113 @@ func TestBackend_VerifyEnforcesBodyRules(t *testing.T) {
 		assert.ErrorContains(t, err, "blob gas used mismatch")
 		assert.ErrorContains(t, chain.Validator().ValidateBody(lying), "blob gas used mismatch")
 	})
+}
+
+// A proposal sealed by an address outside the validator set must be rejected at
+// proposal-verification time, before it can reach a committed-seal quorum.
+//
+// The author here is BLS-registered, so the Randao header check resolves its public key,
+// but has no staking entry and is therefore demoted out of the qualified set.
+func TestVerifyRejectsUnauthorizedProposalAuthor(t *testing.T) {
+	const (
+		validatorCount = 5
+		outsiderIndex  = validatorCount - 1
+		minStake       = uint64(5_000_000)
+	)
+
+	setNodeKeys(validatorCount, nil)
+	stakingInfo := makeTestStakingInfo([]uint64{minStake, minStake, minStake, minStake, 0}, 0)
+	stakingInfo.NodeIds = stakingInfo.NodeIds[:outsiderIndex]
+	stakingInfo.StakingContracts = stakingInfo.StakingContracts[:outsiderIndex]
+	stakingInfo.RewardAddrs = stakingInfo.RewardAddrs[:outsiderIndex]
+	stakingInfo.StakingAmounts = stakingInfo.StakingAmounts[:outsiderIndex]
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mStaking := staking_mock.NewMockStakingModule(ctrl)
+	mStaking.EXPECT().GetStakingInfo(gomock.Any()).Return(stakingInfo, nil).AnyTimes()
+
+	config := testRandaoConfig.Copy()
+	config.IstanbulCompatibleBlock = common.Big0
+	config.PermissionlessCompatibleBlock = nil
+	config.Istanbul.ProposerPolicy = params.WeightedRandom
+	config.Governance.Reward.MinimumStake = new(big.Int).SetUint64(minStake)
+	config.Governance.Reward.StakingUpdateInterval = 1
+	config.Governance.Reward.ProposerUpdateInterval = 1
+
+	chain, engine := newBlockChain(t, validatorCount, config, mStaking, blockPeriod(0))
+	defer chain.Stop()
+	defer engine.Stop()
+
+	outsiderKey, outsiderAddr := nodeKeys[outsiderIndex], addrs[outsiderIndex]
+	outsiderBlsKey, err := bls.DeriveFromECDSA(outsiderKey)
+	require.NoError(t, err)
+
+	proposal := sealProposalWithForeignAuthor(t, chain, outsiderKey, outsiderBlsKey)
+
+	qualified, err := engine.valsetModule.GetQualifiedValidators(proposal.NumberU64())
+	require.NoError(t, err)
+	require.NotContains(t, qualified, outsiderAddr, "author must be outside the qualified set")
+
+	author, err := engine.sealer.Author(proposal.Header())
+	require.NoError(t, err)
+	require.Equal(t, outsiderAddr, author)
+
+	require.ErrorIs(t, chain.ValidateProposalHeader(proposal.Header()), consensus.ErrUnauthorized)
+
+	_, err = engine.Verify(proposal)
+	require.ErrorIs(t, err, consensus.ErrUnauthorized,
+		"backend.Verify must reject a proposal sealed by an unauthorized author")
+}
+
+// A well-formed proposal must still be accepted, its absent committed seals raising no error.
+func TestVerifyAcceptsWellFormedProposal(t *testing.T) {
+	chain, engine := newBlockChain(t, 1)
+	defer chain.Stop()
+	defer engine.Stop()
+
+	block := makeBlockWithoutSeal(chain, engine, chain.Genesis())
+	proposal, err := engine.updateBlock(block)
+	require.NoError(t, err)
+
+	require.NoError(t, chain.ValidateProposalHeader(proposal.Header()))
+	_, err = engine.Verify(proposal)
+	require.NoError(t, err)
+}
+
+func sealProposalWithForeignAuthor(t *testing.T, chain *blockchain.BlockChain, authorKey *ecdsa.PrivateKey, authorBlsKey bls.SecretKey) *types.Block {
+	t.Helper()
+
+	parent := chain.CurrentBlock()
+	header := makeHeader(parent, chain.Config())
+	require.NoError(t, chain.PrepareHeader(header))
+
+	// Re-derive the Randao fields under the other author's BLS key so the Randao header
+	// module resolves that author's registered public key.
+	msg := common.BytesToHash(header.Number.Bytes())
+	header.RandomReveal = bls.Sign(authorBlsKey, msg.Bytes()).Marshal()
+	var prevMixHash []byte
+	if chain.Config().IsRandaoForkBlockParent(parent.Number()) {
+		prevMixHash = append([]byte(nil), params.ZeroMixHash...)
+	} else {
+		prevMixHash = append([]byte(nil), parent.Header().MixHash...)
+	}
+	require.Len(t, prevMixHash, 32)
+	revealHash := crypto.Keccak256(header.RandomReveal)
+	header.MixHash = make([]byte, 32)
+	for i := range 32 {
+		header.MixHash[i] = prevMixHash[i] ^ revealHash[i]
+	}
+
+	state, err := chain.StateAt(parent.Root())
+	require.NoError(t, err)
+	block, err := chain.Processor().FinalizeState(header, state, nil, nil)
+	require.NoError(t, err)
+
+	sealed := block.Header()
+	s := istanbul.NewSealerImpl(authorKey)
+	seal, err := s.MakeAuthorSeal(sealed)
+	require.NoError(t, err)
+	require.NoError(t, s.WriteAuthorSeal(sealed, seal))
+	return block.WithSeal(sealed)
 }

--- a/kaiax/gov/impl/mock/blockchain_mock.go
+++ b/kaiax/gov/impl/mock/blockchain_mock.go
@@ -80,20 +80,6 @@ func (mr *MockBlockChainMockRecorder) CurrentHeader() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentHeader", reflect.TypeOf((*MockBlockChain)(nil).CurrentHeader))
 }
 
-// HasBadBlock mocks base method.
-func (m *MockBlockChain) HasBadBlock(arg0 common.Hash) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasBadBlock", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// HasBadBlock indicates an expected call of HasBadBlock.
-func (mr *MockBlockChainMockRecorder) HasBadBlock(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBadBlock", reflect.TypeOf((*MockBlockChain)(nil).HasBadBlock), arg0)
-}
-
 // GetBlock mocks base method.
 func (m *MockBlockChain) GetBlock(arg0 common.Hash, arg1 uint64) *types.Block {
 	m.ctrl.T.Helper()
@@ -148,6 +134,20 @@ func (m *MockBlockChain) GetHeaderByNumber(arg0 uint64) *types.Header {
 func (mr *MockBlockChainMockRecorder) GetHeaderByNumber(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeaderByNumber", reflect.TypeOf((*MockBlockChain)(nil).GetHeaderByNumber), arg0)
+}
+
+// HasBadBlock mocks base method.
+func (m *MockBlockChain) HasBadBlock(arg0 common.Hash) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasBadBlock", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasBadBlock indicates an expected call of HasBadBlock.
+func (mr *MockBlockChainMockRecorder) HasBadBlock(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBadBlock", reflect.TypeOf((*MockBlockChain)(nil).HasBadBlock), arg0)
 }
 
 // Sealer mocks base method.
@@ -206,4 +206,18 @@ func (m *MockBlockChain) ValidateHeader(arg0 *types.Header) error {
 func (mr *MockBlockChainMockRecorder) ValidateHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateHeader", reflect.TypeOf((*MockBlockChain)(nil).ValidateHeader), arg0)
+}
+
+// ValidateProposalHeader mocks base method.
+func (m *MockBlockChain) ValidateProposalHeader(arg0 *types.Header) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateProposalHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateProposalHeader indicates an expected call of ValidateProposalHeader.
+func (mr *MockBlockChainMockRecorder) ValidateProposalHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateProposalHeader", reflect.TypeOf((*MockBlockChain)(nil).ValidateProposalHeader), arg0)
 }

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -222,6 +222,11 @@ func (e *eestAdaptor) Preprocess(headers []*types.Header) (chan<- struct{}, <-ch
 	return nil, nil
 }
 
+// ValidateProposalHeader is unused by the EEST adaptor, which has no consensus path.
+func (e *eestAdaptor) ValidateProposalHeader(header *types.Header) error {
+	return e.ValidateHeader(header)
+}
+
 func (e *eestAdaptor) ValidateHeader(header *types.Header) error {
 	if header == nil || header.Number == nil {
 		return consensus.ErrUnknownBlock

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -1091,6 +1091,20 @@ func (mr *MockBlockChainMockRecorder) ValidateHeader(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateHeader", reflect.TypeOf((*MockBlockChain)(nil).ValidateHeader), arg0)
 }
 
+// ValidateProposalHeader mocks base method.
+func (m *MockBlockChain) ValidateProposalHeader(arg0 *types.Header) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateProposalHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateProposalHeader indicates an expected call of ValidateProposalHeader.
+func (mr *MockBlockChainMockRecorder) ValidateProposalHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateProposalHeader", reflect.TypeOf((*MockBlockChain)(nil).ValidateProposalHeader), arg0)
+}
+
 // Validator mocks base method.
 func (m *MockBlockChain) Validator() blockchain.Validator {
 	m.ctrl.T.Helper()

--- a/work/mocks/blockchain_mock.go
+++ b/work/mocks/blockchain_mock.go
@@ -1092,6 +1092,20 @@ func (mr *MockBlockChainMockRecorder) ValidateHeader(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateHeader", reflect.TypeOf((*MockBlockChain)(nil).ValidateHeader), arg0)
 }
 
+// ValidateProposalHeader mocks base method.
+func (m *MockBlockChain) ValidateProposalHeader(arg0 *types.Header) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateProposalHeader", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateProposalHeader indicates an expected call of ValidateProposalHeader.
+func (mr *MockBlockChainMockRecorder) ValidateProposalHeader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateProposalHeader", reflect.TypeOf((*MockBlockChain)(nil).ValidateProposalHeader), arg0)
+}
+
 // Validator mocks base method.
 func (m *MockBlockChain) Validator() blockchain.Validator {
 	m.ctrl.T.Helper()

--- a/work/work.go
+++ b/work/work.go
@@ -276,6 +276,7 @@ type BlockChain interface {
 	Export(w io.Writer) error
 	ExportN(w io.Writer, first, last uint64) error
 	ValidateHeader(header *types.Header) error
+	ValidateProposalHeader(header *types.Header) error
 	Sealer() consensus.Sealer
 	PrepareHeader(header *types.Header) error
 	RegisterKaiaxModules(mGov gov.GovModule, mValset valset.ValsetModule, mExecution []kaiax.ExecutionModule, mRewindable []kaiax.RewindableModule, mHeader []kaiax.HeaderModule, mBlockState []kaiax.BlockStateModule)


### PR DESCRIPTION
## Proposed changes

- One entry point served two callers: the import path passes a finalized header, the consensus path a proposal, which has no committed seals yet.
- Splits it in two: `ValidateHeader` (all rules) and `ValidateProposalHeader` (all rules except the committed-seal ones).
- Author authorization now runs on both paths, `backend.Verify` uses the proposal entry point and no longer tolerates `ErrEmptyCommittedSeals`.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
