### PR TITLE
api: bound the consensus-info block range by inclusive count

### DIFF
--- a/api/api_kaia_blockchain.go
+++ b/api/api_kaia_blockchain.go
@@ -48,6 +48,9 @@ import (
 
 var logger = log.NewModuleLogger(log.API)
 
+// maxConsensusInfoBlocks bounds an inclusive block range requested at once.
+const maxConsensusInfoBlocks = 50
+
 // Error variables for consensus info APIs
 var (
 	errInternalError           = errors.New("internal error")
@@ -57,7 +60,7 @@ var (
 	errStartNotPositive        = errors.New("start block number should be positive")
 	errEndLargetThanLatest     = errors.New("end block number should be smaller than the latest block number")
 	errStartLargerThanEnd      = errors.New("start should be smaller than end")
-	errRequestedBlocksTooLarge = errors.New("number of requested blocks should be smaller than 50")
+	errRequestedBlocksTooLarge = fmt.Errorf("number of requested blocks should not exceed %d", maxConsensusInfoBlocks)
 	errNoCypressCreditContract = errors.New("no mainnet credit contract")
 )
 
@@ -326,8 +329,8 @@ func (s *KaiaBlockChainAPI) GetBlockWithConsensusInfoByNumberRange(ctx context.C
 		return nil, errStartLargerThanEnd
 	}
 
-	if (endNum - startNum) > 50 {
-		logger.Trace("number of requested blocks should be smaller than 51 (inclusive)", "start", startNum, "end", endNum)
+	if endNum-startNum+1 > maxConsensusInfoBlocks {
+		logger.Trace("too many blocks requested", "start", startNum, "end", endNum, "max", maxConsensusInfoBlocks)
 		return nil, errRequestedBlocksTooLarge
 	}
 


### PR DESCRIPTION
## Proposed changes

The limit compared the gap between the range endpoints while the loop is inclusive, so a request for 51 blocks passed a check meant for 50, and the returned error, the trace log and the code each stated a different number. Count inclusively against one named constant. The accepted maximum becomes 50 blocks.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
