### PR TITLE
consensus: derive committee state from the new view

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -334,7 +334,7 @@ func (c *core) startNewRound(round *big.Int) {
 		}
 	}
 
-	seq, r := newView.Sequence.Uint64(), round.Uint64()
+	seq, r := newView.Sequence.Uint64(), newView.Round.Uint64()
 	qualified, committeeSet, proposer, committeeSize, requiredMsgCnt, fNum, err := getRoundCommitteeState(c, seq, r)
 	if err != nil {
 		logger.Error("Failed to get round committee state", "err", err)

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -168,6 +168,39 @@ func TestGetRoundCommitteeStateUsesReturnedCommitteeSize(t *testing.T) {
 	}
 }
 
+func TestStartNewRoundUsesViewRound(t *testing.T) {
+	validators := []common.Address{
+		common.HexToAddress("0x1"),
+		common.HexToAddress("0x2"),
+		common.HexToAddress("0x3"),
+		common.HexToAddress("0x4"),
+	}
+	ctrl := gomock.NewController(t)
+	backend := mock_istanbul.NewMockBackend(ctrl)
+	backend.EXPECT().Address().Return(validators[0]).AnyTimes()
+	backend.EXPECT().LastProposal().Return(types.NewBlockWithHeader(&types.Header{Number: big.NewInt(10)}), common.Address{})
+	backend.EXPECT().SetCurrentView(gomock.Any())
+	backend.EXPECT().EventMux().Return(new(event.TypeMux))
+
+	mValset := valset_mock.NewMockValsetModule(ctrl)
+	mValset.EXPECT().GetCouncil(uint64(11)).Return(validators, nil)
+	mValset.EXPECT().GetDemotedValidators(uint64(11)).Return(nil, nil)
+	mValset.EXPECT().GetCommittee(uint64(11), uint64(0)).Return(validators, nil)
+	mValset.EXPECT().GetProposer(uint64(11), uint64(0)).Return(validators[1], nil)
+
+	c := New(backend, istanbul.DefaultConfig).(*core)
+	c.RegisterKaiaxModules(mValset, mock_gov.NewMockGovModule(ctrl))
+	c.current = newRoundState(
+		&bft.View{Sequence: big.NewInt(10), Round: big.NewInt(0)},
+		valset.NewAddressSet(validators), common.Hash{}, nil, nil, backend.HasBadProposal,
+	)
+	c.startNewRound(big.NewInt(3))
+	t.Cleanup(c.stopTimer)
+
+	assert.Equal(t, uint64(0), c.current.Round().Uint64())
+	assert.Equal(t, validators[1], c.current.proposer)
+}
+
 // getTestCommitteeState returns qualified, committee, proposer, nonCommittee for tests using the same logic as newMockBackend
 func getTestCommitteeState(validatorAddrs []common.Address, committeeSize uint64, seq, round uint64) (qualified, committee *valset.AddressSet, proposer common.Address, nonCommittee *valset.AddressSet) {
 	qualified = valset.NewAddressSet(validatorAddrs).Subtract(valset.NewAddressSet([]common.Address{}))


### PR DESCRIPTION
## Proposed changes

- Use the new consensus view’s round when selecting the committee and proposer.
- Keep round state consistent when advancing to a new sequence.
- Add regression coverage for the round-zero catch-up path.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
