### PR TITLE
storage/statedb: separate node and code sync cache keys

### DIFF
--- a/storage/statedb/sync.go
+++ b/storage/statedb/sync.go
@@ -108,6 +108,11 @@ type syncMemBatch struct {
 	codes map[common.Hash][]byte // In-memory membatch of recently completed codes
 }
 
+type (
+	syncNodeExistKey common.Hash
+	syncCodeExistKey common.Hash
+)
+
 // newSyncMemBatch allocates a new memory-buffer for not-yet persisted trie nodes.
 func newSyncMemBatch() *syncMemBatch {
 	return &syncMemBatch{
@@ -179,7 +184,7 @@ func (s *TrieSync) AddSubTrie(root common.Hash, path []byte, depth int, parent c
 		return
 	}
 	if s.exist != nil {
-		if _, ok := s.exist.Get(root); ok {
+		if _, ok := s.exist.Get(syncNodeExistKey(root)); ok {
 			// already written in migration, skip the node
 			return
 		}
@@ -225,7 +230,7 @@ func (s *TrieSync) AddCodeEntry(hash common.Hash, path []byte, depth int, parent
 		return
 	}
 	if s.exist != nil {
-		if _, ok := s.exist.Get(hash); ok {
+		if _, ok := s.exist.Get(syncCodeExistKey(hash)); ok {
 			// already written in migration, skip the node
 			return
 		}
@@ -356,7 +361,7 @@ func (s *TrieSync) Commit(dbw database.Batch) (int, error) {
 			s.bloom.Add(key[:])
 		}
 		if s.exist != nil {
-			s.exist.Add(key, nil)
+			s.exist.Add(syncNodeExistKey(key), nil)
 		}
 		written += 1
 	}
@@ -368,7 +373,7 @@ func (s *TrieSync) Commit(dbw database.Batch) (int, error) {
 			s.bloom.Add(key[:])
 		}
 		if s.exist != nil {
-			s.exist.Add(key, nil)
+			s.exist.Add(syncCodeExistKey(key), nil)
 		}
 		written += 1
 	}
@@ -475,7 +480,7 @@ func (s *TrieSync) children(req *request, object node) ([]*request, error) {
 				continue
 			}
 			if s.exist != nil {
-				if _, ok := s.exist.Get(hash); ok {
+				if _, ok := s.exist.Get(syncNodeExistKey(hash)); ok {
 					// already written in migration, skip the node
 					continue
 				}

--- a/storage/statedb/sync_test.go
+++ b/storage/statedb/sync_test.go
@@ -113,6 +113,54 @@ func TestEmptyTrieSync(t *testing.T) {
 	}
 }
 
+func TestTrieSyncExistCacheSeparatesNodesAndCode(t *testing.T) {
+	hash := common.HexToHash("0x01")
+
+	tests := []struct {
+		name     string
+		populate func(*TrieSync)
+		schedule func(*TrieSync)
+	}{
+		{
+			name: "code does not hide node",
+			populate: func(sync *TrieSync) {
+				sync.membatch.codes[hash] = []byte{0x01}
+			},
+			schedule: func(sync *TrieSync) {
+				sync.AddSubTrie(hash, nil, 0, common.Hash{}, nil)
+			},
+		},
+		{
+			name: "node does not hide code",
+			populate: func(sync *TrieSync) {
+				sync.membatch.nodes[hash] = []byte{0x01}
+			},
+			schedule: func(sync *TrieSync) {
+				sync.AddCodeEntry(hash, nil, 0, common.Hash{})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dbm := database.NewMemoryDBManager()
+			cache, err := lru.New(10)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sync := NewTrieSync(types.EmptyRootHash, dbm, nil, nil, cache)
+			test.populate(sync)
+			if _, err := sync.Commit(dbm.GetMemDB().NewBatch()); err != nil {
+				t.Fatal(err)
+			}
+			test.schedule(sync)
+			if sync.Pending() != 1 {
+				t.Fatalf("pending requests = %d, want 1", sync.Pending())
+			}
+		})
+	}
+}
+
 // Tests that given a root hash, a trie can sync iteratively on a single thread,
 // requesting retrieval tasks and returning all of them in one go.
 func TestIterativeSyncIndividual(t *testing.T)       { testIterativeTrieSync(t, 1, false) }


### PR DESCRIPTION
## Proposed changes

- Use distinct cache keys for trie nodes and contract code.
- Apply the typed keys consistently to cache lookups and writes.
- The behavior change is limited to state migration; persisted state data and other synchronization paths remain unchanged.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
