### PR TITLE
consensus: bound consensus message shape

### DIFF
--- a/consensus/bft/codec.go
+++ b/consensus/bft/codec.go
@@ -23,6 +23,7 @@ import (
 	"io"
 
 	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/rlp"
 )
 
@@ -81,6 +82,9 @@ func (m *Message) FromPayload(b []byte, validateFn func([]byte, []byte) (common.
 	if err := rlp.DecodeBytes(b, &m); err != nil {
 		return err
 	}
+	if err := m.validateCommittedSealLength(); err != nil {
+		return err
+	}
 	if validateFn != nil {
 		payload, err := m.PayloadNoSig()
 		if err != nil {
@@ -92,6 +96,21 @@ func (m *Message) FromPayload(b []byte, validateFn func([]byte, []byte) (common.
 		}
 		if !bytes.Equal(signerAddr.Bytes(), m.Address.Bytes()) {
 			return ErrInvalidSigner
+		}
+	}
+	return nil
+}
+
+// validateCommittedSealLength checks the envelope shape before signature recovery.
+func (m *Message) validateCommittedSealLength() error {
+	switch m.Code {
+	case MsgCommit:
+		if len(m.CommittedSeal) != crypto.SignatureLength {
+			return fmt.Errorf("%w: committed seal length %d", ErrInvalidMessage, len(m.CommittedSeal))
+		}
+	case MsgPreprepare, MsgPrepare, MsgRoundChange:
+		if len(m.CommittedSeal) != 0 {
+			return fmt.Errorf("%w: unexpected committed seal on message code %d", ErrInvalidMessage, m.Code)
 		}
 	}
 	return nil

--- a/consensus/bft/messages_test.go
+++ b/consensus/bft/messages_test.go
@@ -18,11 +18,13 @@ package bft_test
 
 import (
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/crypto"
 	"github.com/kaiachain/kaia/rlp"
 )
 
@@ -131,6 +133,82 @@ func TestMessageRoundTrip(t *testing.T) {
 		!equalBytes(decoded.Signature, orig.Signature) ||
 		!equalBytes(decoded.CommittedSeal, orig.CommittedSeal) {
 		t.Fatalf("round-trip mismatch: got %+v want %+v", &decoded, orig)
+	}
+}
+
+func TestMessageFromPayloadRejectsUnexpectedCommittedSealLengthBeforeSignatureRecovery(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *bft.Message
+	}{
+		{
+			name: "prepare with committed seal",
+			msg: &bft.Message{
+				Code: bft.MsgPrepare, Signature: make([]byte, crypto.SignatureLength),
+				CommittedSeal: []byte{1},
+			},
+		},
+		{
+			name: "round change with committed seal",
+			msg: &bft.Message{
+				Code: bft.MsgRoundChange, Signature: make([]byte, crypto.SignatureLength),
+				CommittedSeal: []byte{1},
+			},
+		},
+		{
+			name: "commit without committed seal",
+			msg:  &bft.Message{Code: bft.MsgCommit, Signature: make([]byte, crypto.SignatureLength)},
+		},
+		{
+			name: "commit with oversized committed seal",
+			msg: &bft.Message{
+				Code: bft.MsgCommit, Signature: make([]byte, crypto.SignatureLength),
+				CommittedSeal: make([]byte, crypto.SignatureLength+1),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := tc.msg.Payload()
+			if err != nil {
+				t.Fatal(err)
+			}
+			called := false
+			var decoded bft.Message
+			err = decoded.FromPayload(payload, func([]byte, []byte) (common.Address, error) {
+				called = true
+				return tc.msg.Address, nil
+			})
+			if !errors.Is(err, bft.ErrInvalidMessage) {
+				t.Fatalf("got %v, want ErrInvalidMessage", err)
+			}
+			if called {
+				t.Fatal("signature recovery ran for an invalid committed seal")
+			}
+		})
+	}
+}
+
+func TestMessageFromPayloadAcceptsValidEnvelopeShapes(t *testing.T) {
+	tests := []*bft.Message{
+		{Code: bft.MsgPreprepare, Signature: make([]byte, crypto.SignatureLength)},
+		{Code: bft.MsgPrepare, Signature: make([]byte, crypto.SignatureLength)},
+		{Code: bft.MsgCommit, Signature: make([]byte, crypto.SignatureLength), CommittedSeal: make([]byte, crypto.SignatureLength)},
+		{Code: bft.MsgRoundChange, Signature: make([]byte, crypto.SignatureLength)},
+	}
+
+	for _, msg := range tests {
+		payload, err := msg.Payload()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var decoded bft.Message
+		if err := decoded.FromPayload(payload, func([]byte, []byte) (common.Address, error) {
+			return msg.Address, nil
+		}); err != nil {
+			t.Fatalf("message code %d: %v", msg.Code, err)
+		}
 	}
 }
 

--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -23,6 +23,8 @@
 package core
 
 import (
+	"math/big"
+
 	"github.com/kaiachain/kaia/common"
 	"github.com/kaiachain/kaia/common/prque"
 	"github.com/kaiachain/kaia/consensus/bft"
@@ -35,6 +37,22 @@ var msgPriority = map[uint64]int{
 	bft.MsgCommit:     2,
 	bft.MsgPrepare:    3,
 }
+
+const (
+	// The limits below bound both the number and payload size of retained future
+	// messages. A PREPREPARE carries an entire block, so a count-only limit is
+	// not sufficient to bound backlog memory.
+	maxBacklogMessagesPerSender     = 128
+	maxBacklogPayloadBytesPerSender = 16 * 1024 * 1024
+	// Global limits allow up to eight senders to reach their per-sender limits.
+	maxBacklogMessages     = 1024
+	maxBacklogPayloadBytes = 128 * 1024 * 1024
+	// Keep only a small future-sequence window so far-future messages cannot
+	// occupy the global backlog budget until the node catches up. A node further
+	// behind than this window catches up through block synchronization rather
+	// than through retained consensus messages.
+	maxBacklogSequencesAhead = 8
+)
 
 // checkMessage checks the message state
 // return bft.ErrInvalidMessage if the message is invalid
@@ -99,25 +117,78 @@ func (c *core) storeBacklog(msg *bft.Message, src common.Address) {
 	defer c.backlogsMu.Unlock()
 
 	backlog := c.backlogs[src]
+	messageBytes := backlogMessageBytes(msg)
+	if c.backlogLimitReached(src, backlog, messageBytes) {
+		// A full backlog is expected under load; avoid a warning for every
+		// dropped message.
+		logger.Trace("Discarding future message: backlog limit reached")
+		return
+	}
+
+	view, err := msg.GetView()
+	if err != nil || view == nil || view.Sequence == nil || view.Round == nil {
+		logger.Trace("Discarding future message: cannot decode view", "err", err)
+		return
+	}
+	if c.isBacklogSequenceTooFar(view.Sequence) {
+		logger.Trace("Discarding future message: sequence is too far ahead", "sequence", view.Sequence)
+		return
+	}
 	if backlog == nil {
 		backlog = prque.New()
+		c.backlogs[src] = backlog
 	}
-	switch msg.Code {
-	case bft.MsgPreprepare:
-		var p *bft.Preprepare
-		err := msg.Decode(&p)
-		if err == nil {
-			backlog.Push(msg, toPriority(msg.Code, p.View))
-		}
-		// for bft.MsgRoundChange, bft.MsgPrepare and bft.MsgCommit cases
-	default:
-		var p *bft.Subject
-		err := msg.Decode(&p)
-		if err == nil {
-			backlog.Push(msg, toPriority(msg.Code, p.View))
-		}
+	// toPriority truncates the sequence, so it runs only after
+	// isBacklogSequenceTooFar has rejected sequences that do not fit in uint64.
+	backlog.Push(msg, toPriority(msg.Code, view))
+	c.backlogMessageCount++
+	c.backlogSenderBytes[src] += messageBytes
+	c.backlogPayloadBytes += messageBytes
+}
+
+func (c *core) isBacklogSequenceTooFar(sequence *big.Int) bool {
+	if !sequence.IsUint64() {
+		return true
 	}
-	c.backlogs[src] = backlog
+	maxSequence := new(big.Int).Add(c.currentView().Sequence, big.NewInt(maxBacklogSequencesAhead))
+	return sequence.Cmp(maxSequence) > 0
+}
+
+func backlogMessageBytes(msg *bft.Message) uint64 {
+	return uint64(len(msg.Msg)) + uint64(len(msg.Signature)) + uint64(len(msg.CommittedSeal))
+}
+
+func exceedsBacklogLimit(used, additional, limit uint64) bool {
+	return additional > limit || used > limit-additional
+}
+
+// backlogLimitReached reports whether retaining a message would exceed a
+// per-sender or global backlog limit. backlogsMu must be held by the caller.
+func (c *core) backlogLimitReached(src common.Address, backlog *prque.Prque, messageBytes uint64) bool {
+	if backlog != nil && backlog.Size() >= maxBacklogMessagesPerSender {
+		return true
+	}
+	if c.backlogMessageCount >= maxBacklogMessages {
+		return true
+	}
+	if exceedsBacklogLimit(c.backlogSenderBytes[src], messageBytes, maxBacklogPayloadBytesPerSender) {
+		return true
+	}
+	return exceedsBacklogLimit(c.backlogPayloadBytes, messageBytes, maxBacklogPayloadBytes)
+}
+
+// removeBacklogMessage updates accounting while backlogsMu is held. It also
+// drops the sender's byte entry once its last retained message is removed, so
+// no explicit cleanup is needed when the sender's queue becomes empty.
+func (c *core) removeBacklogMessage(src common.Address, msg *bft.Message) {
+	messageBytes := backlogMessageBytes(msg)
+	c.backlogMessageCount--
+	c.backlogPayloadBytes -= messageBytes
+	if senderBytes := c.backlogSenderBytes[src]; senderBytes > messageBytes {
+		c.backlogSenderBytes[src] = senderBytes - messageBytes
+	} else {
+		delete(c.backlogSenderBytes, src)
+	}
 }
 
 func (c *core) processBacklog() {
@@ -130,12 +201,11 @@ func (c *core) processBacklog() {
 		}
 
 		logger := c.logger.NewWith("from", src, "state", c.state)
-		isFuture := false
 
 		// We stop processing if
 		//   1. backlog is empty
 		//   2. The first message in queue is a future message
-		for !(backlog.Empty() || isFuture) {
+		for !backlog.Empty() {
 			m, prio := backlog.Pop()
 			msg := m.(*bft.Message)
 			var view *bft.View
@@ -143,22 +213,22 @@ func (c *core) processBacklog() {
 			switch msg.Code {
 			case bft.MsgPreprepare:
 				var m *bft.Preprepare
-				err := msg.Decode(&m)
-				if err == nil {
+				if err := msg.Decode(&m); err == nil && m != nil {
 					view = m.View
+					if m.Proposal != nil {
+						prevHash = m.Proposal.ParentHash()
+					}
 				}
-				prevHash = m.Proposal.ParentHash()
-				// for bft.MsgRoundChange, bft.MsgPrepare and bft.MsgCommit cases
 			default:
 				var sub *bft.Subject
-				err := msg.Decode(&sub)
-				if err == nil {
+				if err := msg.Decode(&sub); err == nil && sub != nil {
 					view = sub.View
+					prevHash = sub.PrevHash
 				}
-				prevHash = sub.PrevHash
 			}
 			if view == nil {
 				logger.Debug("Nil view", "msg", msg)
+				c.removeBacklogMessage(src, msg)
 				continue
 			}
 			// Push back if it's a future message
@@ -167,19 +237,26 @@ func (c *core) processBacklog() {
 				if err == errFutureMessage {
 					logger.Trace("Stop processing backlog", "msg", msg)
 					backlog.Push(msg, prio)
-					isFuture = true
 					break
 				}
 				logger.Trace("Skip the backlog event", "msg", msg, "err", err)
+				c.removeBacklogMessage(src, msg)
 				continue
 			}
 			logger.Trace("Post backlog event", "msg", msg)
+			c.removeBacklogMessage(src, msg)
 
 			go c.sendEvent(backlogEvent{
 				src:  src,
 				msg:  msg,
 				Hash: prevHash,
 			})
+		}
+
+		// Do not retain prque's backing storage after all messages from this
+		// sender have been processed or discarded.
+		if backlog.Empty() {
+			delete(c.backlogs, src)
 		}
 	}
 }

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/common/prque"
+	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBacklogCore() *core {
+	qualified := valset.NewAddressSet(nil)
+	return &core{
+		address:            common.HexToAddress("0xdead"),
+		state:              StateAcceptRequest,
+		logger:             logger.NewWith(),
+		backlogs:           make(map[common.Address]*prque.Prque),
+		backlogsMu:         new(sync.Mutex),
+		backlogSenderBytes: make(map[common.Address]uint64),
+		current:            newRoundState(&bft.View{Sequence: big.NewInt(1), Round: big.NewInt(0)}, qualified, common.Hash{}, nil, nil, nil),
+	}
+}
+
+// backlogSender returns a sender address that never collides with the address of
+// the core under test, so senders can be numbered from one.
+func backlogSender(i int) common.Address {
+	return common.BigToAddress(big.NewInt(int64(i)))
+}
+
+func newTestBacklogMessage(t *testing.T, sequence int64) *bft.Message {
+	t.Helper()
+	payload, err := bft.Encode(&bft.Subject{View: &bft.View{
+		Sequence: big.NewInt(sequence),
+		Round:    big.NewInt(0),
+	}})
+	require.NoError(t, err)
+	return &bft.Message{Code: bft.MsgPrepare, Msg: payload}
+}
+
+func TestStoreBacklogBoundsMessagesPerSender(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	c := newTestBacklogCore()
+	msg := newTestBacklogMessage(t, 2)
+
+	for range maxBacklogMessagesPerSender + 1 {
+		c.storeBacklog(msg, src)
+	}
+
+	assert.Equal(t, maxBacklogMessagesPerSender, c.backlogs[src].Size())
+	assert.Equal(t, maxBacklogMessagesPerSender, c.backlogMessageCount)
+}
+
+func TestStoreBacklogBoundsPayloadBytesPerSender(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	msg := newTestBacklogMessage(t, 2)
+	c := newTestBacklogCore()
+	msg.Signature = make([]byte, int(maxBacklogPayloadBytesPerSender-backlogMessageBytes(msg)+1))
+
+	c.storeBacklog(msg, src)
+
+	assert.Empty(t, c.backlogs)
+	assert.Empty(t, c.backlogSenderBytes)
+	assert.Zero(t, c.backlogMessageCount)
+	assert.Zero(t, c.backlogPayloadBytes)
+}
+
+func TestStoreBacklogBoundsMessagesAcrossSenders(t *testing.T) {
+	require.Zero(t, maxBacklogMessages%maxBacklogMessagesPerSender,
+		"the test fills the global cap with senders that each reach the per-sender cap")
+	senders := maxBacklogMessages / maxBacklogMessagesPerSender
+	c := newTestBacklogCore()
+	msg := newTestBacklogMessage(t, 2)
+
+	for sender := 1; sender <= senders; sender++ {
+		for range maxBacklogMessagesPerSender {
+			c.storeBacklog(msg, backlogSender(sender))
+		}
+	}
+	rejected := backlogSender(senders + 1)
+	c.storeBacklog(msg, rejected)
+
+	assert.Equal(t, maxBacklogMessages, c.backlogMessageCount)
+	assert.Len(t, c.backlogs, senders)
+	assert.NotContains(t, c.backlogs, rejected)
+}
+
+func TestStoreBacklogBoundsPayloadBytesAcrossSenders(t *testing.T) {
+	require.Zero(t, maxBacklogPayloadBytes%maxBacklogPayloadBytesPerSender,
+		"the test fills the global cap with senders that each reach the per-sender byte cap")
+	senders := maxBacklogPayloadBytes / maxBacklogPayloadBytesPerSender
+	msg := newTestBacklogMessage(t, 2)
+	// One message per sender, sized to exactly the per-sender byte cap.
+	msg.Signature = make([]byte, int(maxBacklogPayloadBytesPerSender-backlogMessageBytes(msg)))
+	c := newTestBacklogCore()
+
+	for sender := 1; sender <= senders; sender++ {
+		c.storeBacklog(msg, backlogSender(sender))
+	}
+	rejected := backlogSender(senders + 1)
+	c.storeBacklog(msg, rejected)
+
+	assert.Equal(t, senders, c.backlogMessageCount)
+	assert.Equal(t, uint64(maxBacklogPayloadBytes), c.backlogPayloadBytes)
+	assert.NotContains(t, c.backlogs, rejected)
+}
+
+func TestStoreBacklogBoundsFutureSequence(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	c := newTestBacklogCore()
+
+	c.storeBacklog(newTestBacklogMessage(t, 1+maxBacklogSequencesAhead), src)
+	c.storeBacklog(newTestBacklogMessage(t, 2+maxBacklogSequencesAhead), src)
+
+	assert.Equal(t, 1, c.backlogs[src].Size())
+	assert.Equal(t, 1, c.backlogMessageCount)
+}
+
+func TestBacklogRejectsSequenceOutsideUint64(t *testing.T) {
+	c := newTestBacklogCore()
+	// Put the local sequence at the top of uint64 so the window alone would
+	// admit the message; only the uint64 check may reject it.
+	c.current = newRoundState(
+		&bft.View{Sequence: new(big.Int).SetUint64(math.MaxUint64), Round: big.NewInt(0)},
+		valset.NewAddressSet(nil), common.Hash{}, nil, nil, nil)
+	tooLarge := new(big.Int).Add(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(1))
+
+	assert.True(t, c.isBacklogSequenceTooFar(tooLarge))
+}
+
+func TestStoreBacklogSkipsUndecodableMessage(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	c := newTestBacklogCore()
+
+	c.storeBacklog(&bft.Message{Code: bft.MsgPrepare, Msg: []byte{0xff}}, src)
+
+	assert.Empty(t, c.backlogs)
+	assert.Empty(t, c.backlogSenderBytes)
+	assert.Zero(t, c.backlogMessageCount)
+	assert.Zero(t, c.backlogPayloadBytes)
+}
+
+func TestProcessBacklogFreesCapacityForLaterMessages(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	c := newTestBacklogCore()
+	qualified := valset.NewAddressSet(nil)
+	msg := newTestBacklogMessage(t, 2)
+
+	for range maxBacklogMessagesPerSender {
+		c.storeBacklog(msg, src)
+	}
+	c.current = newRoundState(&bft.View{Sequence: big.NewInt(3), Round: big.NewInt(0)}, qualified, common.Hash{}, nil, nil, nil)
+	c.processBacklog()
+
+	assert.Empty(t, c.backlogs)
+	assert.Empty(t, c.backlogSenderBytes)
+	assert.Zero(t, c.backlogMessageCount)
+	assert.Zero(t, c.backlogPayloadBytes)
+
+	c.storeBacklog(msg, src)
+	assert.Equal(t, 1, c.backlogs[src].Size())
+	assert.Equal(t, 1, c.backlogMessageCount)
+}
+
+func TestProcessBacklogRemovesMessageWithNilView(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	c := newTestBacklogCore()
+	payload, err := bft.Encode(&bft.Subject{})
+	require.NoError(t, err)
+	msg := &bft.Message{Code: bft.MsgPrepare, Msg: payload}
+
+	c.backlogs[src] = prque.New()
+	c.backlogs[src].Push(msg, 0)
+	c.backlogMessageCount = 1
+	c.backlogSenderBytes[src] = backlogMessageBytes(msg)
+	c.backlogPayloadBytes = backlogMessageBytes(msg)
+	c.processBacklog()
+
+	assert.Empty(t, c.backlogs)
+	assert.Empty(t, c.backlogSenderBytes)
+	assert.Zero(t, c.backlogMessageCount)
+	assert.Zero(t, c.backlogPayloadBytes)
+}
+
+func TestExceedsBacklogLimit(t *testing.T) {
+	assert.False(t, exceedsBacklogLimit(15, 1, 16))
+	assert.True(t, exceedsBacklogLimit(15, 2, 16))
+	assert.True(t, exceedsBacklogLimit(0, 17, 16))
+}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -104,6 +104,7 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 		backend:            backend,
 		backlogs:           make(map[common.Address]*prque.Prque),
 		backlogsMu:         new(sync.Mutex),
+		backlogSenderBytes: make(map[common.Address]uint64),
 		pendingRequests:    prque.New(),
 		pendingRequestsMu:  new(sync.Mutex),
 		consensusTimestamp: time.Time{},
@@ -140,8 +141,11 @@ type core struct {
 	waitingForRoundChange bool
 	validateFn            func([]byte, []byte) (common.Address, error)
 
-	backlogs   map[common.Address]*prque.Prque
-	backlogsMu *sync.Mutex
+	backlogs            map[common.Address]*prque.Prque
+	backlogsMu          *sync.Mutex
+	backlogSenderBytes  map[common.Address]uint64
+	backlogMessageCount int
+	backlogPayloadBytes uint64
 
 	current   *roundState
 	handlerWg *sync.WaitGroup

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -360,7 +360,7 @@ func (c *core) startNewRound(round *big.Int) {
 	// New snapshot for new round
 	c.updateRoundState(newView, roundChange, qualified, committeeSet, proposer, committeeSize, requiredMsgCnt, fNum)
 	// Clear invalid ROUND CHANGE messages
-	c.roundChangeSet = newRoundChangeSet(c.current.qualified)
+	c.roundChangeSet = newRoundChangeSet(c.current.qualified, c.current.requiredMessageCount)
 	// Calculate new proposer
 	c.waitingForRoundChange = false
 	c.setState(StateAcceptRequest)

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -35,6 +35,12 @@ var (
 	// errFutureMessage is returned when current view is earlier than the
 	// view of the received message.
 	errFutureMessage = errors.New("future message")
+	// errRoundChangeTooFar is returned when a ROUND CHANGE is outside the
+	// retained future-round window.
+	errRoundChangeTooFar = errors.New("round change is too far in the future")
+	// errRoundChangeMessageLimit is returned when a ROUND CHANGE bucket already
+	// retains a quorum of distinct senders.
+	errRoundChangeMessageLimit = errors.New("round change message limit reached")
 	// errOldMessage is returned when the received message's view is earlier
 	// than current view.
 	errOldMessage = errors.New("old message")

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -31,6 +31,12 @@ import (
 	"github.com/kaiachain/kaia/kaiax/valset"
 )
 
+// maxRoundChangeRoundsAhead retains the current round plus this many future
+// rounds while a sequence is stalled. The window bounds memory while keeping the
+// near-round buckets the node needs to catch up. It deliberately trades catch-up
+// beyond this window for bounded local memory.
+const maxRoundChangeRoundsAhead = 128
+
 // sendNextRoundChange sends the ROUND CHANGE message with current round + 1
 func (c *core) sendNextRoundChange(loc string) {
 	if c.backend.NodeType() != common.CONSENSUSNODE {
@@ -115,9 +121,9 @@ func (c *core) handleRoundChange(msg *bft.Message, src common.Address) error {
 
 	// Add the ROUND CHANGE message to its message set and return how many
 	// messages we've got with the same round number and sequence number.
-	num, err := c.roundChangeSet.Add(roundView.Round, msg)
+	num, err := c.roundChangeSet.Add(cv.Round, roundView.Round, msg)
 	if err != nil {
-		logger.Warn("Failed to add round change message", "from", src, "msg", msg, "err", err)
+		logger.Trace("Discarding ROUND CHANGE", "from", src, "round", roundView.Round, "err", err)
 		return err
 	}
 
@@ -151,7 +157,7 @@ func (c *core) handleRoundChange(msg *bft.Message, src common.Address) error {
 		return nil
 	} else if cv.Round.Cmp(roundView.Round) < 0 {
 		// Only gossip the message with current round to other validators.
-		logger.Warn("[RC] Received round is bigger but not enough number of messages. Message ignored",
+		logger.Trace("[RC] Received round is bigger but not enough number of messages. Message ignored",
 			"currentRound", cv.Round.String(), "newRound", roundView.Round.String(), "numRC", num)
 		return errIgnored
 	}
@@ -160,34 +166,57 @@ func (c *core) handleRoundChange(msg *bft.Message, src common.Address) error {
 
 // ----------------------------------------------------------------------------
 
-func newRoundChangeSet(qualified *valset.AddressSet) *roundChangeSet {
+func newRoundChangeSet(qualified *valset.AddressSet, maxMessagesPerRound int) *roundChangeSet {
 	return &roundChangeSet{
-		qualified:    qualified,
-		roundChanges: make(map[uint64]*messageSet),
-		mu:           new(sync.Mutex),
+		qualified:           qualified,
+		maxMessagesPerRound: maxMessagesPerRound,
+		roundChanges:        make(map[uint64]*messageSet),
+		mu:                  new(sync.Mutex),
 	}
 }
 
 type roundChangeSet struct {
-	qualified    *valset.AddressSet
-	roundChanges map[uint64]*messageSet
-	mu           *sync.Mutex
+	qualified           *valset.AddressSet
+	maxMessagesPerRound int
+	roundChanges        map[uint64]*messageSet
+	mu                  *sync.Mutex
 }
 
-// Add adds the round and message into round change set
-func (rcs *roundChangeSet) Add(r *big.Int, msg *bft.Message) (int, error) {
+// Add retains a ROUND CHANGE only when its round is within the current window.
+// A retained round needs no more than a quorum's worth of messages: once that
+// limit is reached, any further distinct sender cannot change its outcome.
+// Add holds rcs.mu and is the only writer of a retained messageSet, so reading
+// that set's size before adding to it cannot race.
+func (rcs *roundChangeSet) Add(currentRound, messageRound *big.Int, msg *bft.Message) (int, error) {
+	// roundChanges is keyed by uint64, so reject values that would truncate to
+	// an existing bucket even if callers bypass checkMessage.
+	if !messageRound.IsUint64() {
+		return 0, bft.ErrInvalidMessage
+	}
+
 	rcs.mu.Lock()
 	defer rcs.mu.Unlock()
 
-	round := r.Uint64()
-	if rcs.roundChanges[round] == nil {
-		rcs.roundChanges[round] = newMessageSet(rcs.qualified)
+	maxRound := new(big.Int).Add(currentRound, big.NewInt(maxRoundChangeRoundsAhead))
+	if messageRound.Cmp(maxRound) > 0 {
+		return 0, errRoundChangeTooFar
 	}
-	err := rcs.roundChanges[round].Add(msg)
-	if err != nil {
+
+	// A bucket is stored only after a message is accepted, so a rejected message
+	// never leaves an empty bucket behind.
+	round := messageRound.Uint64()
+	messages := rcs.roundChanges[round]
+	if messages == nil {
+		messages = newMessageSet(rcs.qualified)
+	}
+	if messages.Get(msg.Address) == nil && messages.Size() >= rcs.maxMessagesPerRound {
+		return 0, errRoundChangeMessageLimit
+	}
+	if err := messages.Add(msg); err != nil {
 		return 0, err
 	}
-	return rcs.roundChanges[round].Size(), nil
+	rcs.roundChanges[round] = messages
+	return messages.Size(), nil
 }
 
 // Clear deletes the messages with smaller round

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The Kaia Authors
+// This file is part of the Kaia library.
+//
+// The Kaia library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Kaia library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Kaia library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/consensus/bft"
+	"github.com/kaiachain/kaia/kaiax/valset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundChangeSetBoundsMessagesPerRound(t *testing.T) {
+	addrs := []common.Address{
+		common.HexToAddress("0x1"),
+		common.HexToAddress("0x2"),
+		common.HexToAddress("0x3"),
+	}
+	rcs := newRoundChangeSet(valset.NewAddressSet(addrs), 2)
+	round := big.NewInt(1)
+	currentRound := big.NewInt(0)
+
+	for _, addr := range addrs[:2] {
+		_, err := rcs.Add(currentRound, round, &bft.Message{Address: addr})
+		require.NoError(t, err)
+	}
+
+	_, err := rcs.Add(currentRound, round, &bft.Message{Address: addrs[2]})
+	require.ErrorIs(t, err, errRoundChangeMessageLimit)
+	assert.Equal(t, 2, rcs.roundChanges[round.Uint64()].Size())
+
+	// A duplicate sender may still replace its prior message after the limit.
+	count, err := rcs.Add(currentRound, round, &bft.Message{Address: addrs[0]})
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+// A zero quorum means no ROUND CHANGE can contribute to progress, so not even a
+// freshly created bucket may retain one.
+func TestRoundChangeSetRejectsEveryMessageWhenLimitIsZero(t *testing.T) {
+	addr := common.HexToAddress("0x1")
+	rcs := newRoundChangeSet(valset.NewAddressSet([]common.Address{addr}), 0)
+
+	_, err := rcs.Add(big.NewInt(0), big.NewInt(1), &bft.Message{Address: addr})
+
+	require.ErrorIs(t, err, errRoundChangeMessageLimit)
+	assert.Empty(t, rcs.roundChanges)
+}
+
+func TestRoundChangeSetClearDropsOlderBuckets(t *testing.T) {
+	addr := common.HexToAddress("0x1")
+	rcs := newRoundChangeSet(valset.NewAddressSet([]common.Address{addr}), 1)
+	for _, round := range []int64{1, 2} {
+		_, err := rcs.Add(big.NewInt(0), big.NewInt(round), &bft.Message{Address: addr})
+		require.NoError(t, err)
+	}
+
+	rcs.Clear(big.NewInt(2))
+
+	assert.NotContains(t, rcs.roundChanges, uint64(1))
+	assert.Contains(t, rcs.roundChanges, uint64(2))
+}
+
+func TestRoundChangeSetEnforcesFutureRoundWindow(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	rcs := newRoundChangeSet(valset.NewAddressSet([]common.Address{src}), 1)
+	currentRound := big.NewInt(0)
+
+	_, err := rcs.Add(currentRound, big.NewInt(maxRoundChangeRoundsAhead), &bft.Message{Address: src})
+	require.NoError(t, err)
+
+	_, err = rcs.Add(currentRound, big.NewInt(maxRoundChangeRoundsAhead+1), &bft.Message{Address: src})
+	require.ErrorIs(t, err, errRoundChangeTooFar)
+	assert.Len(t, rcs.roundChanges, 1)
+}
+
+func TestRoundChangeSetRejectsRoundOutsideUint64(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	rcs := newRoundChangeSet(valset.NewAddressSet([]common.Address{src}), 1)
+	tooLarge := new(big.Int).Lsh(big.NewInt(1), 64)
+
+	_, err := rcs.Add(big.NewInt(0), tooLarge, &bft.Message{Address: src})
+
+	require.ErrorIs(t, err, bft.ErrInvalidMessage)
+	assert.Empty(t, rcs.roundChanges)
+}
+
+func TestHandleRoundChangeEnforcesFutureRoundWindow(t *testing.T) {
+	src := common.HexToAddress("0x1")
+	qualified := valset.NewAddressSet([]common.Address{src})
+	current := newRoundState(&bft.View{Sequence: big.NewInt(1), Round: big.NewInt(0)}, qualified, common.Hash{}, nil, nil, nil)
+	current.committee = qualified
+	current.requiredMessageCount = 2
+	c := &core{
+		state:          StateAcceptRequest,
+		logger:         logger.NewWith(),
+		current:        current,
+		roundChangeSet: newRoundChangeSet(qualified, current.requiredMessageCount),
+	}
+
+	boundary := roundChangeMessage(t, src, maxRoundChangeRoundsAhead)
+	err := c.handleRoundChange(boundary, src)
+	require.ErrorIs(t, err, errIgnored)
+	assert.Contains(t, c.roundChangeSet.roundChanges, uint64(maxRoundChangeRoundsAhead))
+
+	tooFar := roundChangeMessage(t, src, maxRoundChangeRoundsAhead+1)
+	err = c.handleRoundChange(tooFar, src)
+	require.ErrorIs(t, err, errRoundChangeTooFar)
+	assert.Len(t, c.roundChangeSet.roundChanges, 1)
+}
+
+func roundChangeMessage(t *testing.T, src common.Address, round uint64) *bft.Message {
+	t.Helper()
+	payload, err := bft.Encode(&bft.Subject{View: &bft.View{
+		Sequence: big.NewInt(1),
+		Round:    new(big.Int).SetUint64(round),
+	}})
+	require.NoError(t, err)
+	return &bft.Message{Address: src, Code: bft.MsgRoundChange, Msg: payload}
+}


### PR DESCRIPTION
## Proposed changes

- Enforce message-type-specific committed-seal lengths during payload decoding, before signature recovery.
  - Require COMMIT messages to carry a 65-byte committed seal.
  - Require PREPREPARE, PREPARE, and ROUND CHANGE messages to carry no committed seal.
  - Add tests covering accepted envelope shapes and early rejection of unexpected lengths.

**This is a follow-up of 1053. Will be rebased after 1053 merge.**

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [ ] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [ ] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [ ] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
