### PR TITLE
refactor(system): use slices.SortFunc for KIP-113 nodes

### DIFF
--- a/blockchain/system/kip113.go
+++ b/blockchain/system/kip113.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"maps"
 	"math/big"
-	"sort"
+	"slices"
 	"strings"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -129,8 +129,8 @@ func AllocKip113Proxy(init AllocKip113Init) map[common.Hash]common.Hash {
 	for addr := range init.Infos {
 		addrs = append(addrs, addr)
 	}
-	sort.Slice(addrs, func(i, j int) bool {
-		return strings.Compare(addrs[i].Hex(), addrs[j].Hex()) > 0
+	slices.SortFunc(addrs, func(a, b common.Address) int {
+		return strings.Compare(b.Hex(), a.Hex())
 	})
 
 	// slot[201]: address[] allNodeIds;


### PR DESCRIPTION
## Proposed changes

<!--
- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Use `slices.SortFunc` for KIP-113 node address ordering while preserving the existing ordering and storage layout.


## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

N/A (behavior-preserving refactor)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


The comparator still produces the same address ordering; no hardfork or consensus behavior is introduced.