### PR TITLE
kaiax/vrank, consensus: record the parent round with a certificate

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -94,6 +94,8 @@ type Sealer interface {
 	Author(header *types.Header) (common.Address, error)
 	Committers(header *types.Header) ([]common.Address, error)
 	CommittersWithRound(header *types.Header) ([]common.Address, error)
+	// RecoverCommitters recovers seal signers without a header to read them from.
+	RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error)
 	Vanity(header *types.Header) ([]byte, error)
 	RawSeals(header *types.Header) ([]byte, [][]byte, error)
 	Round(header *types.Header) (byte, error)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -95,7 +95,7 @@ type Sealer interface {
 	Committers(header *types.Header) ([]common.Address, error)
 	CommittersWithRound(header *types.Header) ([]common.Address, error)
 	// RecoverCommitters recovers seal signers without a header to read them from.
-	RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error)
+	RecoverCommitters(blockNum uint64, hash common.Hash, round byte, seals [][]byte) ([]common.Address, error)
 	Vanity(header *types.Header) ([]byte, error)
 	RawSeals(header *types.Header) ([]byte, [][]byte, error)
 	Round(header *types.Header) (byte, error)

--- a/consensus/engine/sealer.go
+++ b/consensus/engine/sealer.go
@@ -87,8 +87,8 @@ func (s *dynamicSealer) CommittersWithRound(header *types.Header) ([]common.Addr
 	return s.implAt(header.Number.Uint64()).CommittersWithRound(header)
 }
 
-func (s *dynamicSealer) RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
-	return s.implAt(0).RecoverCommitters(hash, round, seals) // implAt ignores the number
+func (s *dynamicSealer) RecoverCommitters(blockNum uint64, hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
+	return s.implAt(blockNum).RecoverCommitters(blockNum, hash, round, seals)
 }
 
 func (s *dynamicSealer) Vanity(header *types.Header) ([]byte, error) {

--- a/consensus/engine/sealer.go
+++ b/consensus/engine/sealer.go
@@ -87,6 +87,10 @@ func (s *dynamicSealer) CommittersWithRound(header *types.Header) ([]common.Addr
 	return s.implAt(header.Number.Uint64()).CommittersWithRound(header)
 }
 
+func (s *dynamicSealer) RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
+	return s.implAt(0).RecoverCommitters(hash, round, seals) // implAt ignores the number
+}
+
 func (s *dynamicSealer) Vanity(header *types.Header) ([]byte, error) {
 	if header == nil || header.Number == nil {
 		return nil, consensus.ErrUnknownBlock

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -185,6 +185,14 @@ func (f *Faker) CommittersWithRound(header *types.Header) ([]common.Address, err
 	return f.Committers(header)
 }
 
+func (f *Faker) RecoverCommitters(_ common.Hash, _ byte, seals [][]byte) ([]common.Address, error) {
+	committers := make([]common.Address, len(seals))
+	for i := range seals {
+		committers[i] = f.address
+	}
+	return committers, nil
+}
+
 func (f *Faker) Vanity(header *types.Header) ([]byte, error) {
 	if err := f.verifyFailure(header); err != nil {
 		return nil, err

--- a/consensus/faker/faker.go
+++ b/consensus/faker/faker.go
@@ -185,7 +185,7 @@ func (f *Faker) CommittersWithRound(header *types.Header) ([]common.Address, err
 	return f.Committers(header)
 }
 
-func (f *Faker) RecoverCommitters(_ common.Hash, _ byte, seals [][]byte) ([]common.Address, error) {
+func (f *Faker) RecoverCommitters(_ uint64, _ common.Hash, _ byte, seals [][]byte) ([]common.Address, error) {
 	committers := make([]common.Address, len(seals))
 	for i := range seals {
 		committers[i] = f.address

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -66,8 +66,8 @@ type Backend interface {
 	// LastProposal retrieves latest committed proposal and the address of proposer
 	LastProposal() (bft.Proposal, common.Address)
 
-	// HasPropsal checks if the combination of the given hash and height matches any existing blocks
-	HasPropsal(hash common.Hash, number *big.Int) bool
+	// ProposalRound returns the round stored in the matching block, and whether it exists.
+	ProposalRound(hash common.Hash, number *big.Int) (byte, bool)
 
 	// HasBadProposal returns whether the proposal with the hash is a bad proposal
 	HasBadProposal(hash common.Hash) bool

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -434,9 +434,16 @@ func (sb *backend) Sign(data []byte) ([]byte, error) {
 	return crypto.Sign(hashData, sb.privateKey)
 }
 
-// HasPropsal implements istanbul.Backend.HashBlock
-func (sb *backend) HasPropsal(hash common.Hash, number *big.Int) bool {
-	return sb.chain.GetHeader(hash, number.Uint64()) != nil
+func (sb *backend) ProposalRound(hash common.Hash, number *big.Int) (byte, bool) {
+	header := sb.chain.GetHeader(hash, number.Uint64())
+	if header == nil {
+		return 0, false
+	}
+	round, err := sb.Sealer().Round(header)
+	if err != nil {
+		return 0, false
+	}
+	return round, true
 }
 
 func (sb *backend) LastProposal() (bft.Proposal, common.Address) {

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -84,11 +84,16 @@ func (c *core) handlePreprepare(msg *bft.Message, src common.Address) error {
 			// Broadcast COMMIT if it is an existing block
 			// 1. The proposer needs to match the given (Sequence + Round)
 			// 2. The given block must exist
+			// 3. Post-permissionless, the stored round must match: the seal binds the round,
+			//    so answering another round would attest a quorum that never formed.
 			proposer, getProposerErr := c.valsetModule.GetProposer(preprepare.View.Sequence.Uint64(), preprepare.View.Round.Uint64())
 			if getProposerErr != nil {
 				return getProposerErr
 			}
-			if proposer == src && c.backend.HasPropsal(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
+			storedRound, hasProposal := c.backend.ProposalRound(preprepare.Proposal.Hash(), preprepare.Proposal.Number())
+			roundMatches := !c.backend.IsPermissionlessAt(preprepare.View.Sequence.Uint64()) ||
+				uint64(storedRound) == preprepare.View.Round.Uint64()
+			if proposer == src && hasProposal && roundMatches {
 				c.sendCommitForOldBlock(preprepare.View, preprepare.Proposal.Hash(), preprepare.Proposal.ParentHash())
 				return nil
 			}

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -81,11 +81,15 @@ func (c *core) handlePreprepare(msg *bft.Message, src common.Address) error {
 	// If it is old message, see if we need to broadcast COMMIT
 	if err := c.checkMessage(bft.MsgPreprepare, preprepare.View); err != nil {
 		if err == errOldMessage {
-			// Broadcast COMMIT if it is an existing block
-			// 1. The proposer needs to match the given (Sequence + Round)
-			// 2. The given block must exist
-			// 3. Post-permissionless, the stored round must match: the seal binds the round,
-			//    so answering another round would attest a quorum that never formed.
+			// This PRE-PREPARE targets an already-finalized height. Reply with a COMMIT
+			// to help the sender finish that block, only if:
+			// 1. The sender is the scheduled proposer of the given (sequence, round).
+			// 2. This node has the given block in its chain.
+			// 3. Post-permissionless: the given round equals the round this node stored.
+			//    The committed seal signs (hash, round), so answering another round would
+			//    sign a commit at a round this node never committed at; callers could
+			//    collect such seals into a quorum certificate for a round that never
+			//    reached quorum.
 			proposer, getProposerErr := c.valsetModule.GetProposer(preprepare.View.Sequence.Uint64(), preprepare.View.Round.Uint64())
 			if getProposerErr != nil {
 				return getProposerErr

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -20,9 +20,17 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	mock_istanbul "github.com/kaiachain/kaia/consensus/istanbul/mocks"
+	"github.com/kaiachain/kaia/crypto"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	valset_mock "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProposalNumberMatchesView(t *testing.T) {
@@ -37,4 +45,69 @@ func TestProposalNumberMatchesView(t *testing.T) {
 	assert.True(t, proposalNumberMatchesView(mk(big.NewInt(5), big.NewInt(5))), "matching number should pass")
 	assert.False(t, proposalNumberMatchesView(mk(big.NewInt(9), big.NewInt(5))), "in-range mismatch should fail")
 	assert.False(t, proposalNumberMatchesView(mk(overflow, big.NewInt(5))), "out-of-uint64 mismatch should fail")
+}
+
+// TestHandlePreprepareOldBlockCommitRequiresStoredRound covers the COMMIT rebroadcast for an
+// already-committed block: post-permissionless the answer is bound to the round this node stored.
+func TestHandlePreprepareOldBlockCommitRequiresStoredRound(t *testing.T) {
+	const blockNum = uint64(10)
+
+	testcases := []struct {
+		name            string
+		permissionless  bool
+		storedRound     byte
+		requestedRound  int64
+		expectBroadcast bool
+	}{
+		{"permissionless answers the stored round", true, 1, 1, true},
+		{"permissionless refuses another round", true, 1, 5, false},
+		{"before fork answers any round", false, 1, 5, true},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			t.Cleanup(mockCtrl.Finish)
+
+			key, err := crypto.GenerateKey()
+			require.NoError(t, err)
+			src := crypto.PubkeyToAddress(key.PublicKey)
+
+			proposal := types.NewBlockWithHeader(&types.Header{Number: new(big.Int).SetUint64(blockNum)})
+			view := &bft.View{Round: big.NewInt(tc.requestedRound), Sequence: new(big.Int).SetUint64(blockNum)}
+
+			broadcast := false
+			mockBackend := mock_istanbul.NewMockBackend(mockCtrl)
+			mockBackend.EXPECT().Address().Return(src).AnyTimes()
+			mockBackend.EXPECT().Sealer().Return(istanbul.NewSealerImpl(key)).AnyTimes()
+			mockBackend.EXPECT().Sign(gomock.Any()).Return(nil, nil).AnyTimes()
+			mockBackend.EXPECT().IsPermissionlessAt(blockNum).Return(tc.permissionless).AnyTimes()
+			mockBackend.EXPECT().ProposalRound(proposal.Hash(), proposal.Number()).Return(tc.storedRound, true)
+			mockBackend.EXPECT().Broadcast(gomock.Any(), gomock.Any()).DoAndReturn(func(common.Hash, []byte) error {
+				broadcast = true
+				return nil
+			}).AnyTimes()
+
+			mockValset := valset_mock.NewMockValsetModule(mockCtrl)
+			mockValset.EXPECT().GetProposer(blockNum, uint64(tc.requestedRound)).Return(src, nil)
+
+			istCore := New(mockBackend, istanbul.DefaultConfig.Copy()).(*core)
+			istCore.RegisterKaiaxModules(mockValset, nil)
+			// Already past blockNum, so the PRE-PREPARE arrives as an old message.
+			istCore.current = newRoundState(
+				&bft.View{Round: big.NewInt(0), Sequence: new(big.Int).SetUint64(blockNum + 1)},
+				valset.NewAddressSet([]common.Address{src}), common.Hash{}, nil, nil, nil)
+
+			payload, err := bft.Encode(&bft.Preprepare{View: view, Proposal: proposal})
+			require.NoError(t, err)
+			err = istCore.handlePreprepare(&bft.Message{Code: bft.MsgPreprepare, Msg: payload}, src)
+
+			assert.Equal(t, tc.expectBroadcast, broadcast)
+			if tc.expectBroadcast {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, errOldMessage)
+			}
+		})
+	}
 }

--- a/consensus/istanbul/mocks/backend_mock.go
+++ b/consensus/istanbul/mocks/backend_mock.go
@@ -135,18 +135,18 @@ func (mr *MockBackendMockRecorder) HasBadProposal(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBadProposal", reflect.TypeOf((*MockBackend)(nil).HasBadProposal), arg0)
 }
 
-// HasPropsal mocks base method.
-func (m *MockBackend) HasPropsal(arg0 common.Hash, arg1 *big.Int) bool {
+// IsPermissionlessAt mocks base method.
+func (m *MockBackend) IsPermissionlessAt(arg0 uint64) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPropsal", arg0, arg1)
+	ret := m.ctrl.Call(m, "IsPermissionlessAt", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// HasPropsal indicates an expected call of HasPropsal.
-func (mr *MockBackendMockRecorder) HasPropsal(arg0, arg1 interface{}) *gomock.Call {
+// IsPermissionlessAt indicates an expected call of IsPermissionlessAt.
+func (mr *MockBackendMockRecorder) IsPermissionlessAt(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPropsal", reflect.TypeOf((*MockBackend)(nil).HasPropsal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPermissionlessAt", reflect.TypeOf((*MockBackend)(nil).IsPermissionlessAt), arg0)
 }
 
 // LastProposal mocks base method.
@@ -178,18 +178,19 @@ func (mr *MockBackendMockRecorder) NodeType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeType", reflect.TypeOf((*MockBackend)(nil).NodeType))
 }
 
-// IsPermissionlessAt mocks base method.
-func (m *MockBackend) IsPermissionlessAt(num uint64) bool {
+// ProposalRound mocks base method.
+func (m *MockBackend) ProposalRound(arg0 common.Hash, arg1 *big.Int) (byte, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPermissionlessAt", num)
-	ret0, _ := ret[0].(bool)
-	return ret0
+	ret := m.ctrl.Call(m, "ProposalRound", arg0, arg1)
+	ret0, _ := ret[0].(byte)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
-// IsPermissionlessAt indicates an expected call of IsPermissionlessAt.
-func (mr *MockBackendMockRecorder) IsPermissionlessAt(num interface{}) *gomock.Call {
+// ProposalRound indicates an expected call of ProposalRound.
+func (mr *MockBackendMockRecorder) ProposalRound(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPermissionlessAt", reflect.TypeOf((*MockBackend)(nil).IsPermissionlessAt), num)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProposalRound", reflect.TypeOf((*MockBackend)(nil).ProposalRound), arg0, arg1)
 }
 
 // Sealer mocks base method.

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -187,7 +187,7 @@ func (m *IstanbulSealer) CommittersWithRound(header *types.Header) ([]common.Add
 	return m.committers(header, PrepareCommittedSealWithRound(m.HeaderHash(header), round))
 }
 
-func (m *IstanbulSealer) RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
+func (m *IstanbulSealer) RecoverCommitters(_ uint64, hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
 	proposalSeal := PrepareCommittedSealWithRound(hash, round)
 	committers := make([]common.Address, 0, len(seals))
 	for _, seal := range seals {

--- a/consensus/istanbul/sealer.go
+++ b/consensus/istanbul/sealer.go
@@ -187,6 +187,22 @@ func (m *IstanbulSealer) CommittersWithRound(header *types.Header) ([]common.Add
 	return m.committers(header, PrepareCommittedSealWithRound(m.HeaderHash(header), round))
 }
 
+func (m *IstanbulSealer) RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
+	proposalSeal := PrepareCommittedSealWithRound(hash, round)
+	committers := make([]common.Address, 0, len(seals))
+	for _, seal := range seals {
+		if len(seal) != IstanbulExtraSeal {
+			return nil, ErrInvalidCommittedSeals
+		}
+		addr, err := cacheSignatureAddress(proposalSeal, seal)
+		if err != nil {
+			return nil, ErrInvalidSignature
+		}
+		committers = append(committers, addr)
+	}
+	return committers, nil
+}
+
 func (m *IstanbulSealer) committers(header *types.Header, proposalSeal []byte) ([]common.Address, error) {
 	extra, err := m.parseIstanbulExtra(header.Extra)
 	if err != nil {

--- a/consensus/istanbul/sealer_test.go
+++ b/consensus/istanbul/sealer_test.go
@@ -76,6 +76,33 @@ func TestCommittersWithRoundDetectsRoundMutation(t *testing.T) {
 	assert.NotEqual(t, []common.Address{addr}, mutated)
 }
 
+// TestRecoverCommitters: a seal of the wrong length is rejected before recovery, since
+// signature recovery on a truncated seal would report an arbitrary address.
+func TestRecoverCommitters(t *testing.T) {
+	addr, sealer, header := singleValidatorHeader(t, 0)
+	hash := sealer.HeaderHash(header)
+	seal, err := sealer.MakeCommittedSealFromHashWithRound(hash, 0)
+	require.NoError(t, err)
+
+	got, err := sealer.RecoverCommitters(header.Number.Uint64(), hash, 0, [][]byte{seal})
+	require.NoError(t, err)
+	assert.Equal(t, []common.Address{addr}, got)
+
+	for _, tc := range []struct {
+		desc string
+		seal []byte
+	}{
+		{"truncated", seal[:len(seal)-1]},
+		{"overlong", append(append([]byte{}, seal...), 0)},
+		{"empty", nil},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := sealer.RecoverCommitters(header.Number.Uint64(), hash, 0, [][]byte{tc.seal})
+			assert.Equal(t, ErrInvalidCommittedSeals, err)
+		})
+	}
+}
+
 // TestCommittersRoundIndependent: the legacy Committers ignores the round byte,
 // so pre-fork blocks validate the same regardless of it.
 func TestCommittersRoundIndependent(t *testing.T) {

--- a/kaiax/vrank/errors.go
+++ b/kaiax/vrank/errors.go
@@ -40,4 +40,8 @@ var (
 	ErrInvalidVRankCandidate               = errors.New("invalid vrank: address is not a candidate")
 	ErrDuplicateVRankCandidate             = errors.New("invalid vrank: duplicate candidate address")
 	ErrVRankNotSorted                      = errors.New("invalid vrank: addresses not sorted")
+	ErrUnexpectedParentRound               = errors.New("invalid vrank: unexpected parent round")
+	ErrUnexpectedParentSeal                = errors.New("invalid vrank: unexpected parent committed seal")
+	ErrTooManyParentSeals                  = errors.New("invalid vrank: more parent seals than committee members")
+	ErrInvalidParentCertificate            = errors.New("invalid vrank: parent round is not backed by a committee quorum")
 )

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -102,7 +102,7 @@ func (v *VRankModule) verifyParentRound(header *types.Header, payload vrank.VRan
 	if len(payload.ParentCommittedSeal) > len(committee) {
 		return vrank.ErrTooManyParentSeals
 	}
-	committers, err := v.Sealer.RecoverCommitters(header.ParentHash, payload.ParentRound, payload.ParentCommittedSeal)
+	committers, err := v.Sealer.RecoverCommitters(parentNum, header.ParentHash, payload.ParentRound, payload.ParentCommittedSeal)
 	if err != nil {
 		return vrank.ErrInvalidParentCertificate
 	}

--- a/kaiax/vrank/impl/consensus.go
+++ b/kaiax/vrank/impl/consensus.go
@@ -23,13 +23,15 @@ import (
 
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/kaiax/valset"
 	"github.com/kaiachain/kaia/kaiax/vrank"
 )
 
 // VerifyHeader checks the VRank field in the header:
 //   - Before the permissionless fork: VRank must be absent.
-//   - At epoch-start blocks: VRank must be RLPEncode(CandTesting(N)) or RLPEncode([]).
-//   - Otherwise: a cfReport whose failed addresses are sorted, deduped, and ⊆ CandTesting.
+//   - At epoch-start blocks: Report must equal CandTesting(N).
+//   - Otherwise: Report is a cfReport whose failed addresses are sorted, deduped, and ⊆ CandTesting.
+//   - Always: ParentRound must be backed by a committee quorum that committed the parent there.
 func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error {
 	number := header.Number.Uint64()
 	permissionless := v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(number))
@@ -42,24 +44,28 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 		return nil
 	}
 
+	payload, err := vrank.DecodeVRank(header.VRank)
+	if err != nil {
+		return vrank.ErrInvalidVRankFormat
+	}
+	if err := v.verifyParentRound(header, payload); err != nil {
+		return err
+	}
+
 	// Epoch-start block
 	if number%v.vrankEpoch() == 0 {
-		expected, err := v.encodeEpochStartVRank(number)
+		candidates, err := v.Valset.GetCandTesting(number)
 		if err != nil {
 			return err
 		}
-		if !bytes.Equal(header.VRank, expected) {
+		if !slices.Equal(payload.Report, candidates) {
 			return vrank.ErrEpochStartVRankMismatch
 		}
 		return nil
 	}
 
 	// Non-epoch-start block
-	report, err := vrank.DecodeReport(header.VRank)
-	if err != nil {
-		return vrank.ErrInvalidVRankFormat
-	}
-	if len(report) == 0 {
+	if len(payload.Report) == 0 {
 		return nil
 	}
 	// Failures score against the reporter's own byzantine-filterable column regardless of content,
@@ -68,14 +74,69 @@ func (v *VRankModule) VerifyHeader(header *types.Header, _ *types.Header) error 
 	if err != nil {
 		return err
 	}
-	return validateNonEpochVRank(report, candidates)
+	return validateNonEpochVRank(payload.Report, candidates)
+}
+
+// verifyParentRound checks that the seals prove a committee quorum committed the parent at the
+// claimed round. It never compares against this node's own stored round: two honest nodes can hold
+// different rounds for one block, so comparing would make them reject each other's headers.
+// The seals prove that the round happened, not that it was the last one, so a proposer can claim a
+// lower round that really happened but cannot invent a higher one.
+func (v *VRankModule) verifyParentRound(header *types.Header, payload vrank.VRankPayload) error {
+	if !v.hasParentCertificate(header.Number.Uint64()) || payload.ParentRound == 0 {
+		if payload.ParentRound != 0 {
+			return vrank.ErrUnexpectedParentRound
+		}
+		if len(payload.ParentCommittedSeal) > 0 {
+			return vrank.ErrUnexpectedParentSeal
+		}
+		return nil
+	}
+
+	parentNum := header.Number.Uint64() - 1
+	committee, err := v.Valset.GetCommittee(parentNum, uint64(payload.ParentRound))
+	if err != nil {
+		return err
+	}
+	// Bound the recovery work: seals beyond the committee size can never help.
+	if len(payload.ParentCommittedSeal) > len(committee) {
+		return vrank.ErrTooManyParentSeals
+	}
+	committers, err := v.Sealer.RecoverCommitters(header.ParentHash, payload.ParentRound, payload.ParentCommittedSeal)
+	if err != nil {
+		return vrank.ErrInvalidParentCertificate
+	}
+	committeeSet := valset.NewAddressSet(committee)
+	valid := 0
+	for _, addr := range committers {
+		if !committeeSet.Remove(addr) {
+			return vrank.ErrInvalidParentCertificate
+		}
+		valid++
+	}
+	// The committee equals the qualified set post-permissionless, so pass its size for both.
+	if valid < v.Sealer.Quorum(parentNum, len(committee), len(committee)) {
+		return vrank.ErrInvalidParentCertificate
+	}
+	return nil
+}
+
+// hasParentCertificate reports whether block num records its parent's round. Two blocks do not:
+// an epoch start, whose parent's failures belong to the previous epoch, and the first
+// permissionless block, whose parent's seals predate the round binding.
+func (v *VRankModule) hasParentCertificate(num uint64) bool {
+	if num == 0 || num%v.vrankEpoch() == 0 {
+		return false
+	}
+	return v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(num - 1))
 }
 
 // PrepareHeader fills header.VRank per KIP-227.
 //
-//   - At epoch-start blocks: VRank is CandTesting(N), encoded even when empty.
-//   - Otherwise: VRank is a cfReport about this proposer's own most recent prior proposal in
-//     the current epoch, or nil when there is no such block or no failures.
+//   - At epoch-start blocks: Report is CandTesting(N).
+//   - Otherwise: Report is a cfReport about this proposer's own most recent prior proposal in
+//     the current epoch, or empty when there is no such block or no failures.
+//   - ParentRound and its seals are copied from this node's own stored parent header.
 func (v *VRankModule) PrepareHeader(header *types.Header) error {
 	number := header.Number.Uint64()
 	if !v.ChainConfig.IsPermissionlessForkEnabled(header.Number) {
@@ -83,39 +144,64 @@ func (v *VRankModule) PrepareHeader(header *types.Header) error {
 		return nil
 	}
 
+	var payload vrank.VRankPayload
 	if number%v.vrankEpoch() == 0 {
-		encoded, err := v.encodeEpochStartVRank(number)
+		candidates, err := v.Valset.GetCandTesting(number)
 		if err != nil {
+			logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", number, "err", err)
 			return err
 		}
-		header.VRank = encoded
+		payload.Report = candidates
 	} else {
-		encoded, err := v.encodeCandidateFailureVRank(number)
+		report, err := v.evaluateCandidateFailures(number)
 		if err != nil {
 			return err
 		}
-		header.VRank = encoded
+		payload.Report = report
 	}
 
+	round, seals, err := v.parentRoundCertificate(number)
+	if err != nil {
+		return err
+	}
+	payload.ParentRound = round
+	payload.ParentCommittedSeal = seals
+
+	encoded, err := vrank.EncodeVRank(payload)
+	if err != nil {
+		logger.Error("Failed to encode VRank payload", "err", err, "num", number)
+		return err
+	}
+	header.VRank = encoded
 	return nil
 }
 
-// encodeEpochStartVRank returns RLPEncode(CandTesting(N)) or RLPEncode([]) = 0xc0 when empty.
-func (v *VRankModule) encodeEpochStartVRank(number uint64) ([]byte, error) {
-	candidates, err := v.Valset.GetCandTesting(number)
-	if err != nil {
-		logger.Error("epoch-start VRank fill: GetCandTesting failed", "num", number, "err", err)
-		return nil, err
+// parentRoundCertificate reads the round and seals from this node's own stored parent, never from
+// seals gathered off the network: the proof of that round is the parent this node accepted.
+func (v *VRankModule) parentRoundCertificate(number uint64) (uint8, [][]byte, error) {
+	if !v.hasParentCertificate(number) {
+		return 0, nil, nil
 	}
-	encoded, err := vrank.EncodeAddressList(candidates)
-	if err != nil {
-		logger.Error("epoch-start VRank fill: EncodeAddressList failed", "num", number, "err", err)
-		return nil, err
+	parent := v.Chain.GetHeaderByNumber(number - 1)
+	if parent == nil {
+		return 0, nil, vrank.ErrHeaderNotFound
 	}
-	return encoded, nil
+	round, err := v.Sealer.Round(parent)
+	if err != nil {
+		return 0, nil, err
+	}
+	if round == 0 {
+		return 0, nil, nil
+	}
+	_, seals, err := v.Sealer.RawSeals(parent)
+	if err != nil {
+		return 0, nil, err
+	}
+	return round, seals, nil
 }
 
-func (v *VRankModule) encodeCandidateFailureVRank(number uint64) ([]byte, error) {
+// evaluateCandidateFailures reports on this proposer's own most recent prior proposal this epoch.
+func (v *VRankModule) evaluateCandidateFailures(number uint64) ([]common.Address, error) {
 	targetNum, round, ok := v.selectReportTarget(number)
 	if !ok {
 		// No own prior proposal this epoch (first proposal, or restart). Empty report — fail-safe.
@@ -127,15 +213,7 @@ func (v *VRankModule) encodeCandidateFailureVRank(number uint64) ([]byte, error)
 		return nil, err
 	}
 	v.collector.PruneReported(targetNum) // drop views older than targetNum; targetNum stays for re-report
-	if len(report) == 0 {
-		return nil, nil
-	}
-	encoded, err := vrank.EncodeReport(report)
-	if err != nil {
-		logger.Error("Failed to encode VRank report", "err", err, "report", report)
-		return nil, err
-	}
-	return encoded, nil
+	return report, nil
 }
 
 func validateNonEpochVRank(report, candidates []common.Address) error {

--- a/kaiax/vrank/impl/consensus_test.go
+++ b/kaiax/vrank/impl/consensus_test.go
@@ -17,6 +17,7 @@
 package impl
 
 import (
+	"crypto/ecdsa"
 	"math/big"
 	"testing"
 	"time"
@@ -24,6 +25,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/istanbul"
+	"github.com/kaiachain/kaia/crypto"
 	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/kaiax/vrank"
 	"github.com/kaiachain/kaia/params"
@@ -37,7 +40,7 @@ func makeSelfReportHeader(t *testing.T, number uint64, cfAddrs []common.Address)
 	t.Helper()
 	h := makeHeaderWithRound(number, 0)
 	if len(cfAddrs) > 0 {
-		encoded, err := vrank.EncodeReport(cfAddrs)
+		encoded, err := vrank.EncodeVRank(vrank.VRankPayload{Report: cfAddrs})
 		require.NoError(t, err)
 		h.VRank = encoded
 	}
@@ -46,7 +49,7 @@ func makeSelfReportHeader(t *testing.T, number uint64, cfAddrs []common.Address)
 
 func makeEpochStartVRankHeader(t *testing.T, number uint64, candidates []common.Address) *types.Header {
 	t.Helper()
-	encoded, err := vrank.EncodeAddressList(candidates)
+	encoded, err := vrank.EncodeVRank(vrank.VRankPayload{Report: candidates})
 	require.NoError(t, err)
 	return &types.Header{Number: big.NewInt(int64(number)), VRank: encoded}
 }
@@ -88,10 +91,10 @@ func TestVerifyHeader(t *testing.T) {
 			vrank.ErrEpochStartVRankMismatch)
 	})
 
-	t.Run("epoch-start: empty CandTesting is encoded as an RLP list", func(t *testing.T) {
+	t.Run("epoch-start: empty CandTesting leaves VRank absent", func(t *testing.T) {
 		v := newCN(t, withCandidates(nil)).VRankModule
 		h := makeEpochStartVRankHeader(t, params.DefaultVRankEpoch, nil)
-		assert.Equal(t, []byte{0xc0}, h.VRank)
+		assert.Nil(t, h.VRank)
 		assert.NoError(t, v.VerifyHeader(h, nil))
 	})
 
@@ -177,27 +180,27 @@ func TestPrepareHeader(t *testing.T) {
 	})
 
 	t.Run("epoch-start fills CandTesting", func(t *testing.T) {
-		v := newCN(t, withCandidates(candidates), withoutStart()).VRankModule
+		v := newCN(t, withCandidates(candidates), withoutStart(), withParentAt(params.DefaultVRankEpoch)).VRankModule
 		header := &types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}
 
 		require.NoError(t, v.PrepareHeader(header))
-		expected, err := vrank.EncodeAddressList(candidates)
+		expected, err := vrank.EncodeVRank(vrank.VRankPayload{Report: candidates})
 		require.NoError(t, err)
 		assert.Equal(t, expected, header.VRank)
 		assert.NoError(t, v.VerifyHeader(header, nil))
 	})
 
-	t.Run("epoch-start with no candidates writes encoded empty list", func(t *testing.T) {
-		v := newCN(t, withCandidates(nil), withoutStart()).VRankModule
+	t.Run("epoch-start with no candidates leaves VRank nil", func(t *testing.T) {
+		v := newCN(t, withCandidates(nil), withoutStart(), withParentAt(params.DefaultVRankEpoch)).VRankModule
 		header := &types.Header{Number: big.NewInt(int64(params.DefaultVRankEpoch))}
 
 		require.NoError(t, v.PrepareHeader(header))
-		assert.Equal(t, []byte{0xc0}, header.VRank)
+		assert.Nil(t, header.VRank)
 		assert.NoError(t, v.VerifyHeader(header, nil))
 	})
 
 	t.Run("non-epoch with no own proposal leaves VRank nil", func(t *testing.T) {
-		v := newCN(t, withoutStart()).VRankModule
+		v := newCN(t, withoutStart(), withParentAt(11)).VRankModule
 		header := &types.Header{Number: big.NewInt(11)}
 
 		require.NoError(t, v.PrepareHeader(header))
@@ -210,8 +213,11 @@ func TestPrepareHeader(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
 		valset.EXPECT().GetCandTesting(gomock.Any()).Return(candidates, nil).AnyTimes()
 		targetHeader := makeHeaderWithRound(target, round)
-		cn := newCN(t, withValset(valset), withoutStart(),
-			withHeaders(map[uint64]*types.Header{target: targetHeader}))
+		cn := newCN(t, withValset(valset), withoutStart(), withHeaders(map[uint64]*types.Header{
+			target: targetHeader,
+			// PrepareHeader(target+1) reads its parent for the certificate.
+			target + 1: makeHeaderWithRound(target+1, 0),
+		}))
 		valset.EXPECT().GetProposer(gomock.Any(), gomock.Any()).Return(cn.Addr, nil).AnyTimes()
 		cn.VRankModule.collector.AddPrepreparedTime(
 			vrank.ViewKey{N: target, R: uint8(round)}, time.Now(), types.NewBlockWithHeader(targetHeader).Hash())
@@ -219,24 +225,26 @@ func TestPrepareHeader(t *testing.T) {
 	}
 
 	t.Run("non-epoch reports candidate failures of own prior proposal", func(t *testing.T) {
-		v := setupOwnProposal(t, 10, 1)
+		v := setupOwnProposal(t, 10, 0)
 		header := makeHeaderWithRound(11, 0)
 
 		require.NoError(t, v.PrepareHeader(header))
-		report, err := vrank.DecodeReport(header.VRank)
+		payload, err := vrank.DecodeVRank(header.VRank)
 		require.NoError(t, err)
-		assert.Equal(t, candidates, report) // no responses collected ⇒ all candidates failed
+		assert.Equal(t, candidates, payload.Report) // no responses collected ⇒ all candidates failed
 		assert.NoError(t, v.VerifyHeader(header, nil))
 	})
 
-	t.Run("high-round own proposal yields nil VRank", func(t *testing.T) {
+	t.Run("high-round own proposal yields an empty report", func(t *testing.T) {
 		// An own proposal committed above MaxRound is evaluated as empty (candidate msgs were dropped),
 		// so it must not fail PrepareHeader.
 		v := setupOwnProposal(t, 10, int64(vrank.MaxRound+1))
 		header := &types.Header{Number: big.NewInt(11)}
 
 		require.NoError(t, v.PrepareHeader(header))
-		assert.Nil(t, header.VRank)
+		payload, err := vrank.DecodeVRank(header.VRank)
+		require.NoError(t, err)
+		assert.Empty(t, payload.Report)
 	})
 }
 
@@ -313,5 +321,153 @@ func TestSelectReportTarget(t *testing.T) {
 
 		_, _, ok := v.selectReportTarget(epoch + 1)
 		assert.False(t, ok)
+	})
+}
+
+// certifiedParent returns a parent committed at `round`, the hash the child must carry as
+// ParentHash, and the signers' seals over that (hash, round).
+func certifiedParent(t *testing.T, number uint64, round byte, signers []*ecdsa.PrivateKey) (*types.Header, common.Hash, [][]byte) {
+	t.Helper()
+	parent := makeHeaderWithRound(number, int64(round))
+	hash := newTestSealer().HeaderHash(parent)
+	seals := make([][]byte, 0, len(signers))
+	for _, key := range signers {
+		seal, err := istanbul.NewSealerImpl(key).MakeCommittedSealFromHashWithRound(hash, round)
+		require.NoError(t, err)
+		seals = append(seals, seal)
+	}
+	return parent, hash, seals
+}
+
+// TestVerifyHeaderParentRound covers the parent-round certificate: a committee quorum must have
+// committed the parent at the claimed round.
+func TestVerifyHeaderParentRound(t *testing.T) {
+	const (
+		parentNum   = uint64(20)
+		parentRound = byte(2)
+	)
+
+	keys := make([]*ecdsa.PrivateKey, 4)
+	committee := make([]common.Address, 4)
+	for i := range keys {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		keys[i] = key
+		committee[i] = crypto.PubkeyToAddress(key.PublicKey)
+	}
+	strangerKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	// quorum over a 4-member committee is 3
+	_, parentHash, quorumSeals := certifiedParent(t, parentNum, parentRound, keys[:3])
+	_, _, wrongRoundSeals := certifiedParent(t, parentNum, parentRound+1, keys[:3])
+	_, _, strangerSeals := certifiedParent(t, parentNum, parentRound, []*ecdsa.PrivateKey{keys[0], keys[1], strangerKey})
+	_, _, dupSeals := certifiedParent(t, parentNum, parentRound, []*ecdsa.PrivateKey{keys[0], keys[0], keys[1]})
+	_, _, overlongSeals := certifiedParent(t, parentNum, parentRound, append(keys, keys[0]))
+
+	testcases := []struct {
+		name        string
+		payload     vrank.VRankPayload
+		expectedErr error
+	}{
+		{"quorum of the round's committee is accepted", vrank.VRankPayload{ParentRound: parentRound, ParentCommittedSeal: quorumSeals}, nil},
+		{"seals bound to another round are rejected", vrank.VRankPayload{ParentRound: parentRound, ParentCommittedSeal: wrongRoundSeals}, vrank.ErrInvalidParentCertificate},
+		{"a signer outside the committee is rejected", vrank.VRankPayload{ParentRound: parentRound, ParentCommittedSeal: strangerSeals}, vrank.ErrInvalidParentCertificate},
+		{"a repeated signer is rejected", vrank.VRankPayload{ParentRound: parentRound, ParentCommittedSeal: dupSeals}, vrank.ErrInvalidParentCertificate},
+		{"below quorum is rejected", vrank.VRankPayload{ParentRound: parentRound, ParentCommittedSeal: quorumSeals[:2]}, vrank.ErrInvalidParentCertificate},
+		{"a round without seals is rejected", vrank.VRankPayload{ParentRound: parentRound}, vrank.ErrInvalidParentCertificate},
+		{"more seals than the committee is rejected", vrank.VRankPayload{ParentRound: parentRound, ParentCommittedSeal: overlongSeals}, vrank.ErrTooManyParentSeals},
+		{"round zero with seals is rejected", vrank.VRankPayload{ParentCommittedSeal: quorumSeals}, vrank.ErrUnexpectedParentSeal},
+		{"round zero without seals is accepted", vrank.VRankPayload{}, nil},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
+			valset.EXPECT().GetCommittee(parentNum, uint64(parentRound)).Return(committee, nil).AnyTimes()
+			valset.EXPECT().GetCandTesting(gomock.Any()).Return(nil, nil).AnyTimes()
+			v := newCN(t, withValset(valset), withoutStart()).VRankModule
+
+			encoded, err := vrank.EncodeVRank(tc.payload)
+			require.NoError(t, err)
+			header := &types.Header{
+				Number:     big.NewInt(int64(parentNum + 1)),
+				ParentHash: parentHash,
+				VRank:      encoded,
+			}
+
+			err = v.VerifyHeader(header, nil)
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+// TestPrepareHeaderCopiesParentCertificate checks that the certificate is copied from this node's
+// own stored parent and that the result verifies.
+func TestPrepareHeaderCopiesParentCertificate(t *testing.T) {
+	const (
+		parentNum   = uint64(30)
+		parentRound = byte(2)
+	)
+
+	keys := make([]*ecdsa.PrivateKey, 4)
+	committee := make([]common.Address, 4)
+	for i := range keys {
+		key, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		keys[i] = key
+		committee[i] = crypto.PubkeyToAddress(key.PublicKey)
+	}
+
+	parent, parentHash, seals := certifiedParent(t, parentNum, parentRound, keys[:3])
+	require.NoError(t, newTestSealer().WriteCommittedSeals(parent, seals))
+
+	valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
+	valset.EXPECT().GetCommittee(parentNum, uint64(parentRound)).Return(committee, nil).AnyTimes()
+	valset.EXPECT().GetCandTesting(gomock.Any()).Return(nil, nil).AnyTimes()
+	v := newCN(t, withValset(valset), withoutStart(),
+		withHeaders(map[uint64]*types.Header{parentNum: parent})).VRankModule
+
+	header := &types.Header{Number: big.NewInt(int64(parentNum + 1)), ParentHash: parentHash}
+	require.NoError(t, v.PrepareHeader(header))
+
+	payload, err := vrank.DecodeVRank(header.VRank)
+	require.NoError(t, err)
+	assert.Equal(t, parentRound, payload.ParentRound)
+	assert.Equal(t, seals, payload.ParentCommittedSeal)
+	assert.NoError(t, v.VerifyHeader(header, nil))
+}
+
+// TestParentRoundAbsentAtEpochStart checks that an epoch start records no parent round: its parent
+// belongs to the previous epoch, whose failures may not score into this one.
+func TestParentRoundAbsentAtEpochStart(t *testing.T) {
+	const epochStart = uint64(params.DefaultVRankEpoch)
+
+	t.Run("PrepareHeader drops a non-zero parent round", func(t *testing.T) {
+		parent := makeHeaderWithRound(epochStart-1, 2)
+		v := newCN(t, withCandidates(nil), withoutStart(),
+			withHeaders(map[uint64]*types.Header{epochStart - 1: parent})).VRankModule
+
+		header := &types.Header{Number: new(big.Int).SetUint64(epochStart)}
+		require.NoError(t, v.PrepareHeader(header))
+
+		payload, err := vrank.DecodeVRank(header.VRank)
+		require.NoError(t, err)
+		assert.Zero(t, payload.ParentRound)
+		assert.Empty(t, payload.ParentCommittedSeal)
+	})
+
+	t.Run("VerifyHeader rejects a recorded parent round", func(t *testing.T) {
+		v := newCN(t, withCandidates(nil), withoutStart()).VRankModule
+
+		encoded, err := vrank.EncodeVRank(vrank.VRankPayload{ParentRound: 2})
+		require.NoError(t, err)
+		header := &types.Header{Number: new(big.Int).SetUint64(epochStart), VRank: encoded}
+
+		assert.ErrorIs(t, v.VerifyHeader(header, nil), vrank.ErrUnexpectedParentRound)
 	})
 }

--- a/kaiax/vrank/impl/getter.go
+++ b/kaiax/vrank/impl/getter.go
@@ -40,18 +40,23 @@ func (v *VRankModule) cfReport(blockNum uint64) ([]common.Address, error) {
 	if header == nil {
 		return nil, vrank.ErrHeaderNotFound
 	}
-	return vrank.DecodeReport(header.VRank)
+	payload, err := vrank.DecodeVRank(header.VRank)
+	if err != nil {
+		return nil, err
+	}
+	return payload.Report, nil
 }
 
-// GetPfReport reads the committed pfReport for block blockNum from header.Extra.
-// Returns an empty report if the block was finalized at round 0.
+// GetPfReport returns the proposers that failed to produce block blockNum-1, as recorded in
+// block blockNum. Empty when the parent committed at round 0 or is not scored by blockNum.
 // Returns ErrNotPermissionless if blockNum is before the permissionless fork.
 // Used by applyBlocksForPFS so that catchUp can process pre-fork blocks without error.
-// GetPfReport returns the proposal failure report for the given block.
 func (v *VRankModule) GetPfReport(blockNum uint64) ([]common.Address, error) {
 	return v.pfReport(blockNum)
 }
 
+// pfReport reads ParentRound, not the parent's own round byte: that byte is outside the block
+// hash, so nodes may hold different values for one block.
 func (v *VRankModule) pfReport(blockNum uint64) ([]common.Address, error) {
 	if !v.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) {
 		return nil, vrank.ErrNotPermissionless
@@ -60,18 +65,18 @@ func (v *VRankModule) pfReport(blockNum uint64) ([]common.Address, error) {
 	if header == nil {
 		return nil, vrank.ErrHeaderNotFound
 	}
-	roundByte, err := v.Sealer.Round(header)
+	payload, err := vrank.DecodeVRank(header.VRank)
 	if err != nil {
 		return nil, err
 	}
-	round := uint64(roundByte)
-	if round == 0 {
+	if payload.ParentRound == 0 {
 		return []common.Address{}, nil
 	}
 
-	pfReport := make([]common.Address, 0, round)
-	for r := uint64(0); r < round; r++ {
-		proposer, err := v.Valset.GetProposer(blockNum, r)
+	parentNum := blockNum - 1
+	pfReport := make([]common.Address, 0, payload.ParentRound)
+	for r := uint64(0); r < uint64(payload.ParentRound); r++ {
+		proposer, err := v.Valset.GetProposer(parentNum, r)
 		if err != nil {
 			return nil, err
 		}

--- a/kaiax/vrank/impl/getter_test.go
+++ b/kaiax/vrank/impl/getter_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kaiachain/kaia/blockchain/types"
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/bft"
-	"github.com/kaiachain/kaia/consensus/istanbul"
 	mock_randao "github.com/kaiachain/kaia/kaiax/randao/mock"
 	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/kaiax/vrank"
@@ -40,7 +39,7 @@ import (
 func TestGetCfReport(t *testing.T) {
 	t.Run("returns decoded report from header.VRank", func(t *testing.T) {
 		c1, c2 := numToAddr(1), numToAddr(2)
-		encoded, err := vrank.EncodeReport([]common.Address{c1, c2})
+		encoded, err := vrank.EncodeVRank(vrank.VRankPayload{Report: []common.Address{c1, c2}})
 		require.NoError(t, err)
 		h := makeHeaderWithRound(10, 0)
 		h.VRank = encoded
@@ -93,7 +92,7 @@ func TestGetCfReport_Errors(t *testing.T) {
 // TestGetPfReport
 // ---------------------------------------------------------------------------
 func TestGetPfReport(t *testing.T) {
-	t.Run("round zero returns empty report", func(t *testing.T) {
+	t.Run("parent round zero returns empty report", func(t *testing.T) {
 		v := newCN(t, withHeaders(map[uint64]*types.Header{
 			10: makeHeaderWithRound(10, 0),
 		})).VRankModule
@@ -103,15 +102,15 @@ func TestGetPfReport(t *testing.T) {
 		assert.Empty(t, report)
 	})
 
-	t.Run("round greater than zero returns proposers in round order", func(t *testing.T) {
+	t.Run("parent round greater than zero returns proposers in round order", func(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
 		p0, p1, p2 := numToAddr(1), numToAddr(2), numToAddr(3)
-		valset.EXPECT().GetProposer(uint64(20), uint64(0)).Return(p0, nil).Times(2)
-		valset.EXPECT().GetProposer(uint64(20), uint64(1)).Return(p1, nil).Times(2)
-		valset.EXPECT().GetProposer(uint64(20), uint64(2)).Return(p2, nil).Times(2)
+		valset.EXPECT().GetProposer(uint64(19), uint64(0)).Return(p0, nil).Times(2)
+		valset.EXPECT().GetProposer(uint64(19), uint64(1)).Return(p1, nil).Times(2)
+		valset.EXPECT().GetProposer(uint64(19), uint64(2)).Return(p2, nil).Times(2)
 
 		v := newCN(t, withValset(valset), withHeaders(map[uint64]*types.Header{
-			20: makeHeaderWithRound(20, 3),
+			20: makeHeaderWithParentRound(20, 3),
 		})).VRankModule
 
 		report, err := v.pfReport(20)
@@ -146,24 +145,24 @@ func TestGetPfReport_Errors(t *testing.T) {
 		assert.Nil(t, report)
 	})
 
-	t.Run("short extra returns error", func(t *testing.T) {
-		v := newCN(t, withHeaders(map[uint64]*types.Header{
-			40: {Number: big.NewInt(40), Extra: make([]byte, istanbul.IstanbulExtraVanity-1)},
-		})).VRankModule
+	t.Run("undecodable vrank returns error", func(t *testing.T) {
+		header := makeHeaderWithRound(40, 0)
+		header.VRank = []byte{0x01, 0x02, 0x03}
+		v := newCN(t, withHeaders(map[uint64]*types.Header{40: header})).VRankModule
 
 		report, err := v.pfReport(40)
-		require.ErrorContains(t, err, "header extra is too short")
+		require.Error(t, err)
 		assert.Nil(t, report)
 	})
 
 	t.Run("GetProposer error is propagated", func(t *testing.T) {
 		valset := mock_valset.NewMockValsetModule(gomock.NewController(t))
 		p0 := numToAddr(11)
-		valset.EXPECT().GetProposer(uint64(50), uint64(0)).Return(p0, nil).Times(1)
-		valset.EXPECT().GetProposer(uint64(50), uint64(1)).Return(common.Address{}, assert.AnError).Times(1)
+		valset.EXPECT().GetProposer(uint64(49), uint64(0)).Return(p0, nil).Times(1)
+		valset.EXPECT().GetProposer(uint64(49), uint64(1)).Return(common.Address{}, assert.AnError).Times(1)
 
 		v := newCN(t, withValset(valset), withHeaders(map[uint64]*types.Header{
-			50: makeHeaderWithRound(50, 2),
+			50: makeHeaderWithParentRound(50, 2),
 		})).VRankModule
 
 		report, err := v.pfReport(50)

--- a/kaiax/vrank/impl/init_test.go
+++ b/kaiax/vrank/impl/init_test.go
@@ -263,8 +263,8 @@ func (testIstanbulSealer) RawSeals(h *types.Header) ([]byte, [][]byte, error) {
 	return newTestSealer().RawSeals(h)
 }
 
-func (testIstanbulSealer) RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
-	return newTestSealer().RecoverCommitters(hash, round, seals)
+func (testIstanbulSealer) RecoverCommitters(blockNum uint64, hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
+	return newTestSealer().RecoverCommitters(blockNum, hash, round, seals)
 }
 
 func (testIstanbulSealer) Quorum(blockNum uint64, qualifiedLen, committeeSize int) int {

--- a/kaiax/vrank/impl/init_test.go
+++ b/kaiax/vrank/impl/init_test.go
@@ -240,8 +240,16 @@ func (c *testChain) GetHeaderByNumber(number uint64) *types.Header {
 	return c.headers[number]
 }
 
+var testSealerKey, _ = crypto.GenerateKey()
+
+// newTestSealer returns a real sealer so seal writes and recovery behave as in production.
+func newTestSealer() *istanbul.IstanbulSealer {
+	return istanbul.NewSealerImpl(testSealerKey)
+}
+
 // testIstanbulSealer implements the vrank.Sealer interface for tests by reading the
-// round byte that makeHeaderWithRound writes into header.Extra.
+// round byte that makeHeaderWithRound writes into header.Extra. Seal reads and recovery
+// delegate to a real sealer, which is what the parent certificate is verified against.
 type testIstanbulSealer struct{}
 
 func (testIstanbulSealer) Round(h *types.Header) (byte, error) {
@@ -249,6 +257,18 @@ func (testIstanbulSealer) Round(h *types.Header) (byte, error) {
 		return 0, errors.New("header extra is too short")
 	}
 	return h.Extra[istanbul.IstanbulExtraVanity-1], nil
+}
+
+func (testIstanbulSealer) RawSeals(h *types.Header) ([]byte, [][]byte, error) {
+	return newTestSealer().RawSeals(h)
+}
+
+func (testIstanbulSealer) RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error) {
+	return newTestSealer().RecoverCommitters(hash, round, seals)
+}
+
+func (testIstanbulSealer) Quorum(blockNum uint64, qualifiedLen, committeeSize int) int {
+	return newTestSealer().Quorum(blockNum, qualifiedLen, committeeSize)
 }
 
 // Author returns the address withAuthor stashed in Rewardbase, so tests can make the author
@@ -271,9 +291,30 @@ func makeHeaderWithRound(number uint64, round int64) *types.Header {
 		Number:     big.NewInt(int64(number)),
 		Time:       big.NewInt(0),
 		BlockScore: big.NewInt(1),
-		Extra:      make([]byte, istanbul.IstanbulExtraVanity),
 	}
-	h.Extra[istanbul.IstanbulExtraVanity-1] = byte(round)
+	sealer := newTestSealer()
+	// A well-formed Istanbul extra, so the sealer can parse this header.
+	if err := sealer.WriteValidators(h, nil); err != nil {
+		panic(err)
+	}
+	sealer.WriteRound(h, round)
+	return h
+}
+
+// withParentAt seeds the round-0 parent that PrepareHeader(num) reads for the certificate.
+func withParentAt(num uint64) vrankOpt {
+	return withHeaders(map[uint64]*types.Header{num - 1: makeHeaderWithRound(num-1, 0)})
+}
+
+// makeHeaderWithParentRound declares the parent's round without a certificate: pfReport reads
+// the round, only VerifyHeader checks the seals.
+func makeHeaderWithParentRound(number uint64, parentRound uint8) *types.Header {
+	h := makeHeaderWithRound(number, 0)
+	encoded, err := vrank.EncodeVRank(vrank.VRankPayload{ParentRound: parentRound})
+	if err != nil {
+		panic(err)
+	}
+	h.VRank = encoded
 	return h
 }
 
@@ -302,12 +343,16 @@ func TestInit_CatchUpFromCheckpoint(t *testing.T) {
 	checkpoint := testCheckpointInterval // must be a testCheckpointInterval multiple
 	P1, P2, C1 := numToAddr(1), numToAddr(2), numToAddr(10)
 
-	// The tail block (checkpoint+1) has round=1, author=P2 and cfReport=[C1]:
-	//   - PFS:      pfReport=[P1] (proposer at round 0) → pfs[P1] incremented
-	//   - cpMatrix: reporter=P2   (the block's author)  → cpMatrix[C1][P2] incremented
+	// Tail block (checkpoint+1): round=1, author=P2, parent round=1, cfReport=[C1].
+	//   - PFS:      pfReport=[P1], the parent's round-0 proposer
+	//   - cpMatrix: reporter=P2, the block's author
+	tail := withAuthor(makeHeaderWithRound(checkpoint+1, 1), P2)
+	tailVRank, err := vrank.EncodeVRank(vrank.VRankPayload{Report: []common.Address{C1}, ParentRound: 1})
+	require.NoError(t, err)
+	tail.VRank = tailVRank
 	headers := map[uint64]*types.Header{
 		checkpoint:     makeHeaderWithRound(checkpoint, 0),
-		checkpoint + 1: withAuthor(makeHeaderWithVRank(checkpoint+1, 1, []common.Address{C1}), P2),
+		checkpoint + 1: tail,
 	}
 
 	db := database.NewMemDB()

--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -17,6 +17,7 @@
 package impl
 
 import (
+	"fmt"
 	"maps"
 	"math/big"
 	"slices"
@@ -154,7 +155,7 @@ func (v *VRankModule) epochCandidates(blockNum uint64) ([]common.Address, error)
 	logger.Warn("CandTesting unavailable from state, reading the epoch-start header", "num", blockNum, "err", err)
 	payload, decodeErr := vrank.DecodeVRank(header.VRank)
 	if decodeErr != nil {
-		return nil, err
+		return nil, fmt.Errorf("get CandTesting from state err: %v; decode epoch-start header VRank err: %w", err, decodeErr)
 	}
 	return payload.Report, nil
 }

--- a/kaiax/vrank/impl/scoring.go
+++ b/kaiax/vrank/impl/scoring.go
@@ -152,10 +152,15 @@ func (v *VRankModule) epochCandidates(blockNum uint64) ([]common.Address, error)
 		return nil, err
 	}
 	logger.Warn("CandTesting unavailable from state, reading the epoch-start header", "num", blockNum, "err", err)
-	return vrank.DecodeReport(header.VRank)
+	payload, decodeErr := vrank.DecodeVRank(header.VRank)
+	if decodeErr != nil {
+		return nil, err
+	}
+	return payload.Report, nil
 }
 
-// applyBlocksForPFS accumulates the pfReport for blocks in [start, end].
+// applyBlocksForPFS accumulates the pfReport recorded in blocks [start, end], which reports the
+// proposal failures at blocks [start, end-1]: an epoch start records nothing.
 func (v *VRankModule) applyBlocksForPFS(start, end uint64, seed map[common.Address]uint64) (map[common.Address]uint64, error) {
 	pfs := cloneMap(seed)
 	for blockNum := start; blockNum <= end; blockNum++ {

--- a/kaiax/vrank/impl/scoring_test.go
+++ b/kaiax/vrank/impl/scoring_test.go
@@ -47,7 +47,7 @@ func computeCFS(v *VRankModule, start, end uint64) (map[common.Address]uint64, e
 // cfAddrs may be nil/empty for an empty report.
 func makeHeaderWithVRank(number uint64, round int64, cfAddrs []common.Address) *types.Header {
 	h := makeHeaderWithRound(number, round)
-	encoded, err := vrank.EncodeReport(cfAddrs)
+	encoded, err := vrank.EncodeVRank(vrank.VRankPayload{Report: cfAddrs})
 	if err != nil {
 		panic(err)
 	}
@@ -111,14 +111,14 @@ func TestGetPFS(t *testing.T) {
 		headers := map[uint64]*types.Header{
 			0: makeHeaderWithRound(0, 0),
 			1: makeHeaderWithRound(1, 0),
-			2: makeHeaderWithRound(2, 1),
-			3: makeHeaderWithRound(3, 2),
+			2: makeHeaderWithParentRound(2, 1),
+			3: makeHeaderWithParentRound(3, 2),
 		}
 
 		cn := newCN(t, withHeaders(headers))
+		cn.Valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(p1, nil).Times(1)
 		cn.Valset.EXPECT().GetProposer(uint64(2), uint64(0)).Return(p1, nil).Times(1)
-		cn.Valset.EXPECT().GetProposer(uint64(3), uint64(0)).Return(p1, nil).Times(1)
-		cn.Valset.EXPECT().GetProposer(uint64(3), uint64(1)).Return(p2, nil).Times(1)
+		cn.Valset.EXPECT().GetProposer(uint64(2), uint64(1)).Return(p2, nil).Times(1)
 
 		v := cn.VRankModule
 		pfs, err := v.GetPFS(1)
@@ -139,7 +139,7 @@ func TestGetPFS(t *testing.T) {
 	})
 	t.Run("new epoch - scan one header", func(t *testing.T) {
 		epochStart := uint64(params.DefaultVRankEpoch)
-		headers := map[uint64]*types.Header{epochStart: makeHeaderWithRound(epochStart, 1)}
+		headers := map[uint64]*types.Header{epochStart: makeHeaderWithParentRound(epochStart, 1)}
 
 		cn := newCN(t, withHeaders(headers))
 		v := cn.VRankModule
@@ -149,7 +149,7 @@ func TestGetPFS(t *testing.T) {
 		pfs, err := v.GetPFS(epochStart - 1)
 		assert.Equal(t, uint64(99), pfs[proposer])
 
-		cn.Valset.EXPECT().GetProposer(uint64(epochStart), uint64(0)).Return(proposer, nil).Times(1)
+		cn.Valset.EXPECT().GetProposer(uint64(epochStart-1), uint64(0)).Return(proposer, nil).Times(1)
 		pfs, err = v.GetPFS(epochStart)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), pfs[proposer], "PFS must reset at epoch")
@@ -182,7 +182,7 @@ func TestGetPFS(t *testing.T) {
 		for i := range uint64(5) {
 			headers[i] = makeHeaderWithRound(i, 0)
 		}
-		headers[5] = makeHeaderWithRound(5, 1)
+		headers[5] = makeHeaderWithParentRound(5, 1)
 
 		proposer := numToAddr(1)
 		v := newCN(t, withProposer(proposer), withHeaders(headers)).VRankModule
@@ -221,12 +221,12 @@ func TestGetPFS_Errors(t *testing.T) {
 	t.Run("GetProposer error", func(t *testing.T) {
 		headers := map[uint64]*types.Header{
 			0: makeHeaderWithRound(0, 0),
-			1: makeHeaderWithRound(1, 1), // round=1 → needs GetProposer(1, 0)
+			1: makeHeaderWithParentRound(1, 1), // parent round=1 → needs GetProposer(0, 0)
 		}
 		cn := newCN(t, withHeaders(headers))
 		v := cn.VRankModule
 
-		cn.Valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(common.Address{}, assert.AnError)
+		cn.Valset.EXPECT().GetProposer(uint64(0), uint64(0)).Return(common.Address{}, assert.AnError)
 
 		_, err := v.GetPFS(1)
 		assert.ErrorIs(t, err, assert.AnError)
@@ -251,8 +251,8 @@ func TestGetPFS_CacheFallback(t *testing.T) {
 		for i := range uint64(5) {
 			headers[i] = makeHeaderWithRound(i, 0)
 		}
-		headers[5] = makeHeaderWithRound(5, 1)
-		headers[6] = makeHeaderWithRound(6, 1)
+		headers[5] = makeHeaderWithParentRound(5, 1)
+		headers[6] = makeHeaderWithParentRound(6, 1)
 
 		v := newCN(t, withHeaders(headers), withProposer(proposer)).VRankModule
 
@@ -273,8 +273,8 @@ func TestGetPFS_CacheFallback(t *testing.T) {
 	t.Run("no cache hit - scan all headers", func(t *testing.T) {
 		headers := map[uint64]*types.Header{
 			0: makeHeaderWithRound(0, 0),
-			1: makeHeaderWithRound(1, 1),
-			2: makeHeaderWithRound(2, 2),
+			1: makeHeaderWithParentRound(1, 1),
+			2: makeHeaderWithParentRound(2, 2),
 		}
 
 		// ensure no DB, no cache. Scans all headers in this case.
@@ -284,9 +284,9 @@ func TestGetPFS_CacheFallback(t *testing.T) {
 			require.False(t, inCache, "cache must be cold before first call")
 		}
 
+		cn.Valset.EXPECT().GetProposer(uint64(0), uint64(0)).Return(proposer, nil).Times(1)
 		cn.Valset.EXPECT().GetProposer(uint64(1), uint64(0)).Return(proposer, nil).Times(1)
-		cn.Valset.EXPECT().GetProposer(uint64(2), uint64(0)).Return(proposer, nil).Times(1)
-		cn.Valset.EXPECT().GetProposer(uint64(2), uint64(1)).Return(proposer, nil).Times(1)
+		cn.Valset.EXPECT().GetProposer(uint64(1), uint64(1)).Return(proposer, nil).Times(1)
 
 		pfs, err := cn.VRankModule.GetPFS(2)
 		require.NoError(t, err)
@@ -300,14 +300,14 @@ func TestGetPFS_CacheFallback(t *testing.T) {
 		for i := range blockNum {
 			headers[i] = makeHeaderWithRound(i, 0)
 		}
-		headers[blockNum] = makeHeaderWithRound(blockNum, 1) // one failure
+		headers[blockNum] = makeHeaderWithParentRound(blockNum, 1) // one failure
 
 		cn := newCN(t, withHeaders(headers))
 
 		// forge cache - it must be used
 		cn.VRankModule.pfsCache.Add(boundary, map[common.Address]uint64{proposer: 12345})
 
-		cn.Valset.EXPECT().GetProposer(blockNum, uint64(0)).Return(proposer, nil).Times(1)
+		cn.Valset.EXPECT().GetProposer(blockNum-1, uint64(0)).Return(proposer, nil).Times(1)
 
 		pfs, err := cn.VRankModule.GetPFS(blockNum)
 		require.NoError(t, err)
@@ -321,14 +321,14 @@ func TestGetPFS_CacheFallback(t *testing.T) {
 		for i := range blockNum {
 			headers[i] = makeHeaderWithRound(i, 0)
 		}
-		headers[blockNum] = makeHeaderWithRound(blockNum, 1) // one failure
+		headers[blockNum] = makeHeaderWithParentRound(blockNum, 1) // one failure
 
 		cn := newCN(t, withHeaders(headers))
 
 		// forge cache - it must NOT be used
 		cn.VRankModule.pfsCache.Add(boundary-1, map[common.Address]uint64{proposer: 12345})
 
-		cn.Valset.EXPECT().GetProposer(blockNum, uint64(0)).Return(proposer, nil).Times(1)
+		cn.Valset.EXPECT().GetProposer(blockNum-1, uint64(0)).Return(proposer, nil).Times(1)
 
 		pfs, err := cn.VRankModule.GetPFS(blockNum)
 		require.NoError(t, err)
@@ -354,16 +354,16 @@ func TestGetPFS_DBFallback(t *testing.T) {
 		assert.Equal(t, uint64(12345), pfs[proposer], "GetPFS(ckpt) must return the DB-stored checkpoint seed verbatim")
 	})
 	t.Run("checkpoint hit - advance one block accumulates", func(t *testing.T) {
-		headers := map[uint64]*types.Header{ckpt + 1: makeHeaderWithRound(ckpt+1, 1)}
+		headers := map[uint64]*types.Header{ckpt + 1: makeHeaderWithParentRound(ckpt+1, 1)}
 
 		db := database.NewMemDB()
 		WriteCheckpoint(db, ckpt, map[common.Address]uint64{proposer: 12345}, vrank.CPMatrix{})
 		WriteLastCheckpoint(db, ckpt)
 
 		cn := newCN(t, withDB(db), withHeaders(headers))
-		// ckpt+1 has round=1 → adds one pfReport on top of the checkpoint seed.
+		// ckpt+1 declares parent round 1 → adds one pfReport on top of the checkpoint seed.
 		// No epoch reset because ckpt is not an epoch boundary (ckpt = vrankEpoch/8).
-		cn.Valset.EXPECT().GetProposer(uint64(ckpt+1), uint64(0)).Return(proposer, nil).Times(1)
+		cn.Valset.EXPECT().GetProposer(uint64(ckpt), uint64(0)).Return(proposer, nil).Times(1)
 
 		pfs, err := cn.VRankModule.GetPFS(ckpt + 1)
 		require.NoError(t, err)
@@ -702,17 +702,17 @@ func TestApplyBlocksForPFS(t *testing.T) {
 	v.Chain = &testChain{
 		headers: map[uint64]*types.Header{
 			10: makeHeaderWithRound(10, 0),
-			11: makeHeaderWithRound(11, 2),
-			12: makeHeaderWithRound(12, 1),
+			11: makeHeaderWithParentRound(11, 2),
+			12: makeHeaderWithParentRound(12, 1),
 		},
 	}
 
 	// block 10, round 0: no GetProposer calls (loop [0,0) is empty)
 	// block 11, round 2: proposers for rounds 0 and 1
-	valset.EXPECT().GetProposer(uint64(11), uint64(0)).Return(p1, nil)
-	valset.EXPECT().GetProposer(uint64(11), uint64(1)).Return(p2, nil)
+	valset.EXPECT().GetProposer(uint64(10), uint64(0)).Return(p1, nil)
+	valset.EXPECT().GetProposer(uint64(10), uint64(1)).Return(p2, nil)
 	// block 12, round 1: proposer for round 0
-	valset.EXPECT().GetProposer(uint64(12), uint64(0)).Return(p1, nil)
+	valset.EXPECT().GetProposer(uint64(11), uint64(0)).Return(p1, nil)
 
 	pfs, err := v.applyBlocksForPFS(10, 12, make(map[common.Address]uint64))
 	require.NoError(t, err)

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -50,7 +50,7 @@ type Sealer interface {
 	Round(header *types.Header) (byte, error)
 	Author(header *types.Header) (common.Address, error)
 	RawSeals(header *types.Header) ([]byte, [][]byte, error)
-	RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error)
+	RecoverCommitters(blockNum uint64, hash common.Hash, round byte, seals [][]byte) ([]common.Address, error)
 	Quorum(blockNum uint64, qualifiedlen, committeeSize int) int
 }
 

--- a/kaiax/vrank/interface.go
+++ b/kaiax/vrank/interface.go
@@ -44,11 +44,14 @@ type BlsPubkeyGetter interface {
 	GetBlsPubkey(nodeId common.Address, num *big.Int) (bls.PublicKey, error)
 }
 
-// Sealer is a narrow interface for reading the round and the author from a block header.
+// Sealer is a narrow view of the seal data VRank reads and verifies.
 // Typically satisfied by consensus.Sealer via the istanbul backend.
 type Sealer interface {
 	Round(header *types.Header) (byte, error)
 	Author(header *types.Header) (common.Address, error)
+	RawSeals(header *types.Header) ([]byte, [][]byte, error)
+	RecoverCommitters(hash common.Hash, round byte, seals [][]byte) ([]common.Address, error)
+	Quorum(blockNum uint64, qualifiedlen, committeeSize int) int
 }
 
 type VRankModule interface {

--- a/kaiax/vrank/types.go
+++ b/kaiax/vrank/types.go
@@ -94,27 +94,39 @@ type VRankCandidate struct {
 	BlsSig      [blstypes.SignatureLength]byte // Sign(vrankCandidateSigHash(), blsKey)
 }
 
-// EncodeReport encodes the failed CandTesting addresses, or nil when empty so an absent VRank stays
-// the "nothing" encoding.
-func EncodeReport(failed []common.Address) ([]byte, error) {
-	if len(failed) == 0 {
+// VRankPayload is the decoded header.VRank field.
+type VRankPayload struct {
+	// Report is CandTesting(N) at epoch-start blocks and the cfReport elsewhere.
+	Report []common.Address
+	// ParentRound is the canonical round of block N-1, proven by ParentCommittedSeal.
+	// Round 0 claims no proposal failure, so it carries no seals.
+	ParentRound         uint8
+	ParentCommittedSeal [][]byte
+}
+
+// EncodeVRank returns nil for an empty payload so an absent VRank stays the "nothing" encoding.
+func EncodeVRank(payload VRankPayload) ([]byte, error) {
+	if len(payload.Report) == 0 && payload.ParentRound == 0 && len(payload.ParentCommittedSeal) == 0 {
 		return nil, nil
 	}
-	return EncodeAddressList(failed)
+	return rlp.EncodeToBytes(&payload)
 }
 
-func EncodeAddressList(addrs []common.Address) ([]byte, error) {
-	return rlp.EncodeToBytes(addrs)
-}
-
-func DecodeReport(data []byte) ([]common.Address, error) {
+func DecodeVRank(data []byte) (VRankPayload, error) {
+	// Decoded payloads always carry non-nil slices.
 	if len(data) == 0 {
-		return []common.Address{}, nil
+		return VRankPayload{Report: []common.Address{}, ParentCommittedSeal: [][]byte{}}, nil
 	}
 
-	var report []common.Address
-	if err := rlp.DecodeBytes(data, &report); err != nil {
-		return nil, err
+	var payload VRankPayload
+	if err := rlp.DecodeBytes(data, &payload); err != nil {
+		return VRankPayload{}, err
 	}
-	return report, nil
+	if payload.Report == nil {
+		payload.Report = []common.Address{}
+	}
+	if payload.ParentCommittedSeal == nil {
+		payload.ParentCommittedSeal = [][]byte{}
+	}
+	return payload, nil
 }

--- a/kaiax/vrank/types_test.go
+++ b/kaiax/vrank/types_test.go
@@ -82,6 +82,38 @@ type varSizePreprepare struct {
 	Sig   []byte
 }
 
+// ParentRound is a uint8, so RLP itself rejects a wider round: a header cannot declare a
+// parent round that the certificate could never be verified against.
+func TestDecodeVRankRejectsWideParentRound(t *testing.T) {
+	// Same field order as VRankPayload, with the round widened.
+	type widePayload struct {
+		Report              []common.Address
+		ParentRound         uint16
+		ParentCommittedSeal [][]byte
+	}
+	for _, tc := range []struct {
+		name    string
+		round   uint16
+		wantErr bool
+	}{
+		{"fits in a byte", 255, false},
+		{"needs two bytes", 256, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := rlp.EncodeToBytes(&widePayload{[]common.Address{}, tc.round, [][]byte{}})
+			require.NoError(t, err)
+
+			payload, err := DecodeVRank(data)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, uint8(tc.round), payload.ParentRound)
+		})
+	}
+}
+
 // The fixed-size fields are the only length guard: node/cn dropped its check for VRankCandidate
 // and never had one for VRankPreprepare.
 func TestVRankRLPSignatureLengths(t *testing.T) {

--- a/kaiax/vrank/types_test.go
+++ b/kaiax/vrank/types_test.go
@@ -31,41 +31,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEncodeDecodeReport(t *testing.T) {
+func TestEncodeDecodeVRank(t *testing.T) {
+	addrs := []common.Address{
+		common.HexToAddress("0x15d34AAf54267DB7D7cC839724318F2730aC377B"),
+		common.HexToAddress("0x9965507D1a55bcC2695C58ba16FB37d819D0A4DC"),
+	}
+	seals := [][]byte{make([]byte, 65), make([]byte, 65)}
+
 	cases := []struct {
-		name   string
-		report []common.Address
+		name        string
+		payload     VRankPayload
+		expectEmpty bool
 	}{
-		{
-			name:   "addresses",
-			report: []common.Address{common.HexToAddress("0x15d34AAf54267DB7D7cC839724318F2730aC377B"), common.HexToAddress("0x9965507D1a55bcC2695C58ba16FB37d819D0A4DC")},
-		},
-		{
-			name:   "empty",
-			report: []common.Address{},
-		},
+		// Decoding always yields non-nil slices, so the expectations spell out the empty ones.
+		{"report only", VRankPayload{Report: addrs, ParentCommittedSeal: [][]byte{}}, false},
+		{"parent round with seals", VRankPayload{Report: []common.Address{}, ParentRound: 3, ParentCommittedSeal: seals}, false},
+		{"both", VRankPayload{Report: addrs, ParentRound: 1, ParentCommittedSeal: seals}, false},
+		{"empty", VRankPayload{Report: []common.Address{}, ParentCommittedSeal: [][]byte{}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			enc, err := EncodeReport(tc.report)
-			assert.NoError(t, err)
-			if len(tc.report) == 0 {
-				assert.Nil(t, enc, "an empty report is encoded as absent bytes")
+			enc, err := EncodeVRank(tc.payload)
+			require.NoError(t, err)
+			if tc.expectEmpty {
+				assert.Nil(t, enc, "an empty payload is encoded as absent bytes")
 			} else {
 				assert.NotEmpty(t, enc)
 			}
-			gotReport, err := DecodeReport(enc)
-			assert.NoError(t, err)
-			assert.Equal(t, tc.report, gotReport)
+			got, err := DecodeVRank(enc)
+			require.NoError(t, err)
+			assert.Equal(t, tc.payload.Report, got.Report)
+			assert.Equal(t, tc.payload.ParentRound, got.ParentRound)
+			assert.Equal(t, tc.payload.ParentCommittedSeal, got.ParentCommittedSeal)
 		})
 	}
-}
-
-func TestEncodeAddressList_EmptyList(t *testing.T) {
-	// Epoch-start VRank encodes an empty CandTesting list as the canonical empty RLP list (0xc0).
-	enc, err := EncodeAddressList(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, []byte{0xc0}, enc)
 }
 
 // The pre-fixed-size shapes. A wrong signature length is only expressible from here.

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -890,6 +890,7 @@ func TestHandleBidMsg(t *testing.T) {
 
 			module := auction_mock.NewMockAuctionModule(ctrl)
 			peer := NewMockPeer(ctrl)
+			peer.EXPECT().ConnType().Return(common.CONSENSUSNODE).AnyTimes()
 			if tc.wantCall {
 				peer.EXPECT().GetID().Return(nodeids[0].String()).Times(1)
 				module.EXPECT().HandleBid(gomock.Any(), gomock.Any()).Times(1)


### PR DESCRIPTION
## Proposed changes

The consensus round is stored in a header byte that both header hashes clear, so two nodes can end up holding the same block with different rounds. `pfReport` is derived from that byte, so those nodes then compute different proposal failures, different node-state transitions and different qualified validator sets, and the node on the minority side rejects the next block with `header extra validators do not match qualified validators` and cannot recover.

This records the parent's round in `header.VRank` instead, with the parent's committed seals as proof that a committee quorum committed it at that round. Every node then reads one value agreed by the quorum that committed the block carrying it, rather than whichever round it happened to store. Epoch starts record no parent round, since their parent belongs to the previous epoch whose failures must not score into this one.

Verification checks only that the claimed round happened. It never compares against the node's own stored round: two honest nodes legitimately hold different rounds for one block, so comparing would make them reject each other's headers. A proposer can therefore claim a lower round that really happened, but cannot invent a higher one.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [x] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

## Further comments

Verified on a four-node local network with #1022 and #1031 applied on top of this branch. Both are needed for the scenario to exist at all: without #1022 a hash-locked re-proposal is rejected outright, so a second representation never forms. The control was the same two PRs on `dev` without this branch, so the only difference between the two runs is the commits here.

A temporary patch made three nodes drop that height's round-0 COMMITs and its propagated block, so one node committed the block at round 0 while the other three committed the same block, with the same hash, at round 1. On the control the node holding round 0 derived an empty proposal failure report, kept a four-validator qualified set and rejected the next block with `header extra validators do not match qualified validators`; the block went into the bad block database and that node stopped following the chain. With this branch the same split produced identical proposal failure reports, node states and state roots on all four nodes, and the node stayed with the chain. A separate run confirmed that the block following a round change carries the parent round together with a quorum of the parent's committed seals, and that every node accepts it.

The first commit belongs here rather than in a separate PR. This change makes committed seals decide proposal failures, so the question becomes whether seals can be obtained for a round that never happened. They can: the COMMIT rebroadcast for an already-committed block signs whatever round the caller names, without checking it against the round the responder stored. A caller can therefore gather a genuine quorum certificate for a round at which no quorum ever formed, and claim any number of failures. The first commit closes that by answering only for the round the node stored, which is what makes "cannot invent a higher round" true.

Determinism is what this buys; the recorded round is not guaranteed to be the highest one that happened, since absence cannot be proven. The header round byte is left in place for consensus and is no longer read by any state-affecting path. No chain has the permissionless fork enabled, so the format change affects no existing network.

The `GetProposer` fast path returns a block's author rather than the round's scheduled proposer, which makes `pfReport` node-dependent again once a recorded round reaches 2. #1031 removes it and should land alongside this.
