### PR TITLE
node/cn: reject bid messages from non-CN peers

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1277,6 +1277,9 @@ func handleBidMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	if pm.IsAuctionModuleDisabled() {
 		return nil
 	}
+	if p.ConnType() != common.CONSENSUSNODE {
+		return errResp(ErrInvalidMsgCode, "bid message from a non-CN peer: conntype %d", p.ConnType())
+	}
 
 	var data *auction.Bid
 	if err := msg.Decode(&data); err != nil {

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -865,6 +865,7 @@ func TestHandleBidMsg(t *testing.T) {
 
 	msg := generateMsg(t, BidMsg, testBid)
 
+	mockPeer.EXPECT().ConnType().Return(common.CONSENSUSNODE).AnyTimes()
 	mockPeer.EXPECT().GetVersion().Return(kaia63).Times(11)
 	assert.Error(t, pm.handleMsg(mockPeer, addrs[0], msg), "should return error when protocol version is not kaia66")
 
@@ -872,6 +873,43 @@ func TestHandleBidMsg(t *testing.T) {
 	assert.NoError(t, pm.handleMsg(mockPeer, addrs[0], msg), "should not return error when protocol version is kaia66")
 
 	mockCtrl.Finish()
+}
+
+func TestHandleBidMsgFromNonCNPeer(t *testing.T) {
+	tcs := []struct {
+		name       string
+		connType   common.ConnType
+		auctionOff bool
+		wantErr    bool
+		wantCalls  int
+	}{
+		{"cn", common.CONSENSUSNODE, false, false, 1},
+		{"en", common.ENDPOINTNODE, false, true, 0},
+		{"pn", common.PROXYNODE, false, true, 0},
+		{"en without auction", common.ENDPOINTNODE, true, false, 0},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockPeer := NewMockPeer(mockCtrl)
+			mockPeer.EXPECT().ConnType().Return(tc.connType).AnyTimes()
+			mockPeer.EXPECT().GetVersion().Return(kaia66).AnyTimes()
+			mockPeer.EXPECT().GetID().Return(nodeids[0].String()).AnyTimes()
+
+			pm := &ProtocolManager{}
+			if !tc.auctionOff {
+				mockAuction := auction_mock.NewMockAuctionModule(mockCtrl)
+				mockAuction.EXPECT().HandleBid(gomock.Any(), gomock.Any()).Times(tc.wantCalls)
+				pm.auctionModule = mockAuction
+			}
+			msg := generateMsg(t, BidMsg, &auction.Bid{BidData: auction.BidData{Bid: common.Big0}})
+
+			err := pm.handleMsg(mockPeer, addrs[0], msg)
+			assert.Equal(t, tc.wantErr, err != nil, "err: %v", err)
+		})
+	}
 }
 
 func TestHandleBlobSidecarsRequestMsg(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Inbound `BidMsg` was dispatched on protocol version and message code alone, so any peer could reach a consensus node's bid path. `BroadcastBid` already targets CN peers only; require the same inbound. Resource bounds for the same path are in #1041.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
