### PR TITLE
p2p: limit frames before peer handshake

### DIFF
--- a/networks/p2p/rlpx/rlpx.go
+++ b/networks/p2p/rlpx/rlpx.go
@@ -61,6 +61,8 @@ type Conn struct {
 	conn     net.Conn
 	session  *sessionState
 
+	readFrameLimit uint32
+
 	// These are the buffers for snappy compression.
 	// Compression is enabled if they are non-nil.
 	snappyReadBuffer  []byte
@@ -120,6 +122,12 @@ func (c *Conn) SetSnappy(snappy bool) {
 	}
 }
 
+// SetReadFrameLimit limits encrypted frame content before it is allocated.
+// A zero limit allows the full RLPx frame size.
+func (c *Conn) SetReadFrameLimit(limit uint32) {
+	c.readFrameLimit = limit
+}
+
 // SetReadDeadline sets the deadline for all future read operations.
 func (c *Conn) SetReadDeadline(time time.Time) error {
 	return c.conn.SetReadDeadline(time)
@@ -142,7 +150,7 @@ func (c *Conn) Read() (code uint64, data []byte, err error) {
 		panic("can't ReadMsg before handshake")
 	}
 
-	frame, err := c.session.readFrame(c.conn)
+	frame, err := c.session.readFrame(c.conn, c.readFrameLimit)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -167,7 +175,7 @@ func (c *Conn) Read() (code uint64, data []byte, err error) {
 	return code, data, err
 }
 
-func (h *sessionState) readFrame(conn io.Reader) ([]byte, error) {
+func (h *sessionState) readFrame(conn io.Reader, limit uint32) ([]byte, error) {
 	h.rbuf.reset()
 
 	// Read the frame header.
@@ -185,6 +193,9 @@ func (h *sessionState) readFrame(conn io.Reader) ([]byte, error) {
 	// Decrypt the frame header to get the frame size.
 	h.dec.XORKeyStream(header[:16], header[:16])
 	fsize := readUint24(header[:16])
+	if limit != 0 && fsize > limit {
+		return nil, errFrameTooLarge
+	}
 	// Frame size rounded up to 16 byte boundary for padding.
 	rsize := fsize
 	if padding := fsize % 16; padding > 0 {
@@ -405,6 +416,7 @@ var (
 	// errPlainMessageTooLarge is returned if a decompressed message length exceeds
 	// the allowed 24 bits (i.e. length >= 16MB).
 	errPlainMessageTooLarge = errors.New("message length >= 16MB")
+	errFrameTooLarge        = errors.New("frame too large")
 )
 
 // Secrets represents the connection secrets which are negotiated during the handshake.

--- a/networks/p2p/rlpx/rlpx_test.go
+++ b/networks/p2p/rlpx/rlpx_test.go
@@ -153,7 +153,7 @@ func TestFrameReadWrite(t *testing.T) {
 	}
 
 	// Check readFrame on the test vector.
-	content, err := h.readFrame(bytes.NewReader(golden))
+	content, err := h.readFrame(bytes.NewReader(golden), 0)
 	if err != nil {
 		t.Fatalf("ReadMsg error: %v", err)
 	}
@@ -161,6 +161,26 @@ func TestFrameReadWrite(t *testing.T) {
 	if !bytes.Equal(content, wantContent) {
 		t.Errorf("frame content mismatch:\ngot  %x\nwant %x", content, wantContent)
 	}
+}
+
+func TestFrameReadLimit(t *testing.T) {
+	conn := NewConn(nil, nil)
+	hash := fakeHash(bytes.Repeat([]byte{1}, 32))
+	conn.InitWithSecrets(Secrets{
+		AES:        crypto.Keccak256(),
+		MAC:        crypto.Keccak256(),
+		IngressMAC: hash,
+		EgressMAC:  hash,
+	})
+	h := conn.session
+
+	buf := new(bytes.Buffer)
+	if err := h.writeFrame(buf, 0, make([]byte, 2048)); err != nil {
+		t.Fatal(err)
+	}
+	_, err := h.readFrame(bytes.NewReader(buf.Bytes()), 2048)
+	assert.ErrorIs(t, err, errFrameTooLarge)
+	assert.LessOrEqual(t, cap(h.rbuf.data), 32)
 }
 
 type fakeHash []byte

--- a/networks/p2p/transport.go
+++ b/networks/p2p/transport.go
@@ -44,6 +44,8 @@ const (
 	// This is shorter than the usual timeout because we don't want
 	// to wait if the connection is known to be bad anyway.
 	discWriteTimeout = 1 * time.Second
+
+	protocolHandshakeFrameLimit = baseProtocolMaxMsgSize + 9 // payload plus an RLP-encoded message code
 )
 
 type transport interface {
@@ -70,7 +72,9 @@ type rlpxTransport struct {
 }
 
 func newRLPX(conn net.Conn, dialDest *ecdsa.PublicKey) transport {
-	return &rlpxTransport{conn: rlpx.NewConn(conn, dialDest)}
+	rconn := rlpx.NewConn(conn, dialDest)
+	rconn.SetReadFrameLimit(protocolHandshakeFrameLimit)
+	return &rlpxTransport{conn: rconn}
 }
 
 func (t *rlpxTransport) ReadMsg() (Msg, error) {
@@ -156,6 +160,8 @@ func (t *rlpxTransport) doProtoHandshake(our *protoHandshake) (their *protoHands
 	if err := <-werr; err != nil {
 		return nil, fmt.Errorf("write error: %v", err)
 	}
+	// A zero limit allows the full RLPx frame size after the handshake.
+	t.conn.SetReadFrameLimit(0)
 	// If the protocol version supports Snappy encoding, upgrade immediately
 	t.conn.SetSnappy(their.Version >= snappyProtocolVersion)
 

--- a/networks/p2p/transport_test.go
+++ b/networks/p2p/transport_test.go
@@ -19,6 +19,7 @@ package p2p
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -39,6 +40,7 @@ func TestProtocolHandshake(t *testing.T) {
 		pub1    = crypto.FromECDSAPub(&prv1.PublicKey)[1:]
 		id1, _  = discover.BytesID(pub1)
 		hs1     = &protoHandshake{Version: 3, ID: id1, ListenPort: []uint64{}, Caps: []Cap{{"c", 1}, {"d", 3}}}
+		large   = make([]byte, baseProtocolMaxMsgSize+1)
 
 		wg sync.WaitGroup
 	)
@@ -73,6 +75,10 @@ func TestProtocolHandshake(t *testing.T) {
 			t.Errorf("dial side proto handshake mismatch:\ngot: %s\nwant: %s\n", spew.Sdump(phs), spew.Sdump(hs1))
 			return
 		}
+		if err := Send(frame, 42, large); err != nil {
+			t.Errorf("dial side large message error: %v", err)
+			return
+		}
 		frame.close(DiscQuitting)
 	}()
 	go func() {
@@ -97,6 +103,10 @@ func TestProtocolHandshake(t *testing.T) {
 		phs.Rest = nil
 		if !reflect.DeepEqual(phs, hs0) {
 			t.Errorf("listen side proto handshake mismatch:\ngot: %s\nwant: %s\n", spew.Sdump(phs), spew.Sdump(hs0))
+			return
+		}
+		if err := ExpectMsg(rlpx, 42, large); err != nil {
+			t.Errorf("error receiving large message: %v", err)
 			return
 		}
 
@@ -147,5 +157,50 @@ func TestProtocolHandshakeErrors(t *testing.T) {
 		if !reflect.DeepEqual(err, test.err) {
 			t.Errorf("test %d: error mismatch: got %q, want %q", i, err, test.err)
 		}
+	}
+}
+
+func TestProtocolHandshakeFrameLimit(t *testing.T) {
+	prv0, _ := crypto.GenerateKey()
+	prv1, _ := crypto.GenerateKey()
+	pub1 := crypto.FromECDSAPub(&prv1.PublicKey)[1:]
+	id1, _ := discover.BytesID(pub1)
+
+	fd0, fd1, err := pipes.TCPPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fd0.Close()
+	defer fd1.Close()
+
+	client := newRLPX(fd0, &prv1.PublicKey)
+	server := newRLPX(fd1, nil)
+	encDone := make(chan error, 1)
+	go func() {
+		_, err := server.doEncHandshake(prv1)
+		encDone <- err
+	}()
+	if _, err := client.doEncHandshake(prv0); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-encDone; err != nil {
+		t.Fatal(err)
+	}
+
+	protoDone := make(chan error, 1)
+	go func() {
+		_, err := server.doProtoHandshake(&protoHandshake{Version: 3, ID: id1})
+		protoDone <- err
+	}()
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- Send(client, handshakeMsg, make([]byte, 4096)) }()
+	if _, err := client.ReadMsg(); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-protoDone; err == nil || !strings.Contains(err.Error(), "frame too large") {
+		t.Fatalf("unexpected handshake error: %v", err)
 	}
 }


### PR DESCRIPTION
## Proposed changes

- Add temporary RLPx read-frame limit enforced before allocating frame content.
- Apply the base-protocol message limit, including RLP message-code overhead, while the protocol handshake is in progress.
- Remove the temporary limit after a successful handshake so normal protocol messages retain their existing size allowance.
- Add tests covering early frame rejection and larger post-handshake messages.

## Types of changes

<!-- Check ALL boxes that apply: -->

- [ ] 🐛 Bug fix
- [x] ✨ Non-hardfork changes (node upgrade not required)
- [ ] 💥 Hardfork / consensus-breaking changes
- [ ] 🧪 Test improvements
- [ ] 🧰 CI / build tool
- [ ] ♻️ Chore / Refactor / Non-functional changes

## Checklist

<!-- Make sure to check all the following items -->

- [x] 📖 I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia/blob/main/CONTRIBUTING.md) doc
- [x] 📝 I have signed in the PR comment `I have read the CLA Document and I hereby sign the CLA` in first time contribute after having read [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6)
- [x] 🟢 Lint and unit tests pass locally with my changes (`$ make test`)

## Related issues

<!-- Please leave the issue numbers or links related to this PR here. -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
