### PR TITLE
p2p: bound the listen ports a peer can advertise

### DIFF
--- a/networks/p2p/server_multi.go
+++ b/networks/p2p/server_multi.go
@@ -25,6 +25,7 @@ package p2p
 import (
 	"context"
 	"errors"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -336,13 +337,15 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 	c.caps, c.name, c.multiChannel = phs.Caps, phs.Name, phs.Multichannel
 
 	if c.multiChannel && dialDest != nil && (dialDest.TCPs == nil || len(dialDest.TCPs) < 2) && len(dialDest.TCPs) < len(phs.ListenPort) {
+		tcps, err := listenPortsToTCPs(phs.ListenPort, len(srv.ListenAddrs))
+		if err != nil {
+			clog.Trace("Rejected multichannel peer", "ports", len(phs.ListenPort), "err", err)
+			return err
+		}
 		logger.Debug("[Dial] update and retry the dial candidate as a multichannel",
 			"id", dialDest.ID, "addr", dialDest.IP, "previous", dialDest.TCPs, "new", phs.ListenPort)
 
-		dialDest.TCPs = make([]uint16, 0, len(phs.ListenPort))
-		for _, listenPort := range phs.ListenPort {
-			dialDest.TCPs = append(dialDest.TCPs, uint16(listenPort))
-		}
+		dialDest.TCPs = tcps
 		return errUpdateDial
 	}
 
@@ -355,6 +358,22 @@ func (srv *MultiChannelServer) setupConn(c *conn, flags connFlag, dialDest *disc
 	// launched by handleAddPeerConn.
 	clog.Trace("connection set up", "inbound", dialDest == nil)
 	return nil
+}
+
+// listenPortsToTCPs turns a peer's advertised ports into dial targets, one dial per entry,
+// so the count may not exceed this node's listener count.
+func listenPortsToTCPs(listenPorts []uint64, maxChannels int) ([]uint16, error) {
+	if len(listenPorts) > maxChannels {
+		return nil, DiscProtocolError
+	}
+	tcps := make([]uint16, 0, len(listenPorts))
+	for _, port := range listenPorts {
+		if port == 0 || port > math.MaxUint16 {
+			return nil, DiscProtocolError
+		}
+		tcps = append(tcps, uint16(port))
+	}
+	return tcps, nil
 }
 
 // Override BaseServer.handleAddPeerConn because multichannel peer admission

--- a/networks/p2p/server_multi_test.go
+++ b/networks/p2p/server_multi_test.go
@@ -155,3 +155,31 @@ func TestMultiChannelStopClosesCandidates(t *testing.T) {
 	assert.Equal(t, DiscQuitting, tt.closeErr)
 	assert.Empty(t, srv.CandidateConns)
 }
+
+// A peer's advertised port list drives one dial each, so it is bounded before it is used.
+func TestListenPortsToTCPs(t *testing.T) {
+	const maxChannels = 2
+	testcases := []struct {
+		name  string
+		ports []uint64
+		want  []uint16
+	}{
+		{"single channel", []uint64{30303}, []uint16{30303}},
+		{"all channels", []uint64{30303, 30304}, []uint16{30303, 30304}},
+		{"more ports than listeners", []uint64{30303, 30304, 30305}, nil},
+		{"port zero", []uint64{30303, 0}, nil},
+		{"port above uint16", []uint64{30303, 65536 + 22}, nil},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tcps, err := listenPortsToTCPs(tc.ports, maxChannels)
+			if tc.want == nil {
+				assert.Equal(t, DiscProtocolError, err)
+				assert.Nil(t, tcps)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, tcps)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

Problem

- A multichannel dial copies the peer's advertised `ListenPort` list into the dial target and opens one TCP connection per entry, with no limit on how many entries it accepts.
- Only the 2 KiB handshake cap bounds that list, so one peer can turn a single dial into hundreds of outbound connections and handshakes, all of them opened before any admission check runs.
- Each port is narrowed with `uint16(listenPort)`, so a value above 65535 silently becomes a different port.

Fix

- Refuse a peer that advertises more ports than this node has listeners. `handleAddPeerConn` already rejects a `portOrder` past that count, so this applies the same bound before the connections are opened instead of after.
- Reject a zero or out-of-range port rather than truncating it.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

The bound is taken from `len(srv.ListenAddrs)` rather than a fixed constant so it tracks the listeners the server actually opens. Rejecting duplicate ports and giving each candidate its own dial budget were considered and left out: once the count is capped at the listener count, neither changes what a peer can cause.
