### PR TITLE
node/cn: hand the downloader a live staking module

### DIFF
--- a/node/cn/backend.go
+++ b/node/cn/backend.go
@@ -363,7 +363,7 @@ func New(ctx *node.ServiceContext, config *Config) (*CN, error) {
 	if !ok {
 		return nil, errUnsupportedEnginePolicy
 	}
-	if cn.protocolManager, err = NewProtocolManager(cn.chainConfig, config.SyncMode, config.NetworkId, cn.eventMux, cn.txPool, handler, cn.blockchain, chainDB, cacheLimit, ctx.NodeType(), config); err != nil {
+	if cn.protocolManager, err = NewProtocolManager(cn.chainConfig, config.SyncMode, config.NetworkId, cn.eventMux, cn.txPool, handler, cn.blockchain, chainDB, cacheLimit, ctx.NodeType(), config, cn.stakingModule); err != nil {
 		return nil, err
 	}
 

--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -200,7 +200,7 @@ type ProtocolManager struct {
 // with the Kaia network.
 func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, networkId uint64, mux *event.TypeMux,
 	txpool work.TxPool, handler consensus.Handler, blockchain work.BlockChain, chainDB database.DBManager, cacheLimit int,
-	nodetype common.ConnType, cnconfig *Config,
+	nodetype common.ConnType, cnconfig *Config, stakingModule staking.StakingModule,
 ) (*ProtocolManager, error) {
 	// Create the protocol manager with the base fields
 	manager := &ProtocolManager{
@@ -217,6 +217,7 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		quitResendCh:      make(chan struct{}),
 		handler:           handler,
 		nodetype:          nodetype,
+		stakingModule:     stakingModule,
 		txResendUseLegacy: cnconfig.TxResendUseLegacy,
 		verifiedBlobTxs:   newKnownHashSet(maxVerifiedBlobTxs),
 		blobSidecarReqManager: &sidecarReqManager{

--- a/node/cn/handler_test.go
+++ b/node/cn/handler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/datasync/downloader"
 	"github.com/kaiachain/kaia/event"
+	staking_mock "github.com/kaiachain/kaia/kaiax/staking/mock"
 	"github.com/kaiachain/kaia/networks/p2p"
 	"github.com/kaiachain/kaia/networks/p2p/discover"
 	"github.com/kaiachain/kaia/node/cn/mocks"
@@ -158,11 +159,35 @@ func TestNewProtocolManager(t *testing.T) {
 
 		pm, err := NewProtocolManager(params.TestChainConfig, downloader.FastSync, 0, nil, mockTxPool,
 			&testConsensusHandler{}, mockBlockChain, nil, 1, common.CONSENSUSNODE,
-			&Config{DownloaderDisable: true, FetcherDisable: true})
+			&Config{DownloaderDisable: true, FetcherDisable: true}, nil)
 
 		assert.NotNil(t, pm)
 		assert.NoError(t, err)
 	}
+}
+
+// The downloader must be constructed with a live staking module.
+func TestNewProtocolManager_downloaderHoldsStakingModule(t *testing.T) {
+	mockCtrl, mockBlockChain, mockTxPool := newMocks(t)
+	defer mockCtrl.Finish()
+
+	// Staking info recovery refuses ranges at or after the Kaia fork, so use a config with none.
+	config := params.TestKaiaConfig("istanbul")
+	mockBlockChain.EXPECT().Config().Return(config).AnyTimes()
+	mockBlockChain.EXPECT().CurrentBlock().Return(newBlock(0)).AnyTimes()
+
+	db := database.NewMemoryDBManager()
+	db.WriteCanonicalHash(common.HexToHash("0x1"), 0)
+
+	mStaking := staking_mock.NewMockStakingModule(mockCtrl)
+	mStaking.EXPECT().GetStakingInfoFromDB(uint64(0)).Return(nil).Times(1)
+
+	pm, err := NewProtocolManager(config, downloader.FullSync, 0, nil, mockTxPool,
+		&testConsensusHandler{}, mockBlockChain, db, 1, common.CONSENSUSNODE,
+		&Config{FetcherDisable: true}, mStaking)
+	assert.NoError(t, err)
+
+	assert.Error(t, pm.Downloader().SyncStakingInfo("no-such-peer", 0, 0))
 }
 
 func TestProtocolManager_RegisterValidator(t *testing.T) {
@@ -1382,7 +1407,7 @@ func TestGetBlockHeaders(t *testing.T) {
 		},
 	}
 
-	pm, err := NewProtocolManager(params.TestChainConfig, downloader.FullSync, 1, nil, nil, faker.NewFaker(), backend, db, 1, common.ENDPOINTNODE, &Config{TxResendUseLegacy: false, TxResendInterval: 1, TxResendCount: 0})
+	pm, err := NewProtocolManager(params.TestChainConfig, downloader.FullSync, 1, nil, nil, faker.NewFaker(), backend, db, 1, common.ENDPOINTNODE, &Config{TxResendUseLegacy: false, TxResendInterval: 1, TxResendCount: 0}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Proposed changes

`downloader.New` was handed `manager.stakingModule` before it was set, so the downloader kept a nil copy for the life of the process. Pass the module in as a constructor argument.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
