### PR TITLE
kaiax/valset: order violation transitions by severity

### DIFF
--- a/kaiax/valset/impl/transition_context.go
+++ b/kaiax/valset/impl/transition_context.go
@@ -297,33 +297,37 @@ func (ctx *TransitionContext) applyViolationTransition(m valset.NodeMap) valset.
 	// which validator is processed first, so random map iteration would be nondeterministic.
 	sortedAddrs := newValidators.Addresses()
 
-	// rule1: staking amount dropped below MinimumStake
-	for _, addr := range sortedAddrs {
-		val := newValidators[addr]
-		if val.StakingAmount >= ctx.MinStake {
-			continue
-		}
-		switch val.State {
-		case valset.ValActive:
-			// ValActive → ValExiting (slot + minActiveCount: removing an active validator reduces consensus participants)
-			if canDemoteActive(valset.ValExiting) {
-				logger.Trace("MinStake violation: ValActive → ValExiting", "addr", addr, "staking", val.StakingAmount, "minStake", ctx.MinStake)
-				val.State = valset.ValExiting
-			} else {
-				logger.Trace("MinStake violation: slot full, skipping ValActive transition", "addr", addr, "staking", val.StakingAmount)
+	// rule1: staking amount dropped below MinimumStake.
+	// Pass per source state: ValActive and ValPaused both draw on the ValExiting slots,
+	// and ValActive additionally draws on the active floor, so it is served first.
+	for _, state := range []valset.NodeState{valset.ValActive, valset.ValPaused, valset.ValReady} {
+		for _, addr := range sortedAddrs {
+			val := newValidators[addr]
+			if val.State != state || val.StakingAmount >= ctx.MinStake {
+				continue
 			}
-		case valset.ValPaused:
-			// ValPaused → ValExiting (slot only: ValPaused is already not in active set)
-			if hasSlot(valset.ValExiting) {
-				logger.Trace("MinStake violation: ValPaused → ValExiting", "addr", addr, "staking", val.StakingAmount, "minStake", ctx.MinStake)
-				val.State = valset.ValExiting
-			} else {
-				logger.Trace("MinStake violation: slot full, skipping ValPaused transition", "addr", addr, "staking", val.StakingAmount)
+			switch val.State {
+			case valset.ValActive:
+				// ValActive → ValExiting (slot + minActiveCount: removing an active validator reduces consensus participants)
+				if canDemoteActive(valset.ValExiting) {
+					logger.Trace("MinStake violation: ValActive → ValExiting", "addr", addr, "staking", val.StakingAmount, "minStake", ctx.MinStake)
+					val.State = valset.ValExiting
+				} else {
+					logger.Trace("MinStake violation: slot full, skipping ValActive transition", "addr", addr, "staking", val.StakingAmount)
+				}
+			case valset.ValPaused:
+				// ValPaused → ValExiting (slot only: ValPaused is already not in active set)
+				if hasSlot(valset.ValExiting) {
+					logger.Trace("MinStake violation: ValPaused → ValExiting", "addr", addr, "staking", val.StakingAmount, "minStake", ctx.MinStake)
+					val.State = valset.ValExiting
+				} else {
+					logger.Trace("MinStake violation: slot full, skipping ValPaused transition", "addr", addr, "staking", val.StakingAmount)
+				}
+			case valset.ValReady:
+				// ValReady → ValInactive (no slot check, not in active set)
+				logger.Trace("MinStake violation: ValReady → ValInactive", "addr", addr, "staking", val.StakingAmount, "minStake", ctx.MinStake)
+				val.State = valset.ValInactive
 			}
-		case valset.ValReady:
-			// ValReady → ValInactive (no slot check, not in active set)
-			logger.Trace("MinStake violation: ValReady → ValInactive", "addr", addr, "staking", val.StakingAmount, "minStake", ctx.MinStake)
-			val.State = valset.ValInactive
 		}
 	}
 
@@ -333,23 +337,39 @@ func (ctx *TransitionContext) applyViolationTransition(m valset.NodeMap) valset.
 	if len(ctx.PfReport) == 0 {
 		return newValidators
 	}
+
+	// Severe and minor violations both consume the active floor, so severe ones are
+	// served first and, within a severity, the worst PFS first. Address only breaks ties.
+	violators := make([]common.Address, 0, len(sortedAddrs))
 	for _, addr := range sortedAddrs {
+		if newValidators[addr].State == valset.ValActive && ctx.PFS[addr] > 0 {
+			violators = append(violators, addr)
+		}
+	}
+	slices.SortFunc(violators, func(a, b common.Address) int {
+		if c := cmp.Compare(ctx.PFS[b], ctx.PFS[a]); c != 0 {
+			return c
+		}
+		return bytes.Compare(a[:], b[:])
+	})
+
+	for _, addr := range violators {
 		val := newValidators[addr]
-		if val.State != valset.ValActive {
-			continue
-		}
-		pfs, ok := ctx.PFS[addr]
-		if !ok || pfs == 0 {
-			continue
-		}
-		if pfs >= ctx.PfsThreshold {
+		if pfs := ctx.PFS[addr]; pfs >= ctx.PfsThreshold {
 			if canDemoteActive(valset.ValExiting) {
 				logger.Trace("PFS severe violation: transitioning to ValExiting", "addr", addr, "pfs", pfs, "pfsThreshold", ctx.PfsThreshold)
 				val.State = valset.ValExiting
 			} else {
 				logger.Trace("PFS severe violation: slot full, skipping transition", "addr", addr, "pfs", pfs)
 			}
-		} else {
+		}
+	}
+	for _, addr := range violators {
+		val := newValidators[addr]
+		if val.State != valset.ValActive {
+			continue
+		}
+		if pfs := ctx.PFS[addr]; pfs < ctx.PfsThreshold {
 			if canDemoteActive(valset.ValPaused) {
 				logger.Trace("PFS minor violation: transitioning to ValPaused", "addr", addr, "pfs", pfs, "pfsThreshold", ctx.PfsThreshold)
 				val.State = valset.ValPaused

--- a/kaiax/valset/impl/transition_context_test.go
+++ b/kaiax/valset/impl/transition_context_test.go
@@ -530,6 +530,68 @@ func TestApplyViolationTransition_EmptyPfReport_NoOp(t *testing.T) {
 // With n=4, maxSlot=1 for each but minActive=3 means only 1 total can leave ValActive
 // (either 1 paused or 1 exiting, not both), since 4-2=2 < minActive=3.
 // ============================================================
+func TestApplyViolationTransition_Priority(t *testing.T) {
+	const (
+		slotMax      = uint64(1) // maxSlotAvailable(4)
+		minActive    = uint64(3) // minActiveCount(4)
+		pfsThreshold = uint64(2)
+	)
+	fourActive := func() NodeMap {
+		return NodeMap{
+			addr1: {State: ValActive, StakingAmount: aboveMinStake},
+			addr2: {State: ValActive, StakingAmount: aboveMinStake},
+			addr3: {State: ValActive, StakingAmount: aboveMinStake},
+			addr4: {State: ValActive, StakingAmount: aboveMinStake},
+		}
+	}
+	pfsCtx := func(pfs map[common.Address]uint64) *TransitionContext {
+		return violationCtx(t, ctxOpts{
+			PfsThreshold:     pfsThreshold,
+			MaxSlotAvailable: slotMax,
+			MinActiveCount:   minActive,
+			PFS:              pfs,
+			PfReport:         []common.Address{addr1},
+		})
+	}
+
+	t.Run("severe is served before minor regardless of address", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			pfs     map[common.Address]uint64
+			exiting common.Address
+		}{
+			{"severe on the higher address", map[common.Address]uint64{addr1: pfsThreshold - 1, addr2: pfsThreshold + 1}, addr2},
+			{"severe on the lower address", map[common.Address]uint64{addr1: pfsThreshold + 1, addr2: pfsThreshold - 1}, addr1},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				out := pfsCtx(tc.pfs).applyViolationTransition(fourActive())
+				assert.Equal(t, ValExiting, out[tc.exiting].State, "the severe violator must take the last slot")
+				assert.Equal(t, 0, int(out.CountByState(ValPaused)), "the minor violator must not consume the floor first")
+			})
+		}
+	})
+
+	t.Run("worst PFS is served first within a severity", func(t *testing.T) {
+		out := pfsCtx(map[common.Address]uint64{addr1: pfsThreshold + 1, addr2: pfsThreshold + 5}).applyViolationTransition(fourActive())
+		assert.Equal(t, ValExiting, out[addr2].State)
+		assert.Equal(t, ValActive, out[addr1].State)
+	})
+
+	t.Run("minStake: active is served before paused for the exiting slot", func(t *testing.T) {
+		m := NodeMap{
+			addr1: {State: ValPaused, StakingAmount: belowMinStake},
+			addr2: {State: ValActive, StakingAmount: belowMinStake},
+			addr3: {State: ValActive, StakingAmount: aboveMinStake},
+			addr4: {State: ValActive, StakingAmount: aboveMinStake},
+		}
+		ctx := violationCtx(t, ctxOpts{MaxSlotAvailable: slotMax, MinActiveCount: 2})
+		out := ctx.applyViolationTransition(m)
+		assert.Equal(t, ValExiting, out[addr2].State)
+		assert.Equal(t, ValPaused, out[addr1].State)
+	})
+}
+
 func TestApplyViolationTransition_SlotLimits(t *testing.T) {
 	const (
 		slotMax      = uint64(1) // maxSlotAvailable(4)


### PR DESCRIPTION
## Proposed changes

`applyViolationTransition` walked the validators once in address order and decided the severity inside the loop, so a minor violator with a lower address could consume the last demotion budget and leave a severe one active. Each rule now runs in passes ordered by what they consume: in rule 1 `ValActive → ValExiting` precedes `ValPaused → ValExiting` because both draw on the exiting slots, and in rule 2 every severe violation is served before any minor one, worst PFS first with the address only breaking ties. Ordering by PFS keeps the result identical on every node, since PFS is derived from the header.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
