### PR TITLE
node/cn: expect the bid conntype check in the test

### DIFF
--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -890,6 +890,7 @@ func TestHandleBidMsg(t *testing.T) {
 
 			module := auction_mock.NewMockAuctionModule(ctrl)
 			peer := NewMockPeer(ctrl)
+			peer.EXPECT().ConnType().Return(common.CONSENSUSNODE).AnyTimes()
 			if tc.wantCall {
 				peer.EXPECT().GetID().Return(nodeids[0].String()).Times(1)
 				module.EXPECT().HandleBid(gomock.Any(), gomock.Any()).Times(1)


### PR DESCRIPTION
## Proposed changes

`handleBidMsg` gained a conntype check, but the size-gate subtests set up their peer mock without it, so the call is rejected and the handler returns before reaching the pool. Expect it, the way the sibling cases in this file already do.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [x] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

`dev` currently fails this test: the check and these subtests landed in separate PRs, so neither CI run saw the other.
