### PR TITLE
auction: bound the bid ingress ahead of validation

### DIFF
--- a/kaiax/auction/impl/bid_pool.go
+++ b/kaiax/auction/impl/bid_pool.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/kaiachain/kaia/accounts/abi/bind/backends"
 	"github.com/kaiachain/kaia/blockchain"
 	"github.com/kaiachain/kaia/blockchain/system"
@@ -43,6 +44,7 @@ const (
 
 	// Rate limiting
 	bidsPerSecondPerPeer = 300 // Max bids per second per peer
+	rateLimiterCacheSize = 1024
 )
 
 type BidPool struct {
@@ -61,8 +63,8 @@ type BidPool struct {
 	bidWinnerMap map[uint64]map[common.Address]common.Hash // (blockNum, sender) -> bidHash
 
 	// Rate limiting per peer
-	peerRateLimiterMu sync.RWMutex
-	peerRateLimiter   map[string]*rate.Limiter // peerID -> rate limiter
+	peerRateLimiterMu sync.Mutex
+	peerRateLimiter   *lru.Cache // peerID -> *rate.Limiter
 
 	bidMsgCh   chan *auction.Bid
 	newBidCh   chan *auction.Bid
@@ -80,13 +82,15 @@ func NewBidPool(chainConfig *params.ChainConfig, chain backends.BlockChainForCal
 		return nil
 	}
 
+	peerRateLimiter, _ := lru.New(rateLimiterCacheSize)
+
 	bp := &BidPool{
 		ChainConfig:     chainConfig,
 		Chain:           chain,
 		bidMap:          make(map[common.Hash]*auction.Bid),
 		bidTargetMap:    make(map[uint64]map[common.Hash]*auction.Bid),
 		bidWinnerMap:    make(map[uint64]map[common.Address]common.Hash),
-		peerRateLimiter: make(map[string]*rate.Limiter),
+		peerRateLimiter: peerRateLimiter,
 		bidMsgCh:        make(chan *auction.Bid, bidChSize),
 		newBidCh:        make(chan *auction.Bid, bidChSize),
 		maxBidPoolSize:  auctionConfig.MaxBidPoolSize,
@@ -425,7 +429,11 @@ func (bp *BidPool) HandleBid(peerID string, bid *auction.Bid) {
 		return
 	}
 
-	bp.bidMsgCh <- bid
+	select {
+	case bp.bidMsgCh <- bid:
+	default:
+		logger.Trace("Bid queue is full, dropping bid", "peerID", peerID)
+	}
 }
 
 // checkRateLimit checks if the peer is within rate limit
@@ -433,17 +441,17 @@ func (bp *BidPool) checkRateLimit(peerID string) bool {
 	bp.peerRateLimiterMu.Lock()
 	defer bp.peerRateLimiterMu.Unlock()
 
-	limiter, exists := bp.peerRateLimiter[peerID]
+	limiter, exists := bp.peerRateLimiter.Get(peerID)
 	if !exists {
 		// Create new rate limiter for this peer
 		// Use burst equal to the rate limit (we only use rate limit, not the burst)
 		limiter = rate.NewLimiter(rate.Limit(bidsPerSecondPerPeer), bidsPerSecondPerPeer)
-		bp.peerRateLimiter[peerID] = limiter
+		bp.peerRateLimiter.Add(peerID, limiter)
 	}
 
 	// It'll simply discard the bid if the rate limit is exceeded
 	// We don't need to reserve for a bid here because the original bid will be sent from auctioneer through different channel (see #api.SubmitBid)
-	return limiter.Allow()
+	return limiter.(*rate.Limiter).Allow()
 }
 
 func (bp *BidPool) handleBidMsg() {

--- a/kaiax/auction/impl/bid_pool_test.go
+++ b/kaiax/auction/impl/bid_pool_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain/types"
@@ -668,4 +669,51 @@ func TestBidPool_ConcurrentAddBid_OneWinnerPerSender(t *testing.T) {
 				"iter %d: both same-sender bids accepted", i)
 		}()
 	}
+}
+
+// HandleBid must not block the p2p worker that delivered the bid: the queue is
+// shared, so one blocked sender stalls every peer's bid ingress.
+func TestBidPool_HandleBidDropsWhenQueueFull(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pool := NewBidPool(testChainConfig, chain_mock.NewMockBlockChain(mockCtrl), &auction.AuctionConfig{MaxBidPoolSize: 1024})
+	require.NotNil(t, pool)
+	atomic.StoreUint32(&pool.running, 1)
+
+	for range cap(pool.bidMsgCh) {
+		pool.bidMsgCh <- testBids[0]
+	}
+
+	returned := make(chan struct{})
+	go func() {
+		pool.HandleBid("flooding-peer", testBids[0])
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HandleBid blocked on a full bid queue")
+	}
+	require.Equal(t, cap(pool.bidMsgCh), len(pool.bidMsgCh))
+}
+
+// A rejected bid still allocates a rate limiter, so peer IDs must not accumulate
+// without bound as a peer reconnects under fresh identities.
+func TestBidPool_RateLimiterEvictsStalePeers(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pool := NewBidPool(testChainConfig, chain_mock.NewMockBlockChain(mockCtrl), &auction.AuctionConfig{MaxBidPoolSize: 1024})
+	require.NotNil(t, pool)
+
+	const overflow = 16
+	for i := range rateLimiterCacheSize + overflow {
+		require.True(t, pool.checkRateLimit(fmt.Sprintf("peer-%d", i)))
+	}
+
+	require.Equal(t, rateLimiterCacheSize, pool.peerRateLimiter.Len())
+	require.False(t, pool.peerRateLimiter.Contains("peer-0"), "oldest peer should be evicted")
+	require.True(t, pool.peerRateLimiter.Contains(fmt.Sprintf("peer-%d", rateLimiterCacheSize+overflow-1)))
 }

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kaiachain/kaia/datasync/fetcher"
 	"github.com/kaiachain/kaia/event"
 	"github.com/kaiachain/kaia/kaiax/auction"
+	auction_impl "github.com/kaiachain/kaia/kaiax/auction/impl"
 	"github.com/kaiachain/kaia/kaiax/staking"
 	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/networks/p2p"
@@ -1272,10 +1273,17 @@ func handleStakingInfoMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	return nil
 }
 
+// maxBidMsgSize bounds an encoded BidMsg: the Data cap plus slack for the other fields.
+const maxBidMsgSize = auction_impl.BidTxMaxDataSize + 2048
+
 // handleBidMsg handles bid message.
 func handleBidMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	if pm.IsAuctionModuleDisabled() {
 		return nil
+	}
+
+	if uint64(msg.Size) > maxBidMsgSize {
+		return errResp(ErrMsgTooLarge, "msg %v: %v > %v", msg, msg.Size, maxBidMsgSize)
 	}
 
 	var data *auction.Bid

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kaiachain/kaia/crypto/kzg4844"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/kaiax/auction"
+	auction_impl "github.com/kaiachain/kaia/kaiax/auction/impl"
 	auction_mock "github.com/kaiachain/kaia/kaiax/auction/mock"
 	"github.com/kaiachain/kaia/kaiax/staking"
 	staking_mock "github.com/kaiachain/kaia/kaiax/staking/mock"
@@ -872,6 +873,38 @@ func TestHandleBidMsg(t *testing.T) {
 	assert.NoError(t, pm.handleMsg(mockPeer, addrs[0], msg), "should not return error when protocol version is kaia66")
 
 	mockCtrl.Finish()
+
+	// The size gate runs before msg.Decode, so an oversized bid never reaches the pool.
+	for _, tc := range []struct {
+		name     string
+		dataLen  int
+		wantCall bool
+	}{
+		{"max legal data reaches the pool", int(auction_impl.BidTxMaxDataSize), true},
+		{"oversized data is refused", int(maxBidMsgSize) + 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			module := auction_mock.NewMockAuctionModule(ctrl)
+			peer := NewMockPeer(ctrl)
+			if tc.wantCall {
+				peer.EXPECT().GetID().Return(nodeids[0].String()).Times(1)
+				module.EXPECT().HandleBid(gomock.Any(), gomock.Any()).Times(1)
+			}
+
+			sized := &auction.Bid{BidData: bidData}
+			sized.Data = make([]byte, tc.dataLen)
+			err := handleBidMsg(&ProtocolManager{auctionModule: module}, peer, generateMsg(t, BidMsg, sized))
+
+			if tc.wantCall {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, "Message too long")
+			}
+		})
+	}
 }
 
 func TestHandleBlobSidecarsRequestMsg(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Problem

- `handleBidMsg` decodes a `BidMsg` at the 12 MiB protocol ceiling, while the pool refuses any bid whose `Data` exceeds 64 KiB. The check that would reject the message runs after it has been fully materialized, hashed and queued.
- `HandleBid` blocks on a full queue. The queue is shared across peers, so one peer's backlog stalls the p2p worker carrying another peer's bid, and once that peer's worker pool is exhausted, its read loop with it.
- A peer that sends a single bid allocates a rate limiter that nothing ever removes: neither `clearBidPool` nor `stop` touches the map, so rotated peer IDs accumulate for the lifetime of the process.

Fix

- Refuse a `BidMsg` larger than a bid can legally encode before decoding it, deriving the bound from the pool's own `Data` cap plus room for the remaining fields.
- Drop the bid instead of blocking once the queue is full. The read loop's liveness should not depend on the bid consumer's throughput, and the auctioneer's own submissions reach the pool through `SubmitBid`, not through this queue.
- Keep the limiters in an LRU sized above any node's peer count, so a connected peer is never evicted while rotated peer IDs age out.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
