### PR TITLE
homi: default the minimum stake to the admission amount

### DIFF
--- a/cmd/homi/setup/flags.go
+++ b/cmd/homi/setup/flags.go
@@ -384,7 +384,7 @@ var (
 	rewardMinimumStakeFlag = &cli.StringFlag{
 		Name:    "reward-minimum-stake",
 		Usage:   "reward minimum stake flag",
-		Value:   "2000000",
+		Value:   "5000000",
 		Aliases: []string{"genesis.reward.minimum-stake"},
 	}
 


### PR DESCRIPTION
## Proposed changes

A permissionless genesis deposits the amount AddressBookV2 admits validators at, but the generic governance default for `reward.minimumstake` is lower, and that lower value is what the lifecycle demotes against. A validator could therefore withdraw down to it and stay active, while a new one still had to meet the higher amount to enter. Default the flag to the admission amount, which is what every other genesis template already writes.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
