### PR TITLE
blockchain: defer transaction sender recovery

### DIFF
--- a/blockchain/tx_pool.go
+++ b/blockchain/tx_pool.go
@@ -1367,8 +1367,6 @@ func (pool *TxPool) HandleTxMsg(txs types.Transactions) {
 		}
 	}
 
-	// TODO-Kaia: Consider removing the next line and move the above logic to `addTx` or `AddRemotes`
-	senderCacher.recover(pool.signer, txs)
 	pool.txMsgCh <- txs
 }
 

--- a/blockchain/tx_pool_test.go
+++ b/blockchain/tx_pool_test.go
@@ -340,6 +340,29 @@ func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateK
 	return pool, key
 }
 
+func TestHandleTxMsgDefersSenderRecovery(t *testing.T) {
+	original := senderCacher
+	blocked := &txSenderCacher{threads: 1, tasks: make(chan *txSenderCacherRequest, 1)}
+	blocked.tasks <- &txSenderCacherRequest{}
+	senderCacher = blocked
+	defer func() { senderCacher = original }()
+
+	pool := &TxPool{txMsgCh: make(chan types.Transactions, 1)}
+	done := make(chan struct{})
+	go func() {
+		pool.HandleTxMsg(types.Transactions{nil})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		<-blocked.tasks
+		<-done
+		t.Fatal("HandleTxMsg performed sender recovery before queueing")
+	}
+}
+
 func setupTxPoolWithBlobStorage(t *testing.T) (*TxPool, *testBlockChain, *ecdsa.PrivateKey, string) {
 	tmpDir := t.TempDir()
 	config := testTxPoolConfig


### PR DESCRIPTION
## Proposed changes

Remove the initial sender-recovery pre-warmup from `HandleTxMsg` and retain sender recovery in the transaction-pool admission path. Sender validation remains unchanged in the transaction-pool admission path.

as-is:
  ```
  HandleTxMsg
  ├─ senderCacher.recover
  └─ queue to txMsgCh
     └─ AddRemotes
        └─ addTxs
           └─ senderCacher.recover
  ```

to-be:
  ```
  HandleTxMsg
  └─ queue to txMsgCh
     └─ AddRemotes
        └─ addTxs
           └─ senderCacher.recover
  ```

- Normal-load admission latency improved by 18–28% in local A/B benchmarks.
- Under over-capacity input, competing sender-recovery latency decreased from approximately 64 ms to 0.2 ms.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
