### PR TITLE
blockchain/vm: copy the jump table before editing opcodes in place

### DIFF
--- a/blockchain/vm/eips.go
+++ b/blockchain/vm/eips.go
@@ -413,6 +413,8 @@ func enablePermissionlessComputationCostModification(jt *JumpTable) {
 }
 
 func ChangeGasCostForTest(jt *JumpTable) {
+	// Callers pass a table whose entries are shared with a package-level one.
+	*jt = *copyJumpTable(jt)
 	// EIP-1052 must be activated for backward compatibility on Kaia. But EIP-2929 is activated instead of it on Ethereum
 	jt[EXTCODEHASH].constantGas = params.WarmStorageReadCostEIP2929
 	jt[EXTCODEHASH].dynamicGas = gasEip2929AccountCheck

--- a/blockchain/vm/interpreter.go
+++ b/blockchain/vm/interpreter.go
@@ -123,6 +123,10 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 		default:
 			jt = ConstantinopleInstructionSet
 		}
+		if len(cfg.ExtraEips) > 0 {
+			// Deep-copy to prevent modification of opcodes in other tables.
+			jt = *copyJumpTable(&jt)
+		}
 		for i, eip := range cfg.ExtraEips {
 			if err := EnableEIP(eip, &jt); err != nil {
 				// Disable it, so caller can check if it's activated or not

--- a/blockchain/vm/jump_table.go
+++ b/blockchain/vm/jump_table.go
@@ -71,6 +71,19 @@ var (
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]*operation
 
+// copyJumpTable deep-copies a table. Assigning a JumpTable copies only the
+// pointers, so the entries would stay shared with the source.
+func copyJumpTable(source *JumpTable) *JumpTable {
+	dest := *source
+	for i, op := range source {
+		if op != nil {
+			opCopy := *op
+			dest[i] = &opCopy
+		}
+	}
+	return &dest
+}
+
 func newPermissionlessInstructionSet() JumpTable {
 	instructionSet := newOsakaInstructionSet()
 	enablePermissionlessComputationCostModification(&instructionSet)

--- a/blockchain/vm/jump_table_test.go
+++ b/blockchain/vm/jump_table_test.go
@@ -1,3 +1,19 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
 package vm
 
 import (

--- a/blockchain/vm/jump_table_test.go
+++ b/blockchain/vm/jump_table_test.go
@@ -1,0 +1,82 @@
+package vm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/blockchain/state"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/params"
+	"github.com/kaiachain/kaia/storage/database"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJumpTableCopy(t *testing.T) {
+	tbl := newConstantinopleInstructionSet()
+	require.Equal(t, params.SloadGasEIP150, tbl[SLOAD].constantGas)
+
+	deepCopy := copyJumpTable(&tbl)
+	deepCopy[SLOAD].constantGas = params.SloadGasEIP2200
+
+	require.Equal(t, params.SloadGasEIP2200, deepCopy[SLOAD].constantGas)
+	require.Equal(t, params.SloadGasEIP150, tbl[SLOAD].constantGas)
+}
+
+func newTestEVM(t *testing.T, config *params.ChainConfig, vmConfig *Config) *EVM {
+	t.Helper()
+	statedb, err := state.New(common.Hash{}, state.NewDatabase(database.NewMemoryDBManager()), nil, nil)
+	require.NoError(t, err)
+	blockCtx := BlockContext{
+		BlockNumber: big.NewInt(1),
+		Time:        big.NewInt(0),
+		CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
+		Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
+	}
+	return NewEVM(blockCtx, TxContext{}, statedb, config, vmConfig)
+}
+
+// preIstanbulConfig pins the interpreter to ConstantinopleInstructionSet.
+func preIstanbulConfig() *params.ChainConfig {
+	config := params.TestChainConfig.Copy()
+	far := big.NewInt(1000000)
+	config.IstanbulCompatibleBlock = far
+	config.LondonCompatibleBlock = far
+	config.KoreCompatibleBlock = far
+	config.ShanghaiCompatibleBlock = far
+	config.CancunCompatibleBlock = far
+	config.PragueCompatibleBlock = far
+	config.OsakaCompatibleBlock = far
+	config.PermissionlessCompatibleBlock = far
+	return config
+}
+
+// ExtraEips must apply to the interpreter's own table only. EnableEIP mutates
+// operations in place, so without a deep copy it rewrites the package-level table
+// and every later interpreter on the same fork inherits the extra EIP.
+func TestExtraEipsKeepSharedTableIntact(t *testing.T) {
+	config := preIstanbulConfig()
+
+	evm := newTestEVM(t, config, &Config{ExtraEips: []int{2200}})
+	require.Equal(t, params.SloadGasEIP2200, evm.Config.JumpTable[SLOAD].constantGas, "ExtraEips was not applied")
+
+	require.Equal(t, params.SloadGasEIP150, ConstantinopleInstructionSet[SLOAD].constantGas)
+
+	victim := newTestEVM(t, config, &Config{})
+	require.Equal(t, params.SloadGasEIP150, victim.Config.JumpTable[SLOAD].constantGas)
+}
+
+// ChangeGasCostForTest is handed evm.Config.JumpTable, which shares its operations
+// with a package-level table. It runs for every Cancun-or-later fixture in the
+// tests package, so the leak needs no ExtraEips at all.
+func TestChangeGasCostForTestKeepsSharedTableIntact(t *testing.T) {
+	config := params.TestChainConfig
+	require.True(t, config.Rules(big.NewInt(1)).IsOsaka, "fixture must select OsakaInstructionSet")
+	before := OsakaInstructionSet[EXTCODEHASH].constantGas
+	require.NotEqual(t, params.WarmStorageReadCostEIP2929, before)
+
+	evm := newTestEVM(t, config, &Config{})
+	ChangeGasCostForTest(&evm.Config.JumpTable)
+
+	require.Equal(t, params.WarmStorageReadCostEIP2929, evm.Config.JumpTable[EXTCODEHASH].constantGas)
+	require.Equal(t, before, OsakaInstructionSet[EXTCODEHASH].constantGas)
+}


### PR DESCRIPTION
## Proposed changes

Problem

- `JumpTable` is `[256]*operation`, so assigning a package-level fork table shares its opcode objects instead of copying them.
- `EnableEIP` and `ChangeGasCostForTest` write through those pointers, so one interpreter's edit rewrites the template that every later interpreter on the same fork reads. `EnableEIP` already documents the contract this breaks: "callers need to ensure that the globally defined jump tables are not polluted".
- Only tests reach this today: `Config.ExtraEips` has no CLI or config field, and `ChangeGasCostForTest` is called only from `tests`.

Fix

- Add `copyJumpTable` and deep-copy before both mutation sites.
- Keep the copy conditional, so an interpreter with no extra EIPs shares the table and allocates nothing.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

`copyJumpTable` and the guard on the `ExtraEips` loop are [geth's](https://github.com/ethereum/go-ethereum/blob/v1.17.5/core/vm/jump_table.go#L1115). geth stops there; `ChangeGasCostForTest` is called with no extra EIPs, so it copies inside the function instead. Making `JumpTable` a value array would cover both at once, but it diverges from upstream and pays the copy on every interpreter.
