### PR TITLE
cmd/utils: deprecate fast sync with an actionable error

### DIFF
--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -604,6 +604,9 @@ func (kCfg *KaiaConfig) SetKaiaConfig(ctx *cli.Context, stack *node.Node) {
 
 	if ctx.IsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
+		if cfg.SyncMode == downloader.FastSync {
+			log.Fatalf("Fast sync is no longer supported. Use --syncmode full, or bootstrap from a chaindata snapshot: https://docs.kaia.io")
+		}
 		if cfg.SyncMode != downloader.FullSync && cfg.SyncMode != downloader.SnapSync {
 			log.Fatalf("Full Sync or Snap Sync (prototype) is supported only!")
 		}

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -605,7 +605,7 @@ func (kCfg *KaiaConfig) SetKaiaConfig(ctx *cli.Context, stack *node.Node) {
 	if ctx.IsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
 		if cfg.SyncMode == downloader.FastSync {
-			log.Fatalf("Fast sync is no longer supported. Use --syncmode full, or bootstrap from a chaindata snapshot: https://docs.kaia.io")
+			log.Fatalf("Fast sync is no longer supported. Use --syncmode full, or bootstrap from a chaindata snapshot: https://docs.kaia.io/misc/operation/chaindata-snapshot/")
 		}
 		if cfg.SyncMode != downloader.FullSync && cfg.SyncMode != downloader.SnapSync {
 			log.Fatalf("Full Sync or Snap Sync (prototype) is supported only!")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -172,7 +172,7 @@ var (
 	defaultSyncMode = cn.GetDefaultConfig().SyncMode
 	SyncModeFlag    = &TextMarshalerFlag{
 		Name:     "syncmode",
-		Usage:    `Blockchain sync mode ("full" or "snap")`,
+		Usage:    `Blockchain sync mode ("full")`,
 		Value:    &defaultSyncMode,
 		Aliases:  []string{"common.syncmode"},
 		EnvVars:  []string{"KLAYTN_SYNCMODE", "KAIA_SYNCMODE"},

--- a/datasync/downloader/modes.go
+++ b/datasync/downloader/modes.go
@@ -75,7 +75,7 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 	case "light":
 		*mode = LightSync
 	default:
-		return fmt.Errorf(`unknown sync mode %q, want "full", "fast" or "light"`, text)
+		return fmt.Errorf(`unknown sync mode %q, want "full"`, text)
 	}
 	return nil
 }


### PR DESCRIPTION
## Proposed changes

Problem

- `--syncmode fast` is already refused at startup, but the message only lists the supported modes; an operator running fast sync is not told what to do instead.

Fix

- Give fast sync its own branch so the error names it and points at full sync or a chaindata snapshot. The catch-all below still covers light and invalid modes.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments
