### PR TITLE
node/cn: bound transaction batches

### DIFF
--- a/node/cn/handler.go
+++ b/node/cn/handler.go
@@ -988,10 +988,8 @@ func handleBlockHeadersRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) erro
 	return p.SendBlockHeaders(headers)
 }
 
-// decodeResponseList decodes a response list one element at a time, refusing a list
-// longer than limit. Decoding the whole list at once lets a peer turn a message-sized
-// packet into an arbitrarily larger object graph, and we never request more than limit.
-func decodeResponseList[T any](msg p2p.Msg, limit int) ([]T, error) {
+// decodeList decodes one item at a time and refuses lists longer than limit.
+func decodeList[T any](msg p2p.Msg, limit int) ([]T, error) {
 	stream := rlp.NewStream(msg.Payload, uint64(msg.Size))
 	if _, err := stream.List(); err != nil {
 		return nil, errResp(ErrDecode, "msg %v: %v", msg, err)
@@ -1014,7 +1012,7 @@ func decodeResponseList[T any](msg p2p.Msg, limit int) ([]T, error) {
 // handleBlockHeadersMsg handles block header response message.
 func handleBlockHeadersMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of headers arrived to one of our previous requests
-	headers, err := decodeResponseList[*types.Header](msg, downloader.MaxHeaderFetch)
+	headers, err := decodeList[*types.Header](msg, downloader.MaxHeaderFetch)
 	if err != nil {
 		return err
 	}
@@ -1071,7 +1069,7 @@ func handleBlockBodiesRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error
 // handleGetBlockBodiesMsg handles block body response message.
 func handleBlockBodiesMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of block bodies arrived to one of our previous requests
-	request, err := decodeResponseList[*blockBody](msg, downloader.MaxBlockFetch)
+	request, err := decodeList[*blockBody](msg, downloader.MaxBlockFetch)
 	if err != nil {
 		return err
 	}
@@ -1130,7 +1128,7 @@ func handleNodeDataRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 // handleNodeDataMsg handles node data response message.
 func handleNodeDataMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of node state data arrived to one of our previous requests
-	data, err := decodeResponseList[[]byte](msg, downloader.MaxStateFetch)
+	data, err := decodeList[[]byte](msg, downloader.MaxStateFetch)
 	if err != nil {
 		return err
 	}
@@ -1185,7 +1183,7 @@ func handleReceiptsRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 // handleReceiptsMsg handles receipt response message.
 func handleReceiptsMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of receipts arrived to one of our previous requests
-	receipts, err := decodeResponseList[[]*types.Receipt](msg, downloader.MaxReceiptFetch)
+	receipts, err := decodeList[[]*types.Receipt](msg, downloader.MaxReceiptFetch)
 	if err != nil {
 		return err
 	}
@@ -1263,7 +1261,7 @@ func handleStakingInfoMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	}
 
 	// A batch of stakingInfos arrived to one of our previous requests
-	stakingInfos, err := decodeResponseList[*staking.P2PStakingInfo](msg, downloader.MaxStakingInfoFetch)
+	stakingInfos, err := decodeList[*staking.P2PStakingInfo](msg, downloader.MaxStakingInfoFetch)
 	if err != nil {
 		return err
 	}
@@ -1405,7 +1403,7 @@ func handleBlobSidecarsMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		return errors.New("blob sidecar request manager is not initialized")
 	}
 
-	sidecars, err := decodeResponseList[*blobSidecarsData](msg, downloader.MaxBlobSidecarsFetch)
+	sidecars, err := decodeList[*blobSidecarsData](msg, downloader.MaxBlobSidecarsFetch)
 	if err != nil {
 		return err
 	}
@@ -1554,7 +1552,7 @@ func handleBlockBodiesFetchRequestMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) 
 // handleBlockBodiesFetchResponseMsg handles block bodies fetch response message.
 func handleBlockBodiesFetchResponseMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	// A batch of block bodies arrived to one of our previous requests
-	request, err := decodeResponseList[*blockBody](msg, downloader.MaxBlockFetch)
+	request, err := decodeList[*blockBody](msg, downloader.MaxBlockFetch)
 	if err != nil {
 		return err
 	}
@@ -1617,18 +1615,18 @@ func handleTxMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 	if pm.acceptTxs.Load() == 0 {
 		return nil
 	}
-	// Transactions can be processed, parse all of them and deliver to the pool
-	var txs types.Transactions
-	if err := msg.Decode(&txs); err != nil {
-		return errResp(ErrDecode, "msg %v: %v", msg, err)
+	// Transactions can be processed, parse them and deliver to the pool
+	txs, err := decodeList[*types.Transaction](msg, maxTxMsgItems)
+	if err != nil {
+		return err
 	}
 	// Only valid txs should be pushed into the pool.
 	validTxs := make(types.Transactions, 0, len(txs))
-	var err error
+	var lastErr error
 	for i, tx := range txs {
 		// Validate and mark the remote transaction
 		if tx == nil {
-			err = errResp(ErrDecode, "transaction %d is nil", i)
+			lastErr = errResp(ErrDecode, "transaction %d is nil", i)
 			continue
 		}
 		// Validate blob transactions to detect KZG verification errors early
@@ -1659,7 +1657,7 @@ func handleTxMsg(pm *ProtocolManager, p Peer, msg p2p.Msg) error {
 		txReceiveCounter.Inc(1)
 	}
 	pm.txpool.HandleTxMsg(validTxs)
-	return err
+	return lastErr
 }
 
 // sampleSize calculates the number of peers to send block.

--- a/node/cn/handler_msg_test.go
+++ b/node/cn/handler_msg_test.go
@@ -348,6 +348,37 @@ func TestHandleTxMsg(t *testing.T) {
 	}
 }
 
+func TestHandleTxMsg_ItemLimit(t *testing.T) {
+	txs := make(types.Transactions, maxTxMsgItems+1)
+	for i := range txs {
+		txs[i] = tx1
+	}
+
+	t.Run("at limit", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		pm := &ProtocolManager{}
+		pm.acceptTxs.Store(1)
+		mockTxPool := mocks.NewMockTxPool(mockCtrl)
+		mockTxPool.EXPECT().HandleTxMsg(gomock.Len(maxTxMsgItems)).Times(1)
+		pm.txpool = mockTxPool
+
+		peer := NewMockPeer(mockCtrl)
+		peer.EXPECT().AddToKnownTxs(gomock.Any()).Times(maxTxMsgItems)
+
+		require.NoError(t, handleTxMsg(pm, peer, generateMsg(t, TxMsg, txs[:maxTxMsgItems])))
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		pm := &ProtocolManager{}
+		pm.acceptTxs.Store(1)
+
+		err := handleTxMsg(pm, nil, generateMsg(t, TxMsg, txs))
+		require.ErrorContains(t, err, "Too many items")
+	})
+}
+
 // prepareBlobTxMsg returns a protocol manager, a peer and a signed blob transaction
 // with a valid v1 sidecar. Callers corrupt the sidecar via blobTx.BlobTxSidecar().
 func prepareBlobTxMsg(t *testing.T, mockCtrl *gomock.Controller) (*ProtocolManager, *MockPeer, *types.Transaction) {

--- a/node/cn/peer.go
+++ b/node/cn/peer.go
@@ -562,12 +562,30 @@ func (p *basePeer) SendTransactions(txs types.Transactions) error {
 	for _, tx := range txs {
 		p.AddToKnownTxs(tx.Hash())
 	}
-	return p2p.Send(p.rw, TxMsg, txs)
+	return sendTransactionBatches(txs, func(batch types.Transactions) error {
+		return p2p.Send(p.rw, TxMsg, batch)
+	})
 }
 
 // ReSendTransactions sends txs to a peer in order to prevent the txs from missing.
 func (p *basePeer) ReSendTransactions(txs types.Transactions) error {
-	return p2p.Send(p.rw, TxMsg, txs)
+	return sendTransactionBatches(txs, func(batch types.Transactions) error {
+		return p2p.Send(p.rw, TxMsg, batch)
+	})
+}
+
+func sendTransactionBatches(txs types.Transactions, send func(types.Transactions) error) error {
+	if len(txs) == 0 {
+		return send(txs)
+	}
+	for len(txs) > 0 {
+		count := min(len(txs), maxTxMsgItems)
+		if err := send(txs[:count]); err != nil {
+			return err
+		}
+		txs = txs[count:]
+	}
+	return nil
 }
 
 func (p *basePeer) AsyncSendTransactions(txs types.Transactions) {
@@ -1034,12 +1052,16 @@ func (p *multiChannelPeer) SendTransactions(txs types.Transactions) error {
 	for _, tx := range txs {
 		p.AddToKnownTxs(tx.Hash())
 	}
-	return p.msgSender(TxMsg, txs)
+	return sendTransactionBatches(txs, func(batch types.Transactions) error {
+		return p.msgSender(TxMsg, batch)
+	})
 }
 
 // ReSendTransactions sends txs to a peer in order to prevent the txs from missing.
 func (p *multiChannelPeer) ReSendTransactions(txs types.Transactions) error {
-	return p.msgSender(TxMsg, txs)
+	return sendTransactionBatches(txs, func(batch types.Transactions) error {
+		return p.msgSender(TxMsg, batch)
+	})
 }
 
 // SendNewBlockHashes announces the availability of a number of blocks through

--- a/node/cn/peer_test.go
+++ b/node/cn/peer_test.go
@@ -135,6 +135,26 @@ func TestBasePeer_ReSendTransactions(t *testing.T) {
 	assert.Equal(t, sendTxBinary, receivedTxBinary)
 }
 
+func TestSendTransactionBatches(t *testing.T) {
+	tests := []struct {
+		count int
+		want  []int
+	}{
+		{0, []int{0}},
+		{maxTxMsgItems, []int{maxTxMsgItems}},
+		{maxTxMsgItems + 1, []int{maxTxMsgItems, 1}},
+	}
+	for _, test := range tests {
+		var got []int
+		err := sendTransactionBatches(make(types.Transactions, test.count), func(batch types.Transactions) error {
+			got = append(got, len(batch))
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, test.want, got)
+	}
+}
+
 func TestBasePeer_AsyncSendTransactions(t *testing.T) {
 	sentTxs := types.Transactions{tx1}
 	lastTxs := types.Transactions{types.NewTransaction(333, addrs[0], big.NewInt(333), 333, big.NewInt(333), addrs[0][:])}

--- a/node/cn/protocol.go
+++ b/node/cn/protocol.go
@@ -65,7 +65,10 @@ var ConsensusProtocol = Protocol{
 	Lengths:  []uint64{28, 26, 24, 23, 21},
 }
 
-const ProtocolMaxMsgSize = 12 * 1024 * 1024 // Maximum cap on the size of a protocol message
+const (
+	ProtocolMaxMsgSize = 12 * 1024 * 1024 // Maximum cap on the size of a protocol message
+	maxTxMsgItems      = 4096             // Maximum transactions in one TxMsg
+)
 
 // Kaia protocol message codes
 // TODO-Klaytn-Issue751 Protocol message should be refactored. Present code is not used.


### PR DESCRIPTION
## Proposed changes

- Limit each transaction propagation message to 4,096 transactions.
- Decode transaction lists incrementally and stop when the item limit is exceeded.
- Split larger outbound transaction sets into multiple messages for both regular and multi-channel peers.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [x] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
