### PR TITLE
kaiax/gov: validate the governing node successor

### DIFF
--- a/kaiax/gov/headergov/impl/header.go
+++ b/kaiax/gov/headergov/impl/header.go
@@ -164,10 +164,7 @@ func (h *headerGovModule) checkConsistency(blockNum uint64, vote headergov.VoteD
 			return nil
 		}
 
-		// we'll use blockNum-1 for the blocknumber of GetCouncil since blockNum cannot be available(eg. vote)
-		// it's definite that the valSet vote is not included in this block
-		// so the council(blockNum - 1) and council(blockNum) should be same
-		council, err := h.ValSet.GetCouncil(blockNum - 1)
+		council, err := h.ValSet.GetCouncil(blockNum)
 		if err != nil {
 			return err
 		}

--- a/kaiax/gov/headergov/impl/header.go
+++ b/kaiax/gov/headergov/impl/header.go
@@ -172,10 +172,22 @@ func (h *headerGovModule) checkConsistency(blockNum uint64, vote headergov.VoteD
 			return err
 		}
 
-		if slices.Contains(council, params.GoverningNode) {
+		if !slices.Contains(council, params.GoverningNode) {
+			return ErrGovNodeNotInValSetList
+		}
+		if !h.ChainConfig.IsPermissionlessForkEnabled(new(big.Int).SetUint64(blockNum)) {
 			return nil
 		}
-		return ErrGovNodeNotInValSetList
+
+		// After Permissionless only the governing node may vote, so a successor outside the council could never vote again.
+		newNode, ok := vote.Value().(common.Address)
+		if !ok || common.EmptyAddress(newNode) {
+			return ErrInvalidKeyValue
+		}
+		if !slices.Contains(council, newNode) {
+			return ErrGovNodeNotInValSetList
+		}
+		return nil
 	case gov.Kip71LowerBoundBaseFee:
 		params := h.GetParamSet(blockNum)
 		if vote.Value().(uint64) > params.UpperBoundBaseFee {

--- a/kaiax/gov/headergov/impl/header_test.go
+++ b/kaiax/gov/headergov/impl/header_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/kaiax/gov"
 	"github.com/kaiachain/kaia/kaiax/gov/headergov"
+	mock_valset "github.com/kaiachain/kaia/kaiax/valset/mock"
 	"github.com/kaiachain/kaia/log"
 	"github.com/kaiachain/kaia/storage/database"
 	"github.com/kaiachain/kaia/work/mocks"
@@ -175,6 +176,28 @@ func TestVerifyVote_GoverningNodeSuccessor(t *testing.T) {
 			assert.Equal(t, tc.expectedError, h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra}))
 		})
 	}
+}
+
+// VerifyVote admits a voter from the council at the block being verified, so the successor
+// is held to that council rather than the previous one.
+func TestVerifyVote_SuccessorUsesCouncilAtBlock(t *testing.T) {
+	newcomer := common.Address{7}
+	config := getTestChainConfig()
+	config.Governance.GoverningNode = validVoter
+	config.PermissionlessCompatibleBlock = common.Big0
+	h := newHeaderGovModule(t, config)
+
+	// The successor joined the council at the block being verified, not before it.
+	valSet := mock_valset.NewMockValsetModule(gomock.NewController(t))
+	valSet.EXPECT().GetCouncil(uint64(1)).Return([]common.Address{validVoter, newcomer}, nil).AnyTimes()
+	valSet.EXPECT().GetCouncil(uint64(0)).Return([]common.Address{validVoter}, nil).AnyTimes()
+	valSet.EXPECT().GetProposer(gomock.Any(), gomock.Any()).Return(validVoter, nil).AnyTimes()
+	h.ValSet = valSet
+
+	vote := headergov.NewVoteData(validVoter, string(gov.GovernanceGoverningNode), newcomer)
+	vb, err := vote.ToVoteBytes()
+	require.NoError(t, err)
+	assert.NoError(t, h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra}))
 }
 
 func TestGetVotesInEpoch(t *testing.T) {

--- a/kaiax/gov/headergov/impl/header_test.go
+++ b/kaiax/gov/headergov/impl/header_test.go
@@ -143,6 +143,40 @@ func TestVerifyVote_SingleMode(t *testing.T) {
 	})
 }
 
+// A successor outside the council could never vote after Permissionless, since only the
+// governing node may vote from then on.
+func TestVerifyVote_GoverningNodeSuccessor(t *testing.T) {
+	tcs := []struct {
+		desc           string
+		permissionless bool
+		governingNode  common.Address
+		successor      common.Address
+		expectedError  error
+	}{
+		{"council member", true, validVoter, validVoter, nil},
+		{"zero address", true, validVoter, common.Address{}, ErrInvalidKeyValue},
+		{"outside the council", true, validVoter, common.Address{9}, ErrGovNodeNotInValSetList},
+		{"pre-permissionless accepts any address", false, validVoter, common.Address{}, nil},
+		{"governing node outside the council", false, common.Address{2}, validVoter, ErrGovNodeNotInValSetList},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			config := getTestChainConfig()
+			config.Governance.GoverningNode = tc.governingNode
+			if tc.permissionless {
+				config.PermissionlessCompatibleBlock = common.Big0
+			} else {
+				config.PermissionlessCompatibleBlock = nil
+			}
+			h := newHeaderGovModule(t, config)
+			vote := headergov.NewVoteData(validVoter, string(gov.GovernanceGoverningNode), tc.successor)
+			vb, err := vote.ToVoteBytes()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedError, h.VerifyVote(&types.Header{Number: big.NewInt(1), Vote: vb, Extra: extra}))
+		})
+	}
+}
+
 func TestGetVotesInEpoch(t *testing.T) {
 	h := newHeaderGovModule(t, getTestChainConfig())
 


### PR DESCRIPTION
## Proposed changes

The consistency check for a governing-node vote compares the *current* governing node against the council and never inspects the proposed value, which only has to be a well-formed address. After Permissionless only the governing node may vote, and voting requires council membership, so a successor that is the zero address or outside the council leaves header governance with no way back. Validate the proposed value where that rule applies.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

The check is gated on Permissionless because `VerifyVote` also runs on pre-fork headers, and tightening it unconditionally could reject a header that was accepted before.
