### PR TITLE
datasync/downloader: bind fetched staking info to the requested block

### DIFF
--- a/datasync/downloader/downloader.go
+++ b/datasync/downloader/downloader.go
@@ -92,6 +92,7 @@ var (
 	errInvalidChain            = errors.New("retrieved hash chain is invalid")
 	errInvalidBody             = errors.New("retrieved block body is invalid")
 	errInvalidReceipt          = errors.New("retrieved receipt is invalid")
+	errInvalidStakingInfo      = errors.New("retrieved staking info is invalid")
 	errCancelStateFetch        = errors.New("state data download canceled (requested)")
 	errCancelContentProcessing = errors.New("content processing canceled (requested)")
 	errCanceled                = errors.New("syncing canceled (requested)")
@@ -1887,8 +1888,9 @@ func (d *Downloader) commitFastSyncData(results []*fetchResult, stateSync *state
 		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions)
 		receipts[i] = result.Receipts
 		if result.StakingInfo != nil {
-			d.stakingModule.PutStakingInfoToDB(result.StakingInfo.BlockNum, staking.ToStakingInfo(result.StakingInfo))
-			logger.Info("Imported new staking information", "number", result.StakingInfo.BlockNum)
+			num := result.Header.Number.Uint64()
+			d.stakingModule.PutStakingInfoToDB(num, staking.ToStakingInfo(result.StakingInfo))
+			logger.Info("Imported new staking information", "number", num)
 		}
 	}
 	if index, err := d.blockchain.InsertReceiptChain(blocks, receipts); err != nil {
@@ -1902,8 +1904,8 @@ func (d *Downloader) commitPivotBlock(result *fetchResult) error {
 	block := types.NewBlockWithHeader(result.Header).WithBody(result.Transactions)
 	logger.Debug("Committing fast sync pivot as new head", "number", block.Number(), "hash", block.Hash())
 	if result.StakingInfo != nil {
-		d.stakingModule.PutStakingInfoToDB(result.StakingInfo.BlockNum, staking.ToStakingInfo(result.StakingInfo))
-		logger.Info("Imported new staking information on pivot block", "number", result.StakingInfo.BlockNum, "pivot", block.Number())
+		d.stakingModule.PutStakingInfoToDB(block.NumberU64(), staking.ToStakingInfo(result.StakingInfo))
+		logger.Info("Imported new staking information on pivot block", "number", block.NumberU64())
 	}
 	if _, err := d.blockchain.InsertReceiptChain([]*types.Block{block}, []types.Receipts{result.Receipts}); err != nil {
 		return err

--- a/datasync/downloader/queue.go
+++ b/datasync/downloader/queue.go
@@ -954,7 +954,12 @@ func (q *queue) DeliverStakingInfos(id string, stakingInfoList []*staking.P2PSta
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	validate := func(index int, header *types.Header) error {
-		// TODO-Kaia-Snapsync update validation logic
+		// The staking info is not committed to the header, so only its binding to the
+		// requested block can be checked here. The block number must match the header
+		// whose hash was requested; the result is later persisted under that number.
+		if stakingInfoList[index] == nil || stakingInfoList[index].BlockNum != header.Number.Uint64() {
+			return errInvalidStakingInfo
+		}
 		return nil
 	}
 

--- a/datasync/downloader/queue_test.go
+++ b/datasync/downloader/queue_test.go
@@ -23,6 +23,7 @@
 package downloader
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -573,4 +574,82 @@ func (n *network) headers(from int) []*types.Header {
 		}
 	}
 	return hdrs
+}
+
+// newStakingInfoQueue schedules the test chain on a fresh queue and reserves the
+// first two staking info fetches (blocks 4 and 8) for "peer-1".
+func newStakingInfoQueue(t *testing.T) *queue {
+	config := params.TestChainConfig.Copy()
+	config.Governance.Reward.StakingUpdateInterval = testInterval
+	config.KaiaCompatibleBlock = nil
+
+	q := newQueue(50, 50, uint64(istanbul.WeightedRandom), config)
+	q.Prepare(1, FastSync)
+	q.Schedule(chain.headers(), 1)
+
+	fetchReq, _, _ := q.ReserveStakingInfos(dummyPeer("peer-1"), 2)
+	if got, exp := len(fetchReq.Headers), 2; got != exp {
+		t.Fatalf("expected %d requests, got %d", exp, got)
+	}
+	for i, exp := range []uint64{4, 8} {
+		if got := fetchReq.Headers[i].Number.Uint64(); got != exp {
+			t.Fatalf("expected header %d at index %d, got %d", exp, i, got)
+		}
+	}
+	return q
+}
+
+// Tests that a staking info whose block number does not match the requested
+// header is rejected, the fetch is returned to the queue, and a matching
+// redelivery is accepted.
+func TestDeliverStakingInfosRejectsMismatchedBlockNum(t *testing.T) {
+	q := newStakingInfoQueue(t)
+	pending := q.PendingStakingInfos()
+
+	// The first entry claims block 8 for the header of block 4.
+	accepted, err := q.DeliverStakingInfos("peer-1", []*staking.P2PStakingInfo{{BlockNum: 8}, {BlockNum: 8}})
+	if accepted != 0 {
+		t.Fatalf("expected no accepted staking info, got %d", accepted)
+	}
+	if !errors.Is(err, errInvalidStakingInfo) {
+		t.Fatalf("expected %v, got %v", errInvalidStakingInfo, err)
+	}
+	if got, exp := q.PendingStakingInfos(), pending+2; got != exp {
+		t.Fatalf("expected %d pending staking infos after rejection, got %d", exp, got)
+	}
+
+	// The same blocks can be reserved again and a matching delivery is accepted.
+	fetchReq, _, _ := q.ReserveStakingInfos(dummyPeer("peer-1"), 2)
+	if got, exp := len(fetchReq.Headers), 2; got != exp {
+		t.Fatalf("expected %d requests, got %d", exp, got)
+	}
+	accepted, err = q.DeliverStakingInfos("peer-1", []*staking.P2PStakingInfo{{BlockNum: 4}, {BlockNum: 8}})
+	if accepted != 2 || err != nil {
+		t.Fatalf("expected 2 accepted staking infos, got %d (err %v)", accepted, err)
+	}
+	if got, exp := q.PendingStakingInfos(), pending; got != exp {
+		t.Fatalf("expected %d pending staking infos after delivery, got %d", exp, got)
+	}
+}
+
+// Tests that a batch is accepted only up to the first mismatched entry and the
+// rest is returned to the queue.
+func TestDeliverStakingInfosAcceptsValidPrefix(t *testing.T) {
+	q := newStakingInfoQueue(t)
+	pending := q.PendingStakingInfos()
+
+	accepted, err := q.DeliverStakingInfos("peer-1", []*staking.P2PStakingInfo{{BlockNum: 4}, {BlockNum: 12}})
+	if accepted != 1 {
+		t.Fatalf("expected 1 accepted staking info, got %d", accepted)
+	}
+	if err == nil {
+		t.Fatal("expected a partial failure, got nil")
+	}
+	if got, exp := q.PendingStakingInfos(), pending+1; got != exp {
+		t.Fatalf("expected %d pending staking infos, got %d", exp, got)
+	}
+	fetchReq, _, _ := q.ReserveStakingInfos(dummyPeer("peer-1"), 1)
+	if got, exp := fetchReq.Headers[0].Number.Uint64(), uint64(8); got != exp {
+		t.Fatalf("expected the rejected block %d to be requeued, got %d", exp, got)
+	}
 }


### PR DESCRIPTION
## Proposed changes

During fast and snap sync, a staking info reply from the peer holding the pending request was accepted without any check against the requested header (`queue.DeliverStakingInfos` had a `TODO` validator that always returned nil), and the result was persisted under the `BlockNum` embedded in the reply. A peer could therefore mark a requested block as done while writing its data under a different block number, and the requested block was never fetched again.

This change rejects a reply entry whose `BlockNum` does not match the header whose hash was requested (`errInvalidStakingInfo`), so `queue.deliver` returns the fetch to the task queue and it is retried, and persists the result under the header's block number in `commitFastSyncData` and `commitPivotBlock`. The recovery path (`SyncStakingInfo`) was already bound to its request in #1051 and is unchanged.

Fast sync is rejected at startup and snap sync is rejected in `checkSyncMode`, so this path is not reachable on a running node today. The check is a prerequisite for enabling snap sync again.

Known limitation kept as is: a peer that keeps returning a mismatched entry is set idle and retried, not dropped. This matches how `errInvalidBody` and `errInvalidReceipt` are handled today.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

Follow-up to #1051.

## Further comments

The staking info is not committed to the header, so the content of an entry cannot be verified during sync; only its binding to the requested block can be. The two new tests in `queue_test.go` cover a mismatched batch (rejected whole and requeued, then accepted on a matching redelivery) and a batch with a valid prefix (accepted up to the first mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
