### PR TITLE
datasync/downloader: bind staking info recovery to the requested peer

### DIFF
--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -104,6 +104,7 @@ type Downloader struct {
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
 	isStakingInfoRecovery     bool
+	stakingInfoRecoveryPeer   string
 	stakingInfoRecoveryTotal  int
 	stakingInfoRecoveryCh     chan []*staking.P2PStakingInfo
 	stakingInfoRecoveryBlocks []uint64
@@ -636,6 +637,7 @@ func (d *Downloader) SyncStakingInfo(id string, from, to uint64) error {
 		return errors.New("the given peer is not registered")
 	}
 
+	d.stakingInfoRecoveryPeer = id
 	d.stakingInfoRecoveryBlocks = blockNums
 	d.stakingInfoRecoveryTotal = len(blockNums)
 	d.stakingInfoRecoveryCh = make(chan []*staking.P2PStakingInfo, 1)
@@ -669,15 +671,21 @@ func (d *Downloader) SyncStakingInfo(id string, from, to uint64) error {
 				return
 			case stakingInfos := <-d.stakingInfoRecoveryCh:
 				logger.Info("received stakinginfos", "len", len(stakingInfos))
-				for _, stakingInfo := range stakingInfos {
-					if d.stakingInfoRecoveryBlocks[0] != stakingInfo.BlockNum {
-						logger.Error("failed to receive expected block", "expected", d.stakingInfoRecoveryBlocks[0], "actual", stakingInfo.BlockNum)
+				if len(stakingInfos) > len(d.stakingInfoRecoveryBlocks) {
+					logger.Error("received more staking infos than requested", "received", len(stakingInfos), "pending", len(d.stakingInfoRecoveryBlocks))
+					return
+				}
+				for i, stakingInfo := range stakingInfos {
+					if d.stakingInfoRecoveryBlocks[i] != stakingInfo.BlockNum {
+						logger.Error("failed to receive expected block", "expected", d.stakingInfoRecoveryBlocks[i], "actual", stakingInfo.BlockNum)
 						return
 					}
-					d.stakingModule.PutStakingInfoToDB(stakingInfo.BlockNum, staking.ToStakingInfo(stakingInfo))
-					fixed++
-					d.stakingInfoRecoveryBlocks = d.stakingInfoRecoveryBlocks[1:]
 				}
+				for i, stakingInfo := range stakingInfos {
+					d.stakingModule.PutStakingInfoToDB(d.stakingInfoRecoveryBlocks[i], staking.ToStakingInfo(stakingInfo))
+					fixed++
+				}
+				d.stakingInfoRecoveryBlocks = d.stakingInfoRecoveryBlocks[len(stakingInfos):]
 
 				if len(d.stakingInfoRecoveryBlocks) == 0 {
 					logger.Info("syncing staking info is finished", "fixed", fixed)
@@ -1934,8 +1942,11 @@ func (d *Downloader) DeliverReceipts(id string, receipts [][]*types.Receipt) (er
 
 // DeliverStakingInfos injects a new batch of staking information received from a remote node.
 func (d *Downloader) DeliverStakingInfos(id string, stakingInfos []*staking.P2PStakingInfo) error {
-	if d.isStakingInfoRecovery {
-		d.stakingInfoRecoveryCh <- stakingInfos
+	if d.isStakingInfoRecovery && id == d.stakingInfoRecoveryPeer {
+		select {
+		case d.stakingInfoRecoveryCh <- stakingInfos:
+		default:
+		}
 	}
 	return d.deliver(id, d.stakingInfoCh, &stakingInfoPack{id, stakingInfos}, stakingInfoInMeter, stakingInfoDropMeter)
 }

--- a/datasync/downloader/downloader_test.go
+++ b/datasync/downloader/downloader_test.go
@@ -1992,6 +1992,57 @@ func testStakingInfoSync(t *testing.T, protocol int) {
 	}
 }
 
+// newRecoveryTester starts a staking info recovery from "requested" and returns the
+// tester. The peer answers slowly, so the recovery is still pending on return.
+func newRecoveryTester(t *testing.T) *downloadTester {
+	config := params.TestKaiaConfig("cancun")
+	config.Governance.Reward.StakingUpdateInterval = testInterval
+
+	tester := newTesterWithConfig(t, config)
+	hashes, headers, blocks, receipts, stakingInfos := tester.makeChain(16, 0, tester.genesis, nil, false)
+	if err := tester.newSlowPeer("requested", 65, hashes, headers, blocks, receipts, stakingInfos, 500*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	for hash, info := range stakingInfos {
+		tester.stateDb.WriteCanonicalHash(hash, info.BlockNum)
+	}
+	// Pending blocks become [4, 8].
+	if err := tester.downloader.SyncStakingInfo("requested", 9, 9); err != nil {
+		t.Fatal(err)
+	}
+	return tester
+}
+
+func TestSyncStakingInfoIgnoresUnselectedPeer(t *testing.T) {
+	tester := newRecoveryTester(t)
+	defer tester.terminate()
+
+	forged := &staking.P2PStakingInfo{BlockNum: 4, KEFAddr: common.HexToAddress("0x2222222222222222222222222222222222222222")}
+	tester.downloader.DeliverStakingInfos("mallory", []*staking.P2PStakingInfo{forged})
+	time.Sleep(200 * time.Millisecond)
+
+	if si := staking_impl.ReadStakingInfo(tester.stateDb.GetMiscDB(), forged.BlockNum); si != nil {
+		t.Fatalf("staking info from an unselected peer was persisted: %+v", si)
+	}
+}
+
+func TestSyncStakingInfoRejectsOverlongBatch(t *testing.T) {
+	tester := newRecoveryTester(t)
+	defer tester.terminate()
+
+	// Three entries against two pending blocks: the batch must be dropped whole.
+	tester.downloader.DeliverStakingInfos("requested", []*staking.P2PStakingInfo{
+		{BlockNum: 4}, {BlockNum: 8}, {BlockNum: 12},
+	})
+	time.Sleep(200 * time.Millisecond)
+
+	for _, num := range []uint64{4, 8, 12} {
+		if si := staking_impl.ReadStakingInfo(tester.stateDb.GetMiscDB(), num); si != nil {
+			t.Fatalf("an entry of the overlong batch was persisted at %d: %+v", num, si)
+		}
+	}
+}
+
 func TestCalcStakingBlockNumber(t *testing.T) {
 	testCase := []struct {
 		interval uint64


### PR DESCRIPTION
## Proposed changes

Staking info recovery accepted a `StakingInfoMsg` from any connected peer, not just the one it was started with, and applied the reply entry by entry — so a reply holding more entries than were requested walked past the end of the pending list and panicked the recovery goroutine. Accept only the selected peer, validate the whole batch against the pending list before writing any of it, and keep the channel send from blocking the p2p reader.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
