### PR TITLE
node: bound blob sidecars

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -1594,17 +1594,21 @@ func handleTxMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		// defensive measure against potential DoS attacks.
 		if tx.Type() == types.TxTypeEthereumBlob {
 			// Without blob hashes the verification below passes vacuously.
-			if len(tx.BlobHashes()) == 0 {
+			hashes := tx.BlobHashes()
+			if len(hashes) == 0 {
 				return errResp(ErrDecode, "Invalid blob transaction with sidecar: %v", errBloblessBlobTx)
+			}
+			if len(hashes) > params.BlobTxMaxBlobs {
+				return errResp(ErrDecode, "Invalid blob transaction with sidecar: blob limit exceeded: have %d, permitted %d", len(hashes), params.BlobTxMaxBlobs)
 			}
 			sidecar := tx.BlobTxSidecar()
 			if sidecar != nil {
-				key := blobSidecarKey(tx.BlobHashes(), sidecar)
+				key := blobSidecarKey(hashes, sidecar)
 				if !pm.verifiedBlobTxs.Contains(key) {
 					// If any of the transaction contains invalid KZG sidecar, terminate transaction processing immediately.
 					// KZG verification is computationally expensive, so this acts as a
 					// defensive measure against potential DoS attacks.
-					if err := sidecar.ValidateWithBlobHashes(tx.BlobHashes()); err != nil {
+					if err := sidecar.ValidateWithBlobHashes(hashes); err != nil {
 						logger.Warn("Disconnect peer for protocol violation", "peer", p.GetID(), "error", err)
 						return errResp(ErrDecode, "Invalid blob transaction with sidecar: %v", errKZGVerificationError)
 					}

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -456,6 +456,24 @@ func TestHandleTxMsg_BloblessBlobTx(t *testing.T) {
 	assert.Contains(t, err.Error(), errBloblessBlobTx.Error())
 }
 
+func TestHandleTxMsg_BlobLimit(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pm, mockPeer, _ := prepareBlobTxMsg(t, mockCtrl)
+	sidecar, hashes := newBlobSidecar(t)
+	sidecar.Blobs = append(sidecar.Blobs, sidecar.Blobs[0])
+	sidecar.Commitments = append(sidecar.Commitments, sidecar.Commitments[0])
+	sidecar.Proofs = append(sidecar.Proofs, sidecar.Proofs...)
+	hashes = append(hashes, hashes[0])
+	tx := newBlobTx(t, 0, hashes, sidecar)
+
+	err := handleTxMsg(pm, mockPeer, generateMsg(t, TxMsg, types.Transactions{tx}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "blob limit exceeded")
+	assert.Equal(t, 0, pm.verifiedBlobTxs.Len())
+}
+
 func prepareTestHandleBlockHeaderFetchRequestMsg(t *testing.T) (*gomock.Controller, *MockPeer, *mocks.MockBlockChain, *ProtocolManager) {
 	mockCtrl := gomock.NewController(t)
 	mockPeer := NewMockPeer(mockCtrl)


### PR DESCRIPTION
## Proposed changes

- Enforce BlobTxMaxBlobs before processing blob sidecars.
- Reuse the validated blob hashes for sidecar verification and caching.
- Add a regression test confirming that transactions exceeding the limit are rejected before sidecar verification.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
