### PR TITLE
vrank: ignore post-insert warming failures

### DIFF
--- a/kaiax/vrank/README.md
+++ b/kaiax/vrank/README.md
@@ -183,7 +183,7 @@ Called when a `VRankCandidate` message is received. The handler does not try to 
 
 #### PostInsertBlock
 
-After each canonical block is inserted, proactively calls `GetPFS` and `getCPMatrix` to keep caches warm. At every `scoreCheckpointInterval` boundary, writes the current PFS and CP matrix to the DB and updates the `lastCheckpoint` pointer.
+After each block is inserted, proactively calls `GetPFS` and `getCPMatrix` to keep caches warm. At every `scoreCheckpointInterval` boundary, writes the current PFS and CP matrix to the DB and updates the `lastCheckpoint` pointer. Warming may fail, but errors are logged and ignored; a skipped checkpoint is rebuilt from the epoch start on a later cold lookup.
 
 ### Rewind
 

--- a/kaiax/vrank/impl/execution.go
+++ b/kaiax/vrank/impl/execution.go
@@ -17,10 +17,12 @@
 package impl
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/kaiax"
+	"github.com/kaiachain/kaia/kaiax/vrank"
 )
 
 var _ kaiax.ExecutionModule = (*VRankModule)(nil)
@@ -31,13 +33,18 @@ func (v *VRankModule) PostInsertBlock(block *types.Block) error {
 		return nil
 	}
 
+	// Score warming is best effort. This runs after the block is already written
+	// (canonical or side), so a cache failure must not make the importer reject
+	// the chain or drop its peer.
 	pfs, err := v.GetPFS(blockNum)
 	if err != nil {
-		return err
+		logScoreWarmingFailure("PFS", blockNum, err)
+		return nil
 	}
 	cpMatrix, err := v.getCPMatrix(blockNum)
 	if err != nil {
-		return err
+		logScoreWarmingFailure("CP matrix", blockNum, err)
+		return nil
 	}
 
 	if blockNum%v.scoreCheckpointInterval() == 0 {
@@ -45,4 +52,12 @@ func (v *VRankModule) PostInsertBlock(block *types.Block) error {
 		WriteLastCheckpoint(v.ChainKv, blockNum)
 	}
 	return nil
+}
+
+func logScoreWarmingFailure(score string, blockNum uint64, err error) {
+	if errors.Is(err, vrank.ErrNotPermissionless) || errors.Is(err, vrank.ErrFutureBlock) {
+		logger.Debug("Failed to warm score cache", "score", score, "num", blockNum, "err", err)
+	} else {
+		logger.Warn("Failed to warm score cache", "score", score, "num", blockNum, "err", err)
+	}
 }

--- a/kaiax/vrank/impl/execution_test.go
+++ b/kaiax/vrank/impl/execution_test.go
@@ -32,6 +32,90 @@ func TestPostInsertBlock(t *testing.T) {
 	cp := testCheckpointInterval
 	P1, C1 := numToAddr(1), numToAddr(10)
 
+	t.Run("score warming failure is ignored", func(t *testing.T) {
+		const (
+			forkBlock = uint64(120)
+			epoch     = uint64(50)
+		)
+		cn := newCN(t, withHeaders(map[uint64]*types.Header{
+			forkBlock: makeHeaderWithRound(forkBlock, 0),
+		}))
+		cn.VRankModule.ChainConfig.PermissionlessCompatibleBlock = new(big.Int).SetUint64(forkBlock)
+		cn.VRankModule.ChainConfig.VRankEpoch = epoch
+
+		// This invalid configuration puts the fork in the middle of the epoch
+		// [100, 149], so score warming reaches into pre-fork blocks.
+		_, err := cn.VRankModule.GetPFS(forkBlock)
+		require.ErrorIs(t, err, vrank.ErrNotPermissionless)
+
+		block := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(forkBlock)})
+		require.NoError(t, cn.VRankModule.PostInsertBlock(block))
+
+		_, ok := cn.VRankModule.pfsCache.Get(forkBlock)
+		assert.False(t, ok, "failed PFS warming should not populate the cache")
+		_, ok = cn.VRankModule.cpMatrixCache.Get(forkBlock)
+		assert.False(t, ok, "CP matrix warming should be skipped after PFS failure")
+		assert.Nil(t, ReadCheckpointPFS(cn.DB, forkBlock), "partial checkpoint should not be written")
+		_, hasCP := ReadLastCheckpoint(cn.DB)
+		assert.False(t, hasCP, "lastCheckpoint should not advance after a warming failure")
+	})
+
+	t.Run("CP matrix warming failure is ignored", func(t *testing.T) {
+		cn := newCN(t, withHeaders(map[uint64]*types.Header{
+			cp: makeHeaderWithRound(cp, 0),
+		}))
+		cn.VRankModule.pfsCache.Add(cp, map[common.Address]uint64{})
+		// Block 0 is intentionally absent, so epochCandidates cannot fall back to
+		// the epoch-start header when GetCandTesting fails.
+		cn.Valset.EXPECT().GetCandTesting(cp).Return(nil, assert.AnError)
+
+		block := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(cp)})
+		require.NoError(t, cn.VRankModule.PostInsertBlock(block))
+
+		_, ok := cn.VRankModule.cpMatrixCache.Get(cp)
+		assert.False(t, ok, "failed CP matrix warming should not populate the cache")
+		assert.Nil(t, ReadCheckpointPFS(cn.DB, cp), "partial checkpoint should not be written")
+		_, hasCP := ReadLastCheckpoint(cn.DB)
+		assert.False(t, hasCP, "lastCheckpoint should not advance after a warming failure")
+	})
+
+	t.Run("later checkpoint succeeds after warming failure", func(t *testing.T) {
+		const (
+			epoch          = uint64(16)
+			checkpoint     = epoch / 8
+			nextCheckpoint = 2 * checkpoint
+		)
+		headers := map[uint64]*types.Header{
+			1:          makeHeaderWithRound(1, 0),
+			checkpoint: makeHeaderWithRound(checkpoint, 0),
+		}
+		cn := newCN(t, withHeaders(headers), withProposer(P1))
+		cn.VRankModule.ChainConfig.VRankEpoch = epoch
+		cn.VRankModule.pfsCache.Add(checkpoint, map[common.Address]uint64{})
+
+		// The first checkpoint cannot initialize its CP matrix because neither
+		// CandTesting state nor the epoch-start header is available.
+		cn.Valset.EXPECT().GetCandTesting(checkpoint).Return(nil, assert.AnError)
+		block := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(checkpoint)})
+		require.NoError(t, cn.VRankModule.PostInsertBlock(block))
+		assert.Nil(t, ReadCheckpointPFS(cn.DB, checkpoint))
+
+		// Once the missing inputs become available, the next checkpoint succeeds
+		// and advances lastCheckpoint across the gap.
+		headers[0] = makeHeaderWithRound(0, 0)
+		headers[3] = makeHeaderWithRound(3, 0)
+		headers[nextCheckpoint] = makeHeaderWithRound(nextCheckpoint, 0)
+		cn.Valset.EXPECT().GetCandTesting(nextCheckpoint).Return([]common.Address{C1}, nil)
+		block = types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(nextCheckpoint)})
+		require.NoError(t, cn.VRankModule.PostInsertBlock(block))
+
+		assert.NotNil(t, ReadCheckpointPFS(cn.DB, nextCheckpoint))
+		assert.NotNil(t, ReadCheckpointCPMatrix(cn.DB, nextCheckpoint))
+		lastCP, hasCP := ReadLastCheckpoint(cn.DB)
+		assert.True(t, hasCP)
+		assert.Equal(t, nextCheckpoint, lastCP)
+	})
+
 	t.Run("DB/cache write at checkpoint", func(t *testing.T) {
 		// Build just enough headers around the checkpoint block.
 		// Seed the cache at cp-1 so GetPFS/GetCFS use the nearby-hit branch


### PR DESCRIPTION
## Proposed changes

This PR prevents VRank score-warming failures in PostInsertBlock from interrupting block import.
PostInsertBlock should eventually stop returning errors altogether, but it's a low-priority refactoring so it will be addressed separately.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
